### PR TITLE
Modified interpolation in SpatialPlotTool

### DIFF
--- a/isis/src/qisis/objs/SpatialPlotTool/SpatialPlotTool.cpp
+++ b/isis/src/qisis/objs/SpatialPlotTool/SpatialPlotTool.cpp
@@ -118,7 +118,7 @@ namespace Isis {
     m_interpolationCombo->addItem("Cubic Convolution",
         Interpolator::CubicConvolutionType);
     m_interpolationCombo->setCurrentIndex(
-        m_interpolationCombo->findText("BiLinear"));
+        m_interpolationCombo->findText("Nearest Neighbor"));
     connect(m_interpolationCombo, SIGNAL(currentIndexChanged(int)),
             this, SLOT(refreshPlot()));
 
@@ -466,11 +466,6 @@ namespace Isis {
         // Get length of "green" line on the screen
         int acrossLength = qRound(sqrt(acrossVectorX * acrossVectorX +
                                        acrossVectorY * acrossVectorY));
-                                       
-        // Prevent length of zero for later calculations
-        if (acrossLength == 0) {
-          acrossLength = 1;
-        }
         
         double sampleStepAcross = (1.0 / (double)acrossLength) * acrossVectorX;
         double lineStepAcross = (1.0 / (double)acrossLength) * acrossVectorY;

--- a/isis/src/qisis/objs/SpatialPlotTool/SpatialPlotTool.h
+++ b/isis/src/qisis/objs/SpatialPlotTool/SpatialPlotTool.h
@@ -56,6 +56,8 @@ namespace Isis {
    *                           References #2089.
    *   @history 2018-01-12 Summer Stapleton - Prevented lengths of zero for the rotated rectangle 
    *                           selection to address segfault. Fixes #4953.
+   *   @history 2018-01-18 Summer Stapleton - Modified the default interpolation mode to
+   *                           "Nearest Neighbor". Fixes #1949, 5257.
    */
   class SpatialPlotTool : public AbstractPlotTool {
       Q_OBJECT


### PR DESCRIPTION
Modified interpolation in SpatialPlotTool to be "Nearest Neighbor" to be more intuitive. Fixes 1949