### PR TITLE
Removed deprecated function iTime::loadLeapSecondKernel(). Fixes #5325.

### DIFF
--- a/isis/src/base/objs/iTime/iTime.cpp
+++ b/isis/src/base/objs/iTime/iTime.cpp
@@ -62,8 +62,6 @@ namespace Isis {
 
     p_et = et;
     NaifStatus::CheckErrors();
-
-    UnloadLeapSecondKernel();
   }
 
 
@@ -79,7 +77,7 @@ namespace Isis {
    */
   void iTime::operator=(const QString &time) {
     LoadLeapSecondKernel();
-    
+
     NaifStatus::CheckErrors();
     // Convert the time string to a double ephemeris time
     SpiceDouble et;
@@ -87,8 +85,6 @@ namespace Isis {
 
     p_et = et;
     NaifStatus::CheckErrors();
-
-    UnloadLeapSecondKernel();
   }
 
   // Overload of "=" with a c string
@@ -102,8 +98,6 @@ namespace Isis {
 
     p_et = et;
     NaifStatus::CheckErrors();
-
-    UnloadLeapSecondKernel();
   }
 
 
@@ -111,7 +105,6 @@ namespace Isis {
   void iTime::operator=(const double time) {
     LoadLeapSecondKernel();
     p_et = time;
-    UnloadLeapSecondKernel();
   }
 
   /**
@@ -482,15 +475,6 @@ namespace Isis {
     NaifStatus::CheckErrors();
 
     p_lpInitialized = true;
-  }
-
-  //! Uses the Naif routines to unload the leap second kernel.
-  void iTime::UnloadLeapSecondKernel() {
-    // Inorder to improve the speed of iTime comparisons, the leapsecond
-    // kernel is loaded only once and left open.
-
-    //string leapSecondName(p_leapSecond.expanded());
-    //unload_c (leapSecondName.c_str());
   }
 
   /**

--- a/isis/src/base/objs/iTime/iTime.h
+++ b/isis/src/base/objs/iTime/iTime.h
@@ -70,6 +70,8 @@ namespace Isis {
    *           setEt and addition operators
    *  @history 2015-07-21 Kristin Berry - Added NaifStatus::CheckErrors() to see if any NAIF errors
    *           were signaled. References #2248.
+   *  @history 2018-03-15 Adam Goins - Removed deprecated function iTime::UnloadLeapSecondKernel().
+   *                          Fixes #5325.
    */
   class iTime {
     public:
@@ -139,7 +141,7 @@ namespace Isis {
       QString UTC() const;
       static QString CurrentGMT();
       static QString CurrentLocalTime();
-      
+
       void setEt(double et);
       void setUtc(QString utcString);
 
@@ -148,11 +150,9 @@ namespace Isis {
                            passed into the constructor or the operator= member*/
 
       void LoadLeapSecondKernel();
-      void UnloadLeapSecondKernel();
 
       static bool p_lpInitialized;
   };
 };
 
 #endif
-


### PR DESCRIPTION
Removed deprecated function iTime::loadLeapSecondKernel() and references to it. Added history comment.