### PR TITLE
Improved ControlNetVersioner code coverage

### DIFF
--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -1230,8 +1230,8 @@ namespace Isis {
 
     BigInt numberOfPoints = 0;
 
-    if ( header.hasGroup("ControlNetworkInfo") ) {
-      const PvlGroup &networkInfo = header.findGroup("ControlNetworkInfo");
+    if ( protoBufferInfo.hasGroup("ControlNetworkInfo") ) {
+      const PvlGroup &networkInfo = protoBufferInfo.findGroup("ControlNetworkInfo");
 
       if ( networkInfo.hasKeyword("NumberOfPoints") ) {
         try {

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
@@ -549,3 +549,20 @@ Conversion to Pvl stays consistent
 Reading/Writing control network is consistent
 Check conversions between the binary format and the pvl format.
 The conversion methods for pvl->bin and bin->pvl are correct.
+
+Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork5_PvlV0003.pvl...
+
+Read network...
+Write the network and re-read it...
+After reading and writing to a binary form does Pvl match?
+Reading/Writing control network is consistent
+
+Test writing from ControlNet objects
+
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
+Adding Control Points to Network...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
+
+Test writing with invalid target
+

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
@@ -2,13 +2,16 @@ Test ControlNetVersioner
 Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork2_PvlV0001.net...
 
 Read network...
-**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_PvlNetwork2_PvlV0001.net] failed.
+Reading Control Points...
+0% Processed**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_PvlNetwork2_PvlV0001.net] failed.
 **I/O ERROR** Failed to initialize control point at index [0].
 **I/O ERROR** Unable to get target body radii for [] when calculating covariance matrix.
 
 Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork3_PvlV0001.net...
 
 Read network...
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
 Converted directly to Pvl:
 Object = ControlNetwork
   NetworkId    = Null
@@ -63,6 +66,8 @@ Reading/Writing control network is consistent
 Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork1_PvlV0001.net...
 
 Read network...
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
 Converted directly to Pvl:
 Object = ControlNetwork
   NetworkId    = TestNet01
@@ -117,6 +122,8 @@ Reading/Writing control network is consistent
 Reading: $control/testData/unitTest_ControlNetVersioner_ProtoNetwork1_ProtoV0001.net...
 
 Read network...
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
 Converted directly to Pvl:
 Object = ControlNetwork
   NetworkId    = Test
@@ -303,6 +310,8 @@ Read network...
 Reading: $control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net...
 
 Read network...
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
 Write the network and re-read it...
 After reading and writing to a binary form does Pvl match?
 Reading/Writing control network is consistent
@@ -310,6 +319,8 @@ Reading/Writing control network is consistent
 Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork4_PvlV0003.pvl...
 
 Read network...
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
 Converted directly to Pvl:
 Object = ControlNetwork
   NetworkId    = LUNAE_PALUS_THEMIS_DIR
@@ -553,6 +564,36 @@ The conversion methods for pvl->bin and bin->pvl are correct.
 Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork5_PvlV0003.pvl...
 
 Read network...
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
+Write the network and re-read it...
+After reading and writing to a binary form does Pvl match?
+Reading/Writing control network is consistent
+
+Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork3_PvlV0001.net...
+
+Read network...
+Write the network and re-read it...
+After reading and writing to a binary form does Pvl match?
+Reading/Writing control network is consistent
+
+Reading: $control/testData/unitTest_ControlNetVersioner_ProtoNetwork1_ProtoV0001.net...
+
+Read network...
+Write the network and re-read it...
+After reading and writing to a binary form does Pvl match?
+Reading/Writing control network is consistent
+
+Reading: $control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net...
+
+Read network...
+Write the network and re-read it...
+After reading and writing to a binary form does Pvl match?
+Reading/Writing control network is consistent
+
+Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork4_PvlV0003.pvl...
+
+Read network...
 Write the network and re-read it...
 After reading and writing to a binary form does Pvl match?
 Reading/Writing control network is consistent
@@ -564,5 +605,53 @@ Reading Control Points...
 Adding Control Points to Network...
 0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
 
+Test reading version 1 protobuf network
+
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
+Take all of the control points and delete them.
+  1 point taken
+  2 points taken
+  3 points taken
+  4 points taken
+
+Test reading version 5 protobuf network
+
+Reading Control Points...
+0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
+
 Test writing with invalid target
 
+
+Test reading a random PVL file
+
+**I/O ERROR** Reading the control network [equirectangular.map] failed.
+**I/O ERROR** Could not determine the control network file type.
+
+Test reading a PVL files with missing header information
+
+**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV1.net] failed.
+**I/O ERROR** Missing required header information.
+**ERROR** PVL Keyword [TargetName] does not exist in [Object = ControlNetwork] in file [/usgs/cpkgs/isis3/data/control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV1.net].
+**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV2.net] failed.
+**I/O ERROR** Missing required header information.
+**ERROR** PVL Keyword [TargetName] does not exist in [Object = ControlNetwork] in file [/usgs/cpkgs/isis3/data/control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV2.net].
+**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV3.net] failed.
+**I/O ERROR** Missing required header information.
+**ERROR** PVL Keyword [TargetName] does not exist in [Object = ControlNetwork] in file [/usgs/cpkgs/isis3/data/control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV3.net].
+**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV4.net] failed.
+**I/O ERROR** Missing required header information.
+**ERROR** PVL Keyword [TargetName] does not exist in [Object = ControlNetwork] in file [/usgs/cpkgs/isis3/data/control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV4.net].
+**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV5.net] failed.
+**I/O ERROR** Missing required header information.
+**ERROR** PVL Keyword [TargetName] does not exist in [Object = ControlNetwork] in file [/usgs/cpkgs/isis3/data/control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV5.net].
+
+Test reading a protobuf file with a bad version number
+
+**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_ProtoNetwork_BadVersion.net] failed.
+**I/O ERROR** The Protobuf file version [7] is not supported.
+
+Test reading a protobuf file with no version number
+
+**I/O ERROR** Reading the control network [unitTest_ControlNetVersioner_ProtoNetwork_NoVersion.net] failed.
+**ERROR** PVL Keyword [StartByte] does not exist in [Object = Core].

