### PR TITLE
Added pointAdded method to ControlNet 

### DIFF
--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -338,11 +338,65 @@ namespace Isis {
 
     point->parentNetwork = this;
 
-    // notify control network of new (non-ignored) measures
-    foreach(ControlMeasure * measure, point->getMeasures()) {
-      measureAdded(measure);
-    }
+    // notify control network of new point
+    pointAdded(point);
+
     emit networkStructureModified();
+  }
+
+
+ /**
+   * Adds a whole point to the control net graph. 
+   *    
+   * @throws IException::Programmer "NULL measure passed to ControlNet::AddControlCubeGraphNode!"
+   * @throws IException::Programmer "Control measure with NULL parent passed to
+   *     ControlNet::AddControlCubeGraphNode!"
+   * @throws IException::Programmer "ControlNet does not contain the point."
+   */
+  void ControlNet::pointAdded(ControlPoint *point) {
+    if (!point) {
+      IString msg = "NULL point passed to "
+          "ControlNet::AddControlCubeGraphNode!";
+      throw IException(IException::Programmer, msg, _FILEINFO_);
+    }
+
+    if (!ContainsPoint(point->GetId())) {
+      QString msg = "ControlNet does not contain the point [";
+      msg += point->GetId() + "]";
+      throw IException(IException::Programmer, msg, _FILEINFO_);
+    }
+
+    // make sure there is a node for every measure
+    for (int i = 0; i < point->GetNumMeasures(); i++) {
+      QString sn = point->GetMeasure(i)->GetCubeSerialNumber();
+      if (!cubeGraphNodes->contains(sn)) {
+        cubeGraphNodes->insert(sn, new ControlCubeGraphNode(sn));
+      }
+    }
+
+    foreach(ControlMeasure* measure, point->getMeasures()) {
+      // add the measure to the corresponding node
+      QString serial = measure->GetCubeSerialNumber();
+      ControlCubeGraphNode *node = (*cubeGraphNodes)[serial];
+      node->addMeasure(measure);
+
+      // in this measure's node add connections to the other nodes reachable from
+      // its point
+      if (!point->IsIgnored() && !measure->IsIgnored()) {
+        for (int i = 0; i < point->GetNumMeasures(); i++) {
+          ControlMeasure *cm = point->GetMeasure(i);
+          if (!cm->IsIgnored()) {
+            QString sn = cm->GetCubeSerialNumber();
+            ControlCubeGraphNode *neighborNode = (*cubeGraphNodes)[sn];
+
+            if (neighborNode != node) {
+              node->addConnection(neighborNode, point);
+              neighborNode->addConnection(node, point);
+            }
+          }
+        }
+      }
+    }
   }
 
 

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -214,7 +214,6 @@ namespace Isis {
    *   @history 2018-01-26 Kristin Berry - Added pointAdded() function to eliminate redundant measure
    *                           adds to the control network. 
    */
-   */
   class ControlNet : public QObject {
       Q_OBJECT
 

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -211,6 +211,9 @@ namespace Isis {
    *   @history 2018-01-12 Adam Goins - Added Progress support back to Read methods.
    *   @history 2017-01-19 Jesse Mapel - Added a method to get all of the valid measures in an
    *                           image. Previously, this had to be done throug the graph.
+   *   @history 2018-01-26 Kristin Berry -Added PointAdded function eliminated redundant measure
+   *                           adds to the control network. 
+   */
    */
   class ControlNet : public QObject {
       Q_OBJECT
@@ -322,6 +325,7 @@ namespace Isis {
       void nullify();
       void ValidateSerialNumber(QString serialNumber) const;
       void measureAdded(ControlMeasure *measure);
+      void pointAdded(ControlPoint *point);
       void measureDeleted(ControlMeasure *measure);
       void measureIgnored(ControlMeasure *measure);
       void measureUnIgnored(ControlMeasure *measure);

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -211,7 +211,7 @@ namespace Isis {
    *   @history 2018-01-12 Adam Goins - Added Progress support back to Read methods.
    *   @history 2017-01-19 Jesse Mapel - Added a method to get all of the valid measures in an
    *                           image. Previously, this had to be done throug the graph.
-   *   @history 2018-01-26 Kristin Berry -Added PointAdded function eliminated redundant measure
+   *   @history 2018-01-26 Kristin Berry - Added pointAdded() function to eliminate redundant measure
    *                           adds to the control network. 
    */
    */


### PR DESCRIPTION
Added pointAdded method to ControlNet  to eliminate redundant measure updates when adding a whole point at once.

This was part of the ControlNetImprovemets sprint but left off of the big earlier PR. 