### PR TITLE
Updated .gitignore to exlude .html files generated by make docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ object_script.*.Debug
 *_plugin_import.cpp
 *.moc
 ui_*.h
+*.html
 
 # ignore all files created by squish coco
 *csmes


### PR DESCRIPTION
I updated the .gitignore to exclude all .html files generated by a `make docs` or `make html`