### PR TITLE
Ipce

### DIFF
--- a/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.cpp
+++ b/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.cpp
@@ -1768,17 +1768,11 @@ namespace Isis {
         m_xmlHandlerBundleSolutionInfo->m_adjustedImages->append(
             new ImageList(m_xmlHandlerProject, reader()));
       }
-      // TODO: Ken Edmundson - Need to make file handling more automatic instead of always having to
-      //       explicitly create these paths, do we need a
-      //       project->projectBundleSolutionPath() method? And can we let the BundleSolutionInfo
-      //       object create the full path automatically by adding the runTime to the
-      //       projectBundleSolutionPath()?
       else if (localName == "outputControl") {
-        FileName outputControlPath
-            = FileName(m_xmlHandlerProject->projectRoot() + "/results/bundle/"
-                       + m_xmlHandlerBundleSolutionInfo->runTime());
-        m_xmlHandlerBundleSolutionInfo->m_outputControl =
-            new Control(outputControlPath, reader());
+        FileName outputControlPath = FileName(m_xmlHandlerProject->bundleSolutionInfoRoot() + "/"
+                                              + m_xmlHandlerBundleSolutionInfo->runTime());
+
+        m_xmlHandlerBundleSolutionInfo->m_outputControl = new Control(outputControlPath, reader());
       }
     }
     return true;

--- a/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.cpp
+++ b/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.cpp
@@ -1595,16 +1595,8 @@ namespace Isis {
                              .arg(bundleSolutionInfoRoot.path()),
                            _FILEINFO_);
         }
