### PR TITLE
Modified tgocassisstitch to include the Archive group for ingested framelets. Fixes #5333.

### DIFF
--- a/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
@@ -134,22 +134,13 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
   frameCube.create( frameFileName.expanded() );
 
   // Setup the label for the new cube
-  PvlGroup archGroup = firstFrameletCube.group("Archive");
   PvlGroup kernGroup = firstFrameletCube.group("Kernels");
   PvlGroup instGroup = firstFrameletCube.group("Instrument");
   PvlGroup bandBinGroup("BandBin");
   if ( instGroup.hasKeyword("Filter") ) {
     instGroup["Filter"].setValue("FULLCCD");
   }
-  if ( archGroup.hasKeyword("ProductId") ) {
-    archGroup.deleteKeyword("ProductId");
-  }
-  if ( archGroup.hasKeyword("FileName") ) {
-    archGroup.deleteKeyword("FileName");
-  }
-  if ( archGroup.hasKeyword("Window_Count") ) {
-    archGroup.deleteKeyword("Window_Count");
-  }
+
   bandBinGroup += PvlKeyword("FilterName", "FULLCCD");
 
   // Setup Stitch group keywords
@@ -234,7 +225,6 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
   // Finalize the frame cube label
   frameCube.putGroup(instGroup);
   frameCube.putGroup(kernGroup);
-  frameCube.putGroup(archGroup);
   frameCube.putGroup(bandBinGroup);
   frameCube.putGroup(stitchGroup);
 }

--- a/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
@@ -25,7 +25,7 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName);
 
 /**
  * Functor for stitching framelets into a full frame
- * 
+ *
  * @author 2017-09-09 Jesse Mapel
  * @internal
  *   @history 2017-09-09 Original Version.
@@ -37,7 +37,7 @@ public:
   AlphaCube alphaCube() const;
   Cube *outputCube() const;
   void operator()(Isis::Buffer &in) const;
-  
+
 private:
   AlphaCube m_alphaCube;
   Cube *m_outputCube;
@@ -90,9 +90,9 @@ void IsisMain() {
 /**
  * Go through a list of framelet cube files and sort them into frames based on
  * their timing.
- * 
+ *
  * @param frameletList The file containing the list of framelet cubes
- * 
+ *
  * @return @b QMap<QString,FileName> A multi-valued mapping from observation
  *                                   number for a frame to the framelet cube
  *                                   files in that frame.
@@ -114,7 +114,7 @@ QMap<QString, FileName> sortFramelets(FileName frameletListFile) {
 /**
  * Combine several framelet cubes into a single frame cube. The labels from the
  * first framelet will be propegated to the frame cube.
- * 
+ *
  * @param frameletList A list of the framelet cubes to stitch together
  * @param frameFileName The file name of the output frame cube
  */
@@ -203,6 +203,12 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
     stitchGroup["FilterWidths"]    += frameletBandBin["Width"];
     stitchGroup["FilterIkCodes"]   += frameletBandBin["NaifIkCode"];
 
+    PvlGroup archiveGroup = frameletCube->group("Archive");
+    archiveGroup.setName("Archive" + QString(frameletBandBin["FilterName"]));
+    frameCube.putGroup(archiveGroup);
+
+    std::cout << "Archive Group: " << archiveGroup << std::endl;
+
     AlphaCube frameletAlphaCube(*frameletCube);
     stitchGroup["FilterStartSamples"] += toString(frameletAlphaCube.AlphaSample(0.0));
     stitchGroup["FilterSamples"]      += toString(frameletAlphaCube.BetaSamples());
@@ -212,7 +218,7 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
     PvlGroup frameletArchGroup = frameletCube->group("Archive");
     stitchGroup["FilterFileNames"]  += frameletArchGroup["FileName"];
 
