### PR TITLE
Added oblique resolutions to caminfo and the advanced track tool of qview and qnet. Fixes #4100. 

### DIFF
--- a/isis/src/base/apps/caminfo/CamTools.cpp
+++ b/isis/src/base/apps/caminfo/CamTools.cpp
@@ -100,22 +100,22 @@ namespace Isis {
   bool BandGeometry::isPointValid(const double &sample, const double &line,
                                   const Camera *camera) const {
     int nl(_nLines), ns(_nSamps);
-    if(camera != 0) {
+    if (camera != 0) {
       nl = camera->Lines();
       ns = camera->Samples();
     }
 
-    if(line < 0.5) return (false);
-    if(line > (nl + 0.5)) return (false);
-    if(sample < 0.5) return (false);
-    if(sample > (ns + 0.5)) return (false);
+    if (line < 0.5) return (false);
+    if (line > (nl + 0.5)) return (false);
+    if (sample < 0.5) return (false);
+    if (sample > (ns + 0.5)) return (false);
     return (true);
   }
 
   bool BandGeometry::hasCenterGeometry() const {
     BandPropertiesListConstIter b;
-    for(b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
-      if(!IsSpecial(b->centerLatitude)) return (true);
+    for (b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
+      if (!IsSpecial(b->centerLatitude)) return (true);
     }
     // No valid center exists
     return (false);
@@ -137,11 +137,11 @@ namespace Isis {
    */
   bool BandGeometry::hasLimb() const {
     BandPropertiesListConstIter b;
-    for(b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
-      if(IsSpecial(b->upperLeftLatitude)) return (true);
-      if(IsSpecial(b->upperRightLatitude)) return (true);
-      if(IsSpecial(b->lowerRightLatitude)) return (true);
-      if(IsSpecial(b->lowerLeftLatitude)) return (true);
+    for (b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
+      if (IsSpecial(b->upperLeftLatitude)) return (true);
+      if (IsSpecial(b->upperRightLatitude)) return (true);
+      if (IsSpecial(b->lowerRightLatitude)) return (true);
+      if (IsSpecial(b->lowerLeftLatitude)) return (true);
     }
     // All outer geometry points are defined
     return (false);
@@ -181,7 +181,7 @@ namespace Isis {
     _isBandIndependent = camera.IsBandIndependent();
     _hasCenterGeom = false;
     int nbands = (_isBandIndependent ? 1 : _nBands);
-    for(int band = 0 ; band < nbands ; band++) {
+    for (int band = 0 ; band < nbands ; band++) {
       //  Compute band geometry properties
       GProperties g;
       g.lines = _nLines;
@@ -203,7 +203,7 @@ namespace Isis {
       g.centerSamp = centerSamp;
 
       // Now compute elements for the center pixel
-      if(camera.SetImage(centerSamp, centerLine)) {
+      if (camera.SetImage(centerSamp, centerLine)) {
         _hasCenterGeom = true;
         g.centerLatitude  = camera.UniversalLatitude();
         g.centerLongitude = camera.UniversalLongitude();
@@ -247,7 +247,7 @@ namespace Isis {
         g.inc   = camera.IncidenceAngle();
 
         //  Parallax values (Corrected 2012-11-23, KJB)
-        if(!IsSpecial(g.emi) && !IsSpecial(g.subSpacecraftGroundAzimuth)) {
+        if (!IsSpecial(g.emi) && !IsSpecial(g.subSpacecraftGroundAzimuth)) {
           double emi_r  = DegToRad(g.emi);
           double ssga_r = DegToRad(g.subSpacecraftGroundAzimuth);
           g.parallaxx = -tan(emi_r) * cos(ssga_r);
@@ -255,7 +255,7 @@ namespace Isis {
         }
 
         // Shadow values (Corrected 2012-11-23, KJB)
-        if(!IsSpecial(g.inc) && !IsSpecial(g.subSolarGroundAzimuth)) {
+        if (!IsSpecial(g.inc) && !IsSpecial(g.subSolarGroundAzimuth)) {
           double inc_r  = DegToRad(g.inc);
           double ssga_r = DegToRad(g.subSolarGroundAzimuth);
           g.shadowx = -tan(inc_r) * cos(ssga_r);
@@ -264,29 +264,29 @@ namespace Isis {
       }
       //  OK...now get corner pixel geometry.  NOTE this resets image
       //  pixel location from center!!!
-      if(camera.SetImage(1.0, 1.0)) {
+      if (camera.SetImage(1.0, 1.0)) {
         g.upperLeftLongitude = camera.UniversalLongitude();
         g.upperLeftLatitude =  camera.UniversalLatitude();
       }
 
-      if(camera.SetImage(1.0, cLine)) {
+      if (camera.SetImage(1.0, cLine)) {
         g.lowerLeftLongitude = camera.UniversalLongitude();
         g.lowerLeftLatitude =  camera.UniversalLatitude();
       }
 
-      if(camera.SetImage(cSamp, cLine)) {
+      if (camera.SetImage(cSamp, cLine)) {
         g.lowerRightLongitude = camera.UniversalLongitude();
         g.lowerRightLatitude =  camera.UniversalLatitude();
       }
 
-      if(camera.SetImage(cSamp, 1.0)) {
+      if (camera.SetImage(cSamp, 1.0)) {
         g.upperRightLongitude = camera.UniversalLongitude();
         g.upperRightLatitude =  camera.UniversalLatitude();
       }
 
       double minRes = camera.LowestImageResolution();
       double maxRes = camera.HighestImageResolution();
-      if(!(IsSpecial(minRes) || IsSpecial(maxRes))) {
+      if (!(IsSpecial(minRes) || IsSpecial(maxRes))) {
         g.grRes = (minRes + maxRes) / 2.0;
       }
 
@@ -295,20 +295,20 @@ namespace Isis {
       _mapping = camMap;
 
       // Test for interesting intersections
-      if(camera.IntersectsLongitudeDomain(camMap)) g.hasLongitudeBoundary = true;
+      if (camera.IntersectsLongitudeDomain(camMap)) g.hasLongitudeBoundary = true;
       camera.SetBand(band + 1);
-      if(camera.SetUniversalGround(90.0, 0.0)) {
-        if(isPointValid(camera.Sample(), camera.Line(), &camera)) {
+      if (camera.SetUniversalGround(90.0, 0.0)) {
+        if (isPointValid(camera.Sample(), camera.Line(), &camera)) {
           g.hasNorthPole = true;
         }
       }
-      if(camera.SetUniversalGround(-90.0, 0.0)) {
-        if(isPointValid(camera.Sample(), camera.Line(), &camera)) {
+      if (camera.SetUniversalGround(-90.0, 0.0)) {
+        if (isPointValid(camera.Sample(), camera.Line(), &camera)) {
           g.hasSouthPole = true;
         }
       }
 
-      if(doPolygon) {
+      if (doPolygon) {
         // Now compute the the image polygon
         ImagePolygon poly;
         poly.Incidence(_maxIncidence);
@@ -318,7 +318,7 @@ namespace Isis {
             increasePrecision);
         geos::geom::MultiPolygon *multiP = poly.Polys();
         _polys.push_back(multiP->clone());
-        if(_combined == 0) {
+        if (_combined == 0) {
           _combined = multiP->clone();
         }
         else {
@@ -356,7 +356,7 @@ namespace Isis {
     //  Compute the remainder of the summary bands since some of the operations
     //  need the camera model
     _summary = getGeometrySummary();
-    if((size() != 1) && doPolygon) {
+    if ((size() != 1) && doPolygon) {
       geos::geom::MultiPolygon *multiP = makeMultiPolygon(_combined);
       _mapping = getProjGeometry(camera, multiP, _summary);
       delete multiP;
@@ -367,7 +367,7 @@ namespace Isis {
 
 
   void BandGeometry::generateGeometryKeys(PvlObject &pband) {
-    if(size() <= 0) {
+    if (size() <= 0) {
       QString mess = "No Band geometry available!";
       throw IException(IException::Programmer, mess, _FILEINFO_);
     }
@@ -414,7 +414,7 @@ namespace Isis {
     pband += ValidateKey("SlantDistance", g.slantDistance);
 
     double aveRes(Null);
-    if(!IsSpecial(g.sampRes) && !IsSpecial(g.lineRes)) {
+    if (!IsSpecial(g.sampRes) && !IsSpecial(g.lineRes)) {
       aveRes = (g.sampRes + g.lineRes) / 2.0;
     }
 
@@ -445,7 +445,7 @@ namespace Isis {
     pband += ValidateKey("ShadowY", g.shadowy);
 
     //  Determine if image crosses Longitude domain
-    if(g.hasLongitudeBoundary) {
+    if (g.hasLongitudeBoundary) {
       pband += PvlKeyword("HasLongitudeBoundary", "TRUE");
     }
     else {
@@ -453,7 +453,7 @@ namespace Isis {
     }
 
     //  Add test for North pole in image
-    if(g.hasNorthPole) {
+    if (g.hasNorthPole) {
       pband += PvlKeyword("HasNorthPole", "TRUE");
     }
     else {
@@ -461,7 +461,7 @@ namespace Isis {
     }
 
     //  Add test for South pole in image
-    if(g.hasSouthPole) {
+    if (g.hasSouthPole) {
       pband += PvlKeyword("HasSouthPole", "TRUE");
     }
     else {
@@ -472,13 +472,13 @@ namespace Isis {
   }
 
   BandGeometry::GProperties BandGeometry::getGeometrySummary() const {
-    if(_isBandIndependent  || (size() == 1)) {
+    if (_isBandIndependent  || (size() == 1)) {
       return (_gBandList[0]);
     }
 
     //  Get the centroid point of the union polygon
     double plon(Null), plat(Null);
-    if(_combined != 0) {
+    if (_combined != 0) {
       geos::geom::Point *center = _combined->getCentroid();
       plon = center->getX();
       plat = center->getY();
@@ -495,12 +495,12 @@ namespace Isis {
     double radius = getRadius();
 
     BandPropertiesListConstIter b;
-    for(b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
+    for (b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
       double thisDist;
 
       // Ensure the center latitude/logitude is defined (typically occurs when
       // no polygon data is available).  This scheme uses the first one defined.
-      if(IsSpecial(plat) || IsSpecial(plon)) {
+      if (IsSpecial(plat) || IsSpecial(plon)) {
         plat = b->centerLatitude;
         plon = b->centerLongitude;
       }
@@ -509,7 +509,7 @@ namespace Isis {
       bool isCloser = isDistShorter(centerDistance, plat, plon,
                                     b->centerLatitude, b->centerLongitude,
                                     radius, thisDist) ;
-      if(isCloser) {
+      if (isCloser) {
         bestBand = *b;
         centerDistance = thisDist;
       }
@@ -518,7 +518,7 @@ namespace Isis {
       isCloser = isDistShorter(ulDist, plat, plon,
                                b->upperLeftLatitude, b->upperLeftLongitude,
                                radius, thisDist);
-      if(!isCloser) {
+      if (!isCloser) {
         corners.upperLeftLatitude = b->upperLeftLatitude;
         corners.upperLeftLongitude = b->upperLeftLongitude;
         ulDist = thisDist;
@@ -527,7 +527,7 @@ namespace Isis {
       isCloser = isDistShorter(urDist, plat, plon,
                                b->upperRightLatitude, b->upperRightLongitude,
                                radius, thisDist);
-      if(!isCloser) {
+      if (!isCloser) {
         corners.upperRightLatitude = b->upperRightLatitude;
         corners.upperRightLongitude = b->upperRightLongitude;
         urDist = thisDist;
@@ -537,7 +537,7 @@ namespace Isis {
       isCloser = isDistShorter(llDist, plat, plon,
                                b->lowerLeftLatitude, b->lowerLeftLongitude,
                                radius, thisDist);
-      if(!isCloser) {
+      if (!isCloser) {
         corners.lowerLeftLatitude = b->lowerLeftLatitude;
         corners.lowerLeftLongitude = b->lowerLeftLongitude;
         llDist = thisDist;
@@ -546,7 +546,7 @@ namespace Isis {
       isCloser = isDistShorter(lrDist, plat, plon,
                                b->lowerRightLatitude, b->lowerRightLongitude,
                                radius, thisDist);
-      if(!isCloser) {
+      if (!isCloser) {
         corners.lowerRightLatitude = b->lowerRightLatitude;
         corners.lowerRightLongitude = b->lowerRightLongitude;
         lrDist = thisDist;
@@ -578,14 +578,14 @@ namespace Isis {
     double clon = g.centerLongitude;
     double minLon = (double) mapping["MinimumLongitude"];
     double maxLon = (double) mapping["MaximumLongitude"];
-    if(IsSpecial(clon)) clon = (minLon + maxLon) / 2.0;
+    if (IsSpecial(clon)) clon = (minLon + maxLon) / 2.0;
 
     //  Make adjustments for center projection type/ranges.
     //  To be consistant with other implementations, do not
     //  convert poles to 180 domain.
     geos::geom::MultiPolygon *poly180(0), *poly(footprint);
-    if(g.hasLongitudeBoundary) {
-      if(!(g.hasNorthPole || g.hasSouthPole)) {
+    if (g.hasLongitudeBoundary) {
+      if (!(g.hasNorthPole || g.hasSouthPole)) {
         // Convert the mapping group contents to 180 Longitude domain
         PvlKeyword &ldkey = mapping["LongitudeDomain"];
         ldkey.setValue("180");
@@ -622,7 +622,7 @@ namespace Isis {
     delete sinu;
     delete poly180;
 
-    if(camera.SetUniversalGround(g.centroidLatitude, g.centroidLongitude)) {
+    if (camera.SetUniversalGround(g.centroidLatitude, g.centroidLongitude)) {
       g.centroidLine = camera.Line();
       g.centroidSample = camera.Sample();
       g.centroidRadius = camera.LocalRadius().meters();
@@ -632,7 +632,7 @@ namespace Isis {
   }
 
   void BandGeometry::generatePolygonKeys(PvlObject &pband) {
-    if(size() <= 0) {
+    if (size() <= 0) {
       QString mess = "No Band geometry available!";
       throw IException(IException::Programmer, mess, _FILEINFO_);
     }
@@ -640,7 +640,7 @@ namespace Isis {
     // Compute surface area - already done in collection phase
     double radius = getRadius();
     double globalCoverage(Null);
-    if(!IsSpecial(radius)) {
+    if (!IsSpecial(radius)) {
       double globalArea = 4.0 * pi_c() * (radius * radius) / (1000.0 * 1000.0);
       globalCoverage = _summary.surfaceArea / globalArea * 100.0;
       globalCoverage = SetRound(globalCoverage, 6);
@@ -653,10 +653,10 @@ namespace Isis {
     pband += ValidateKey("CentroidRadius", _summary.centroidRadius, "meters");
     pband += ValidateKey("SurfaceArea", _summary.surfaceArea, "km^2");
     pband += ValidateKey("GlobalCoverage", globalCoverage, "percent");
-    if(_combined != 0) {
+    if (_combined != 0) {
       pband += PvlKeyword("SampleIncrement", toString(_sampleInc));
       pband += PvlKeyword("LineIncrement", toString(_lineInc));
-      if(_combined->getGeometryTypeId() != geos::geom::GEOS_MULTIPOLYGON) {
+      if (_combined->getGeometryTypeId() != geos::geom::GEOS_MULTIPOLYGON) {
         geos::geom::MultiPolygon *geom = makeMultiPolygon(_combined);
         pband += PvlKeyword("GisFootprint", geom->toString().c_str());
         delete geom;
@@ -677,20 +677,20 @@ namespace Isis {
   double BandGeometry::getRadius() const {
     Statistics polyRadius, centRadius;
     BandPropertiesListConstIter b;
-    for(b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
+    for (b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
       polyRadius.AddData(b->centroidRadius);
       centRadius.AddData(b->radius);
     }
     double radius = polyRadius.Average();
-    if(IsSpecial(radius)) radius = centRadius.Average();
-    if(IsSpecial(radius)) radius = _radius;
+    if (IsSpecial(radius)) radius = centRadius.Average();
+    if (IsSpecial(radius)) radius = _radius;
     return (radius);
   }
 
   double BandGeometry::getPixelResolution() const {
     Statistics groundRes, pixelRes;
     BandPropertiesListConstIter b;
-    for(b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
+    for (b = _gBandList.begin() ; b != _gBandList.end() ; ++b) {
       pixelRes.AddData(b->sampRes);
       pixelRes.AddData(b->lineRes);
       groundRes.AddData(b->grRes);
@@ -701,7 +701,7 @@ namespace Isis {
     }
 
     double res = groundRes.Average();
-    if(IsSpecial(res)) res = pixelRes.Average();
+    if (IsSpecial(res)) res = pixelRes.Average();
     return (res);
   }
 
@@ -717,11 +717,11 @@ namespace Isis {
   bool BandGeometry::isDistShorter(double bestDist, double lat1, double lon1,
                                    double lat2, double lon2, double radius,
                                    double &thisDist) const {
-    if(IsSpecial(lat1)) return (false);
-    if(IsSpecial(lon1)) return (false);
-    if(IsSpecial(lat2)) return (false);
-    if(IsSpecial(lon2)) return (false);
-    if(IsSpecial(radius)) return (false);
+    if (IsSpecial(lat1)) return (false);
+    if (IsSpecial(lon1)) return (false);
+    if (IsSpecial(lat2)) return (false);
+    if (IsSpecial(lon2)) return (false);
+    if (IsSpecial(radius)) return (false);
 
     SurfacePoint point1(
       Latitude(lat1, Angle::Degrees),

--- a/isis/src/base/apps/caminfo/CamTools.cpp
+++ b/isis/src/base/apps/caminfo/CamTools.cpp
@@ -215,6 +215,11 @@ namespace Isis {
         g.sampRes = camera.SampleResolution();
         g.lineRes = camera.LineResolution();
 
+        g.obliqueSampRes = camera.ObliqueSampleResolution();
+        g.obliqueLineRes = camera.ObliqueLineResolution();
+        g.obliquePixelRes = camera.ObliquePixelResolution();
+        g.obliqueDetectorRes = camera.ObliqueDetectorResolution();
+
         g.solarLongitude = camera.solarLongitude().degrees();
         g.northAzimuth = camera.NorthAzimuth();
         g.offNader = camera.OffNadirAngle();
@@ -417,6 +422,11 @@ namespace Isis {
     pband += ValidateKey("LineResolution", g.lineRes);
     pband += ValidateKey("PixelResolution", aveRes);
     pband += ValidateKey("MeanGroundResolution", g.grRes);
+
+    pband += ValidateKey("ObliqueSampleResolution", g.obliqueSampRes);
+    pband += ValidateKey("ObliqueLineResolution", g.obliqueLineRes);
+    pband += ValidateKey("ObliquePixelResolution", g.obliquePixelRes);
+    pband += ValidateKey("ObliqueDetectorResolution", g.obliqueDetectorRes);
 
     pband += ValidateKey("SubSolarAzimuth", g.subSolarAzimuth);
     pband += ValidateKey("SubSolarGroundAzimuth", g.subSolarGroundAzimuth);
@@ -684,6 +694,10 @@ namespace Isis {
       pixelRes.AddData(b->sampRes);
       pixelRes.AddData(b->lineRes);
       groundRes.AddData(b->grRes);
+      pixelRes.AddData(b->obliqueLineRes);
+      pixelRes.AddData(b->obliqueSampRes);
+      pixelRes.AddData(b->obliquePixelRes);
+      pixelRes.AddData(b->obliqueDetectorRes);
     }
 
     double res = groundRes.Average();

--- a/isis/src/base/apps/caminfo/CamTools.h
+++ b/isis/src/base/apps/caminfo/CamTools.h
@@ -136,9 +136,9 @@ namespace Isis {
    *   @history 2009-08-24 Kris Becker - Added ability to disable use of shape
    *                           model when creating polygons that contains a limb
    *   @history 2011-02-17 Jai Rideout - Replaced pixinc with sinc and linc.
-   *   @history 2012-07-06 Debbie A. Cook, Updated Spice members to be more compliant with Isis 
+   *   @history 2012-07-06 Debbie A. Cook, Updated Spice members to be more compliant with Isis
    *                          coding standards. References #972.
-   *   @history 2012-10-11 Debbie A. Cook, Updated to use new Target class.  References Mantis 
+   *   @history 2012-10-11 Debbie A. Cook, Updated to use new Target class.  References Mantis
    *                          tickets #775 and #1114.
    *   @history 2012-01-20 Debbie A. Cook - Changed to use TProjection and RingPlaneProjection
    *                           instead of Projection.  References #775.
@@ -201,7 +201,8 @@ namespace Isis {
           centroidLatitude(Null), centroidLongitude(Null),
           centroidLine(Null), centroidSample(Null), centroidRadius(Null),
           surfaceArea(Null), phase(Null), emi(Null), inc(Null),
-          sampRes(Null), lineRes(Null), grRes(Null),
+          sampRes(Null), lineRes(Null), grRes(Null), obliqueSampRes(Null),
+          obliqueLineRes(Null), obliquePixelRes(Null), obliqueDetectorRes(Null),
           solarLongitude(Null), northAzimuth(Null), offNader(Null),
           subSolarAzimuth(Null), subSolarGroundAzimuth(Null),
           subSpacecraftAzimuth(Null), subSpacecraftGroundAzimuth(Null),
@@ -230,6 +231,7 @@ namespace Isis {
         double centroidRadius, surfaceArea;
         double phase, emi, inc;
         double sampRes, lineRes, grRes;
+        double obliqueSampRes, obliqueLineRes, obliquePixelRes, obliqueDetectorRes;
         double solarLongitude, northAzimuth, offNader;
         double subSolarAzimuth, subSolarGroundAzimuth;
         double subSpacecraftAzimuth, subSpacecraftGroundAzimuth;

--- a/isis/src/base/apps/caminfo/CamTools.h
+++ b/isis/src/base/apps/caminfo/CamTools.h
@@ -146,6 +146,8 @@ namespace Isis {
    *                          parallaxy, shadowx, shadowy.  Fixes #1296
    *   @history 2013-02-22 Janet Barrett, Modified the CamTools::collect method to allow a
    *                          footprint blob option. Fixes #1452.
+   *   @history 2018-03-30 Kaitlyn Lee, Added oblique sample, line, pixel,
+   *                          and detector resolutions. Fixes #4100.
    */
   class BandGeometry {
 

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -202,7 +202,7 @@ void IsisMain() {
     bandGeom->setMaxEmission(ui.GetDouble("MAXEMISSION"));
     bool precision = ui.GetBoolean("INCREASEPRECISION");
 
-    if(getFootBlob) {
+    if (getFootBlob) {
       // Need to read history to obtain parameters that were used to
       // create the footprint
       History hist( "IsisCube", in.expanded() );

--- a/isis/src/base/apps/caminfo/caminfo.xml
+++ b/isis/src/base/apps/caminfo/caminfo.xml
@@ -126,9 +126,9 @@
       CentroidSample    = 478.35374305118
       CentroidLatitude  = -29.488782021364
       CentroidLongitude = 290.21111567036
-      CentroidRadius    = 2440000.0 <meters>
-      SurfaceArea       = 10664470.286639 <km^2>
-      GlobalCoverage    = 14.254427 <percent>
+      CentroidRadius    = 2440000.0 &lt;meters&gt;
+      SurfaceArea       = 10664470.286639 &lt;km^2&gt;
+      GlobalCoverage    = 14.254427 &lt;percent&gt;
       SampleIncrement   = 102
       LineIncrement     = 102
       GisFootprint      = "MULTIPOLYGON (((0.0000000000000000
@@ -174,8 +174,8 @@
 
       Group = Mapping
         TargetName         = Mercury
-        EquatorialRadius   = 2440000.0 <meters>
-        PolarRadius        = 2440000.0 <meters>
+        EquatorialRadius   = 2440000.0 &lt;meters&gt;
+        PolarRadius        = 2440000.0 &lt;meters&gt;
         LatitudeType       = Planetocentric
         LongitudeDirection = PositiveEast
         LongitudeDomain    = 180
@@ -190,7 +190,6 @@
     End_Object
   End_Object
   End
-
 
 </pre>
 

--- a/isis/src/base/apps/caminfo/caminfo.xml
+++ b/isis/src/base/apps/caminfo/caminfo.xml
@@ -363,7 +363,7 @@
     <change name="Kaitlyn Lee" date="2018-03-06">
       Added oblique sample, line, detector, and pixel resolutions to the
       geometry PVL group. Updated example output in application description,
-      so that the addded oblique elements are included.Fixes #4100.
+      so that the addded oblique elements are included. Fixes #4100.
     </change>
   </history>
 

--- a/isis/src/base/apps/caminfo/caminfo.xml
+++ b/isis/src/base/apps/caminfo/caminfo.xml
@@ -489,6 +489,10 @@
             <LI>LineResolution</LI>
             <LI>PixelResolution</LI>
             <LI>MeanGroundResolution</LI>
+            <LI>ObliqueSampleResolution</LI>
+            <LI>ObliqueLineResolution</LI>
+            <LI>ObliquePixelResolution</LI>
+            <LI>ObliqueDetectorResolution</LI>
             <LI>SubSolarAzimuth</LI>
             <LI>SubSolarGroundAzimuth</LI>
             <LI>SubSolarLatitude</LI>

--- a/isis/src/base/apps/caminfo/caminfo.xml
+++ b/isis/src/base/apps/caminfo/caminfo.xml
@@ -36,162 +36,161 @@
     The following is an example of caminfo output generated when in PVL format:
   </p>
 <pre>
-Object = Caminfo
-  Object = Parameters
-    Program     = caminfo
-    IsisVersion = "3.4.2.0 alpha | 2012-08-28"
-    RunDate     = 2012-11-23T18:21:42
-    IsisId      = MeSSEnGeR/MDIS-WAC/1/0250507146:955000
-    From        = EW0250507146G.lev1.cub
-    Lines       = 512
-    Samples     = 512
-    Bands       = 1
-  End_Object
+  Object = Caminfo
+    Object = Parameters
+      Program     = caminfo
+      IsisVersion = "3.5.2.0 beta | 2017-11-04"
+      RunDate     = 2018-03-30T20:41:47
+      IsisId      = MeSSEnGeR/MDIS-WAC/1/0131773041:923000
+      From        = EW0131773041G.cal.cub
+      Lines       = 1024
+      Samples     = 1024
+      Bands       = 1
+    End_Object
 
-  Object = Camstats
-    MinimumLatitude   = 57.872627357566
-    MaximumLatitude   = 61.299709008025
-    MinimumLongitude  = 18.065988732773
-    MaximumLongitude  = 24.841561067248
-    MinimumResolution = 229.97591146546
-    MaximumResolution = 232.50589076348
-    MinimumPhase      = 75.229196963297
-    MaximumPhase      = 85.75524278645
-    MinimumEmission   = 0.010416983765103
-    MaximumEmission   = 9.5170724264221
-    MinimumIncidence  = 78.991903468001
-    MaximumIncidence  = 81.783782038128
-    LocalTimeMinimum  = 7.0686934940095
-    LocalTimeMaximum  = 7.5203983163079
-  End_Object
+    Object = Camstats
+      MinimumLatitude   = -82.601533727119
+      MaximumLatitude   = 8.4623007205256
+      MinimumLongitude  = 0.053389931705623
+      MaximumLongitude  = 359.98370567299
+      MinimumResolution = 2778.4155965733
+      MaximumResolution = 3185.0347214141
+      MinimumPhase      = 33.385785072039
+      MaximumPhase      = 43.111747273402
+      MinimumEmission   = 0.049809488269691
+      MaximumEmission   = 89.984607164464
+      MinimumIncidence  = 29.083595486132
+      MaximumIncidence  = 123.24917034029
+      LocalTimeMinimum  = 3.7737634370713
+      LocalTimeMaximum  = 12.835343181562
+    End_Object
 
-  Object = Geometry
-    BandsUsed                  = 1
-    ReferenceBand              = 1
-    OriginalBand               = 1
-    Target                     = Mercury
-    StartTime                  = 2012-07-11T15:14:40.902702
-    EndTime                    = 2012-07-11T15:14:40.902702
-    CenterLine                 = 256.0
-    CenterSample               = 256.0
-    CenterLatitude             = 59.604440922996
-    CenterLongitude            = 21.354478199267
-    CenterRadius               = 2440000.0
-    RightAscension             = 149.14971069552
-    Declination                = -47.692390719996
-    UpperLeftLongitude         = 19.403075966477
-    UpperLeftLatitude          = 61.299709008025
-    LowerLeftLongitude         = 18.065988732773
-    LowerLeftLatitude          = 58.619183968695
-    LowerRightLongitude        = 23.126850062052
-    LowerRightLatitude         = 57.872627357566
-    UpperRightLongitude        = 24.841561067248
-    UpperRightLatitude         = 60.495929386174
-    PhaseAngle                 = 80.450057821076
-    EmissionAngle              = 0.19786246622852
-    IncidenceAngle             = 80.389167381747
-    NorthAzimuth               = 253.73558748868
-    OffNadir                   = 0.15660719057979
-    SolarLongitude             = 228.88911417663
-    LocalTime                  = 7.2879261251091
-    TargetCenterDistance       = 3082.770704015
-    SlantDistance              = 642.77373761039
-    SampleResolution           = 229.97699384231
-    LineResolution             = 229.97699384231
-    PixelResolution            = 229.97699384231
-    MeanGroundResolution       = 231.24575069814
-    SubSolarAzimuth            = 0.57284290603718
-    SubSolarGroundAzimuth      = 106.83729602467
-    SubSolarLatitude           = -0.026413277465333
-    SubSolarLongitude          = 92.035586322631
-    SubSpacecraftAzimuth       = 252.66562276234
-    SubSpacecraftGroundAzimuth = 358.93004128485
-    SubSpacecraftLatitude      = 59.645688996553
-    SubSpacecraftLongitude     = 21.352953761563
-    ParallaxX                  = -0.0034527631018843
-    ParallaxY                  = -6.44854385850795e-05
-    ShadowX                    = 1.7105756767263
-    ShadowY                    = 5.6523998602669
-    HasLongitudeBoundary       = FALSE
-    HasNorthPole               = FALSE
-    HasSouthPole               = FALSE
-  End_Object
+    Object = Geometry
+      BandsUsed                  = 1
+      ReferenceBand              = 1
+      OriginalBand               = 1
+      Target                     = Mercury
+      StartTime                  = 2008-10-06T09:33:18.3061195
+      EndTime                    = 2008-10-06T09:33:18.3061195
+      CenterLine                 = 512.0
+      CenterSample               = 512.0
+      CenterLatitude             = -30.303731681153
+      CenterLongitude            = 293.02718174274
+      CenterRadius               = 2440000.0
+      RightAscension             = 339.75734505335
+      Declination                = -19.724712429854
+      UpperLeftLongitude         = NULL
+      UpperLeftLatitude          = NULL
+      LowerLeftLongitude         = NULL
+      LowerLeftLatitude          = NULL
+      LowerRightLongitude        = NULL
+      LowerRightLatitude         = NULL
+      UpperRightLongitude        = 334.11593051093
+      UpperRightLatitude         = 3.3280369550883
+      PhaseAngle                 = 37.725480444144
+      EmissionAngle              = 45.931765597717
+      IncidenceAngle             = 72.841686837124
+      NorthAzimuth               = 248.72752014043
+      OffNadir                   = 5.5984715250291
+      SolarLongitude             = 344.11642585112
+      LocalTime                  = 7.331847358858
+      TargetCenterDistance       = 17970.837424003
+      SlantDistance              = 16188.061078038
+      SampleResolution           = 2895.9905922639
+      LineResolution             = 2895.9905922639
+      PixelResolution            = 2895.9905922639
+      MeanGroundResolution       = 2981.5250345888
+      ObliqueSampleResolution    = 4163.810220016
+      ObliqueLineResolution      = 4163.810220016
+      ObliquePixelResolution     = 4163.810220016
+      ObliqueDetectorResolution  = 4163.810220016
+      SubSolarAzimuth            = 348.1448628345
+      SubSolarGroundAzimuth      = 79.614257577627
+      SubSolarLatitude           = -0.0096113650862139
+      SubSolarLongitude          = 3.049471359866
+      SubSpacecraftAzimuth       = 306.84376212478
+      SubSpacecraftGroundAzimuth = 48.17816960795
+      SubSpacecraftLatitude      = -0.68903187938085
+      SubSpacecraftLongitude     = 321.8672927707
+      ParallaxX                  = -0.68886500480703
+      ParallaxY                  = 0.76986304566071
+      ShadowX                    = -0.58387595477701
+      ShadowY                    = 3.1857545288863
+      HasLongitudeBoundary       = TRUE
+      HasNorthPole               = FALSE
+      HasSouthPole               = FALSE
+    End_Object
 
-  Object = Polygon
-    CentroidLine      = 258.34023273956
-    CentroidSample    = 257.21847692747
-    CentroidLatitude  = 59.590465340438
-    CentroidLongitude = 21.359965088916
-    CentroidRadius    = 2440000.0 &lt;meters&gt;
-    SurfaceArea       = 13898.794042461 &lt;km^2&gt;
-    GlobalCoverage    = 0.018578 &lt;percent&gt;
-    SampleIncrement   = 51
-    LineIncrement     = 51
-    GisFootprint      = "MULTIPOLYGON (((19.4043245299965577
-                         61.3023495859178169, 19.9591033663380273
-                         61.2315368240940714, 20.5109136331950097
-                         61.1586516900412036, 21.0599888059494056
-                         61.0836769590772022, 21.6064014066990424
-                         61.0066139869781026, 22.1502234714845763
-                         60.9274625969637071, 22.6915266780484934
-                         60.8462210727062072, 23.2303824713721276
-                         60.7628861464013283, 23.7668621875485293
-                         60.6774529818562556, 24.3010371765409943
-                         60.5899151525158430, 24.8329789243747072
-                         60.5002646143153129, 24.8468003809156031
-                         60.4950897448882969, 24.6621540377068555
-                         60.2342816512584278, 24.4808344234486128
-                         59.9734256463113198, 24.3026802658222785
-                         59.7124215421160969, 24.1275717810041321
-                         59.4512190020262992, 23.9553945002749487
-                         59.1897673396973545, 23.7860389348923675
-                         58.9280154365526201, 23.6194002639650478
-                         58.6659116571399295, 23.4553780433470500
-                         58.4034037620610960, 23.2938759337506376
-                         58.1404388181350171, 23.1348014464353007
-                         57.8769631054306473, 23.1253981883423947
-                         57.8700250132380773, 22.6291388167111727
-                         57.9542062153035644, 22.1311712748992804
-                         58.0362115673268590, 21.6313369328161791
-                         58.1160668824232829, 21.1295724335347970
-                         58.1937799049820939, 20.6258143687462976
-                         58.2693567261389802, 20.1199991639326754
-                         58.3428018062430951, 19.6120629625565215
-                         58.4141179920416960, 19.1019415087693858
-                         58.4833065286652030, 18.5895700281331031
-                         58.5503670664614404, 18.0748831058364949
-                         58.6152976626940756, 18.0609063686927200
-                         58.6197579732196061, 18.1862320670262285
-                         58.8883242752207750, 18.3131290280031429
-                         59.1564691086538232, 18.4416916210760888
-                         59.4243018649568882, 18.5719929967238073
-                         59.6918797207437137, 18.7041092262310542
-                         59.9592593996394498, 18.8381195168780309
-                         60.2264972751596446, 18.9741064422031833
-                         60.4936494719392712, 19.1121561888774671
-                         60.7607719657418741, 19.2523588218842434
-                         61.0279206826665117, 19.3948085698758135
-                         61.2951515979628851, 19.4043245299965577
-                         61.3023495859178169)))"
+    Object = Polygon
+      CentroidLine      = 502.63655531561
+      CentroidSample    = 478.35374305118
+      CentroidLatitude  = -29.488782021364
+      CentroidLongitude = 290.21111567036
+      CentroidRadius    = 2440000.0 <meters>
+      SurfaceArea       = 10664470.286639 <km^2>
+      GlobalCoverage    = 14.254427 <percent>
+      SampleIncrement   = 102
+      LineIncrement     = 102
+      GisFootprint      = "MULTIPOLYGON (((0.0000000000000000
+                           -66.8476725765257669, 15.1767434740871749
+                           -77.1683730441100266, 0.0000000000000000
+                           -79.4337923235828214, 0.0000000000000000
+                           -66.8476725765257669)), ((242.8869256246104840
+                           5.7263135391777826, 243.5601343627938888
+                           8.4618907890508996, 269.0341283875596332
+                           7.2851012019341370, 280.8571950447025074
+                           6.6018915311447106, 290.1169358498850670
+                           6.0309457247062559, 298.1480749560856793
+                           5.5225220975363509, 305.4806822959274086
+                           5.0563213585314202, 312.4012021168767888
+                           4.6215744329942057, 319.0978711923986566
+                           4.2118017742135532, 325.7167408827046984
+                           3.8228786367084715, 332.3911996847887735
+                           3.4522142367050717, 334.1498367339264064
+                           3.3345474794642787, 333.8009713957027884
+                           -3.2790590364693251, 333.6381205940322729
+                           -9.9542162735993269, 333.6727271018169745
+                           -16.8424968734716280, 333.9555932328583481
+                           -24.1267133773544735, 334.6136711007971485
+                           -32.0823127803993700, 335.9827759566368286
+                           -41.2133542381869944, 339.2994422660955820
+                           -52.7705910044257323, 360.0000000000000000
+                           -66.8476725765257669, 360.0000000000000000
+                           -79.4337923235828214, 344.5259945769852834
+                           -81.7435836352576501, 312.7243093850013906
+                           -82.2871258038501310, 272.7330321887411060
+                           -78.3032904306983113, 256.9120013841559285
+                           -71.6881729956653402, 249.7037103515991134
+                           -64.1402056416296205, 245.7489144278791287
+                           -55.9131045647652911, 243.2871680241342176
+                           -46.7511744912688840, 241.6466123551280418
+                           -36.0395468671273846, 240.8227253946276392
+                           -26.7483720432056948, 241.2427301282905603
+                           -18.4320979403016132, 242.4724806166474309
+                           -10.6121339933036545, 243.0000134753865950
+                           -3.1855953725975596, 243.0379118856032790
+                           1.6814051415971418, 242.8869256246104840
+                           5.7263135391777826)))"
 
-    Group = Mapping
-      TargetName         = Mercury
-      EquatorialRadius   = 2440000.0 &lt;meters&gt;
-      PolarRadius        = 2440000.0 &lt;meters&gt;
-      LatitudeType       = Planetocentric
-      LongitudeDirection = PositiveEast
-      LongitudeDomain    = 360
-      MinimumLatitude    = 57.869205530706
-      MaximumLatitude    = 61.303013149342
-      MinimumLongitude   = 18.059709527443
-      MaximumLongitude   = 24.848591196067
-      PixelResolution    = 229.97590845703
-      ProjectionName     = Sinusoidal
-      CenterLongitude    = 21.354478199267
-    End_Group
+      Group = Mapping
+        TargetName         = Mercury
+        EquatorialRadius   = 2440000.0 <meters>
+        PolarRadius        = 2440000.0 <meters>
+        LatitudeType       = Planetocentric
+        LongitudeDirection = PositiveEast
+        LongitudeDomain    = 180
+        MinimumLatitude    = -82.375420626412
+        MaximumLatitude    = 8.5375281924006
+        MinimumLongitude   = -120.26989718658
+        MaximumLongitude   = 13.797078029821
+        PixelResolution    = 2778.4154540232
+        ProjectionName     = Sinusoidal
+        CenterLongitude    = -53.236409578378
+      End_Group
+    End_Object
   End_Object
-End_Object
-End
+  End
+
 
 </pre>
 
@@ -364,7 +363,8 @@ End
     </change>
     <change name="Kaitlyn Lee" date="2018-03-06">
       Added oblique sample, line, detector, and pixel resolutions to the
-      geometry PVL group. Fixes #4100.
+      geometry PVL group. Updated example output in application description,
+      so that the addded oblique elements are included.Fixes #4100.
     </change>
   </history>
 

--- a/isis/src/base/apps/caminfo/caminfo.xml
+++ b/isis/src/base/apps/caminfo/caminfo.xml
@@ -3,12 +3,12 @@
 <application name="caminfo" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Application/application.xsd">
 
   <brief>
-    Outputs a PVL file that contains camera information. 
+    Outputs a PVL file that contains camera information.
   </brief>
 
   <description>
   <p>
-    This program compiles and outputs various spacecraft and instrument-related information such as 
+    This program compiles and outputs various spacecraft and instrument-related information such as
     geometric, polygon, and mapping information.
   </p>
   <p>
@@ -20,22 +20,22 @@
     running the spiceinit program from within caminfo.
   </p>
   <p>
-    Some information in the output PVL file will consist of a compilation of information for all the 
-    bands in the cube and will be listed in the "Common" object of the PVL. Other information for a given 
+    Some information in the output PVL file will consist of a compilation of information for all the
+    bands in the cube and will be listed in the "Common" object of the PVL. Other information for a given
     band will be placed in the "BandSet" object of the PVL. The user can select the check boxes to control
-    the information that will be output to the PVL file. If the POLYGON or USELABEL option is chosen, 
+    the information that will be output to the PVL file. If the POLYGON or USELABEL option is chosen,
     the image polygon is output in Well-Known Text format (WKT).
   </p>
-  <p>  
+  <p>
     The output file can be in PVL or CSV (Comma Separated Value) format. The "APPEND" option allows
-    the new generated information to be appended to the output file. This is especially useful for 
-    CSV file format. If the CSV format is chosen, only Camstats, Statistics and Geometry options 
-    are allowed. Isis Label, Original Label and Polygon options are disabled for CSV format. 
+    the new generated information to be appended to the output file. This is especially useful for
+    CSV file format. If the CSV format is chosen, only Camstats, Statistics and Geometry options
+    are allowed. Isis Label, Original Label and Polygon options are disabled for CSV format.
   </p>
-  <p> 
+  <p>
     The following is an example of caminfo output generated when in PVL format:
   </p>
-<pre> 
+<pre>
 Object = Caminfo
   Object = Parameters
     Program     = caminfo
@@ -197,14 +197,14 @@ End
 
   <p>
     Output values that do not have a minimum/maximum range associated with them
-    are calculated at the center of the image.  
+    are calculated at the center of the image.
   </p>
   <p>
     Definitions for most of the values output in the PVL file can be found in
     the ISIS 3 documentation glossary including: <def><b>SubSpacecraftLatitude</b></def>,
     <def><b>SubSpacecraftLongitude</b></def>, <def><b>SubSolarLatitude</b></def>,
-    <def><b>SubSolarLongitude</b></def>, <def><b>NorthAzimuth</b></def>, 
-    <def><b>SpacecraftAzimuth</b></def>, and <def><b>SubSolarAzimuth</b></def>, 
+    <def><b>SubSolarLongitude</b></def>, <def><b>NorthAzimuth</b></def>,
+    <def><b>SpacecraftAzimuth</b></def>, and <def><b>SubSolarAzimuth</b></def>,
   </p>
   </description>
 
@@ -219,85 +219,85 @@ End
       Fixed WKT calls
     </change>
     <change name="Tracie Sucharski" date="2007-11-09">
-      Remove ToWKT calls and PolygonTools.h inclusion.  The geos package now 
-      has a method to return a WKT string, so the ToWKT method has been 
+      Remove ToWKT calls and PolygonTools.h inclusion.  The geos package now
+      has a method to return a WKT string, so the ToWKT method has been
       removed from the PolygonTools class.
     </change>
-    <change name="Kris Becker" date="2007-12-07"> 
-      Made the following modifications:  fixed typo in PercentNull and 
-      MaximumLongitude keywords; use the base file name for generation of 
-      temporary files to further ensure uniqueness; run camstats once if 
-      there is only one band - doubles execution speed for single band 
-      images when CAMSTATS option is used; substitute the NULL string for 
-      all special pixel values; added corner pixel keywords for PDS 
-      compatibility; added phase, emission, incidence angles 
-      and line and sample pixel resolution at the center pixel; added test 
-      for intersection of longitude domain, north and south poles and 
-      keywords that report them; added option to output ISIS cube labels; 
+    <change name="Kris Becker" date="2007-12-07">
+      Made the following modifications:  fixed typo in PercentNull and
+      MaximumLongitude keywords; use the base file name for generation of
+      temporary files to further ensure uniqueness; run camstats once if
+      there is only one band - doubles execution speed for single band
+      images when CAMSTATS option is used; substitute the NULL string for
+      all special pixel values; added corner pixel keywords for PDS
+      compatibility; added phase, emission, incidence angles
+      and line and sample pixel resolution at the center pixel; added test
+      for intersection of longitude domain, north and south poles and
+      keywords that report them; added option to output ISIS cube labels;
       corrected computations for parallax and shadow keywords.
      </change>
-     <change name="Kris Becker" date="2007-12-19"> 
-       Renamed the HasLongitudeDomain keyword to HasLongitudeBoundary.  
+     <change name="Kris Becker" date="2007-12-19">
+       Renamed the HasLongitudeDomain keyword to HasLongitudeBoundary.
        Makes more sense.
      </change>
-     <change name="Kris Becker" date="2008-02-27"> 
-       Corrected method call to compute polygon with proper parameters as 
-       well as correct band number.  Added code to better honor specific 
-       cube attributes (such as band numbers) in computations.  Also will 
-       produce NULL valued keywords where NULLs are a produced instead of 
+     <change name="Kris Becker" date="2008-02-27">
+       Corrected method call to compute polygon with proper parameters as
+       well as correct band number.  Added code to better honor specific
+       cube attributes (such as band numbers) in computations.  Also will
+       produce NULL valued keywords where NULLs are a produced instead of
        the real value for the ISIS NULL pixel value.
      </change>
      <change name="Steven Lambright" date="2008-05-12">
-       Removed references to CubeInfo 
+       Removed references to CubeInfo
      </change>
      <change name="Bob Sucharski" date="2008-07-31">
-       Added Camera Test option  to test for a valid camera at center of image 
+       Added Camera Test option  to test for a valid camera at center of image
        and return an error and end if a valid camera cannot be created.
      </change>
-     <change name="Kris Becker" date="2008-09-22"> 
-       Reworked the output PVL format;  added more keywords to the Common object 
+     <change name="Kris Becker" date="2008-09-22">
+       Reworked the output PVL format;  added more keywords to the Common object
        that indicate versions and dates;  added more values to Geometry and
        Polygon object.
      </change>
-     <change name="Kris Becker" date="2008-10-22"> 
-       Corrected generation of polygon for multi-band data.  It created a 
+     <change name="Kris Becker" date="2008-10-22">
+       Corrected generation of polygon for multi-band data.  It created a
        POLYGON union instead of the required MULTIPOLYGON.
      </change>
-     <change name="Kris Becker" date="2008-10-30"> 
-       The target center distance and subspacecraft latitude were not properly 
-       propagated to the output PVL file and consequently were invalid.  This 
+     <change name="Kris Becker" date="2008-10-30">
+       The target center distance and subspacecraft latitude were not properly
+       propagated to the output PVL file and consequently were invalid.  This
        has been corrected.
      </change>
-     <change name="Kris Becker" date="2008-12-29"> 
+     <change name="Kris Becker" date="2008-12-29">
        Added RightAscension, Declination, SubSolarGroundAzimuth, and
-       SubSpacecraftGroundAzimuth computations; added center line/sample image 
-       coordinate used to compute center geometry; added check of valid image 
-       line/sample coordinates when testing for north/south poles (some camera 
-       models return valid states when coordinates are outside of image 
+       SubSpacecraftGroundAzimuth computations; added center line/sample image
+       coordinate used to compute center geometry; added check of valid image
+       line/sample coordinates when testing for north/south poles (some camera
+       models return valid states when coordinates are outside of image
        boundaries).
      </change>
-     <change name="Kris Becker" date="2009-02-26"> 
-       Modified to actually exclude the unconditional computation of the image 
-       polygon to assist in some geometry values.  It is no longer computed if 
-       the user does not select the POLYGON option.  The implications of this 
-       are that some of the keywords in the output Geometry group are no 
-       longer ever relevant.  These keywords were all moved to the Polygon 
-       group.  These keywords are:   CentroidLine, CentroidSample, 
-       CentroidLatitude, CentroidLongitude, CentroidRadius and SurfaceArea.  
-       User will no longer see these values if the POLYGON option is not 
-       selected.  Also the Radius keyword in the Polygon group has been 
+     <change name="Kris Becker" date="2009-02-26">
+       Modified to actually exclude the unconditional computation of the image
+       polygon to assist in some geometry values.  It is no longer computed if
+       the user does not select the POLYGON option.  The implications of this
+       are that some of the keywords in the output Geometry group are no
+       longer ever relevant.  These keywords were all moved to the Polygon
+       group.  These keywords are:   CentroidLine, CentroidSample,
+       CentroidLatitude, CentroidLongitude, CentroidRadius and SurfaceArea.
+       User will no longer see these values if the POLYGON option is not
+       selected.  Also the Radius keyword in the Polygon group has been
        removed as it is redundant with CentroidRadius.
      </change>
-     <change name="Kris Becker" date="2009-05-29"> 
-       Added PIXINC parameter to allow user to specify number of pixels to 
+     <change name="Kris Becker" date="2009-05-29">
+       Added PIXINC parameter to allow user to specify number of pixels to
        skip around the perimeter of the image to compute the polygon.
      </change>
-     <change name="Kris Becker" date="2009-05-29"> 
-       Fixed bug where image was a 0 longitude boundary crosser.  It would 
-       typically fail when determining centroid information unless converted 
-       to 180 domain.  This will also be used at the poles as it seems to work 
-       better in the 180 domain as well.  (This process projects the footprint 
-       to a Sinusoidal projection to determine area which requires an equal 
+     <change name="Kris Becker" date="2009-05-29">
+       Fixed bug where image was a 0 longitude boundary crosser.  It would
+       typically fail when determining centroid information unless converted
+       to 180 domain.  This will also be used at the poles as it seems to work
+       better in the 180 domain as well.  (This process projects the footprint
+       to a Sinusoidal projection to determine area which requires an equal
        area projection, such as Sinusoidal.)
      </change>
      <change name="Kris Becker" date="2009-07-08">
@@ -305,21 +305,21 @@ End
        control limb and terminator polygon generation.
      </change>
      <change name="Kris Becker" date="2009-08-24">
-       Allow disabling of shape model use when constructing polygons that 
+       Allow disabling of shape model use when constructing polygons that
        contain limbs.
      </change>
      <change name="Mackenzie Boyd" date="2010-06-14">
-       Removed polygon options group and placed the options within output 
-       options. Added inclusion for parameters related to polygons to only be 
-       available when polygons are selected. Made TO option not have a 
-       default of None, updated documentation and modified formatting. 
+       Removed polygon options group and placed the options within output
+       options. Added inclusion for parameters related to polygons to only be
+       available when polygons are selected. Made TO option not have a
+       default of None, updated documentation and modified formatting.
      </change>
      <change name="Jai Rideout" date="2011-02-17">
        Replaced PIXINC with POLYSINC and POLYLINC. Renamed SINC and LINC to
        STATSSINC and STATSLINC.
      </change>
      <change name="Sharmila Prasad" date="2011-02-24">
-       Added option for the output file to be in CSV format and also ability 
+       Added option for the output file to be in CSV format and also ability
        to append to the existing output file.
      </change>
      <change name="Jai Rideout" date="2011-03-01">
@@ -351,7 +351,7 @@ End
     </change>
     <change name="Kris Becker" date="2012-11-23">
         The computation of ParallaxX/ParallaxY and ShadowX/ShadowY values was
-        not properly implemented. Updated documentation with a new example. 
+        not properly implemented. Updated documentation with a new example.
         Fixes #1296.
     </change>
     <change name="Janet Barrett" date="2013-01-29">
@@ -361,6 +361,10 @@ End
     </change>
     <change name="Janet Richie" date="2013-02-25">
       Reviewed documentation. References #1452.
+    </change>
+    <change name="Kaitlyn Lee" date="2018-03-06">
+      Added oblique sample, line, detector, and pixel resolutions to the
+      geometry PVL group. Fixes #4100.
     </change>
   </history>
 
@@ -400,7 +404,7 @@ End
         </filter>
       </parameter>
       </group>
-    
+
     <group name="General Output Options">
       <parameter name="FORMAT">
         <type>string</type>
@@ -420,7 +424,7 @@ End
             <brief> Create CSV output </brief>
             <description>
               Caminfo data to be generated in Comma Separated Value (CSV) format
-            </description> 
+            </description>
              <exclusions>
                <item>ISISLABEL</item>
                <item>ORIGINALLABEL</item>
@@ -430,27 +434,27 @@ End
            </option>
          </list>
       </parameter>
-      
+
       <parameter name="APPEND">
         <type>boolean</type>
         <default><item>false</item></default>
         <brief>Append caminfo information to existing data file</brief>
-        <description> Append caminfo information to existing file. This will append the 
-          caminfo data to the filename specified for the TO parameter beginning at a 
-          new line. 
+        <description> Append caminfo information to existing file. This will append the
+          caminfo data to the filename specified for the TO parameter beginning at a
+          new line.
          </description>
       </parameter>
-      
+
       <parameter name="GEOMETRY">
         <type>boolean</type>
         <brief>
           Include geometry information
         </brief>
         <description>
-          Get geometry information from the camera at the center of the image.  
-          These data are listed under the Geometry Object heading.  The keyword/values 
+          Get geometry information from the camera at the center of the image.
+          These data are listed under the Geometry Object heading.  The keyword/values
           contained therein are listed here:
-          
+
           <UL>
             <LI>BandsUsed</LI>
             <LI>ReferenceBand</LI>
@@ -501,8 +505,8 @@ End
             <LI>HasLongitudeBoundary</LI>
             <LI>HasNorthPole</LI>
             <LI>HasSouthPole</LI>
-          </UL> 
-          
+          </UL>
+
         </description>
         <default><item>TRUE</item></default>
       </parameter>
@@ -511,7 +515,7 @@ End
       <parameter name="ISISLABEL">
         <type>boolean</type>
         <brief>
-          Include ISIS label 
+          Include ISIS label
         </brief>
         <description>
           This option will extract the ISIS label and write it to the output PVL
@@ -523,7 +527,7 @@ End
       <parameter name="ORIGINALLABEL">
         <type>boolean</type>
         <brief>
-          Include the original label 
+          Include the original label
         </brief>
         <description>
           Include the original labels of the cube in the PVL.
@@ -538,7 +542,7 @@ End
         </brief>
         <description>
           Include DN statistics for all bands within the cube.  These data are
-          contained in the Statistics object.  The keyword/values contained 
+          contained in the Statistics object.  The keyword/values contained
           therein are:
           <UL>
             <LI>MeanValue</LI>
@@ -562,7 +566,7 @@ End
           Get camera statistics information
         </brief>
         <description>
-          Run camstats to get camera information that can be expressed as a range.  
+          Run camstats to get camera information that can be expressed as a range.
           Camstats will run on the entire cube (common object), and for each band (bandset object).
           The default linc and sinc for camstats is "1". The user can select a different linc and sinc.
           Output values are:
@@ -614,7 +618,7 @@ End
         <minimum inclusive="true">1</minimum>
       </parameter>
     </group>
-      
+
     <group name="Polygon Output  Options">
       <parameter name="USELABEL">
         <type>boolean</type>
@@ -641,12 +645,12 @@ End
         <type>boolean</type>
         <default><item>FALSE</item></default>
         <brief>
-          Create polygon information 
+          Create polygon information
         </brief>
         <description>
-          Use the imagePolygon class to gather polygon information.  The output 
-          polygon will be in well-known text format (WKT).  These data are 
-          contained within the Polygon object.   The keyword/values contained 
+          Use the imagePolygon class to gather polygon information.  The output
+          polygon will be in well-known text format (WKT).  These data are
+          contained within the Polygon object.   The keyword/values contained
           therein are:
             <UL>
               <LI>CentroidLine</LI>
@@ -729,7 +733,7 @@ End
           as well as a change to user input values.
         </description>
       </parameter>
-          
+
       <parameter name="POLYLINC">
         <type>integer</type>
         <internalDefault>10% of the cube's total lines</internalDefault>
@@ -775,7 +779,7 @@ End
         </description>
         <minimum inclusive="true">4</minimum>
       </parameter>
-      
+
       <parameter name="MAXEMISSION">
         <type>double</type>
         <brief>
@@ -783,17 +787,17 @@ End
         </brief>
         <description>
             <p>
-                Specifies the maximum emission angle that a polygon point is 
-                allowed to have.  This limit is useful for eliminating limb data 
-                that cause numerous ragged spikes.  Limb data will generally 
-                result in odd polygon footprints as the geometry becomes 
-                unstable at the limb due to obliqueness particularly when using 
-                a DEM for the shape model (see spiceinit).  This parameter 
-                restricts the emission angle to create better behaved polygons 
+                Specifies the maximum emission angle that a polygon point is
+                allowed to have.  This limit is useful for eliminating limb data
+                that cause numerous ragged spikes.  Limb data will generally
+                result in odd polygon footprints as the geometry becomes
+                unstable at the limb due to obliqueness particularly when using
+                a DEM for the shape model (see spiceinit).  This parameter
+                restricts the emission angle to create better behaved polygons
                 at the limb while sacrificing some (very oblique) data.
             </p>
             <p>
-                Note: For images that have been run through spiceinit with a DEM, the 
+                Note: For images that have been run through spiceinit with a DEM, the
                 emission angle range may need to be decreased. This will avoid the
                 instability that occurs at the limb and will avoid spiking of the
                 data.
@@ -808,11 +812,11 @@ End
           Maximum incidence angle to include in polygon
         </brief>
         <description>
-            Specifies the maximum incidence angle that a polygon point is 
-            allowed to have.  This limit is useful for eliminating 
-            terminator data that will typically be lost in photometric 
-            corrections.  This parameter restricts the incidence angle to 
-            create more data relevant polygons at the terminator while 
+            Specifies the maximum incidence angle that a polygon point is
+            allowed to have.  This limit is useful for eliminating
+            terminator data that will typically be lost in photometric
+            corrections.  This parameter restricts the incidence angle to
+            create more data relevant polygons at the terminator while
             sacrificing some (non-photometric) data.
         </description>
         <default><item>120.0</item></default>
@@ -827,12 +831,12 @@ End
             Run spiceinit on the input
           </brief>
           <description>
-              If the user sets this to true then the spiceinit program will be 
-              run on the input file.  Spiceinit will use the system SPICE kernels, 
-              so any updates to SPICE information will be lost.  Spiceinit is in 
+              If the user sets this to true then the spiceinit program will be
+              run on the input file.  Spiceinit will use the system SPICE kernels,
+              so any updates to SPICE information will be lost.  Spiceinit is in
               this program to facilitate UPC processing.
           </description>
-        </parameter> 
+        </parameter>
         </group>
 
     <group name="Camera Test">
@@ -840,11 +844,11 @@ End
         <type>boolean</type>
         <default><item>FALSE</item></default>
         <brief>
-          Test image center for valid camera 
+          Test image center for valid camera
         </brief>
         <description>
-          If the user sets this parameter to true, a test will determine if a 
-          valid camera can be created at the center of the image band.  If a 
+          If the user sets this parameter to true, a test will determine if a
+          valid camera can be created at the center of the image band.  If a
           valid camera cannot be created the program will end.  The default is to
           output any available information without testing the camera.
         </description>

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
@@ -298,6 +298,7 @@ namespace Isis {
           index++;
       }
     }
+    // cout<<"COUDL NOT FIND: "<< keyword<<endl;
   }
 
   /**
@@ -393,9 +394,12 @@ namespace Isis {
         double lon = cvp->camera()->UniversalLongitude();
 
         double radius = cvp->camera()->LocalRadius().meters();
-        p_tableWin->table()->item(row, getIndex("Planetocentric Latitude"))->setText(QString::number(lat, 'f', 15));
-        p_tableWin->table()->item(row, getIndex("360 Positive East Longitude"))->setText(QString::number(lon, 'f', 15));
-        p_tableWin->table()->item(row, getIndex("Local Radius"))->setText(QString::number(radius, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Planetocentric Latitude"))->
+                             setText(QString::number(lat, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("360 Positive East Longitude"))->
+                             setText(QString::number(lon, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Local Radius"))->
+                             setText(QString::number(radius, 'f', 15));
 
         /* 180 Positive East Lon. */
         p_tableWin->table()->item(row, getIndex("180 Positive East Longitude"))->
@@ -407,12 +411,14 @@ namespace Isis {
         Distance radii[3];
         cvp->camera()->radii(radii);
         lat = TProjection::ToPlanetographic(lat, radii[0].meters(), radii[2].meters());
-        p_tableWin->table()->item(row, getIndex("Planetographic Latitude"))->setText(QString::number(lat, 'f', 15));
-        p_tableWin->table()->item(row, getIndex("360 Positive West Longitude"))->setText(QString::number(lon, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Planetographic Latitude"))->
+                             setText(QString::number(lat, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("360 Positive West Longitude"))->
+                             setText(QString::number(lon, 'f', 15));
 
         /*180 Positive West Lon.  */
         p_tableWin->table()->item(row, getIndex("180 Positive West Longitude"))->setText(
-                                  QString::number(TProjection::To180Domain(lon), 'f', 15));
+                             QString::number(TProjection::To180Domain(lon), 'f', 15));
 
         // Next write out columns, the x/y/z position of the lat/lon, only if set image succeeds
         double pos[3];
@@ -433,7 +439,8 @@ namespace Isis {
         // Write out columns, oblique pixel resolution, only if set image succeeds
         double obliquePRes = cvp->camera()->ObliquePixelResolution();
         if (obliquePRes != Isis::Null) {
-          p_tableWin->table()->item(row, getIndex("Oblique Pixel Resolution"))->setText(QString::number(obliquePRes));
+          p_tableWin->table()->item(row, getIndex("Oblique Pixel Resolution"))->
+                               setText(QString::number(obliquePRes));
         }
         else {
           p_tableWin->table()->item(row, getIndex("Oblique Pixel Resolution"))->setText("");
@@ -442,7 +449,8 @@ namespace Isis {
         // Write out columns, oblique sample resolution, only if set image succeeds
         double obliqueSRes = cvp->camera()->ObliqueSampleResolution();
         if (obliqueSRes != Isis::Null) {
-          p_tableWin->table()->item(row, getIndex("Oblique Sample Resolution"))->setText(QString::number(obliqueSRes));
+          p_tableWin->table()->item(row, getIndex("Oblique Sample Resolution"))->
+                               setText(QString::number(obliqueSRes));
         }
         else {
           p_tableWin->table()->item(row, getIndex("Oblique Sample Resolution"))->setText("");
@@ -451,7 +459,8 @@ namespace Isis {
         // Write out columns, oblique line resolution, only if set image succeeds
         double obliqueLRes = cvp->camera()->ObliqueLineResolution();
         if (obliqueLRes != Isis::Null) {
-          p_tableWin->table()->item(row, getIndex("Oblique Line Resolution"))->setText(QString::number(obliqueLRes));
+          p_tableWin->table()->item(row, getIndex("Oblique Line Resolution"))->
+                               setText(QString::number(obliqueLRes));
         }
         else {
           p_tableWin->table()->item(row, getIndex("Oblique Line Resolution"))->setText("");
@@ -460,7 +469,8 @@ namespace Isis {
         // Write out columns, oblique detector resolution, only if set image succeeds
         double obliqueDRes = cvp->camera()->ObliqueDetectorResolution();
         if (obliqueDRes != Isis::Null) {
-          p_tableWin->table()->item(row, getIndex("Oblique Detector Resolution"))->setText(QString::number(obliqueDRes));
+          p_tableWin->table()->item(row, getIndex("Oblique Detector Resolution"))->
+                               setText(QString::number(obliqueDRes));
         }
         else {
           p_tableWin->table()->item(row, getIndex("Oblique Detector Resolution"))->setText("");
@@ -497,7 +507,8 @@ namespace Isis {
         double northAzi = cvp->camera()->NorthAzimuth();
         if (cvp->camera()->target()->shape()->name() != "Plane"
             && Isis::IsValidPixel(northAzi)) {
-          p_tableWin->table()->item(row, getIndex("North Azimuth"))->setText(QString::number(northAzi));
+          p_tableWin->table()->item(row, getIndex("North Azimuth"))->
+                               setText(QString::number(northAzi));
         }
         else { // north azimuth is meaningless for ring plane projections
           p_tableWin->table()->item(row, getIndex("North Azimuth"))->setText("");
@@ -505,7 +516,8 @@ namespace Isis {
 
         double sunAzi = cvp->camera()->SunAzimuth();
         if (Isis::IsValidPixel(sunAzi)) {
-          p_tableWin->table()->item(row, getIndex("Sun Azimuth"))->setText(QString::number(sunAzi));
+          p_tableWin->table()->item(row, getIndex("Sun Azimuth"))->
+                               setText(QString::number(sunAzi));
         }
         else { // sun azimuth is null
           p_tableWin->table()->item(row, getIndex("Sun Azimuth"))->setText("");
@@ -513,7 +525,8 @@ namespace Isis {
 
         double spacecraftAzi = cvp->camera()->SpacecraftAzimuth();
         if (Isis::IsValidPixel(spacecraftAzi)) {
-          p_tableWin->table()->item(row, getIndex("Spacecraft Azimuth"))->setText(QString::number(spacecraftAzi));
+          p_tableWin->table()->item(row, getIndex("Spacecraft Azimuth"))->
+                               setText(QString::number(spacecraftAzi));
         }
         else { // spacecraft azimuth is null
           p_tableWin->table()->item(row, getIndex("Spacecraft Azimuth"))->setText("");
@@ -521,47 +534,56 @@ namespace Isis {
 
         // Write out columns solar lon, slant distance, local solar time
         double solarLon = cvp->camera()->solarLongitude().degrees();
-        p_tableWin->table()->item(row, getIndex("Solar Longitude"))->setText(QString::number(solarLon));
+        p_tableWin->table()->item(row, getIndex("Solar Longitude"))->
+                             setText(QString::number(solarLon));
         double slantDistance = cvp->camera()->SlantDistance();
-        p_tableWin->table()->item(row, getIndex("Slant Distance"))->setText(QString::number(slantDistance));
+        p_tableWin->table()->item(row, getIndex("Slant Distance"))->
+                             setText(QString::number(slantDistance));
         double lst = cvp->camera()->LocalSolarTime();
-        p_tableWin->table()->item(row, getIndex("Local Solar Time"))->setText(QString::number(lst));
+        p_tableWin->table()->item(row, getIndex("Local Solar Time"))->
+                             setText(QString::number(lst));
       } // end if set image succeeds
 
       // Always write out the x/y/z of the undistorted focal plane
       CameraDistortionMap *distortedMap = cvp->camera()->DistortionMap();
       double undistortedFocalPlaneX = distortedMap->UndistortedFocalPlaneX();
-      p_tableWin->table()->item(row, UNDISTORTED_FOCAL_X)->setText(QString::number(undistortedFocalPlaneX));
+      p_tableWin->table()->item(row, getIndex("Undistorted Focal X"))->
+                           setText(QString::number(undistortedFocalPlaneX));
       double undistortedFocalPlaneY = distortedMap->UndistortedFocalPlaneY();
-      p_tableWin->table()->item(row, UNDISTORTED_FOCAL_Y)->setText(QString::number(undistortedFocalPlaneY));
+      p_tableWin->table()->item(row, getIndex("Undistorted Focal Y"))->
+                           setText(QString::number(undistortedFocalPlaneY));
       double undistortedFocalPlaneZ = distortedMap->UndistortedFocalPlaneZ();
-      p_tableWin->table()->item(row, UNDISTORTED_FOCAL_Z)->setText(QString::number(undistortedFocalPlaneZ));
+      p_tableWin->table()->item(row, getIndex("Undistorted Focal Z"))->
+                           setText(QString::number(undistortedFocalPlaneZ));
 
       // Always write out the x/y of the distorted focal plane
       CameraFocalPlaneMap *focalPlaneMap = cvp->camera()->FocalPlaneMap();
       double distortedFocalPlaneX = focalPlaneMap->FocalPlaneX();
-      p_tableWin->table()->item(row, DISTORTED_FOCAL_X)->setText(QString::number(distortedFocalPlaneX));
+      p_tableWin->table()->item(row, getIndex("Focal Plane X"))->
+                           setText(QString::number(distortedFocalPlaneX));
       double distortedFocalPlaneY = focalPlaneMap->FocalPlaneY();
-      p_tableWin->table()->item(row, DISTORTED_FOCAL_Y)->setText(QString::number(distortedFocalPlaneY));
+      p_tableWin->table()->item(row, getIndex("Focal Plane Y"))->
+                           setText(QString::number(distortedFocalPlaneY));
 
       // Always write out columns ra/dec, regardless of whether set image succeeds
       double ra = cvp->camera()->RightAscension();
-      p_tableWin->table()->item(row, RIGHT_ASCENSION)->setText(QString::number(ra));
+      p_tableWin->table()->item(row, getIndex("Right Ascension"))->setText(QString::number(ra));
       double dec = cvp->camera()->Declination();
-      p_tableWin->table()->item(row, DECLINATION)->setText(QString::number(dec));
+      p_tableWin->table()->item(row, getIndex("Declination"))->setText(QString::number(dec));
 
       // Always write out columns et and utc, regardless of whether set image succeeds
       iTime time(cvp->camera()->time());
-      p_tableWin->table()->item(row, EPHEMERIS_TIME)->setText(QString::number(time.Et(), 'f', 15));
+      p_tableWin->table()->item(row, getIndex("Ephemeris Time"))->
+                           setText(QString::number(time.Et(), 'f', 15));
       QString time_utc = time.UTC();
-      p_tableWin->table()->item(row, UTC)->setText(time_utc);
+      p_tableWin->table()->item(row, getIndex("UTC"))->setText(time_utc);
 
       // Always out columns spacecraft position, regardless of whether set image succeeds
       double pos[3];
       cvp->camera()->instrumentPosition(pos);
-      p_tableWin->table()->item(row, SPACECRAFT_X)->setText(QString::number(pos[0]));
-      p_tableWin->table()->item(row, SPACECRAFT_Y)->setText(QString::number(pos[1]));
-      p_tableWin->table()->item(row, SPACECRAFT_Z)->setText(QString::number(pos[2]));
+      p_tableWin->table()->item(row, getIndex("Spacecraft X"))->setText(QString::number(pos[0]));
+      p_tableWin->table()->item(row, getIndex("Spacecraft Y"))->setText(QString::number(pos[1]));
+      p_tableWin->table()->item(row, getIndex("Spacecraft Z"))->setText(QString::number(pos[2]));
     }
 
     else if (cvp->projection() != NULL) {
@@ -579,21 +601,24 @@ namespace Isis {
           while (wlon < 0.0) wlon += 360.0;
           if (tproj->IsSky()) {
             lon = tproj->Longitude();
-            p_tableWin->table()->item(row, RIGHT_ASCENSION)->setText(QString::number(lon, 'f', 15));
-            p_tableWin->table()->item(row, DECLINATION)->setText(QString::number(lat, 'f', 15));
+            p_tableWin->table()->item(row, getIndex("Right Ascension"))->
+                                 setText(QString::number(lon, 'f', 15));
+            p_tableWin->table()->item(row, getIndex("Declination"))->
+                                 setText(QString::number(lat, 'f', 15));
           }
           else {
             double radius = tproj->LocalRadius();
-            p_tableWin->table()->item(row, PLANETOCENTRIC_LAT)->
+            p_tableWin->table()->item(row, getIndex("Planetocentric Latitude"))->
                                  setText(QString::number(lat, 'f', 15));
-            p_tableWin->table()->item(row, PLANETOGRAPHIC_LAT)->
+            p_tableWin->table()->item(row, getIndex("Planetographic Latitude"))->
                                  setText(QString::number(glat, 'f', 15));
-            p_tableWin->table()->item(row, EAST_LON_360)->
+            p_tableWin->table()->item(row, getIndex("360 Positive East Longitude"))->
                                  setText(QString::number(lon, 'f', 15));
-            p_tableWin->table()->item(row, EAST_LON_180)->
+            p_tableWin->table()->item(row, getIndex("180 Positive East Longitude"))->
                                  setText(QString::number(TProjection::To180Domain(lon), 'f', 15));
-            p_tableWin->table()->item(row, WEST_LON_360)->setText(QString::number(wlon, 'f', 15));
-            p_tableWin->table()->item(row, WEST_LON_180)->
+            p_tableWin->table()->item(row, getIndex("360 Positive West Longitude"))->
+                                 setText(QString::number(wlon, 'f', 15));
+            p_tableWin->table()->item(row, getIndex("180 Positive East Longitude"))->
                                  setText(QString::number(TProjection::To180Domain(wlon), 'f', 15));
             p_tableWin->table()->item(row, RADIUS)->setText(QString::number(radius, 'f', 15));
           }
@@ -606,16 +631,18 @@ namespace Isis {
           double wlon = -lon;
           while (wlon < 0.0) wlon += 360.0;
           double radius = lat;
-          p_tableWin->table()->item(row, PLANETOCENTRIC_LAT)->setText("0.0");
-          p_tableWin->table()->item(row, PLANETOGRAPHIC_LAT)->setText("0.0");
-          p_tableWin->table()->item(row, EAST_LON_360)->
+          p_tableWin->table()->item(row, getIndex("Planetocentric Latitude"))->setText("0.0");
+          p_tableWin->table()->item(row, getIndex("Planetographic Latitude"))->setText("0.0");
+          p_tableWin->table()->item(row, getIndex("360 Positive East Longitude"))->
                                setText(QString::number(lon, 'f', 15));
-          p_tableWin->table()->item(row, EAST_LON_180)->
+          p_tableWin->table()->item(row, getIndex("180 Positive East Longitude"))->
                                setText(QString::number(RingPlaneProjection::To180Domain(lon), 'f', 15));
-          p_tableWin->table()->item(row, WEST_LON_360)->setText(QString::number(wlon, 'f', 15));
-          p_tableWin->table()->item(row, WEST_LON_180)->
+          p_tableWin->table()->item(row, getIndex("360 Positive West Longitude"))->
+                               setText(QString::number(wlon, 'f', 15));
+          p_tableWin->table()->item(row, getIndex("180 Positive West Longitude"))->
                                setText(QString::number(RingPlaneProjection::To180Domain(wlon), 'f', 15));
-          p_tableWin->table()->item(row, RADIUS)->setText(QString::number(radius, 'f', 15));
+          p_tableWin->table()->item(row, getIndex("Local Radius"))->
+                               setText(QString::number(radius, 'f', 15));
         }
       }
     }
@@ -625,8 +652,10 @@ namespace Isis {
       if (cvp->projection()->SetWorld(sample, line)) {
         double projX = cvp->projection()->XCoord();
         double projY = cvp->projection()->YCoord();
-        p_tableWin->table()->item(row, PROJECTED_X)->setText(QString::number(projX, 'f', 15));
-        p_tableWin->table()->item(row, PROJECTED_Y)->setText(QString::number(projY, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Projected X"))->
+                             setText(QString::number(projX, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Projected Y"))->
+                             setText(QString::number(projY, 'f', 15));
       }
     }
 
@@ -635,9 +664,11 @@ namespace Isis {
     QString sSrcFileName = "";
     QString sSrcSerialNum = "";
     TrackMosaicOrigin(cvp, iline, isample, iMosaicOrigin, sSrcFileName, sSrcSerialNum);
-    p_tableWin->table()->item(row, TRACK_MOSAIC_INDEX)->setText(QString::number(iMosaicOrigin));
-    p_tableWin->table()->item(row, TRACK_MOSAIC_FILENAME)->setText(QString(sSrcFileName));
-    p_tableWin->table()->item(row, TRACK_MOSAIC_SERIAL_NUM)->
+    p_tableWin->table()->item(row, getIndex("Track Mosaic Index"))->
+                         setText(QString::number(iMosaicOrigin));
+    p_tableWin->table()->item(row, getIndex("Track Mosaic FileName"))->
+                         setText(QString(sSrcFileName));
+    p_tableWin->table()->item(row, getIndex("Track Mosaic Serial Number"))->
                          setText(QString(sSrcSerialNum));
   }
 

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
@@ -63,55 +63,6 @@ namespace Isis {
     connect(p_action, SIGNAL(triggered()), p_tableWin, SLOT(syncColumns()));
     p_tableWin->installEventFilter(this);
 
-    // p_tableWin->addToTable(false, "Id", "Id");
-    // p_tableWin->addToTable(true, "Sample:Line", "Sample:Line", -1,
-    //                        Qt::Horizontal, "Sample and Line");
-    // p_tableWin->addToTable(false, "Band", "Band");
-    // p_tableWin->addToTable(true, "Pixel", "Pixel");
-    // p_tableWin->addToTable(true, "Planetocentric Latitude", "Planetocentric Lat");
-    // p_tableWin->addToTable(false, "Planetographic Latitude", "Planetographic Lat");
-    // p_tableWin->addToTable(true, "360 Positive East Longitude", "360 East Longitude");
-    // p_tableWin->addToTable(false, "360 Positive West Longitude", "360 West Longitude");
-    // p_tableWin->addToTable(true, "180 Positive East Longitude", "180 East Longitude");
-    // p_tableWin->addToTable(false, "180 Positive West Longitude", "180 West Longitude");
-    // p_tableWin->addToTable(false, "Projected X:Projected Y", "Projected X:Projected Y", -1,
-    //                        Qt::Horizontal, "X and Y values for a projected image");
-    // p_tableWin->addToTable(false, "Local Radius", "Radius");
-    // p_tableWin->addToTable(false, "Point X:Point Y:Point Z", "XYZ", -1, Qt::Horizontal,
-    //                        "The X, Y, and Z of surface intersection in body-fixed coordinates");
-    // p_tableWin->addToTable(false, "Right Ascension:Declination", "Ra:Dec", -1, Qt::Horizontal,
-    //                        "Right Ascension and Declination");
-    // p_tableWin->addToTable(false, "Resolution", "Resolution");
-    // p_tableWin->addToTable(false, "Oblique Pixel Resolution", "Oblique Pixel Res");
-    // p_tableWin->addToTable(false, "Oblique Sample Resolution", "Oblique Sample Res");
-    // p_tableWin->addToTable(false, "Oblique Line Resolution", "Oblique Line Res");
-    // p_tableWin->addToTable(false, "Oblique Detector Resolution", "Oblique Detector Res");
-    // p_tableWin->addToTable(false, "Phase", "Phase");
-    // p_tableWin->addToTable(false, "Incidence", "Incidence");
-    // p_tableWin->addToTable(false, "Emission", "Emission");
-    // p_tableWin->addToTable(false, "LocalIncidence", "LocalIncidence");
-    // p_tableWin->addToTable(false, "LocalEmission", "LocalEmission");
-    // p_tableWin->addToTable(false, "North Azimuth", "North Azimuth");
-    // p_tableWin->addToTable(false, "Sun Azimuth", "Sun Azimuth");
-    // p_tableWin->addToTable(false, "Solar Longitude", "Solar Longitude");
-    // p_tableWin->addToTable(false, "Spacecraft X:Spacecraft Y:Spacecraft Z", "Spacecraft Position",
-    //                        -1, Qt::Horizontal, "The X, Y, and Z of the spacecraft position");
-    // p_tableWin->addToTable(false, "Spacecraft Azimuth", "Spacecraft Azimuth");
-    // p_tableWin->addToTable(false, "Slant Distance", "Slant Distance");
-    // p_tableWin->addToTable(false, "Focal Plane X:Focal Plane Y", "Focal Plane X:Y");
-    // p_tableWin->addToTable(false, "Undistorted Focal X:Undistorted Focal Y: Undistorted Focal Z",
-    //                        "Undistorted Focal Plane X:Y:Z");
-    // p_tableWin->addToTable(false, "Ephemeris Time", "Ephemeris iTime");
-    // p_tableWin->addToTable(false, "Local Solar Time", "Local Solar iTime");
-    // p_tableWin->addToTable(false, "UTC", "UTC", -1, Qt::Horizontal, "Internal time in UTC format");
-    // p_tableWin->addToTable(false, "Path", "Path");
-    // p_tableWin->addToTable(false, "FileName", "FileName");
-    // p_tableWin->addToTable(false, "Serial Number", "Serial Number");
-    // p_tableWin->addToTable(false, "Track Mosaic Index", "Track Mosaic Index");
-    // p_tableWin->addToTable(false, "Track Mosaic FileName", "Track Mosaic FileName");
-    // p_tableWin->addToTable(false, "Track Mosaic Serial Number", "Track Mosaic Serial Number");
-    // p_tableWin->addToTable(false, "Notes", "Notes");
-
     // Adds each item of checkBoxItems to the table.
     // If a tool tip is specified, we cannot skip parameters, so -1 and
     // Qt::Horizontal are specified.
@@ -298,7 +249,8 @@ namespace Isis {
           index++;
       }
     }
-    // cout<<"COUDL NOT FIND: "<< keyword<<endl;
+    IString msg = "Header [" + keyword + "] not found; make sure spelling is correct";
+    throw IException(IException::Io, msg, _FILEINFO_);
   }
 
   /**
@@ -347,7 +299,7 @@ namespace Isis {
     if (line > cvp->cubeLines() + 0.5) return;
 
     // Write cols 0-2 (id, sample, line)
-    p_tableWin->table()->item(row, getIndex("Id"))->setText(QString::number(p_id));
+    p_tableWin->table()->item(row, getIndex("ID"))->setText(QString::number(p_id));
     p_tableWin->table()->item(row, getIndex("Sample"))->setText(QString::number(sample));
     p_tableWin->table()->item(row, getIndex("Line"))->setText(QString::number(line));
 
@@ -620,7 +572,7 @@ namespace Isis {
                                  setText(QString::number(wlon, 'f', 15));
             p_tableWin->table()->item(row, getIndex("180 Positive East Longitude"))->
                                  setText(QString::number(TProjection::To180Domain(wlon), 'f', 15));
-            p_tableWin->table()->item(row, RADIUS)->setText(QString::number(radius, 'f', 15));
+            p_tableWin->table()->item(row, getIndex("Local Radius"))->setText(QString::number(radius, 'f', 15));
           }
         }
         else { // RingPlane
@@ -867,7 +819,7 @@ namespace Isis {
       p_id = 0;
     }
     else {
-      p_id = p_tableWin->table()->item(p_tableWin->currentRow() - 1, ID)->text().toInt() + 1;
+      p_id = p_tableWin->table()->item(p_tableWin->currentRow() - 1, getIndex("ID"))->text().toInt() + 1;
     }
   }
 

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
@@ -274,6 +274,14 @@ namespace Isis {
     }
   }
 
+    /**
+     * This method finds the index of the header in checkBoxItems by looping
+     * through checkBoxItems, grabbing the header from each QList, and parsing
+     * the header at ":" to account for check boxes turning on multiple columns
+     *
+     * @param keyword Header to be found
+     * @return int
+     */
     int AdvancedTrackTool::getIndex(QString keyword) {
       int index = 0;
       QList< QList<QString> >::iterator iter;

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
@@ -13,6 +13,7 @@
 #include <QTableWidgetItem>
 #include <QToolBar>
 #include <QVBoxLayout>
+#include <QListIterator>
 
 #include "Angle.h"
 #include "Camera.h"
@@ -29,6 +30,7 @@
 #include "TableMainWindow.h"
 #include "Target.h"
 #include "TProjection.h"
+using namespace std;
 
 namespace Isis {
 
@@ -61,58 +63,89 @@ namespace Isis {
     connect(p_action, SIGNAL(triggered()), p_tableWin, SLOT(syncColumns()));
     p_tableWin->installEventFilter(this);
 
-    p_tableWin->addToTable(false, "Id", "Id");
-    p_tableWin->addToTable(true, "Sample:Line", "Sample:Line", -1,
-                           Qt::Horizontal, "Sample and Line");
-    p_tableWin->addToTable(false, "Band", "Band");
-    p_tableWin->addToTable(true, "Pixel", "Pixel");
-    p_tableWin->addToTable(true, "Planetocentric Latitude", "Planetocentric Lat");
-    p_tableWin->addToTable(false, "Planetographic Latitude", "Planetographic Lat");
-    p_tableWin->addToTable(true, "360 Positive East Longitude", "360 East Longitude");
-    p_tableWin->addToTable(false, "360 Positive West Longitude", "360 West Longitude");
-    p_tableWin->addToTable(true, "180 Positive East Longitude", "180 East Longitude");
-    p_tableWin->addToTable(false, "180 Positive West Longitude", "180 West Longitude");
-    p_tableWin->addToTable(false, "Projected X:Projected Y", "Projected X:Projected Y", -1,
-                           Qt::Horizontal, "X and Y values for a projected image");
-    p_tableWin->addToTable(false, "Local Radius", "Radius");
-    p_tableWin->addToTable(false, "Point X:Point Y:Point Z", "XYZ", -1, Qt::Horizontal,
-                           "The X, Y, and Z of surface intersection in body-fixed coordinates");
-    p_tableWin->addToTable(false, "Right Ascension:Declination", "Ra:Dec", -1, Qt::Horizontal,
-                           "Right Ascension and Declination");
-    p_tableWin->addToTable(false, "Resolution", "Resolution");
-    p_tableWin->addToTable(false, "Phase", "Phase");
-    p_tableWin->addToTable(false, "Incidence", "Incidence");
-    p_tableWin->addToTable(false, "Emission", "Emission");
-    p_tableWin->addToTable(false, "LocalIncidence", "LocalIncidence");
-    p_tableWin->addToTable(false, "LocalEmission", "LocalEmission");
-    p_tableWin->addToTable(false, "North Azimuth", "North Azimuth");
-    p_tableWin->addToTable(false, "Sun Azimuth", "Sun Azimuth");
-    p_tableWin->addToTable(false, "Solar Longitude", "Solar Longitude");
-    p_tableWin->addToTable(false, "Spacecraft X:Spacecraft Y:Spacecraft Z", "Spacecraft Position",
-                           -1, Qt::Horizontal, "The X, Y, and Z of the spacecraft position");
-    p_tableWin->addToTable(false, "Spacecraft Azimuth", "Spacecraft Azimuth");
-    p_tableWin->addToTable(false, "Slant Distance", "Slant Distance");
-    p_tableWin->addToTable(false, "Focal Plane X:Focal Plane Y", "Focal Plane X:Y");
-    p_tableWin->addToTable(false, "Undistorted Focal X:Undistorted Focal Y: Undistorted Focal Z",
-                           "Undistorted Focal Plane X:Y:Z");
-    p_tableWin->addToTable(false, "Ephemeris Time", "Ephemeris iTime");
-    p_tableWin->addToTable(false, "Local Solar Time", "Local Solar iTime");
-    p_tableWin->addToTable(false, "UTC", "UTC", -1, Qt::Horizontal, "Internal time in UTC format");
-    p_tableWin->addToTable(false, "Path", "Path");
-    p_tableWin->addToTable(false, "FileName", "FileName");
-    p_tableWin->addToTable(false, "Serial Number", "Serial Number");
-    p_tableWin->addToTable(false, "Track Mosaic Index", "Track Mosaic Index");
-    p_tableWin->addToTable(false, "Track Mosaic FileName", "Track Mosaic FileName");
-    p_tableWin->addToTable(false, "Track Mosaic Serial Number", "Track Mosaic Serial Number");
-    p_tableWin->addToTable(false, "Notes", "Notes");
-    //This variable will keep track of how many times
+    // p_tableWin->addToTable(false, "Id", "Id");
+    // p_tableWin->addToTable(true, "Sample:Line", "Sample:Line", -1,
+    //                        Qt::Horizontal, "Sample and Line");
+    // p_tableWin->addToTable(false, "Band", "Band");
+    // p_tableWin->addToTable(true, "Pixel", "Pixel");
+    // p_tableWin->addToTable(true, "Planetocentric Latitude", "Planetocentric Lat");
+    // p_tableWin->addToTable(false, "Planetographic Latitude", "Planetographic Lat");
+    // p_tableWin->addToTable(true, "360 Positive East Longitude", "360 East Longitude");
+    // p_tableWin->addToTable(false, "360 Positive West Longitude", "360 West Longitude");
+    // p_tableWin->addToTable(true, "180 Positive East Longitude", "180 East Longitude");
+    // p_tableWin->addToTable(false, "180 Positive West Longitude", "180 West Longitude");
+    // p_tableWin->addToTable(false, "Projected X:Projected Y", "Projected X:Projected Y", -1,
+    //                        Qt::Horizontal, "X and Y values for a projected image");
+    // p_tableWin->addToTable(false, "Local Radius", "Radius");
+    // p_tableWin->addToTable(false, "Point X:Point Y:Point Z", "XYZ", -1, Qt::Horizontal,
+    //                        "The X, Y, and Z of surface intersection in body-fixed coordinates");
+    // p_tableWin->addToTable(false, "Right Ascension:Declination", "Ra:Dec", -1, Qt::Horizontal,
+    //                        "Right Ascension and Declination");
+    // p_tableWin->addToTable(false, "Resolution", "Resolution");
+    // p_tableWin->addToTable(false, "Oblique Pixel Resolution", "Oblique Pixel Res");
+    // p_tableWin->addToTable(false, "Oblique Sample Resolution", "Oblique Sample Res");
+    // p_tableWin->addToTable(false, "Oblique Line Resolution", "Oblique Line Res");
+    // p_tableWin->addToTable(false, "Oblique Detector Resolution", "Oblique Detector Res");
+    // p_tableWin->addToTable(false, "Phase", "Phase");
+    // p_tableWin->addToTable(false, "Incidence", "Incidence");
+    // p_tableWin->addToTable(false, "Emission", "Emission");
+    // p_tableWin->addToTable(false, "LocalIncidence", "LocalIncidence");
+    // p_tableWin->addToTable(false, "LocalEmission", "LocalEmission");
+    // p_tableWin->addToTable(false, "North Azimuth", "North Azimuth");
+    // p_tableWin->addToTable(false, "Sun Azimuth", "Sun Azimuth");
+    // p_tableWin->addToTable(false, "Solar Longitude", "Solar Longitude");
+    // p_tableWin->addToTable(false, "Spacecraft X:Spacecraft Y:Spacecraft Z", "Spacecraft Position",
+    //                        -1, Qt::Horizontal, "The X, Y, and Z of the spacecraft position");
+    // p_tableWin->addToTable(false, "Spacecraft Azimuth", "Spacecraft Azimuth");
+    // p_tableWin->addToTable(false, "Slant Distance", "Slant Distance");
+    // p_tableWin->addToTable(false, "Focal Plane X:Focal Plane Y", "Focal Plane X:Y");
+    // p_tableWin->addToTable(false, "Undistorted Focal X:Undistorted Focal Y: Undistorted Focal Z",
+    //                        "Undistorted Focal Plane X:Y:Z");
+    // p_tableWin->addToTable(false, "Ephemeris Time", "Ephemeris iTime");
+    // p_tableWin->addToTable(false, "Local Solar Time", "Local Solar iTime");
+    // p_tableWin->addToTable(false, "UTC", "UTC", -1, Qt::Horizontal, "Internal time in UTC format");
+    // p_tableWin->addToTable(false, "Path", "Path");
+    // p_tableWin->addToTable(false, "FileName", "FileName");
+    // p_tableWin->addToTable(false, "Serial Number", "Serial Number");
+    // p_tableWin->addToTable(false, "Track Mosaic Index", "Track Mosaic Index");
+    // p_tableWin->addToTable(false, "Track Mosaic FileName", "Track Mosaic FileName");
+    // p_tableWin->addToTable(false, "Track Mosaic Serial Number", "Track Mosaic Serial Number");
+    // p_tableWin->addToTable(false, "Notes", "Notes");
+
+    // Adds each item of checkBoxItems to the table.
+    // If a tool tip is specified, we cannot skip parameters, so -1 and
+    // Qt::Horizontal are specified.
+    QList< QList<QString> >::iterator iter;
+    for (iter = checkBoxItems.begin(); iter != checkBoxItems.end(); ++iter) {
+      QList<QString> currentList = *iter;
+      QString header = currentList[0];
+      QString menuText = currentList[2];
+      QString toolTip = currentList[3];
+      bool onByDefault;
+      if (currentList[1] == QString("true")) {
+        onByDefault = true;
+      }
+      else {
+        onByDefault = false;
+      }
+
+      if (toolTip != QString("")) {
+        p_tableWin->addToTable(onByDefault, header, menuText,
+                          -1, Qt::Horizontal, toolTip);
+      }
+      else {
+        p_tableWin->addToTable(onByDefault, header, menuText);
+      }
+    }
+
+    // This variable will keep track of how many times
     // the user has issued the 'record' command.
     p_id = 0;
 
     // Setup 10 blank rows in the table
-    for(int r = 0; r < 10; r++) {
+    for (int r = 0; r < 10; r++) {
       p_tableWin->table()->insertRow(r);
-      for(int c = 0; c < p_tableWin->table()->columnCount(); c++) {
+      for (int c = 0; c < p_tableWin->table()->columnCount(); c++) {
         QTableWidgetItem *item = new QTableWidgetItem("");
         p_tableWin->table()->setItem(r, c, item);
       }
@@ -151,7 +184,7 @@ namespace Isis {
    * @return bool
    */
   bool AdvancedTrackTool::eventFilter(QObject *o, QEvent *e) {
-    if(e->type() == QEvent::Show) {
+    if (e->type() == QEvent::Show) {
       activate(true);
       if (m_showHelpOnStart) {
         helpDialog();
@@ -159,7 +192,7 @@ namespace Isis {
         writeSettings();
       }
     }
-    else if(e->type() == QEvent::Hide) {
+    else if (e->type() == QEvent::Hide) {
       activate(false);
     }
     return Tool::eventFilter(o, e);
@@ -202,8 +235,8 @@ namespace Isis {
    */
   void AdvancedTrackTool::mouseLeave() {
 
-    if(cubeViewport()->isLinked()) {
-      for(int i = 0; i < p_numRows; i++) {
+    if (cubeViewport()->isLinked()) {
+      for (int i = 0; i < p_numRows; i++) {
         p_tableWin->clearRow(i + p_tableWin->currentRow());
       }
     }
@@ -220,23 +253,41 @@ namespace Isis {
    */
   void AdvancedTrackTool::updateRow(QPoint p) {
     MdiCubeViewport *cvp = cubeViewport();
-    if(cvp == NULL) {
+    if (cvp == NULL) {
       p_tableWin->clearRow(p_tableWin->currentRow());
       return;
     }
 
-    if(!cubeViewport()->isLinked()) {
+    if (!cubeViewport()->isLinked()) {
       updateRow(cvp, p, p_tableWin->currentRow());
       p_numRows = 1;
     }
     else {
       p_numRows = 0;
-      for(int i = 0; i < (int)cubeViewportList()->size(); i++) {
+      for (int i = 0; i < (int)cubeViewportList()->size(); i++) {
         MdiCubeViewport *d = (*(cubeViewportList()))[i];
-        if(d->isLinked()) {
+        if (d->isLinked()) {
           updateRow(d, p, p_tableWin->currentRow() + p_numRows);
           p_numRows++;
         }
+      }
+    }
+  }
+
+    int AdvancedTrackTool::getIndex(QString keyword) {
+      int index = 0;
+      QList< QList<QString> >::iterator iter;
+      for (iter = checkBoxItems.begin(); iter != checkBoxItems.end(); ++iter) {
+        QList<QString> currentList = *iter;
+
+        QList<QString> splitHeader = currentList[0].split(":");
+        QList<QString>::iterator headerIter;
+        for (headerIter = splitHeader.begin(); headerIter != splitHeader.end(); ++headerIter) {
+          QString header = *headerIter;
+          if (header.toLower() == keyword.toLower()) {
+            return index;
+          }
+          index++;
       }
     }
   }
@@ -257,179 +308,216 @@ namespace Isis {
 
     /*if there are linked cvp's then we want to highlight (select)
     the row of the active cvp.*/
-    if(cvp->isLinked()) {
+    if (cvp->isLinked()) {
 
-      if(cvp == cubeViewport()) {
+      if (cvp == cubeViewport()) {
         p_tableWin->table()->selectRow(row);
       }
 
     }
 
-
     // Do we need more rows?
-    if(row + 1 > p_tableWin->table()->rowCount()) {
+    if (row + 1 > p_tableWin->table()->rowCount()) {
       p_tableWin->table()->insertRow(row);
-      for(int c = 0; c < p_tableWin->table()->columnCount(); c++) {
+      for (int c = 0; c < p_tableWin->table()->columnCount(); c++) {
         QTableWidgetItem *item = new QTableWidgetItem("");
         p_tableWin->table()->setItem(row, c, item);
-        if(c == 0) p_tableWin->table()->scrollToItem(item);
+        if (c == 0) p_tableWin->table()->scrollToItem(item);
       }
     }
 
     // Blank out the row to remove stuff left over from previous cvps
-    for(int c = 0; c < p_tableWin->table()->columnCount(); c++) {
+    for (int c = 0; c < p_tableWin->table()->columnCount(); c++) {
       p_tableWin->table()->item(row, c)->setText("");
     }
 
     // Don't write anything if we are outside the cube
-    if(sample < 0.5) return;
-    if(line < 0.5) return;
-    if(sample > cvp->cubeSamples() + 0.5) return;
-    if(line > cvp->cubeLines() + 0.5) return;
+    if (sample < 0.5) return;
+    if (line < 0.5) return;
+    if (sample > cvp->cubeSamples() + 0.5) return;
+    if (line > cvp->cubeLines() + 0.5) return;
 
     // Write cols 0-2 (id, sample, line)
-    p_tableWin->table()->item(row, ID)->setText(QString::number(p_id));
-    p_tableWin->table()->item(row, SAMPLE)->setText(QString::number(sample));
-    p_tableWin->table()->item(row, LINE)->setText(QString::number(line));
+    p_tableWin->table()->item(row, getIndex("Id"))->setText(QString::number(p_id));
+    p_tableWin->table()->item(row, getIndex("Sample"))->setText(QString::number(sample));
+    p_tableWin->table()->item(row, getIndex("Line"))->setText(QString::number(line));
 
     // Write col 3 (band)
-    if(cvp->isGray()) {
-      p_tableWin->table()->item(row, BAND)->setText(QString::number(cvp->grayBand()));
+    if (cvp->isGray()) {
+      p_tableWin->table()->item(row, getIndex("Band"))->setText(QString::number(cvp->grayBand()));
     }
     else {
-      p_tableWin->table()->item(row, BAND)->setText(QString::number(cvp->redBand()));
+      p_tableWin->table()->item(row, getIndex("Band"))->setText(QString::number(cvp->redBand()));
     }
 
     // Write out the path, filename, and serial number
     FileName fname = FileName(cvp->cube()->fileName()).expanded();
     QString fnamePath = fname.path();
     QString fnameName = fname.name();
-    p_tableWin->table()->item(row, PATH)->setText(fnamePath);
-    p_tableWin->table()->item(row, FILENAME)->setText(fnameName);
+    p_tableWin->table()->item(row, getIndex("Path"))->setText(fnamePath);
+    p_tableWin->table()->item(row, getIndex("FileName"))->setText(fnameName);
     //p_tableWin->table()->item(row,34)->setText(SerialNumber::Compose(*cvp->cube()).c_str());
 
     // If we are outside of the image then we are done
-    if((sample < 0.5) || (line < 0.5) ||
+    if ((sample < 0.5) || (line < 0.5) ||
         (sample > cvp->cubeSamples() + 0.5) ||
         (line > cvp->cubeLines() + 0.5)) {
       return;
     }
 
     // Otherwise write out col 4 (Pixel value)
-    if(cvp->isGray()) {
+    if (cvp->isGray()) {
       QString grayPixel = PixelToString(cvp->grayPixel(isample, iline));
       QString p = grayPixel;
-      p_tableWin->table()->item(row, PIXEL)->setText(p);
+      p_tableWin->table()->item(row, getIndex("Pixel"))->setText(p);
     }
     else {
       QString redPixel = PixelToString(cvp->redPixel(isample, iline));
       QString p = redPixel;
-      p_tableWin->table()->item(row, PIXEL)->setText(p);
+      p_tableWin->table()->item(row, getIndex("Pixel"))->setText(p);
     }
 
     // Do we have a camera model?
-    if(cvp->camera() != NULL) {
-      if(cvp->camera()->SetImage(sample, line)) {
+    if (cvp->camera() != NULL) {
+      if (cvp->camera()->SetImage(sample, line)) {
         // Write columns ocentric lat/lon, and radius, only if set image succeeds
         double lat = cvp->camera()->UniversalLatitude();
         double lon = cvp->camera()->UniversalLongitude();
 
         double radius = cvp->camera()->LocalRadius().meters();
-        p_tableWin->table()->item(row, PLANETOCENTRIC_LAT)->setText(QString::number(lat, 'f', 15));
-        p_tableWin->table()->item(row, EAST_LON_360)->setText(QString::number(lon, 'f', 15));
-        p_tableWin->table()->item(row, RADIUS)->setText(QString::number(radius, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Planetocentric Latitude"))->setText(QString::number(lat, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("360 Positive East Longitude"))->setText(QString::number(lon, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Local Radius"))->setText(QString::number(radius, 'f', 15));
 
         /* 180 Positive East Lon. */
-        p_tableWin->table()->item(row, EAST_LON_180)->
+        p_tableWin->table()->item(row, getIndex("180 Positive East Longitude"))->
                              setText(QString::number(TProjection::To180Domain(lon), 'f', 15));
 
         // Write out the planetographic and positive west values, only if set image succeeds
         lon = -lon;
-        while(lon < 0.0) lon += 360.0;
+        while (lon < 0.0) lon += 360.0;
         Distance radii[3];
         cvp->camera()->radii(radii);
         lat = TProjection::ToPlanetographic(lat, radii[0].meters(), radii[2].meters());
-        p_tableWin->table()->item(row, PLANETOGRAPHIC_LAT)->setText(QString::number(lat, 'f', 15));
-        p_tableWin->table()->item(row, WEST_LON_360)->setText(QString::number(lon, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("Planetographic Latitude"))->setText(QString::number(lat, 'f', 15));
+        p_tableWin->table()->item(row, getIndex("360 Positive West Longitude"))->setText(QString::number(lon, 'f', 15));
 
         /*180 Positive West Lon.  */
-        p_tableWin->table()->item(row, WEST_LON_180)->setText(
+        p_tableWin->table()->item(row, getIndex("180 Positive West Longitude"))->setText(
                                   QString::number(TProjection::To180Domain(lon), 'f', 15));
 
         // Next write out columns, the x/y/z position of the lat/lon, only if set image succeeds
         double pos[3];
         cvp->camera()->Coordinate(pos);
-        p_tableWin->table()->item(row, POINT_X)->setText(QString::number(pos[0]));
-        p_tableWin->table()->item(row, POINT_Y)->setText(QString::number(pos[1]));
-        p_tableWin->table()->item(row, POINT_Z)->setText(QString::number(pos[2]));
+        p_tableWin->table()->item(row, getIndex("Point X"))->setText(QString::number(pos[0]));
+        p_tableWin->table()->item(row, getIndex("Point Y"))->setText(QString::number(pos[1]));
+        p_tableWin->table()->item(row, getIndex("Point Z"))->setText(QString::number(pos[2]));
 
         // Write out columns resolution, only if set image succeeds
-        if (cvp->camera()->PixelResolution() != -1.0) {
-          double res = cvp->camera()->PixelResolution();
-          p_tableWin->table()->item(row, RESOLUTION)->setText(QString::number(res));
+        double res = cvp->camera()->PixelResolution();
+        if (res != -1.0) {
+          p_tableWin->table()->item(row, getIndex("Resolution"))->setText(QString::number(res));
         }
         else {
-          p_tableWin->table()->item(row, RESOLUTION)->setText("");
+          p_tableWin->table()->item(row, getIndex("Resolution"))->setText("");
+        }
+
+        // Write out columns, oblique pixel resolution, only if set image succeeds
+        double obliquePRes = cvp->camera()->ObliquePixelResolution();
+        if (obliquePRes != Isis::Null) {
+          p_tableWin->table()->item(row, getIndex("Oblique Pixel Resolution"))->setText(QString::number(obliquePRes));
+        }
+        else {
+          p_tableWin->table()->item(row, getIndex("Oblique Pixel Resolution"))->setText("");
+        }
+
+        // Write out columns, oblique sample resolution, only if set image succeeds
+        double obliqueSRes = cvp->camera()->ObliqueSampleResolution();
+        if (obliqueSRes != Isis::Null) {
+          p_tableWin->table()->item(row, getIndex("Oblique Sample Resolution"))->setText(QString::number(obliqueSRes));
+        }
+        else {
+          p_tableWin->table()->item(row, getIndex("Oblique Sample Resolution"))->setText("");
+        }
+
+        // Write out columns, oblique line resolution, only if set image succeeds
+        double obliqueLRes = cvp->camera()->ObliqueLineResolution();
+        if (obliqueLRes != Isis::Null) {
+          p_tableWin->table()->item(row, getIndex("Oblique Line Resolution"))->setText(QString::number(obliqueLRes));
+        }
+        else {
+          p_tableWin->table()->item(row, getIndex("Oblique Line Resolution"))->setText("");
+        }
+
+        // Write out columns, oblique detector resolution, only if set image succeeds
+        double obliqueDRes = cvp->camera()->ObliqueDetectorResolution();
+        if (obliqueDRes != Isis::Null) {
+          p_tableWin->table()->item(row, getIndex("Oblique Detector Resolution"))->setText(QString::number(obliqueDRes));
+        }
+        else {
+          p_tableWin->table()->item(row, getIndex("Oblique Detector Resolution"))->setText("");
         }
 
         // Write out columns photometric angle values, only if set image succeeds
         double phase = cvp->camera()->PhaseAngle();
-        p_tableWin->table()->item(row, PHASE)->setText(QString::number(phase));
+        p_tableWin->table()->item(row, getIndex("Phase"))->setText(QString::number(phase));
         double incidence = cvp->camera()->IncidenceAngle();
-        p_tableWin->table()->item(row, INCIDENCE)->setText(QString::number(incidence));
+        p_tableWin->table()->item(row, getIndex("Incidence"))->setText(QString::number(incidence));
         double emission = cvp->camera()->EmissionAngle();
-        p_tableWin->table()->item(row, EMISSION)->setText(QString::number(emission));
+        p_tableWin->table()->item(row, getIndex("Emission"))->setText(QString::number(emission));
 
         // Write out columns local incidence and emission, only if set image
         // succeeds.  This might fail if there are holes in the DEM.
         // Calculates the angles local to the slope for the DEMs, compare against
         // the incidence and emission angles calculated for the sphere
         Angle phaseAngle, incidenceAngle, emissionAngle;
-        bool bSuccess=false;
+        bool bSuccess = false;
         cvp->camera()->LocalPhotometricAngles(phaseAngle, incidenceAngle, emissionAngle, bSuccess);
-        if(bSuccess) {
-          p_tableWin->table()->item(row, LOCAL_INCIDENCE)->
+        if (bSuccess) {
+          p_tableWin->table()->item(row, getIndex("LocalIncidence"))->
                                setText(QString::number(incidenceAngle.degrees()));
-          p_tableWin->table()->item(row, LOCAL_EMISSION)->
+          p_tableWin->table()->item(row, getIndex("LocalEmission"))->
                                setText(QString::number(emissionAngle.degrees()));
         }
         else {
-          p_tableWin->table()->item(row, LOCAL_INCIDENCE)->setText("");
-          p_tableWin->table()->item(row, LOCAL_EMISSION)->setText("");
+          p_tableWin->table()->item(row, getIndex("LocalIncidence"))->setText("");
+          p_tableWin->table()->item(row, getIndex("LocalEmission"))->setText("");
         }
 
         // If set image succeeds, write out columns north azimuth, sun azimuth, solar longitude
         // north azimuth is meaningless for ring plane projections
+        double northAzi = cvp->camera()->NorthAzimuth();
         if (cvp->camera()->target()->shape()->name() != "Plane"
-            && Isis::IsValidPixel(cvp->camera()->NorthAzimuth())) {
-          double northAzi = cvp->camera()->NorthAzimuth();
-          p_tableWin->table()->item(row, NORTH_AZIMUTH)->setText(QString::number(northAzi));
+            && Isis::IsValidPixel(northAzi)) {
+          p_tableWin->table()->item(row, getIndex("North Azimuth"))->setText(QString::number(northAzi));
         }
         else { // north azimuth is meaningless for ring plane projections
-          p_tableWin->table()->item(row, NORTH_AZIMUTH)->setText("");
+          p_tableWin->table()->item(row, getIndex("North Azimuth"))->setText("");
         }
-        if (Isis::IsValidPixel(cvp->camera()->SunAzimuth())) {
-          double sunAzi   = cvp->camera()->SunAzimuth();
-          p_tableWin->table()->item(row, SUN_AZIMUTH)->setText(QString::number(sunAzi));
+
+        double sunAzi = cvp->camera()->SunAzimuth();
+        if (Isis::IsValidPixel(sunAzi)) {
+          p_tableWin->table()->item(row, getIndex("Sun Azimuth"))->setText(QString::number(sunAzi));
         }
         else { // sun azimuth is null
-          p_tableWin->table()->item(row, SUN_AZIMUTH)->setText("");
+          p_tableWin->table()->item(row, getIndex("Sun Azimuth"))->setText("");
         }
-        if (Isis::IsValidPixel(cvp->camera()->SpacecraftAzimuth())) {
-          double spacecraftAzi = cvp->camera()->SpacecraftAzimuth();
-          p_tableWin->table()->item(row, SPACECRAFT_AZIMUTH)->setText(QString::number(spacecraftAzi));
+
+        double spacecraftAzi = cvp->camera()->SpacecraftAzimuth();
+        if (Isis::IsValidPixel(spacecraftAzi)) {
+          p_tableWin->table()->item(row, getIndex("Spacecraft Azimuth"))->setText(QString::number(spacecraftAzi));
         }
         else { // spacecraft azimuth is null
-          p_tableWin->table()->item(row, SPACECRAFT_AZIMUTH)->setText("");
+          p_tableWin->table()->item(row, getIndex("Spacecraft Azimuth"))->setText("");
         }
 
         // Write out columns solar lon, slant distance, local solar time
         double solarLon = cvp->camera()->solarLongitude().degrees();
-        p_tableWin->table()->item(row, SOLAR_LON)->setText(QString::number(solarLon));
+        p_tableWin->table()->item(row, getIndex("Solar Longitude"))->setText(QString::number(solarLon));
         double slantDistance = cvp->camera()->SlantDistance();
-        p_tableWin->table()->item(row, SLANT)->setText(QString::number(slantDistance));
+        p_tableWin->table()->item(row, getIndex("Slant Distance"))->setText(QString::number(slantDistance));
         double lst = cvp->camera()->LocalSolarTime();
-        p_tableWin->table()->item(row, SOLAR_TIME)->setText(QString::number(lst));
+        p_tableWin->table()->item(row, getIndex("Local Solar Time"))->setText(QString::number(lst));
       } // end if set image succeeds
 
       // Always write out the x/y/z of the undistorted focal plane
@@ -480,7 +568,7 @@ namespace Isis {
 
           double glat = tproj->ToPlanetographic(lat);
           double wlon = -lon;
-          while(wlon < 0.0) wlon += 360.0;
+          while (wlon < 0.0) wlon += 360.0;
           if (tproj->IsSky()) {
             lon = tproj->Longitude();
             p_tableWin->table()->item(row, RIGHT_ASCENSION)->setText(QString::number(lon, 'f', 15));
@@ -508,7 +596,7 @@ namespace Isis {
           double lon = rproj->UniversalRingLongitude();
 
           double wlon = -lon;
-          while(wlon < 0.0) wlon += 360.0;
+          while (wlon < 0.0) wlon += 360.0;
           double radius = lat;
           p_tableWin->table()->item(row, PLANETOCENTRIC_LAT)->setText("0.0");
           p_tableWin->table()->item(row, PLANETOGRAPHIC_LAT)->setText("0.0");
@@ -525,8 +613,8 @@ namespace Isis {
     }
 
     //If there is a projection add the Projected X and Y coords to the table
-    if(cvp->projection() != NULL) {
-      if(cvp->projection()->SetWorld(sample, line)) {
+    if (cvp->projection() != NULL) {
+      if (cvp->projection()->SetWorld(sample, line)) {
         double projX = cvp->projection()->XCoord();
         double projY = cvp->projection()->YCoord();
         p_tableWin->table()->item(row, PROJECTED_X)->setText(QString::number(projX, 'f', 15));
@@ -569,21 +657,21 @@ namespace Isis {
         Cube *cCube = cvp->cube();
         int iTrackBand = -1;
 
-        if(cCube->hasTable(TABLE_MOSAIC_SRC)) {
+        if (cCube->hasTable(TABLE_MOSAIC_SRC)) {
           Pvl *cPvl = cCube->label();
           PvlObject cObjIsisCube = cPvl->findObject("IsisCube");
           PvlGroup cGrpBandBin = cObjIsisCube.findGroup("BandBin");
-          for(int i = 0; i < cGrpBandBin.keywords(); i++) {
+          for (int i = 0; i < cGrpBandBin.keywords(); i++) {
             PvlKeyword &cKeyTrackBand = cGrpBandBin[i];
-            for(int j = 0; j < cKeyTrackBand.size(); j++) {
-              if(cKeyTrackBand[j] == "TRACKING") {
+            for (int j = 0; j < cKeyTrackBand.size(); j++) {
+              if (cKeyTrackBand[j] == "TRACKING") {
                 iTrackBand = j;
                 break;
               }
             }
           }
 
-          if(iTrackBand > 0 && iTrackBand <= cCube->bandCount()) {
+          if (iTrackBand > 0 && iTrackBand <= cCube->bandCount()) {
             Portal cOrgPortal(cCube->sampleCount(), 1,
                               cCube->pixelType());
             cOrgPortal.SetPosition(piSample, piLine, iTrackBand + 1); // 1 based
@@ -607,7 +695,7 @@ namespace Isis {
             Table cFileTable(TABLE_MOSAIC_SRC);
             cCube->read(cFileTable);
             int iRecs =   cFileTable.Records();
-            if(piOrigin >= 0 && piOrigin < iRecs) {
+            if (piOrigin >= 0 && piOrigin < iRecs) {
               psSrcFileName = QString(cFileTable[piOrigin][0]);
               psSrcSerialNum = QString(cFileTable[piOrigin][1]);
             }
@@ -679,18 +767,18 @@ namespace Isis {
    *
    */
   void AdvancedTrackTool::record() {
-    if(p_tableWin->table()->isHidden()) return;
-    if(p_tableWin->table()->item(p_tableWin->currentRow(), 0)->text() == "") return;
+    if (p_tableWin->table()->isHidden()) return;
+    if (p_tableWin->table()->item(p_tableWin->currentRow(), 0)->text() == "") return;
 
     int row = 0;
     p_tableWin->setCurrentRow(p_tableWin->currentRow() + p_numRows);
     p_tableWin->setCurrentIndex(p_tableWin->currentIndex() + p_numRows);
-    while(p_tableWin->currentRow() >= p_tableWin->table()->rowCount()) {
+    while (p_tableWin->currentRow() >= p_tableWin->table()->rowCount()) {
 
       row = p_tableWin->table()->rowCount();
 
       p_tableWin->table()->insertRow(row);
-      for(int c = 0; c < p_tableWin->table()->columnCount(); c++) {
+      for (int c = 0; c < p_tableWin->table()->columnCount(); c++) {
         QTableWidgetItem *item = new QTableWidgetItem("");
         p_tableWin->table()->setItem(row, c, item);
       }
@@ -736,10 +824,12 @@ namespace Isis {
    */
   void AdvancedTrackTool::updateID() {
     //Check if the current row is 0
-    if(p_tableWin->currentRow() == 0)
+    if (p_tableWin->currentRow() == 0) {
       p_id = 0;
-    else
+    }
+    else {
       p_id = p_tableWin->table()->item(p_tableWin->currentRow() - 1, ID)->text().toInt() + 1;
+    }
   }
 
 

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
@@ -228,10 +228,10 @@ namespace Isis {
     /**
      * This method finds the index of the header in checkBoxItems by looping
      * through checkBoxItems, grabbing the header from each QList, and parsing
-     * the header at ":" to account for check boxes turning on multiple columns
+     * the header at ":" to account for check boxes selecting multiple columns.
      *
      * @param keyword Header to be found
-     * @return int
+     * @return int The index of the item to be added
      */
     int AdvancedTrackTool::getIndex(QString keyword) {
       int index = 0;

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
@@ -85,8 +85,12 @@ namespace Isis {
    *                          before it attempts to record a point so that a table is created
    *                          to record the point into so that the first recorded point is drawn.
    *                          Fixes #5143.
-   *  @history 2018-03-07 Kaitlyn Lee - Added columns for oblique pixel,
-   *                      sample, line, and detector resolutions. Fixes #4100.
+   *  @history 2018-03-07 Kaitlyn Lee - Added columns for oblique pixel, sample, line,
+`   *                         and detector resolutions. Added checkBoxItems and loop to add
+   *                          the elments to the AdvancedTrackTool, instead of hardcoded method
+   *                          calls. Instead of using the enum, I added a method getIndex()
+   *                          that calculates what column the element should be added to.
+   *                          Fixes #4100.`
    */
   class AdvancedTrackTool : public Tool {
       Q_OBJECT
@@ -96,7 +100,7 @@ namespace Isis {
       void addTo(QMenu *menu);
       void addToPermanent(QToolBar *perm);
       bool eventFilter(QObject *o, QEvent *e);
-      int getindex(QString keyword);
+      int getIndex(QString keyword);
 
     public slots:
       virtual void mouseMove(QPoint p);
@@ -133,7 +137,7 @@ namespace Isis {
       // New entries can be added anywhere in the QList.
       // Format: QList<QString>({<Header>, <onByDefault>, <menuText>, <toolTip>}) <<
       // If a toolTip is not needed, use "".
-      QList<QList<QString> > checkBoxItems = QList<QList<QString> >() <<
+      QList<QList<QString> > checkBoxItems = QList< QList<QString> >() <<
         QList<QString>({"Id", "false", "Id", ""}) <<
         QList<QString>({"Sample:Line", "true", "Sample:Line", ""}) <<
         QList<QString>({"Band", "false", "Band", ""}) <<
@@ -169,7 +173,7 @@ namespace Isis {
         QList<QString>({"Spacecraft Azimuth", "false", "Spacecraft Azimuth", ""}) <<
         QList<QString>({"Slant Distance", "false", "Slant Distance", ""}) <<
         QList<QString>({"Focal Plane X:Focal Plane Y", "false", "Focal Plane X:Y", ""}) <<
-        QList<QString>({"Undistorted Focal X:Undistorted Focal Y: Undistorted Focal Z",
+        QList<QString>({"Undistorted Focal X:Undistorted Focal Y:Undistorted Focal Z",
                            "false", "Undistorted Focal Plane X:Y:Z", ""}) <<
         QList<QString>({"Ephemeris Time", "false", "Ephemeris iTime", ""}) <<
         QList<QString>({"Local Solar Time", "false", "Local Solar iTime", ""}) <<
@@ -185,60 +189,60 @@ namespace Isis {
       /**
        * Enum for column values
        */
-      enum {
-        ID,                     //!< The record ID
-        SAMPLE,                 //!< The current sample
-        LINE,                   //!< The current line
-        BAND,                   //!< The current band
-        PIXEL,                  //!< The current pixel
-        PLANETOCENTRIC_LAT,     //!< The planetocentric latitude for this point
-        PLANETOGRAPHIC_LAT,     //!< The planetographic latitude for this point
-        EAST_LON_360,           //!< The 360 east longitude for this point
-        WEST_LON_360,           //!< The 360 west longitude for this point
-        EAST_LON_180,           //!< The 180 east longitude for this point
-        WEST_LON_180,           //!< The 180 west longitude for this point
-        PROJECTED_X,            //!< Projected X value for valid projections
-        PROJECTED_Y,            //!< Projected Y value for valid projections
-        RADIUS,                 //!< The radius for this point
-        POINT_X,                //!< The x value for this point
-        POINT_Y,                //!< The y value for this point
-        POINT_Z,                //!< The z value for this point
-        RIGHT_ASCENSION,        //!< The right ascension for this point
-        DECLINATION,            //!< The declination for this point
-        RESOLUTION,             //!< The resoultion for this point
-        OBLIQUE_PIXEL_RES,      //!< The oblique pixel resolution
-        OBLIQUE_SAMPLE_RES,     //!< The oblique sample resolution
-        OBLIQUE_LINE_RES,       //!< The oblique line resolution
-        OBLIQUE_DETECTOR_RES,   //!< The oblique detector resolution
-        PHASE,                  //!< The phase for this point
-        INCIDENCE,              //!< The incidence for this point
-        EMISSION,               //!< The emission for this point
-        LOCAL_INCIDENCE,        //!< The local incidence for this point
-        LOCAL_EMISSION,         //!< The local emission for this point
-        NORTH_AZIMUTH,          //!< The north azimuth for this cube
-        SUN_AZIMUTH,            //!< The sun azimuth for this cube
-        SOLAR_LON,              //!< The solar longitude for this point
-        SPACECRAFT_X,           //!< The spacecraft x position for this cube
-        SPACECRAFT_Y,           //!< The spacecraft y position for this cube
-        SPACECRAFT_Z,           //!< The spacecraft z position for this cube
-        SPACECRAFT_AZIMUTH,     //!< The spacecraft azimuth for this cube
-        SLANT,                  //!< The slant for this cube
-        DISTORTED_FOCAL_X,      //!< The x of the distorted focal plane
-        DISTORTED_FOCAL_Y,      //!< The y of the distorted focal plane
-        UNDISTORTED_FOCAL_X,    //!< The x of the undistorted focal plane
-        UNDISTORTED_FOCAL_Y,    //!< The y of the undistorted focal plane
-        UNDISTORTED_FOCAL_Z,    //!< The z of the undistorted focal plane
-        EPHEMERIS_TIME,         //!< The ephemeris time for this cube
-        SOLAR_TIME,             //!< The local solar time for this cube
-        UTC,                    //!< The UTC for this cube
-        PATH,                   //!< The path for this cube
-        FILENAME,               //!< The filename for this cube
-        SERIAL_NUMBER,          //!< The serial number for this cube
-        TRACK_MOSAIC_INDEX,     //!< Track the origin of the Mosaic, display the zero based index
-        TRACK_MOSAIC_FILENAME,  //!< Track the origin of the Mosaic, display file name
-        TRACK_MOSAIC_SERIAL_NUM,//!< Track the origin of the Mosaic, display file name
-        NOTES                   //!< Any notes for this record
-      };
+      // enum {
+      //   ID,                     //!< The record ID
+      //   SAMPLE,                 //!< The current sample
+      //   LINE,                   //!< The current line
+      //   BAND,                   //!< The current band
+      //   PIXEL,                  //!< The current pixel
+      //   PLANETOCENTRIC_LAT,     //!< The planetocentric latitude for this point
+      //   PLANETOGRAPHIC_LAT,     //!< The planetographic latitude for this point
+      //   EAST_LON_360,           //!< The 360 east longitude for this point
+      //   WEST_LON_360,           //!< The 360 west longitude for this point
+      //   EAST_LON_180,           //!< The 180 east longitude for this point
+      //   WEST_LON_180,           //!< The 180 west longitude for this point
+      //   PROJECTED_X,            //!< Projected X value for valid projections
+      //   PROJECTED_Y,            //!< Projected Y value for valid projections
+      //   RADIUS,                 //!< The radius for this point
+      //   POINT_X,                //!< The x value for this point
+      //   POINT_Y,                //!< The y value for this point
+      //   POINT_Z,                //!< The z value for this point
+      //   RIGHT_ASCENSION,        //!< The right ascension for this point
+      //   DECLINATION,            //!< The declination for this point
+      //   RESOLUTION,             //!< The resoultion for this point
+      //   OBLIQUE_PIXEL_RES,      //!< The oblique pixel resolution
+      //   OBLIQUE_SAMPLE_RES,     //!< The oblique sample resolution
+      //   OBLIQUE_LINE_RES,       //!< The oblique line resolution
+      //   OBLIQUE_DETECTOR_RES,   //!< The oblique detector resolution
+      //   PHASE,                  //!< The phase for this point
+      //   INCIDENCE,              //!< The incidence for this point
+      //   EMISSION,               //!< The emission for this point
+      //   LOCAL_INCIDENCE,        //!< The local incidence for this point
+      //   LOCAL_EMISSION,         //!< The local emission for this point
+      //   NORTH_AZIMUTH,          //!< The north azimuth for this cube
+      //   SUN_AZIMUTH,            //!< The sun azimuth for this cube
+      //   SOLAR_LON,              //!< The solar longitude for this point
+      //   SPACECRAFT_X,           //!< The spacecraft x position for this cube
+      //   SPACECRAFT_Y,           //!< The spacecraft y position for this cube
+      //   SPACECRAFT_Z,           //!< The spacecraft z position for this cube
+      //   SPACECRAFT_AZIMUTH,     //!< The spacecraft azimuth for this cube
+      //   SLANT,                  //!< The slant for this cube
+      //   DISTORTED_FOCAL_X,      //!< The x of the distorted focal plane
+      //   DISTORTED_FOCAL_Y,      //!< The y of the distorted focal plane
+      //   UNDISTORTED_FOCAL_X,    //!< The x of the undistorted focal plane
+      //   UNDISTORTED_FOCAL_Y,    //!< The y of the undistorted focal plane
+      //   UNDISTORTED_FOCAL_Z,    //!< The z of the undistorted focal plane
+      //   EPHEMERIS_TIME,         //!< The ephemeris time for this cube
+      //   SOLAR_TIME,             //!< The local solar time for this cube
+      //   UTC,                    //!< The UTC for this cube
+      //   PATH,                   //!< The path for this cube
+      //   FILENAME,               //!< The filename for this cube
+      //   SERIAL_NUMBER,          //!< The serial number for this cube
+      //   TRACK_MOSAIC_INDEX,     //!< Track the origin of the Mosaic, display the zero based index
+      //   TRACK_MOSAIC_FILENAME,  //!< Track the origin of the Mosaic, display file name
+      //   TRACK_MOSAIC_SERIAL_NUM,//!< Track the origin of the Mosaic, display file name
+      //   NOTES                   //!< Any notes for this record
+      // };
       QAction *p_action;                   //!< Action to bring up the track tool
       int p_numRows;                       //!< The number of rows in the table
       int p_id;                            //!< The record id

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
@@ -24,6 +24,9 @@
 
 // The only includes allowed in this file are the direct parents of this class!
 #include "Tool.h"
+#include <QList>
+#include <QString>
+using namespace std;
 
 class QAction;
 
@@ -82,6 +85,8 @@ namespace Isis {
    *                          before it attempts to record a point so that a table is created
    *                          to record the point into so that the first recorded point is drawn.
    *                          Fixes #5143.
+   *  @history 2018-03-07 Kaitlyn Lee - Added columns for oblique pixel,
+   *                      sample, line, and detector resolutions. Fixes #4100.
    */
   class AdvancedTrackTool : public Tool {
       Q_OBJECT
@@ -91,6 +96,7 @@ namespace Isis {
       void addTo(QMenu *menu);
       void addToPermanent(QToolBar *perm);
       bool eventFilter(QObject *o, QEvent *e);
+      int getindex(QString keyword);
 
     public slots:
       virtual void mouseMove(QPoint p);
@@ -123,6 +129,60 @@ namespace Isis {
       void writeSettings();
       QString settingsFilePath() const;
 
+      // Used to store information about each check box to later add to the table
+      // New entries can be added anywhere in the map.
+      // Format: {<Header>, {<onByDefault>, <menuText>, <toolTip>}}
+      // If a toolTip is not needed, use "".
+
+      QList<QList<QString> > checkBoxItems = QList<QList<QString> >()<<
+        QList<QString>({"Id", "false", "Id", ""})<<
+        QList<QString>({"Sample:Line", "true", "Sample:Line", ""})<<
+        QList<QString>({"Band", "false", "Band", ""})<<
+        QList<QString>({"Pixel", "true", "Pixel", ""})<<
+        QList<QString>({"Planetocentric Latitude", "true", "Planetocentric Lat", ""})<<
+        QList<QString>({"Planetographic Latitude", "false", "Planetographic Lat", ""})<<
+        QList<QString>({"360 Positive East Longitude", "true", "360 East Longitude", ""})<<
+        QList<QString>({"360 Positive West Longitude", "false", "360 West Longitude", ""})<<
+        QList<QString>({"180 Positive East Longitude", "true", "180 East Longitude", ""})<<
+        QList<QString>({"180 Positive West Longitude", "false", "180 West Longitude", ""})<<
+        QList<QString>({"Projected X:Projected Y", "false", "Projected X:Projected Y",
+                         "X and Y values for a projected image"})<<
+        QList<QString>({"Local Radius", "false", "Radius", ""})<<
+        QList<QString>({"Point X:Point Y:Point Z", "false", "XYZ",
+                         "The X, Y, and Z of surface intersection in body-fixed coordinates"})<<
+        QList<QString>({"Right Ascension:Declination", "false", "Ra:Dec",
+                         "Right Ascension and Declination"})<<
+        QList<QString>({"Resolution", "false", "Resolution", ""})<<
+        QList<QString>({"Oblique Pixel Resolution", "false", "Oblique Pixel Res", ""})<<
+        QList<QString>({"Oblique Sample Resolution", "false", "Oblique Sample Res", ""})<<
+        QList<QString>({"Oblique Line Resolution", "false", "Oblique Line Res", ""})<<
+        QList<QString>({"Oblique Detector Resolution", "false", "Oblique Detector Res", ""})<<
+        QList<QString>({"Phase", "false", "Phase", ""})<<
+        QList<QString>({"Incidence", "false", "Incidence", ""})<<
+        QList<QString>({"Emission", "false", "Emission", ""})<<
+        QList<QString>({"LocalIncidence", "false", "LocalIncidence", ""})<<
+        QList<QString>({"LocalEmission", "false", "LocalEmission", ""})<<
+        QList<QString>({"North Azimuth", "false", "North Azimuth", ""})<<
+        QList<QString>({"Sun Azimuth", "false", "Sun Azimuth", ""})<<
+        QList<QString>({"Solar Longitude", "false", "Solar Longitude", ""})<<
+        QList<QString>({"Spacecraft X:Spacecraft Y:Spacecraft Z", "false", "Spacecraft Position",
+                           "The X, Y, and Z of the spacecraft position"})<<
+        QList<QString>({"Spacecraft Azimuth", "false", "Spacecraft Azimuth", ""})<<
+        QList<QString>({"Slant Distance", "false", "Slant Distance", ""})<<
+        QList<QString>({"Focal Plane X:Focal Plane Y", "false", "Focal Plane X:Y", ""})<<
+        QList<QString>({"Undistorted Focal X:Undistorted Focal Y: Undistorted Focal Z",
+                           "false", "Undistorted Focal Plane X:Y:Z", ""})<<
+        QList<QString>({"Ephemeris Time", "false", "Ephemeris iTime", ""})<<
+        QList<QString>({"Local Solar Time", "false", "Local Solar iTime", ""})<<
+        QList<QString>({"UTC", "false", "UTC", "Internal time in UTC format"})<<
+        QList<QString>({"Path", "false", "Path", ""})<<
+        QList<QString>({"FileName", "false", "FileName", ""})<<
+        QList<QString>({"Serial Number", "false", "Serial Number", ""})<<
+        QList<QString>({"Track Mosaic Index", "false", "Track Mosaic Index", ""})<<
+        QList<QString>({"Track Mosaic FileName", "false", "Track Mosaic FileName", ""})<<
+        QList<QString>({"Track Mosaic Serial Number", "false", "Track Mosaic Serial Number", ""})<<
+        QList<QString>({"Notes", "false", "Notes", ""});
+
       /**
        * Enum for column values
        */
@@ -147,6 +207,10 @@ namespace Isis {
         RIGHT_ASCENSION,        //!< The right ascension for this point
         DECLINATION,            //!< The declination for this point
         RESOLUTION,             //!< The resoultion for this point
+        OBLIQUE_PIXEL_RES,      //!< The oblique pixel resolution
+        OBLIQUE_SAMPLE_RES,     //!< The oblique sample resolution
+        OBLIQUE_LINE_RES,       //!< The oblique line resolution
+        OBLIQUE_DETECTOR_RES,   //!< The oblique detector resolution
         PHASE,                  //!< The phase for this point
         INCIDENCE,              //!< The incidence for this point
         EMISSION,               //!< The emission for this point
@@ -179,7 +243,7 @@ namespace Isis {
       QAction *p_action;                   //!< Action to bring up the track tool
       int p_numRows;                       //!< The number of rows in the table
       int p_id;                            //!< The record id
-      TableMainWindow *p_tableWin;  //!< The table window
+      TableMainWindow *p_tableWin;         //!< The table window
       bool m_showHelpOnStart;              //!< True to show dialog When tool is started
 
   };

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
@@ -86,11 +86,11 @@ namespace Isis {
    *                          to record the point into so that the first recorded point is drawn.
    *                          Fixes #5143.
    *  @history 2018-03-07 Kaitlyn Lee - Added columns for oblique pixel, sample, line,
-`   *                         and detector resolutions. Added checkBoxItems and loop to add
+   *                          and detector resolutions. Added checkBoxItems and loop to add
    *                          the elments to the AdvancedTrackTool, instead of hardcoded method
    *                          calls. Instead of using the enum, I added a method getIndex()
    *                          that calculates what column the element should be added to.
-   *                          Fixes #4100.`
+   *                          Fixes #4100.
    */
   class AdvancedTrackTool : public Tool {
       Q_OBJECT

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
@@ -186,63 +186,6 @@ namespace Isis {
         QList<QString>({"Track Mosaic Serial Number", "false", "Track Mosaic Serial Number", ""}) <<
         QList<QString>({"Notes", "false", "Notes", ""});
 
-      /**
-       * Enum for column values
-       */
-      // enum {
-      //   ID,                     //!< The record ID
-      //   SAMPLE,                 //!< The current sample
-      //   LINE,                   //!< The current line
-      //   BAND,                   //!< The current band
-      //   PIXEL,                  //!< The current pixel
-      //   PLANETOCENTRIC_LAT,     //!< The planetocentric latitude for this point
-      //   PLANETOGRAPHIC_LAT,     //!< The planetographic latitude for this point
-      //   EAST_LON_360,           //!< The 360 east longitude for this point
-      //   WEST_LON_360,           //!< The 360 west longitude for this point
-      //   EAST_LON_180,           //!< The 180 east longitude for this point
-      //   WEST_LON_180,           //!< The 180 west longitude for this point
-      //   PROJECTED_X,            //!< Projected X value for valid projections
-      //   PROJECTED_Y,            //!< Projected Y value for valid projections
-      //   RADIUS,                 //!< The radius for this point
-      //   POINT_X,                //!< The x value for this point
-      //   POINT_Y,                //!< The y value for this point
-      //   POINT_Z,                //!< The z value for this point
-      //   RIGHT_ASCENSION,        //!< The right ascension for this point
-      //   DECLINATION,            //!< The declination for this point
-      //   RESOLUTION,             //!< The resoultion for this point
-      //   OBLIQUE_PIXEL_RES,      //!< The oblique pixel resolution
-      //   OBLIQUE_SAMPLE_RES,     //!< The oblique sample resolution
-      //   OBLIQUE_LINE_RES,       //!< The oblique line resolution
-      //   OBLIQUE_DETECTOR_RES,   //!< The oblique detector resolution
-      //   PHASE,                  //!< The phase for this point
-      //   INCIDENCE,              //!< The incidence for this point
-      //   EMISSION,               //!< The emission for this point
-      //   LOCAL_INCIDENCE,        //!< The local incidence for this point
-      //   LOCAL_EMISSION,         //!< The local emission for this point
-      //   NORTH_AZIMUTH,          //!< The north azimuth for this cube
-      //   SUN_AZIMUTH,            //!< The sun azimuth for this cube
-      //   SOLAR_LON,              //!< The solar longitude for this point
-      //   SPACECRAFT_X,           //!< The spacecraft x position for this cube
-      //   SPACECRAFT_Y,           //!< The spacecraft y position for this cube
-      //   SPACECRAFT_Z,           //!< The spacecraft z position for this cube
-      //   SPACECRAFT_AZIMUTH,     //!< The spacecraft azimuth for this cube
-      //   SLANT,                  //!< The slant for this cube
-      //   DISTORTED_FOCAL_X,      //!< The x of the distorted focal plane
-      //   DISTORTED_FOCAL_Y,      //!< The y of the distorted focal plane
-      //   UNDISTORTED_FOCAL_X,    //!< The x of the undistorted focal plane
-      //   UNDISTORTED_FOCAL_Y,    //!< The y of the undistorted focal plane
-      //   UNDISTORTED_FOCAL_Z,    //!< The z of the undistorted focal plane
-      //   EPHEMERIS_TIME,         //!< The ephemeris time for this cube
-      //   SOLAR_TIME,             //!< The local solar time for this cube
-      //   UTC,                    //!< The UTC for this cube
-      //   PATH,                   //!< The path for this cube
-      //   FILENAME,               //!< The filename for this cube
-      //   SERIAL_NUMBER,          //!< The serial number for this cube
-      //   TRACK_MOSAIC_INDEX,     //!< Track the origin of the Mosaic, display the zero based index
-      //   TRACK_MOSAIC_FILENAME,  //!< Track the origin of the Mosaic, display file name
-      //   TRACK_MOSAIC_SERIAL_NUM,//!< Track the origin of the Mosaic, display file name
-      //   NOTES                   //!< Any notes for this record
-      // };
       QAction *p_action;                   //!< Action to bring up the track tool
       int p_numRows;                       //!< The number of rows in the table
       int p_id;                            //!< The record id
@@ -250,7 +193,6 @@ namespace Isis {
       bool m_showHelpOnStart;              //!< True to show dialog When tool is started
 
   };
-
 };
 
 #endif

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.h
@@ -130,57 +130,56 @@ namespace Isis {
       QString settingsFilePath() const;
 
       // Used to store information about each check box to later add to the table
-      // New entries can be added anywhere in the map.
-      // Format: {<Header>, {<onByDefault>, <menuText>, <toolTip>}}
+      // New entries can be added anywhere in the QList.
+      // Format: QList<QString>({<Header>, <onByDefault>, <menuText>, <toolTip>}) <<
       // If a toolTip is not needed, use "".
-
-      QList<QList<QString> > checkBoxItems = QList<QList<QString> >()<<
-        QList<QString>({"Id", "false", "Id", ""})<<
-        QList<QString>({"Sample:Line", "true", "Sample:Line", ""})<<
-        QList<QString>({"Band", "false", "Band", ""})<<
-        QList<QString>({"Pixel", "true", "Pixel", ""})<<
-        QList<QString>({"Planetocentric Latitude", "true", "Planetocentric Lat", ""})<<
-        QList<QString>({"Planetographic Latitude", "false", "Planetographic Lat", ""})<<
-        QList<QString>({"360 Positive East Longitude", "true", "360 East Longitude", ""})<<
-        QList<QString>({"360 Positive West Longitude", "false", "360 West Longitude", ""})<<
-        QList<QString>({"180 Positive East Longitude", "true", "180 East Longitude", ""})<<
-        QList<QString>({"180 Positive West Longitude", "false", "180 West Longitude", ""})<<
+      QList<QList<QString> > checkBoxItems = QList<QList<QString> >() <<
+        QList<QString>({"Id", "false", "Id", ""}) <<
+        QList<QString>({"Sample:Line", "true", "Sample:Line", ""}) <<
+        QList<QString>({"Band", "false", "Band", ""}) <<
+        QList<QString>({"Pixel", "true", "Pixel", ""}) <<
+        QList<QString>({"Planetocentric Latitude", "true", "Planetocentric Lat", ""}) <<
+        QList<QString>({"Planetographic Latitude", "false", "Planetographic Lat", ""}) <<
+        QList<QString>({"360 Positive East Longitude", "true", "360 East Longitude", ""}) <<
+        QList<QString>({"360 Positive West Longitude", "false", "360 West Longitude", ""}) <<
+        QList<QString>({"180 Positive East Longitude", "true", "180 East Longitude", ""}) <<
+        QList<QString>({"180 Positive West Longitude", "false", "180 West Longitude", ""}) <<
         QList<QString>({"Projected X:Projected Y", "false", "Projected X:Projected Y",
-                         "X and Y values for a projected image"})<<
-        QList<QString>({"Local Radius", "false", "Radius", ""})<<
+                         "X and Y values for a projected image"}) <<
+        QList<QString>({"Local Radius", "false", "Radius", ""}) <<
         QList<QString>({"Point X:Point Y:Point Z", "false", "XYZ",
-                         "The X, Y, and Z of surface intersection in body-fixed coordinates"})<<
+                         "The X, Y, and Z of surface intersection in body-fixed coordinates"}) <<
         QList<QString>({"Right Ascension:Declination", "false", "Ra:Dec",
-                         "Right Ascension and Declination"})<<
-        QList<QString>({"Resolution", "false", "Resolution", ""})<<
-        QList<QString>({"Oblique Pixel Resolution", "false", "Oblique Pixel Res", ""})<<
-        QList<QString>({"Oblique Sample Resolution", "false", "Oblique Sample Res", ""})<<
-        QList<QString>({"Oblique Line Resolution", "false", "Oblique Line Res", ""})<<
-        QList<QString>({"Oblique Detector Resolution", "false", "Oblique Detector Res", ""})<<
-        QList<QString>({"Phase", "false", "Phase", ""})<<
-        QList<QString>({"Incidence", "false", "Incidence", ""})<<
-        QList<QString>({"Emission", "false", "Emission", ""})<<
-        QList<QString>({"LocalIncidence", "false", "LocalIncidence", ""})<<
-        QList<QString>({"LocalEmission", "false", "LocalEmission", ""})<<
-        QList<QString>({"North Azimuth", "false", "North Azimuth", ""})<<
-        QList<QString>({"Sun Azimuth", "false", "Sun Azimuth", ""})<<
-        QList<QString>({"Solar Longitude", "false", "Solar Longitude", ""})<<
+                         "Right Ascension and Declination"}) <<
+        QList<QString>({"Resolution", "false", "Resolution", ""}) <<
+        QList<QString>({"Oblique Pixel Resolution", "false", "Oblique Pixel Res", ""}) <<
+        QList<QString>({"Oblique Sample Resolution", "false", "Oblique Sample Res", ""}) <<
+        QList<QString>({"Oblique Line Resolution", "false", "Oblique Line Res", ""}) <<
+        QList<QString>({"Oblique Detector Resolution", "false", "Oblique Detector Res", ""}) <<
+        QList<QString>({"Phase", "false", "Phase", ""}) <<
+        QList<QString>({"Incidence", "false", "Incidence", ""}) <<
+        QList<QString>({"Emission", "false", "Emission", ""}) <<
+        QList<QString>({"LocalIncidence", "false", "LocalIncidence", ""}) <<
+        QList<QString>({"LocalEmission", "false", "LocalEmission", ""}) <<
+        QList<QString>({"North Azimuth", "false", "North Azimuth", ""}) <<
+        QList<QString>({"Sun Azimuth", "false", "Sun Azimuth", ""}) <<
+        QList<QString>({"Solar Longitude", "false", "Solar Longitude", ""}) <<
         QList<QString>({"Spacecraft X:Spacecraft Y:Spacecraft Z", "false", "Spacecraft Position",
-                           "The X, Y, and Z of the spacecraft position"})<<
-        QList<QString>({"Spacecraft Azimuth", "false", "Spacecraft Azimuth", ""})<<
-        QList<QString>({"Slant Distance", "false", "Slant Distance", ""})<<
-        QList<QString>({"Focal Plane X:Focal Plane Y", "false", "Focal Plane X:Y", ""})<<
+                           "The X, Y, and Z of the spacecraft position"}) <<
+        QList<QString>({"Spacecraft Azimuth", "false", "Spacecraft Azimuth", ""}) <<
+        QList<QString>({"Slant Distance", "false", "Slant Distance", ""}) <<
+        QList<QString>({"Focal Plane X:Focal Plane Y", "false", "Focal Plane X:Y", ""}) <<
         QList<QString>({"Undistorted Focal X:Undistorted Focal Y: Undistorted Focal Z",
-                           "false", "Undistorted Focal Plane X:Y:Z", ""})<<
-        QList<QString>({"Ephemeris Time", "false", "Ephemeris iTime", ""})<<
-        QList<QString>({"Local Solar Time", "false", "Local Solar iTime", ""})<<
-        QList<QString>({"UTC", "false", "UTC", "Internal time in UTC format"})<<
-        QList<QString>({"Path", "false", "Path", ""})<<
-        QList<QString>({"FileName", "false", "FileName", ""})<<
-        QList<QString>({"Serial Number", "false", "Serial Number", ""})<<
-        QList<QString>({"Track Mosaic Index", "false", "Track Mosaic Index", ""})<<
-        QList<QString>({"Track Mosaic FileName", "false", "Track Mosaic FileName", ""})<<
-        QList<QString>({"Track Mosaic Serial Number", "false", "Track Mosaic Serial Number", ""})<<
+                           "false", "Undistorted Focal Plane X:Y:Z", ""}) <<
+        QList<QString>({"Ephemeris Time", "false", "Ephemeris iTime", ""}) <<
+        QList<QString>({"Local Solar Time", "false", "Local Solar iTime", ""}) <<
+        QList<QString>({"UTC", "false", "UTC", "Internal time in UTC format"}) <<
+        QList<QString>({"Path", "false", "Path", ""}) <<
+        QList<QString>({"FileName", "false", "FileName", ""}) <<
+        QList<QString>({"Serial Number", "false", "Serial Number", ""}) <<
+        QList<QString>({"Track Mosaic Index", "false", "Track Mosaic Index", ""}) <<
+        QList<QString>({"Track Mosaic FileName", "false", "Track Mosaic FileName", ""}) <<
+        QList<QString>({"Track Mosaic Serial Number", "false", "Track Mosaic Serial Number", ""}) <<
         QList<QString>({"Notes", "false", "Notes", ""});
 
       /**


### PR DESCRIPTION
The advanced track tool used to use an enumeration to get the index where each element should be added to to the track tool. When adding the oblique resolutions, I accidentally did not add the resolutions in the same order as they were in the enumeration. To fix this, in the header file, I created a QList that stores the elements we want to add. Then, in the cpp file, I added a loop that adds each item from the QList to the left-hand side of the track tool. I then implemented a method call getIndex() that calculates where each element should be added to the track tool. This way, the index does not depend on the enumeration. 