### PR TITLE
Fixed units conversion in intersectSurface so that the loop is stepping by radians per pixel Fixes #5245

### DIFF
--- a/isis/src/base/objs/EquatorialCylindricalShape/EquatorialCylindricalShape.cpp
+++ b/isis/src/base/objs/EquatorialCylindricalShape/EquatorialCylindricalShape.cpp
@@ -34,7 +34,7 @@ namespace Isis {
    *
    * @param pvl Valid Isis3 cube label.
    */
-  EquatorialCylindricalShape::EquatorialCylindricalShape(Target *target, Pvl &pvl) : 
+  EquatorialCylindricalShape::EquatorialCylindricalShape(Target *target, Pvl &pvl) :
       DemShape(target, pvl) {
     setName("EquatorialCylindricalShape");
 
@@ -63,11 +63,11 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Destructor for Isis3 Equatorial Cylindrical shape model
    */
   EquatorialCylindricalShape::~EquatorialCylindricalShape() {
-    
+
     delete m_minRadius;
     m_minRadius = NULL;
 
@@ -76,14 +76,14 @@ namespace Isis {
    }
 
 
-  /** 
+  /**
    * Finds the surface intersection point.
-   *  
-   * @param observerBodyFixedPosition  Three dimensional position of the observer, 
+   *
+   * @param observerBodyFixedPosition  Three dimensional position of the observer,
    *                                   in the coordinate system of the target body.
-   * @param observerLookVectorToTarget Three dimensional direction vector from 
+   * @param observerLookVectorToTarget Three dimensional direction vector from
    *                                   the observer to the target.
-   *  
+   *
    * @return @b bool Indicates whether this shape model found a valid surface intersection.
    */
   bool EquatorialCylindricalShape::intersectSurface(vector<double> observerBodyFixedPos,
@@ -91,7 +91,7 @@ namespace Isis {
 
     // try to intersect the surface using the DemShape method
     // if this is successful, return
-    // 
+    //
     // otherwise, (i.e. DemShape::intersectSurface() fails) we will attempt to
     // intersect using the following iterative method...
     if (!DemShape::intersectSurface(observerBodyFixedPos, observerLookVectorToTarget)) {
@@ -142,7 +142,7 @@ namespace Isis {
       // JWB - The commented code here is an alternate way of doing this...
       //       which method has less expensive computing???
       //       I believe the alternate one may be (no need for cosine after naif routines)
-      // 
+      //
       //
       // find the vector to the point found by orthogonally projecting the observer position vector
       // onto the line containing the look direction vector
@@ -190,7 +190,7 @@ namespace Isis {
         return hasIntersection();
       }
 
-      double d0 = observerdist * cospsi0 - radiusDiff; 
+      double d0 = observerdist * cospsi0 - radiusDiff;
       double dm = observerdist * cospsi0 + radiusDiff;
 
       // Set the properties at the first test observation point
@@ -216,7 +216,7 @@ namespace Isis {
       // Set dalpha to be half the grid spacing for nyquist sampling
       //double dalpha = (PI/180.0)/(2.0*p_demScale);
       double cmin = cos((90.0 - 1.0 / (2.0 * demScale())) * DEG2RAD);
-      double dalpha = MAX(cos(g1lat * DEG2RAD), cmin) / (2.0 * demScale() * DEG2RAD);
+      double dalpha = MAX(cos(g1lat * DEG2RAD), cmin) / (2.0 * demScale() * RAD2DEG);
 
       // Previous Sensor version used local version of this method with lat and lon doubles.  Steven said
       // it didn't make a significant difference in speed.
@@ -384,14 +384,14 @@ namespace Isis {
         // put in a test (above) for dd being smaller than the pixel
         // convergence tolerance.  If so the loop exits without an
         // intersection
-        dalpha = MAX(cos(g2lat * DEG2RAD), cmin) / (2.0 * demScale() * DEG2RAD);
+        dalpha = MAX(cos(g2lat * DEG2RAD), cmin) / (2.0 * demScale() * RAD2DEG);
       } // end while
 
       SpiceDouble intersectionPoint[3];
       SpiceBoolean found;
 
       NaifStatus::CheckErrors();
-      surfpt_c(&observerBodyFixedPos[0], &observerLookVectorToTarget[0], plen, plen, plen, 
+      surfpt_c(&observerBodyFixedPos[0], &observerLookVectorToTarget[0], plen, plen, plen,
                intersectionPoint, &found);
       NaifStatus::CheckErrors();
 
@@ -412,4 +412,3 @@ namespace Isis {
   }
   // Do nothing since the DEM intersection was already successful
 }
-

--- a/isis/src/base/objs/EquatorialCylindricalShape/EquatorialCylindricalShape.h
+++ b/isis/src/base/objs/EquatorialCylindricalShape/EquatorialCylindricalShape.h
@@ -30,8 +30,8 @@ namespace Isis {
   /**
    * @brief Define shapes and provide utilities for shapes stored as Isis3 EquatorialCylindrical map
    *
-   * This class will define shapes of Isis3 target bodies with the shape defined by an 
-   * EquatorialCylindrical map, as well as provide utilities to retrieve radii and photometric 
+   * This class will define shapes of Isis3 target bodies with the shape defined by an
+   * EquatorialCylindrical map, as well as provide utilities to retrieve radii and photometric
    * information for the intersection point.
    *
    * @author 2010-07-30 Debbie A. Cook
@@ -47,6 +47,9 @@ namespace Isis {
    *                           intersection in intersectSurface() method to prevent early return
    *                           and attempt the iterative method even when the ellipsoid is not
    *                           intersected. Fixes #1438
+   *   @history 2018-01-05 Cole Neubauer - Fixed units conversion in intersectSurface so that the
+   *                           loop is stepping by radians per pixel, as recommended by Jeff
+   *                           Anderson (LROC team). Fixes #5245
    */
   class EquatorialCylindricalShape : public DemShape {
     public:
@@ -67,4 +70,3 @@ namespace Isis {
 };
 
 #endif
-


### PR DESCRIPTION
Fixed units conversion in intersectSurface so that the loop is stepping by radians per pixel as recommended by Jeff Anderson from the LROC team Fixes #5245