### PR TITLE
Removed the search bar and links that are not working on the ISIS website. Fixes #5185.

### DIFF
--- a/isis/src/docsys/build/menu.xsl
+++ b/isis/src/docsys/build/menu.xsl
@@ -81,11 +81,11 @@ Deborah Lee Soltesz
     </div>
 
 
-    <hr/>
-        <h2>Search</h2>
+    <!-- <hr/>
+        <h2>Search</h2> -->
 
         <!-- search -->
-        <form name="seek1" method="get" action="http://search.usgs.gov/query.html" target="_top" style="padding-top:0px;margin-top:0px;">
+        <!-- <form name="seek1" method="get" action="http://search.usgs.gov/query.html" target="_top" style="padding-top:0px;margin-top:0px;">
           <table  style="width:150px;" align="center">
           <tr valign="top">
           <td>
@@ -118,9 +118,8 @@ Deborah Lee Soltesz
           </td>
           </tr>
           </table>
-        </form>
+        </form> -->
 
   </xsl:template>
 
 </xsl:stylesheet>
-


### PR DESCRIPTION
On the ISIS website, the search bar and links to help and advanced were not working. For the time being, it is better to completely remove the search bar and links. I commented them out just in case somebody wanted to go back and edit the code later. Fixes #5185.