### PR TITLE
fits2isis tests now check the labels. Also fixed a few typos in the mdis2isis's default test. Fixes #4923.

### DIFF
--- a/isis/src/base/apps/fits2isis/tsts/default/Makefile
+++ b/isis/src/base/apps/fits2isis/tsts/default/Makefile
@@ -4,10 +4,6 @@ include $(ISISROOT)/make/isismake.tsts
 
 commands:
 	$(APPNAME) from=$(INPUT)/WFPC2u5780205r_c0fx.fits \
-	to=$(OUTPUT)/fitsTruth.cub \
-	> /dev/null;
-	raw2isis from=$(INPUT)/WFPC2u5780205r_c0fx.fits \
-	to=$(OUTPUT)/rawTruth.cub \
-	SAMPLES=200 LINES=200 BANDS=4 SKIP=23040 \
-	BITTYPE=REAL BYTEORDER=MSB \
-	> /dev/null;
+	  to=$(OUTPUT)/fitsTruth.cub > /dev/null;
+	catlab from=$(OUTPUT)/fitsTruth.cub \
+		to=$(OUTPUT)/fitsTruth.pvl > /dev/null;

--- a/isis/src/base/apps/fits2isis/tsts/organization/Makefile
+++ b/isis/src/base/apps/fits2isis/tsts/organization/Makefile
@@ -4,8 +4,10 @@ include $(ISISROOT)/make/isismake.tsts
 
 commands:
 	$(APPNAME) from=$(INPUT)/lsb_0034933739_0x53c_sci_1.fit \
-	to=$(OUTPUT)/bilTruth.cub organization=bil imagenumber=1\
-	> /dev/null;
+		to=$(OUTPUT)/bilTruth.cub organization=bil imagenumber=1 > /dev/null;
+	catlab from=$(OUTPUT)/bilTruth.cub \
+		to=$(OUTPUT)/bilTruth.pvl > /dev/null;
 	$(APPNAME) from=$(INPUT)/lsb_0034933739_0x53c_sci_1.fit \
-	to=$(OUTPUT)/bsqTruth.cub organization=bsq imagenumber=1 \
-	> /dev/null;
+		to=$(OUTPUT)/bsqTruth.cub organization=bsq imagenumber=1 > /dev/null;
+	catlab from=$(OUTPUT)/bsqTruth.cub \
+		to=$(OUTPUT)/bsqTruth.pvl > /dev/null;

--- a/isis/src/messenger/apps/mdis2isis/tsts/default/Makefile
+++ b/isis/src/messenger/apps/mdis2isis/tsts/default/Makefile
@@ -10,9 +10,9 @@ commands:
 	  to=$(OUTPUT)/mdis2isisTruth.pvl> /dev/null
 	$(APPNAME) from=$(INPUT)/EN0089569526M.IMG \
 	  to=$(OUTPUT)/mdis2isisLutTruth.cub > /dev/null
-	catlab from=$(OUTPUT)/mdis2isisTruth.cub \
+	catlab from=$(OUTPUT)/mdis2isisLutTruth.cub \
 	  to=$(OUTPUT)/mdis2isisLutTruth.pvl> /dev/null
 	$(APPNAME) from=$(INPUT)/EN0131771763M.IMG \
 	  to=$(OUTPUT)/mdis2isisStrangeLabelTruth.cub > /dev/null
-	catlab from=$(OUTPUT)/mdis2isisTruth.cub \
+	catlab from=$(OUTPUT)/mdis2isisStrangeLabelTruth.cub \
 	  to=$(OUTPUT)/mdis2isisStrangeLabelTruth.pvl> /dev/null


### PR DESCRIPTION
fits2isis tests now check the labels. Also fixed a few typos in the mdis2isis's default test. Fixes #4923.