--- a/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
@@ -8,6 +8,7 @@
 #include "IException.h"
 #include "IString.h"
 #include "Preference.h"
+#include "Progress.h"
 #include "Pvl.h"
 
 using namespace std;
@@ -26,6 +27,31 @@ int main(int argc, char *argv[]) {
   TestNetwork("$control/testData/unitTest_ControlNetVersioner_BadNetwork_ProtoV0001.net");    // Corrupted (based off of oldNetwork2.net)
   TestNetwork("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net", false);  // Binary V2
   TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork4_PvlV0003.pvl", true, true); // Network with rejected jigsaw points
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork5_PvlV0003.pvl", false, false); // Network full of weird test cases (based on PvlNetwork4)
+
+  std::cout << std::endl << "Test writing from ControlNet objects" << std::endl << std::endl;
+  Progress *testProgress = new Progress();
+  ControlNet *binaryV2Net = new ControlNet("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net",
+                                           testProgress);
+  ControlNetVersioner *binV2Versioner = new ControlNetVersioner(binaryV2Net);
+  binV2Versioner->write("./binaryV2tmp.net");
+  remove("./binaryV2tmp.net");
+  delete binV2Versioner;
+  delete testProgress;
+
+  std::cout << std::endl << "Test writing with invalid target" << std::endl << std::endl;
+  try {
+    binaryV2Net->SetTarget("INVALID_TARGET_NAME");
+    binV2Versioner = new ControlNetVersioner(binaryV2Net);
+  }
+  catch (IException &e) {
+    e.print();
+    if (binV2Versioner) {
+      delete binV2Versioner;
+    }
+  }
+
+  delete binaryV2Net;
 }
 
 void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {

--- a/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/unitTest.cpp
@@ -14,30 +14,55 @@
 using namespace std;
 using namespace Isis;
 
-void TestNetwork(const QString &filename, bool printNetwork = true, bool pvlInput = false);
+void TestNetwork(const QString &filename, Progress *progress, bool printNetwork = true, bool pvlInput = false);
 
 int main(int argc, char *argv[]) {
   Preference::Preferences(true);
+  Progress *testProgress = new Progress();
   std::cout << "Test ControlNetVersioner";
 
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork2_PvlV0001.net");     // No target
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork3_PvlV0001.net");     // Really odd keywords with target
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork1_PvlV0001.net");     // Another set of odd keywords
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork1_ProtoV0001.net"); // Binary V1
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_BadNetwork_ProtoV0001.net");    // Corrupted (based off of oldNetwork2.net)
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net", false);  // Binary V2
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork4_PvlV0003.pvl", true, true); // Network with rejected jigsaw points
-  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork5_PvlV0003.pvl", false, false); // Network full of weird test cases (based on PvlNetwork4)
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork2_PvlV0001.net", testProgress);     // No target
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork3_PvlV0001.net", testProgress);     // Really odd keywords with target
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork1_PvlV0001.net", testProgress);     // Another set of odd keywords
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork1_ProtoV0001.net", testProgress); // Binary V1
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_BadNetwork_ProtoV0001.net", testProgress);    // Corrupted (based off of oldNetwork2.net)
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net", testProgress, false);  // Binary V2
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork4_PvlV0003.pvl", testProgress, true, true); // Network with rejected jigsaw points
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork5_PvlV0003.pvl", testProgress, false, false); // Network full of weird test cases (based on PvlNetwork4)
+
+  // Re-test each version without progress
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork3_PvlV0001.net", 0, false);
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork1_ProtoV0001.net", 0, false);
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net", 0, false);
+  TestNetwork("$control/testData/unitTest_ControlNetVersioner_PvlNetwork4_PvlV0003.pvl", 0, false);
 
   std::cout << std::endl << "Test writing from ControlNet objects" << std::endl << std::endl;
-  Progress *testProgress = new Progress();
   ControlNet *binaryV2Net = new ControlNet("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork2_ProtoV0002.net",
                                            testProgress);
   ControlNetVersioner *binV2Versioner = new ControlNetVersioner(binaryV2Net);
   binV2Versioner->write("./binaryV2tmp.net");
   remove("./binaryV2tmp.net");
   delete binV2Versioner;
-  delete testProgress;
+  binV2Versioner = NULL;
+
+  std::cout << std::endl << "Test reading version 1 protobuf network" << std::endl << std::endl;
+  ControlNetVersioner *binV1Versioner = new ControlNetVersioner(FileName("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork1_ProtoV0001.net"), testProgress);
+  std::cout << "Take all of the control points and delete them." << std::endl;
+  int pointsTaken = 0;
+  ControlPoint *readPoint = binV1Versioner->takeFirstPoint();
+  while (readPoint != NULL) {
+    pointsTaken++;
+    std::cout << "  " << pointsTaken << (pointsTaken > 1 ? " points taken" : " point taken") << std::endl;
+    delete readPoint;
+    readPoint = binV1Versioner->takeFirstPoint();
+  }
+  delete binV1Versioner;
+  binV1Versioner = NULL;
+
+  std::cout << std::endl << "Test reading version 5 protobuf network" << std::endl << std::endl;
+  ControlNetVersioner *binV5Versioner = new ControlNetVersioner(FileName("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork3_ProtoV0005.net"), testProgress);
+  delete binV5Versioner;
+  binV5Versioner = NULL;
 
   std::cout << std::endl << "Test writing with invalid target" << std::endl << std::endl;
   try {
@@ -48,13 +73,70 @@ int main(int argc, char *argv[]) {
     e.print();
     if (binV2Versioner) {
       delete binV2Versioner;
+      binV2Versioner = NULL;
     }
+  }
+
+  std::cout << std::endl << "Test reading a random PVL file" << std::endl << std::endl;
+  try {
+    ControlNetVersioner invalidVersioner("$base/templates/maps/equirectangular.map");
+  }
+  catch (IException &e) {
+    e.print();
+  }
+
+  std::cout << std::endl << "Test reading a PVL files with missing header information" << std::endl << std::endl;
+  try {
+    ControlNetVersioner invalidVersionerV1("$control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV1.net");
+  }
+  catch (IException &e) {
+    e.print();
+  }
+  try {
+    ControlNetVersioner invalidVersionerV2("$control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV2.net");
+  }
+  catch (IException &e) {
+    e.print();
+  }
+  try {
+    ControlNetVersioner invalidVersionerV3("$control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV3.net");
+  }
+  catch (IException &e) {
+    e.print();
+  }
+  try {
+    ControlNetVersioner invalidVersionerV4("$control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV4.net");
+  }
+  catch (IException &e) {
+    e.print();
+  }
+  try {
+    ControlNetVersioner invalidVersionerV5("$control/testData/unitTest_ControlNetVersioner_PvlNetwork_BadHeaderV5.net");
+  }
+  catch (IException &e) {
+    e.print();
+  }
+
+  std::cout << std::endl << "Test reading a protobuf file with a bad version number" << std::endl << std::endl;
+  try {
+    ControlNetVersioner invalidVersioner("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork_BadVersion.net");
+  }
+  catch (IException &e) {
+    e.print();
+  }
+
+  std::cout << std::endl << "Test reading a protobuf file with no version number" << std::endl << std::endl;
+  try {
+    ControlNetVersioner invalidVersioner("$control/testData/unitTest_ControlNetVersioner_ProtoNetwork_NoVersion.net");
+  }
+  catch (IException &e) {
+    e.print();
   }
 
   delete binaryV2Net;
 }
 
-void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
+void TestNetwork(const QString &filename, Progress *progress, bool printNetwork, bool pvlInput) {
   std::cout << "\nReading: " << filename << "...\n";
   FileName networkFileName(filename);
 
@@ -70,7 +152,7 @@ void TestNetwork(const QString &filename, bool printNetwork, bool pvlInput) {
     //   The reason for the intermediate Pvl is described in
     //   ControlNetVersioner.h.
     std::cout << "\nRead network..." << std::endl;
-    test = new ControlNetVersioner(networkFileName);
+    test = new ControlNetVersioner(networkFileName, progress);
 
     if(printNetwork) {
       std::cout << "Converted directly to Pvl:" << std::endl;


### PR DESCRIPTION
Specifically this tests
- ControlNetVersioner(ControlNet*)
- ControlNetVersioner::CreatePoint(ControlPointV0003)
- ControlNetVersioner::CreateMeasure

Because we are expecting multiple commits to this unit test we're gonna conflict everywhere