-        QString oldFile = oldPath + "/" + m_inputControlNetFileName->name();
-        QString newFile = newPath + "/" + m_inputControlNetFileName->name();
-        if (!QFile::copy(oldFile, newFile)) {
-          throw IException(IException::Io,
-                           QString("Failed to copy file [%1] to new file [%2]")
-                             .arg(m_inputControlNetFileName->name()).arg(newFile),
-                           _FILEINFO_);
-        }
-        oldFile = oldPath + "/" + m_outputControl->fileName();
-        newFile = newPath + "/" + m_outputControl->fileName();
+        QString oldFile = oldPath + "/" + FileName(m_outputControl->fileName()).name();
+        QString newFile = newPath + "/" + FileName(m_outputControl->fileName()).name();
         if (!QFile::copy(oldFile, newFile)) {
           throw IException(IException::Io,
                            QString("Failed to copy file [%1] to new file [%2]")

--- a/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.h
+++ b/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.h
@@ -134,6 +134,8 @@ namespace Isis {
    *                              the control's id is added to project upon reading back in. Also
    *                              ensures that an open cneteditor widget containing a
    *                              bundlesolutioninfo's output control is serialized properly.
+   *   @history 2018-03-26 Ken Edmundson - modified save method to properly save output control
+   *                           network file.
    */
   class BundleSolutionInfo : public QObject {
     Q_OBJECT

--- a/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.h
+++ b/isis/src/control/objs/BundleSolutionInfo/BundleSolutionInfo.h
@@ -128,6 +128,12 @@ namespace Isis {
    *                              serialization support.
    *                           3) member variable m_txtBundleOutputFilename and associated accessor
    *                              for bundleout.txt file.
+   *   @history 2018-03-23 Ken Edmundson - modified...
+   *                           1) removed serialization of output control filename
+   *                           2) serialization of output control to be more robust, ensuring that
+   *                              the control's id is added to project upon reading back in. Also
+   *                              ensures that an open cneteditor widget containing a
+   *                              bundlesolutioninfo's output control is serialized properly.
    */
   class BundleSolutionInfo : public QObject {
     Q_OBJECT

--- a/isis/src/qisis/objs/BundleObservationView/BundleObservationView.cpp
+++ b/isis/src/qisis/objs/BundleObservationView/BundleObservationView.cpp
@@ -23,6 +23,7 @@
 
 #include <QDebug>
 #include <QFile>
+#include <QFontDatabase>
 #include <QHeaderView>
 #include <QSizePolicy>
 #include <QStandardItem>
@@ -171,7 +172,12 @@ namespace Isis {
 
     QTextStream in(&file);
     QTextEdit *qText=new QTextEdit();
-    qText->setFontFamily("Courier");
+
+    // From QFontDatabase::systemFont(SystemFont type) method description: returns most adequate
+    //      font for a given typecase (here FixedFont) for proper integration with system's look and
+    //      feel.
+    const QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    qText->setFontFamily(fixedFont.family());
 
     while (!in.atEnd()) {
       qText->append(in.readLine());

--- a/isis/src/qisis/objs/BundleObservationView/BundleObservationView.h
+++ b/isis/src/qisis/objs/BundleObservationView/BundleObservationView.h
@@ -42,6 +42,8 @@ namespace Isis{
    *                           Set SectionResizeMode to QHeaderView::ResizeToContents so columns are
    *                           displayed at the width of the maximum size of the column content.
    *                           Fixes #4850.
+   *   @history 2018-03-26 Ken Edmundson - Modified displayTextFile method to query for system's
+   *                           fixed width font.
    */
 
   class BundleObservationView : public AbstractProjectItemView

--- a/isis/src/qisis/objs/Directory/JigsawWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/JigsawWorkOrder.cpp
@@ -178,28 +178,8 @@ namespace Isis {
     // Get the selected control and bundle settings and give them to the JigsawDialog for now.
     Control *selectedControl = proj->control(internalData().first());
 
-    // if selectedControl is NULL, maybe the Control we want is an output Control in a
-    // BundleSolutionInfo, so let's look there (I think the project()->control() method above should
-    // look in the results area for this automatically
-    // this is a workaround because the BundleSolutionInfo's Control is not in the project's control
-    // list
-    if (!selectedControl) {
-      int nBundles = proj->bundleSolutionInfo().size();
-      for (int i = 0; i < nBundles; i++) {
-        BundleSolutionInfo *bundleSolution = proj->bundleSolutionInfo().at(i);
-        Control *bundleControl = bundleSolution->control();
-        if (bundleControl->id() != internalData().first()) {
-            continue;
-        }
-        else {
-          selectedControl = bundleControl;
-        }
-      }
-    }
-
     QString outputControlFileName = internalData().at(1);
 
-//    JigsawDialog *runDialog = new JigsawDialog(project(), m_bundleSettings, selectedControl);
     JigsawDialog *runDialog = new JigsawDialog(project(), m_bundleSettings, selectedControl,
                                                outputControlFileName);
     runDialog->setAttribute(Qt::WA_DeleteOnClose);

--- a/isis/src/qisis/objs/Directory/JigsawWorkOrder.h
+++ b/isis/src/qisis/objs/Directory/JigsawWorkOrder.h
@@ -53,6 +53,9 @@ namespace Isis {
    *                           network filename to internalData. Modified execute method to look for
    *                           input control network in BundleSolutionInfos if not found under main
    *                           part of project tree.
+   *   @history 2018-03-23 Ken Edmundson - In execute method, removed search for input control
+   *                           network in BundleSolutionInfos. No longer needed as control is now
+   *                           properly saved in projects m_idToControlMap.
    */
   class JigsawWorkOrder : public WorkOrder {
       Q_OBJECT

--- a/isis/src/qisis/objs/JigsawDialog/JigsawDialog.cpp
+++ b/isis/src/qisis/objs/JigsawDialog/JigsawDialog.cpp
@@ -401,12 +401,6 @@ namespace Isis {
     // create Control with output control net and add to m_bundleSolutionInfo
     m_bundleSolutionInfo->setOutputControl(new Control(m_project, outputControlName.expanded()));
 
-    // TODO: it seems like this new Control should be added to the Project, but this doesn't work
-    //       need to make it work, the alternative is the kluge in the JigsawWorkOrder::execute
-    //       method
-
-//    m_bundleSolutionInfo->setOutputControlNetworkFileName(jiggedControlName);
-
     // Iterate through all of the image lists (the "imports" in the project).
     QList<ImageList *> imageLists = m_bundleSolutionInfo->imageList();
     foreach (ImageList *imageList, imageLists) {

--- a/isis/src/qisis/objs/Project/Project.cpp
+++ b/isis/src/qisis/objs/Project/Project.cpp
@@ -1102,12 +1102,17 @@ namespace Isis {
 
   /**
    * Loads bundle solution info into project
+   *
    * @param BundleSolutionInfo
    */
   void Project::loadBundleSolutionInfo(BundleSolutionInfo *bundleSolutionInfo) {
     m_bundleSolutionInfo->append(bundleSolutionInfo);
 
+    // add BundleSolutionInfo to project's m_idToBundleSolutionInfoMap
     (*m_idToBundleSolutionInfoMap)[bundleSolutionInfo->id()] = bundleSolutionInfo;
+
+    // add BundleSolutionInfo's control to project's m_idToControlMap
+    (*m_idToControlMap)[bundleSolutionInfo->control()->id()] = bundleSolutionInfo->control();
 
     emit bundleSolutionInfoAdded(bundleSolutionInfo);
   }
@@ -2904,6 +2909,7 @@ namespace Isis {
     else if (localName == "results") {
       foreach (BundleSolutionInfo *bundleInfo, m_bundleSolutionInfos) {
         m_project->addBundleSolutionInfo(bundleInfo);
+
         // If BundleSolutionInfo contains adjusted images, add to the project id map.
         if (bundleInfo->adjustedImages().count()) {
           foreach (ImageList *adjustedImageList, bundleInfo->adjustedImages()) {

--- a/isis/src/qisis/objs/Project/Project.cpp
+++ b/isis/src/qisis/objs/Project/Project.cpp
@@ -111,7 +111,6 @@ namespace Isis {
     m_activeControl = NULL;
     m_activeImageList = NULL;
 
-
     m_numImagesCurrentlyReading = 0;
 
     m_mutex = NULL;
@@ -130,7 +129,6 @@ namespace Isis {
     m_idToBundleSolutionInfoMap = new QMap<QString, BundleSolutionInfo *>;
 
     m_name = "Project";
-
 
     // Look for old projects
     QDir tempDir = QDir::temp();

--- a/isis/src/qisis/objs/Project/Project.h
+++ b/isis/src/qisis/objs/Project/Project.h
@@ -229,6 +229,9 @@ namespace Isis {
    *                           activeControl and activeImageList when returning a default value.
    *                           This ensures that all the proper error checking is handled and
    *                           prevents duplicate code.
+   *   @history 2018-03-23 Ken Edmundson - Modified loadBundleSolutionInfo method to add the
+   *                           BundleSolutionInfo's output control id to the project member variable
+   *                           m_idToControlMap.
    */
   class Project : public QObject {
     Q_OBJECT


### PR DESCRIPTION
Updates to ensure BundleSolutionInfo's output Control id is properly saved to the project. Plus update to ensure that a visible CNetEditorWidget containing a BundleSolutionInfo Control is serialized properly.