### PR TITLE
ORex SamCam and MapCam won't use PolyCam focus ID. Fixes #5213

### DIFF
--- a/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexOcamsCamera.cpp
+++ b/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexOcamsCamera.cpp
@@ -2,17 +2,17 @@
  * @file
  *
  *   Unless noted otherwise, the portions of Isis written by the USGS are public
- *   domain. See individual third-party library and package descriptions for 
+ *   domain. See individual third-party library and package descriptions for
  *   intellectual property information,user agreements, and related information.
  *
  *   Although Isis has been used by the USGS, no warranty, expressed or implied,
- *   is made by the USGS as to the accuracy and functioning of such software 
- *   and related material nor shall the fact of distribution constitute any such 
- *   warranty, and no responsibility is assumed by the USGS in connection 
+ *   is made by the USGS as to the accuracy and functioning of such software
+ *   and related material nor shall the fact of distribution constitute any such
+ *   warranty, and no responsibility is assumed by the USGS in connection
  *   therewith.
  *
  *   For additional information, launch
- *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see 
+ *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see
  *   the Privacy &amp; Disclaimers page on the Isis website,
  *   http://isis.astrogeology.usgs.gov, and the USGS privacy and disclaimers on
  *   http://www.usgs.gov/privacy.html.
@@ -39,8 +39,8 @@ namespace Isis {
   /**
    * Constructs an OSIRIS-REx Camera Model using the image labels. This model supports MapCam,
    * PolyCam, and SamCam images.
-   *  
-   * @param lab Pvl label from an Osiris Rex MapCam image. 
+   *
+   * @param lab Pvl label from an Osiris Rex MapCam image.
    */
   OsirisRexOcamsCamera::OsirisRexOcamsCamera(Cube &cube) : FramingCamera(cube) {
 
@@ -48,6 +48,9 @@ namespace Isis {
 
     m_spacecraftNameLong = "OSIRIS-REx";
     m_spacecraftNameShort = "OSIRIS-REx";
+
+    Pvl &lab = *cube.label();
+    PvlGroup inst = lab.findGroup("Instrument", Pvl::Traverse);
 
     // The general IK code will be used to retrieve the transx,
     // transy, transs and transl from the iak. The focus position specific
@@ -65,6 +68,12 @@ namespace Isis {
     else if (frameCode == -64360) {
       m_instrumentNameLong = "PolyMath Camera";
       m_instrumentNameShort = "PolyCam";
+      if (inst.hasKeyword("PolyCamFocusPositionNaifId")) {
+        if (QString::compare("NONE", inst["PolyCamFocusPositionNaifId"],
+                             Qt::CaseInsensitive) != 0) {
+          frameCode == inst["PolyCamFocusPositionNaifId"][0].toInt();
+        }
+      }
     }
     else {
       QString msg = "Unable to construct OSIRIS-REx camera model. "
@@ -72,14 +81,7 @@ namespace Isis {
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
-    Pvl &lab = *cube.label();
-    PvlGroup inst = lab.findGroup("Instrument", Pvl::Traverse);
     QString ikCode = toString(frameCode);
-    if (inst.hasKeyword("PolyCamFocusPositionNaifId")) {
-      if (QString::compare("NONE", inst["PolyCamFocusPositionNaifId"], Qt::CaseInsensitive) != 0) {
-        ikCode = inst["PolyCamFocusPositionNaifId"][0];
-      }
-    }
 
     QString focalLength = "INS" + ikCode + "_FOCAL_LENGTH";
     SetFocalLength(getDouble(focalLength));
@@ -112,7 +114,7 @@ namespace Isis {
         Spice::getDouble("INS" + ikCode + "_CCD_CENTER", 1) + 1.0);
 
     // Setup distortion map
-    OsirisRexDistortionMap *distortionMap = new OsirisRexDistortionMap(this); 
+    OsirisRexDistortionMap *distortionMap = new OsirisRexDistortionMap(this);
 
     // Different distortion model for each instrument and filter
     PvlGroup bandBin = lab.findGroup("BandBin", Pvl::Traverse);
@@ -135,37 +137,37 @@ namespace Isis {
 
 
   /**
-   * The frame ID for the spacecraft (or instrument) used by the Camera-matrix 
-   * Kernel. For this camera model, the spacecraft frame is used, represented 
-   * by the frame ID -64000. 
-   *  
-   * @return @b int The appropriate code for the Camera-matrix Kernel. 
+   * The frame ID for the spacecraft (or instrument) used by the Camera-matrix
+   * Kernel. For this camera model, the spacecraft frame is used, represented
+   * by the frame ID -64000.
+   *
+   * @return @b int The appropriate code for the Camera-matrix Kernel.
    */
-  int OsirisRexOcamsCamera::CkFrameId() const { 
-    return -64000; 
+  int OsirisRexOcamsCamera::CkFrameId() const {
+    return -64000;
   }
 
 
   /**
-   * The frame ID for the reference coordinate system used by the Camera-matrix 
-   * Kernel. For this mission, the reference frame J2000, represented by the 
-   * frame ID 1. 
+   * The frame ID for the reference coordinate system used by the Camera-matrix
+   * Kernel. For this mission, the reference frame J2000, represented by the
+   * frame ID 1.
    *
-   * @return @b int The appropriate reference frame ID code for the 
+   * @return @b int The appropriate reference frame ID code for the
    *         Camera-matrix Kernel.
    */
-  int OsirisRexOcamsCamera::CkReferenceId() const { 
-    return 1; 
+  int OsirisRexOcamsCamera::CkReferenceId() const {
+    return 1;
   }
 
 
-  /** 
+  /**
    * The reference frame ID for the Spacecraft Kernel is 1, representing J2000.
    *
    * @return @b int The appropriate frame ID code for the Spacecraft Kernel.
    */
-  int OsirisRexOcamsCamera::SpkReferenceId() const { 
-    return 1; 
+  int OsirisRexOcamsCamera::SpkReferenceId() const {
+    return 1;
   }
 
 

--- a/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexOcamsCamera.cpp
+++ b/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexOcamsCamera.cpp
@@ -49,9 +49,6 @@ namespace Isis {
     m_spacecraftNameLong = "OSIRIS-REx";
     m_spacecraftNameShort = "OSIRIS-REx";
 
-    Pvl &lab = *cube.label();
-    PvlGroup inst = lab.findGroup("Instrument", Pvl::Traverse);
-
     // The general IK code will be used to retrieve the transx,
     // transy, transs and transl from the iak. The focus position specific
     // IK code will be used to find pixel pitch and ccd center in the ik.
@@ -68,12 +65,6 @@ namespace Isis {
     else if (frameCode == -64360) {
       m_instrumentNameLong = "PolyMath Camera";
       m_instrumentNameShort = "PolyCam";
-      if (inst.hasKeyword("PolyCamFocusPositionNaifId")) {
-        if (QString::compare("NONE", inst["PolyCamFocusPositionNaifId"],
-                             Qt::CaseInsensitive) != 0) {
-          frameCode == inst["PolyCamFocusPositionNaifId"][0].toInt();
-        }
-      }
     }
     else {
       QString msg = "Unable to construct OSIRIS-REx camera model. "
@@ -81,7 +72,16 @@ namespace Isis {
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
+    Pvl &lab = *cube.label();
+    PvlGroup inst = lab.findGroup("Instrument", Pvl::Traverse);
+
     QString ikCode = toString(frameCode);
+    if (inst.hasKeyword("PolyCamFocusPositionNaifId") && frameCode == -64360) {
+      if (QString::compare("NONE", inst["PolyCamFocusPositionNaifId"],
+                           Qt::CaseInsensitive) != 0) {
+        ikCode = inst["PolyCamFocusPositionNaifId"][0];
+      }
+    }
 
     QString focalLength = "INS" + ikCode + "_FOCAL_LENGTH";
     SetFocalLength(getDouble(focalLength));

--- a/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexOcamsCamera.h
+++ b/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexOcamsCamera.h
@@ -1,8 +1,8 @@
 #ifndef OsirisRexOcamsCamera_h
 #define OsirisRexOcamsCamera_h
-/** 
- * @file 
- *  
+/**
+ * @file
+ *
  *   Unless noted otherwise, the portions of Isis written by the USGS are public
  *   domain. See individual third-party library and package descriptions for
  *   intellectual property information,user agreements, and related information.
@@ -26,12 +26,12 @@
 
 namespace Isis {
   /**
-   * This class models the behavior and attributes of the OSIRIS-REx Cameras:  Mapping Camera, 
-   * PolyMath Camera, and Sample Camera. 
+   * This class models the behavior and attributes of the OSIRIS-REx Cameras:  Mapping Camera,
+   * PolyMath Camera, and Sample Camera.
    *
    * @ingroup SpiceInstrumentsAndCameras
    * @ingroup Osiris Rex
-   *  
+   *
    * @author  2014-04-02 Janet Barrett
    *
    * @internal
@@ -49,6 +49,8 @@ namespace Isis {
    *                           the Instrument group for focus position specific values (such ase
    *                           focal length) and we read NaifFrameId from the Kernels group the
    *                           instrument frame code. Fixes #5127
+   *   @history 2018-03-27 Jesse Mapel - Changed to only replace the IK code with the PolyCam focus
+   *                                     setting ID if the image is a PolyCam image. Fixes #5213.
    *
    */
   class OsirisRexOcamsCamera : public FramingCamera {
@@ -56,7 +58,7 @@ namespace Isis {
       OsirisRexOcamsCamera(Cube &cube);
       ~OsirisRexOcamsCamera();
 
-      virtual std::pair <iTime, iTime> ShutterOpenCloseTimes(double time, 
+      virtual std::pair <iTime, iTime> ShutterOpenCloseTimes(double time,
                                                              double exposureDuration);
 
       virtual int CkFrameId() const;


### PR DESCRIPTION
The value is still translated from the label, but will be unused.