-    
+
     Pvl &frameletLabel = *frameletCube->label();
     for(int i = 0; i < frameletLabel.objects(); i++) {
       if( frameletLabel.object(i).isNamed("History") ) {
@@ -234,7 +240,7 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
 
 /**
  * Construct a stitch functor for input and output cubes.
- * 
+ *
  * @param inputCube A pointer to the input cube. The alpha cube will be
  *                  extracted from this cube.
  * @param outputCube The output stitched cube that will be written to.
@@ -246,7 +252,7 @@ StitchFunctor::StitchFunctor(Cube *inputCube, Cube *outputCube) :
 /**
  * Return the alpha cube for mapping the input framelet cube into the output
  * frame cube.
- * 
+ *
  * @return @b AlphaCube The framelet cube's alpha cube.
  */
 AlphaCube StitchFunctor::alphaCube() const {
@@ -256,7 +262,7 @@ AlphaCube StitchFunctor::alphaCube() const {
 
 /**
  * Return a pointer to the output frame cube.
- * 
+ *
  * @return @b Cube* The output frame cube.
  */
 Cube *StitchFunctor::outputCube() const {
@@ -267,7 +273,7 @@ Cube *StitchFunctor::outputCube() const {
 /**
  * Process method that maps a line from the input framelet cube to the output
  * frame cube.
- * 
+ *
  * @param in A line of data from the input cube.
  */
 void StitchFunctor::operator()(Isis::Buffer &in) const {

--- a/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
@@ -117,6 +117,10 @@ QMap<QString, FileName> sortFramelets(FileName frameletListFile) {
  *
  * @param frameletList A list of the framelet cubes to stitch together
  * @param frameFileName The file name of the output frame cube
+ *
+ * @internal
+ *   @history 2018-02-15 Adam Goins - Modified stitchFrame to store the Archive
+ *                           group for ingested framelets. Fixes #5333.
  */
 void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
   // Create the frame cube based on the first framelet cube

--- a/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
@@ -207,8 +207,6 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
     archiveGroup.setName("Archive" + QString(frameletBandBin["FilterName"]));
     frameCube.putGroup(archiveGroup);
 
-    std::cout << "Archive Group: " << archiveGroup << std::endl;
-
     AlphaCube frameletAlphaCube(*frameletCube);
     stitchGroup["FilterStartSamples"] += toString(frameletAlphaCube.AlphaSample(0.0));
     stitchGroup["FilterSamples"]      += toString(frameletAlphaCube.BetaSamples());

--- a/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.xml
+++ b/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.xml
@@ -26,6 +26,9 @@
       Backward Compatibility Issue: Changed name from stitch to tgocassisstitch and
       changed output parameter name "TO" to "OUTPUTPREFIX."
     </change>
+    <change name="Adam Goins" date="2018-02-15">
+      Modified stitchFrame to store the Archive group for ingested framelets. Fixes #5333.
+    </change>
   </history>
 
   <category>

--- a/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
@@ -161,7 +161,7 @@ void IsisMain() {
       // The stitched frame has ArchiveRED, ArchiveNIR, ArchivePAN, and ArchiveBLU.
       // We won't add the archive group unless
       if ( group.name().contains("Archive") &&
-           group.name() != "Archive" + g_frameletInfoList[i].m_filterName) {
+           group.name() != "Archive" + g_frameletInfoList[i].m_filterName ) {
              continue;
            }
 

--- a/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
@@ -30,6 +30,10 @@ using namespace Isis;
  *
  * @internal
  *   @history 2017-09-15 Kristin Berry - Original Version
+ *
+ *   @history 2018-02-15 Adam Goins - Modified unstitch to parse the archive group
+ *                           from the stitched frame. Changed "Name" to "FilterName"
+ *                           in bandBin group.
  */
 struct FilterInfo : public PushFrameCameraCcdLayout::FrameletInfo {
   FilterInfo() : FrameletInfo(), m_wavelength(0), m_width(0) { }
@@ -169,7 +173,8 @@ void IsisMain() {
     frameletLabel->findGroup("Instrument", PvlObject::Traverse).addKeyword(PvlKeyword("Filter",
                                           g_frameletInfoList[i].m_filterName), PvlObject::Replace);
 
-    frameletLabel->findGroup("Archive" + g_frameletInfoList[i].m_filterName, PvlObject::Traverse).setName( "Archive" );
+    // Sets the name from ArchiveRED (or NIR, BLU, PAN) to just "Archive" in the unstitched cube.
+    frameletLabel->findGroup("Archive" + g_frameletInfoList[i].m_filterName, PvlObject::Traverse).setName("Archive");
 
     PvlGroup &bandBin = frameletLabel->findGroup("BandBin", PvlObject::Traverse);
 

--- a/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
@@ -75,13 +75,14 @@ void IsisMain() {
   PvlKeyword filterLines = inputLabel->findKeyword("FilterLines", PvlObject::Traverse);
   PvlKeyword filterWavelength = inputLabel->findKeyword("FilterCenters", PvlObject::Traverse);
   PvlKeyword filterWidth = inputLabel->findKeyword("FilterWidths", PvlObject::Traverse);
+
   for (int i = 0; i < filterKey.size(); i++) {
     g_frameletInfoList.append(FilterInfo(filterIkCodes[i].toInt(),
                               filterKey[i],
-                              filterStartSamples[i].toInt(),
+                              filterStartSamples[i].toDouble(),
                               filterStartLines[i].toDouble(),
-                              filterSamples[i].toInt(),
-                              filterLines[i].toInt(),
+                              filterSamples[i].toDouble(),
+                              filterLines[i].toDouble(),
                               filterWavelength[i].toDouble(),
                               filterWidth[i].toDouble()));
   }
@@ -151,16 +152,28 @@ void IsisMain() {
   for (int i = 0; i < g_outputCubes.size(); i++) {
     progress.CheckStatus();
     for (int j = 0; j < inputLabel->findObject("IsisCube").groups(); j++) {
-      g_outputCubes[i]->putGroup(inputLabel->findObject("IsisCube").group(j));
+      PvlGroup group = inputLabel->findObject("IsisCube").group(j);
+
+      // The stitched frame has ArchiveRED, ArchiveNIR, ArchivePAN, and ArchiveBLU.
+      // We won't add the archive group unless
+      if ( group.name().contains("Archive") &&
+           group.name() != "Archive" + g_frameletInfoList[i].m_filterName) {
+             continue;
+           }
+
+      g_outputCubes[i]->putGroup(group);
+
     }
     // Update the labels
     Pvl *frameletLabel = g_outputCubes[i]->label();
     frameletLabel->findGroup("Instrument", PvlObject::Traverse).addKeyword(PvlKeyword("Filter",
                                           g_frameletInfoList[i].m_filterName), PvlObject::Replace);
 
+    frameletLabel->findGroup("Archive" + g_frameletInfoList[i].m_filterName, PvlObject::Traverse).setName( "Archive" );
+
     PvlGroup &bandBin = frameletLabel->findGroup("BandBin", PvlObject::Traverse);
 
-    bandBin.addKeyword(PvlKeyword("Name", g_frameletInfoList[i].m_filterName),
+    bandBin.addKeyword(PvlKeyword("FilterName", g_frameletInfoList[i].m_filterName),
                                                 PvlObject::Replace);
     bandBin.addKeyword(PvlKeyword("Center", toString(g_frameletInfoList[i].m_wavelength)));
     bandBin.addKeyword(PvlKeyword("Width", toString(g_frameletInfoList[i].m_width)));
@@ -214,9 +227,14 @@ void IsisMain() {
  *                           from in.Line() < [...] to inLine() <= [...] to write all lines
  *                           up to and including the last line. Fixes an error where the last lines
  *                           written would be a line of null pixel DN's.
+ *
+ *   @history 2018-02-14 Adam Goins - Modified the copying of the data in the buffer to include
+ *                           the sample offset (m_startSample) for a cube.
+ *
  */
 void unstitchFullFrame(Buffer &in) {
   for (int i=0; i < g_frameletInfoList.size(); i++) {
+
     if (in.Line() >= g_frameletInfoList[i].m_startLine
         && in.Line() <= (g_frameletInfoList[i].m_startLine + g_frameletInfoList[i].m_lines)) {
       int outputCubeLineNumber = (in.Line()-1) % g_frameletInfoList[i].m_startLine + 1;
@@ -224,7 +242,7 @@ void unstitchFullFrame(Buffer &in) {
       mgr.SetLine(outputCubeLineNumber, 1);
 
       for (int j = 0; j < mgr.size(); j++) {
-        mgr[j] = in[j];
+        mgr[j] = in[j + g_frameletInfoList[i].m_startSample];
       }
       g_outputCubes[i]->write(mgr);
       return;

--- a/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.xml
+++ b/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.xml
@@ -17,13 +17,15 @@
     <change name="Kristin Berry" date="2017-11-14">
       Backward Compatibility Issue:  changed application name from unstitch to tgocassisunstitch and
       changed the output parameter name "TO" to "OUTPUTPREFIX" to more accurately reflect its use.
-    </change> 
-     <change name="Kristin Berry" date="2017-11-23">
-      Updated the behavior of the application when the user inputs an OUTPUTPREFIX without the .cub extension, 
-      but containing other '.'s  in the string to not strip off everything after the last period. For example, if the 
-      user inputs CAS-MCO-2016-11-22T16:10:43.505 as the OUTPUTPREFIX, now the 505 will now be retained. 
     </change>
-
+     <change name="Kristin Berry" date="2017-11-23">
+      Updated the behavior of the application when the user inputs an OUTPUTPREFIX without the .cub extension,
+      but containing other '.'s  in the string to not strip off everything after the last period. For example, if the
+      user inputs CAS-MCO-2016-11-22T16:10:43.505 as the OUTPUTPREFIX, now the 505 will now be retained.
+    </change>
+    <change name="Adam Goins" date="2018-02-15">
+     Modified unstitchFrame to parse the Archive group for each framelet.
+   </change>
   </history>
 
   <category>
@@ -36,10 +38,10 @@
         <type>cube</type>
         <fileMode>input</fileMode>
         <brief>
-          A TGO CaSSIS fullframe cube to split into separate framelets. 
+          A TGO CaSSIS fullframe cube to split into separate framelets.
         </brief>
         <description>
-          A TGO CaSSIS fullframe cube to split into separate framelets. 
+          A TGO CaSSIS fullframe cube to split into separate framelets.
         </description>
         <filter>
           *.lis
@@ -54,10 +56,10 @@
          </brief>
          <description>
            The output ISIS cubes will be of the form basename_filter_frameletNumber.cub
-           There will also be a list produced with the same name. 
-	   
+           There will also be a list produced with the same name.
+
 	   This prefix can either be specified in the form "name.cub" or simply "name" without the .cub
-	   extension.  
+	   extension.
          </description>
          <filter>
            *.cub

--- a/isis/src/tgo/apps/tgocassisunstitch/tsts/default/Makefile
+++ b/isis/src/tgo/apps/tgocassisunstitch/tsts/default/Makefile
@@ -4,10 +4,10 @@ include $(ISISROOT)/make/isismake.tsts
 
 commands:
         # Test output prefix with standard extension (will be removed)
-	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-22T16:10:43.505.cub \
-	           outputprefix=$(OUTPUT)/CAS-MCO_2016-11-22T16:10:43.505.cub > /dev/null;
-	mv $(OUTPUT)/CAS-MCO_2016-11-22T16:10:43.505.lis \
-	   $(OUTPUT)/CAS-MCO_2016-11-22T16:10:43.505.txt;
+	$(APPNAME) from=$(INPUT)/stitched-2016-11-26T22:50:27.381.cub \
+	           outputprefix=$(OUTPUT)/stitched-2016-11-26T22:50:27.381.cub > /dev/null;
+	mv $(OUTPUT)/stitched-2016-11-26T22:50:27.381.lis \
+	   $(OUTPUT)/stitched-2016-11-26T22:50:27.381.txt;
 
 
 

--- a/isis/src/tgo/apps/tgocassisunstitch/tsts/spiced/Makefile
+++ b/isis/src/tgo/apps/tgocassisunstitch/tsts/spiced/Makefile
@@ -3,7 +3,7 @@ APPNAME = tgocassisunstitch
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-22T16:10:43.505.cub \
-	           outputprefix=$(OUTPUT)/CAS-MCO-2016-11-22T16:10:43.505.cub > /dev/null;
-	mv $(OUTPUT)/CAS-MCO-2016-11-22T16:10:43.505.lis \
-	   $(OUTPUT)/CAS-MCO-2016-11-22T16:10:43.505.txt;
+	$(APPNAME) from=$(INPUT)/stitched-2016-11-26T22:50:27.381.cub \
+	           outputprefix=$(OUTPUT)/stitched-2016-11-26T22:50:27.381.cub > /dev/null;
+	mv $(OUTPUT)/stitched-2016-11-26T22:50:27.381.lis \
+	   $(OUTPUT)/stitched-2016-11-26T22:50:27.381.txt;


### PR DESCRIPTION
Modified tgocassisunstitch to parse this archive group correctly when unstitching as well.
Modified the tgocassisunstitch test input data to use a stitched cube with these new keywords.
Removed old usages of "Archive" functionality from tgocassisstitch