### PR TITLE
Added ReleaseNotes directory inside $ISISROOT/src/docsys/documents

### DIFF
--- a/isis/src/docsys/documents/ReleaseNotes/README.md
+++ b/isis/src/docsys/documents/ReleaseNotes/README.md
@@ -1,0 +1,2 @@
+This is the folder where the createReleaseNotesXML script creates
+the file:  ReleaseNotesList.xml.  


### PR DESCRIPTION
This PR adds the ReleaseNotes directory to $ISISROOT/src/docsys/documents/ as well as a README.md file inside that directory.  The isis3mgr createReleaseNotesXML script is expecting this directory to be in place before it is run, and it didn't make it over from the svn -> git migration because git doesn't like empty directories (hence, adding the README.md file inside it).  References #5267