### PR TITLE
Moved method documentation of FileName to the cpp file from the h file. Fixes #5230.

### DIFF
--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -40,41 +40,99 @@ using namespace std;
 
 namespace Isis {
 
+  /**
+   * Constructs an empty FileName object.
+   */
   FileName::FileName() {
     m_d = new Data;
   }
 
-
+  /**
+   * Constructs a FileName object using a char pointer as a file name.
+   *
+   * @param file char pointer representing new filename
+   */
   FileName::FileName(const char *file) {
     m_d = new Data;
     m_d->setOriginal(file);
   }
 
-
+  /**
+   * Constructs a FileName object using a QString as a file name.
+   *
+   * @param file Qstring representing new filename
+   */
   FileName::FileName(const QString &file) {
     m_d = new Data;
     m_d->setOriginal(file);
   }
 
-
+  /**
+   * Constructs a copy of a FileName object using another FileName object.
+   *
+   * @param &other FileName object to copy.
+   */
   FileName::FileName(const FileName &other) : m_d(other.m_d) {
   }
 
-
+  /**
+   * Destroys the FileName object.
+   */
   FileName::~FileName() {
   }
 
-
+  /**
+   * Returns the path of the original file name. For *nix operating
+   * systems this includes everything up to but not including the
+   * last slash "/". For filenames created without any slashes
+   * the current working directory will be returned.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "/home/me/img/picture.jpg"
+   *   originalPath() gives:
+   *    "/home/me/img"
+   * </pre>
+   *
+   * @return QString of the path portion of the original filename.
+   */
   QString FileName::originalPath() const {
     return QFileInfo(m_d->original(false)).path();
   }
 
-
+  /**
+   * Returns the path of the file name. For *nix operating
+   * systems this includes everything up to but not including the
+   * last slash "/". For filenames created without any slashes
+   * the current working directory will be returned.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "/home/me/img/picture.jpg"
+   *   path() gives:
+   *    "/home/me/img"
+   * </pre>
+   *
+   * @return QString of the path portion of the filename.
+   */
   QString FileName::path() const {
     return QFileInfo(expanded()).path();
   }
 
-
+  /**
+   * Returns a QString of the attributes in a filename, attributes are expected to be of type
+   * CubeAttributeInput or CubeAttributeOutput. Filenames without any attributes return an
+   * empty QString.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub+Bsq"
+   *   attributes() gives:
+   *    "Bsq"
+   * </pre>
+   *
+   * @return QString of the attributes specified in the filename.
+   */
   QString FileName::attributes() const {
     QString result;
     QString fileNameWithAttribs = QFileInfo(m_d->original(true)).fileName();
@@ -87,32 +145,98 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Returns the name of the file without the path and without extensions.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub.gz"
+   *   baseName() gives:
+   *    "Peaks"
+   * </pre>
+   *
+   * @return QString containing every character excluding the path and all extensions.
+   */
   QString FileName::baseName() const {
     return QFileInfo(m_d->original(false)).completeBaseName();
   }
 
-
+  /**
+   * Returns the name of the file excluding the path and the attributes in the file name.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub+Bsq"
+   *   name() gives:
+   *    "Peaks.cub"
+   * </pre>
+   *
+   * @return QString containing every character in the file name exluding the path and attributes
+   * of the file.
+   */
   QString FileName::name() const {
     return QFileInfo(m_d->original(false)).fileName();
   }
 
-
+  /**
+   * Returns the last extension of the file name.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub.gz"
+   *   extension() gives:
+   *    "gz"
+   * </pre>
+   *
+   * @return QString containing every character in the file name after the last "." character.
+   */
   QString FileName::extension() const {
     return QFileInfo(m_d->original(false)).suffix();
   }
 
-
+  /**
+   * Returns a QString of the full file name including the file path, excluding the attributes.
+   * Any Isis Preferences or environment variables indicated by $, are changed to what they
+   * represent.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   *   expanded() gives:
+   *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
+   * </pre>
+   *
+   * @return QString
+   */
   QString FileName::expanded() const {
     return m_d->expanded(false);
   }
 
-
+  /**
+   * Returns the full file name including the file path
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   *   original() gives:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   * </pre>
+   *
+   * @return QString containing every character in the file name and the path
+   */
   QString FileName::original() const {
     return m_d->original(true);
   }
 
-
+  /**
+   * Adds a new extension to the file name. If the current extension is the same as the
+   * new extension it will return an unchanged FileName object.
+   *
+   * @param newExtension The new file extension to be added at the end of the file name after all
+   * exisiting extensions.
+   *
+   * @return FileName object with added extension
+   */
   FileName FileName::addExtension(const QString &newExtension) const {
     FileName result = *this;
 
@@ -129,7 +253,11 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Removes all extensions in the file name
+   *
+   * @return FileName object with all extensions removed
+   */
   FileName FileName::removeExtension() const {
     QString attributesStr = attributes();
 
@@ -142,7 +270,13 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Sets all current file extensions to a new extension in the file name.
+   *
+   * @param newExtension The new file extension to replace any current file extensions with
+   *
+   * @return FileName object with all existing extensions replaced by the new extension
+   */
   FileName FileName::setExtension(const QString &newExtension) const {
     FileName result = *this;
 
@@ -153,24 +287,44 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Checks to see if a file name is versioned by date or numerically. Returns true if file is
+   * versioned by date or numerically; returns false otherwise.
+   *
+   * @return Boolean
+   */
   bool FileName::isVersioned() const {
     validateVersioningState();
 
     return isNumericallyVersioned() || isDateVersioned();
   }
 
-
+  /**
+   * Checks if the file name is versioned numerically. Returns true if the file is versioned
+   * numerically; returns false otherwise.
+   *
+   * @return Boolean
+   */
   bool FileName::isNumericallyVersioned() const {
     return FileName(expanded()).name().contains("?");
   }
 
-
+  /**
+   * Checks if the file name is versioned by date. Returns true if the file is versioned
+   * by date; returns false otherwise.
+   *
+   * @return Boolean
+   */
   bool FileName::isDateVersioned() const {
     return FileName(expanded()).name().contains(QRegExp("\\{.*\\}"));
   }
 
-
+  /**
+   * Searches the directory specified in the file name for the highest version of the file name.
+   * Returns a FileName object with the file name changed to reflect the highest version.
+   *
+   * @return FileName object
+   */
   FileName FileName::highestVersion() const {
     validateVersioningState();
 
@@ -197,7 +351,15 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Updates the file name to be the latest version. If the file is versioned by date the
+   * newest version will be the current date. If the file is versioned numerically, the newest
+   * version will be the current version plus one.
+   *
+   * @return FileName object with the new version file name.
+   *
+   * @throws Isis::IException::Unknown
+   */
   FileName FileName::newVersion() const {
     validateVersioningState();
 
@@ -238,7 +400,16 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Returns a FileName object of the same file name but versioned numerically by the
+   * number passed in as a parameter.
+   *
+   * @param versionNumber number to version the new FileName object
+   *
+   * @return FileName object with the new version file name.
+   *
+   * @throws Isis::IException::Unknown
+   */
   FileName FileName::version(long versionNumber) const {
     QString file = FileName(expanded()).name();
 
@@ -269,24 +440,56 @@ namespace Isis {
     return FileName(originalPath() + "/" + file);
   }
 
-
+  /**
+   * Returns a FileName object of the same file name but versioned by the
+   * date passed in as a parameter.
+   *
+   * @param versionDate QDate to version the new FileName object
+   *
+   * @return FileName object with the new version file name.
+   *
+   */
   FileName FileName::version(QDate versionDate) const {
     QString newName = versionDate.toString(fileNameQDatePattern());
 
     return FileName(originalPath() + "/" + newName);
   }
 
-
+  /**
+   * Returns true if the file exists; false otherwise.
+   * If the file is a symlink that points to a nonexistent file, false is returned.
+   *
+   * @return Boolean
+   */
   bool FileName::fileExists() const {
     return QFileInfo(expanded()).exists();
   }
 
-
+  /**
+   * Returns the path of the file's parent directory as a QDir object
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub+Bsq"
+   *   dir() gives:
+   *    "/tmp/"
+   * </pre>
+   *
+   * @return QDir
+   */
   QDir FileName::dir() const {
     return QFileInfo(expanded()).dir();
   }
 
-
+  /**
+   * Creates a temporary file and returns a FileName object created using the temporary file.
+   *
+   * @param templateFileName the file name used to create the temporary file.
+   *
+   * @return FileName object created using the temporary file
+   *
+   * @throws Isis::IException::Io
+   */
   FileName FileName::createTempFile(FileName templateFileName) {
     QString preppedFileName = QString("%1/%2XXXXXX.%3").arg(templateFileName.path())
         .arg(templateFileName.baseName()).arg(templateFileName.extension());
@@ -310,18 +513,45 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Returns a QString of the full file name including the file path, excluding the attributes
+   * with any Isis Preferences or environment variables indicated by $, changed to what they
+   * represent.
+   *
+   * <pre>
+   *   for a full file specification of:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   *   toString() gives:
+   *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
+   * </pre>
+   *
+   * @return QString
+   */
   QString FileName::toString() const {
     return expanded();
   }
 
-
+  /**
+   * Clears the current contents of the FileName object and reinitializes it with
+   * the argument.
+   *
+   * @param rhs FileName to replace the current contents of the object.
+   *
+   * @return void
+   */
   FileName &FileName::operator=(const FileName &rhs) {
     m_d = rhs.m_d;
     return *this;
   }
 
-
+  /**
+   * Compares equality of two FileName objects. Returns true if the two objects are equal
+   * and false otherwise.
+   *
+   * @param rhs FileName to compare the current FileName object to.
+   *
+   * @return Boolean
+   */
   bool FileName::operator==(const FileName &rhs) {
     QString expandedOfThis = expanded();
     QString canonicalOfThis = QFileInfo(expandedOfThis).canonicalFilePath();
@@ -342,12 +572,24 @@ namespace Isis {
     return equal;
   }
 
-
+  /**
+   * Compares equality of two FileName objects. Returns false if the two objects are equal
+   * and true otherwise.
+   *
+   * @param rhs FileName to compare the current FileName object to.
+   *
+   * @return Boolean
+   */
   bool FileName::operator!=(const FileName &rhs) {
     return !(*this == rhs);
   }
 
-
+  /**
+   * This looks through the directory of the file and checks for the highest version date of
+   * the file that is versioned date.
+   *
+   * @return QDate
+   */
   QDate FileName::highestVersionDate() const {
     QString fileQDatePattern = fileNameQDatePattern();
 
@@ -405,7 +647,12 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * This looks through the directory of the file and checks for the highest version number of
+   * the file that is versioned numerically.
+   *
+   * @return long
+   */
   long FileName::highestVersionNum() const {
     QString file = FileName(expanded()).name();
     int result = 0;
@@ -441,7 +688,10 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * This verifies the class invariant when using versioning - that the FileName is in an acceptable
+   * state to find file version numbers.
+   */
   void FileName::validateVersioningState() const {
     QString file = QFileInfo(expanded()).fileName();
 
@@ -484,6 +734,12 @@ namespace Isis {
     }
   }
 
+  /**
+   * This changes the files format. Specifically quotes everything not in {} with single quotes
+   * and removes the {} from the file name.
+   *
+   * @return QString
+   */
   QString FileName::fileNameQDatePattern() const {
     // We need to quote everything not in {} with single quotes.
     QString file = FileName(expanded()).name();
@@ -508,7 +764,12 @@ namespace Isis {
     return file;
   }
 
-
+  /**
+   * This returns a QPair of the text (before, after) a version number in a file. Before being
+   * the text before the version number and after being the text after the version number.
+   *
+   * @return QPair
+   */
   QPair<QString, QString> FileName::splitNameAroundVersionNum() const {
     QString file = FileName(expanded()).name();
     QString before;
@@ -525,7 +786,9 @@ namespace Isis {
     return QPair<QString, QString>(before, after);
   }
 
-
+   /**
+    * Data constructor, creates a new Data object.
+    */
   FileName::Data::Data() {
     m_originalFileNameString = NULL;
     m_expandedFileNameString = NULL;
@@ -534,7 +797,11 @@ namespace Isis {
     m_expandedFileNameString = new QString;
   }
 
-
+  /**
+   * Data copy constructor, creates a copy of a Data object.
+   *
+   * @param &other Data object to copy
+   */
   FileName::Data::Data(const Data &other) : QSharedData(other) {
     m_originalFileNameString = NULL;
     m_expandedFileNameString = NULL;
@@ -543,7 +810,9 @@ namespace Isis {
     m_expandedFileNameString = new QString(*other.m_expandedFileNameString);
   }
 
-
+  /**
+   * Destroys the Data object.
+   */
   FileName::Data::~Data() {
     delete m_originalFileNameString;
     m_originalFileNameString = NULL;
@@ -552,7 +821,15 @@ namespace Isis {
     m_expandedFileNameString = NULL;
   }
 
-
+  /**
+   * Returns the original file name, stored in m_originalFileNameString. Boolean
+   * parameter includeAttributes determines if the returned file name has the variables
+   * included.
+   *
+   * @param includeAttributes boolean to represent whether the attricubtes should be included.
+   *
+   * @return Qstring
+   */
   QString FileName::Data::original(bool includeAttributes) const {
     QString result = *m_originalFileNameString;
 
@@ -567,7 +844,13 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Sets the original file name, stored in m_originalFileNameString. QString parameter
+   * is the new file name to store in m_originalFileNameString. The expanded verison is also
+   * set and stored in m_expandedFileNameString when this method is called.
+   *
+   * @param originalStr the new file name
+   */
   void FileName::Data::setOriginal(const QString &originalStr) {
     *m_originalFileNameString = originalStr;
 
@@ -633,7 +916,15 @@ namespace Isis {
     *m_expandedFileNameString = expandedStr;
   }
 
-
+  /**
+   * Returns the expanded file name, stored in m_expandedFileNameString. Boolean
+   *  parameter includeAttributes determines if the returned file name has the variables
+   * included.
+   *
+   * @param includeAttributes boolean to represent whether the attricubtes should be included.
+   *
+   * @return Qstring
+   */
   QString FileName::Data::expanded(bool includeAttributes) const {
     QString result = *m_expandedFileNameString;
 

--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -63,7 +63,6 @@ namespace Isis {
     m_d->setOriginal(file);
   }
 
-  //! Copy Constructor, creates a copy of a FileName object.
   /**
    * Constructs a copy of a FileName object using another FileName object.
    * @param &other FileName object to copy.

--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -40,13 +40,16 @@ using namespace std;
 
 namespace Isis {
 
-  //! Constructs an empty FileName object.
+  /**
+   * Constructs an empty FileName object.
+   */
   FileName::FileName() {
     m_d = new Data;
   }
 
   /**
    * Constructs a FileName object using a char pointer as a file name.
+   *
    * @param *fileName char pointer representing new filename
    */
   FileName::FileName(const char *file) {
@@ -56,6 +59,7 @@ namespace Isis {
 
   /**
    * Constructs a FileName object using a QString as a file name.
+   *
    * @param &fileName Qstring representing new filename
    */
   FileName::FileName(const QString &file) {
@@ -65,12 +69,15 @@ namespace Isis {
 
   /**
    * Constructs a copy of a FileName object using another FileName object.
+   *
    * @param &other FileName object to copy.
    */
   FileName::FileName(const FileName &other) : m_d(other.m_d) {
   }
 
-  //! Destroys the FileName object.
+  /**
+   * Destroys the FileName object.
+   */
   FileName::~FileName() {
   }
 
@@ -80,13 +87,14 @@ namespace Isis {
    * last slash "/". For filenames created without any slashes
    * the current working directory will be returned.
    *
-   * @returns QString of the path portion of the original filename.
    * <pre>
    *   for a full file specification of:
    *    "/home/me/img/picture.jpg"
    *   originalPath() gives:
    *    "/home/me/img"
    * </pre>
+   *
+   * @return QString of the path portion of the original filename.
    */
   QString FileName::originalPath() const {
     return QFileInfo(m_d->original(false)).path();
@@ -98,13 +106,14 @@ namespace Isis {
    * last slash "/". For filenames created without any slashes
    * the current working directory will be returned.
    *
-   * @returns QString of the path portion of the filename.
    * <pre>
    *   for a full file specification of:
    *    "/home/me/img/picture.jpg"
    *   path() gives:
    *    "/home/me/img"
    * </pre>
+   *
+   * @return QString of the path portion of the filename.
    */
   QString FileName::path() const {
     return QFileInfo(expanded()).path();
@@ -115,13 +124,14 @@ namespace Isis {
    * CubeAttributeInput or CubeAttributeOutput. Filenames without any attributes return an
    * empty QString.
    *
-   * @returns QString of the attributes specified in the filename.
    * <pre>
    *   for a full file specification of:
    *    "/tmp/Peaks.cub+Bsq"
    *   attributes() gives:
    *    "Bsq"
    * </pre>
+   *
+   * @return QString of the attributes specified in the filename.
    */
   QString FileName::attributes() const {
     QString result;
@@ -138,13 +148,14 @@ namespace Isis {
   /**
    * Returns the name of the file without the path and without extensions.
    *
-   * @returns QString containing every character excluding the path and all extensions.
    * <pre>
    *   for a full file specification of:
    *    "/tmp/Peaks.cub.gz"
    *   baseName() gives:
    *    "Peaks"
    * </pre>
+   *
+   * @return QString containing every character excluding the path and all extensions.
    */
   QString FileName::baseName() const {
     return QFileInfo(m_d->original(false)).completeBaseName();
@@ -153,14 +164,15 @@ namespace Isis {
   /**
    * Returns the name of the file excluding the path and the attributes in the file name.
    *
-   * @returns QString containing every character in the file name exluding the path and attributes
-   * of the file.
    * <pre>
    *   for a full file specification of:
    *    "/tmp/Peaks.cub+Bsq"
    *   name() gives:
    *    "Peaks.cub"
    * </pre>
+   *
+   * @return QString containing every character in the file name exluding the path and attributes
+   * of the file.
    */
   QString FileName::name() const {
     return QFileInfo(m_d->original(false)).fileName();
@@ -169,13 +181,14 @@ namespace Isis {
   /**
    * Returns the last extension of the file name.
    *
-   * @returns QString containing every character in the file name after the last "." character.
    * <pre>
    *   for a full file specification of:
    *    "/tmp/Peaks.cub.gz"
    *   extension() gives:
    *    "gz"
    * </pre>
+   *
+   * @return QString containing every character in the file name after the last "." character.
    */
   QString FileName::extension() const {
     return QFileInfo(m_d->original(false)).suffix();
@@ -186,13 +199,14 @@ namespace Isis {
    * Any Isis Preferences or environment variables indicated by $, are changed to what they
    * represent.
    *
-   * @returns QString
    * <pre>
    *   for a full file specification of:
    *    "$ISISROOT/tmp/Peaks.cub+Bsq"
    *   expanded() gives:
    *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
    * </pre>
+   *
+   * @return QString
    */
   QString FileName::expanded() const {
     return m_d->expanded(false);
@@ -201,13 +215,14 @@ namespace Isis {
   /**
    * Returns the full file name including the file path
    *
-   * @returns QString containing every character in the file name and the path
    * <pre>
    *   for a full file specification of:
    *    "$ISISROOT/tmp/Peaks.cub+Bsq"
    *   original() gives:
    *    "$ISISROOT/tmp/Peaks.cub+Bsq"
    * </pre>
+   *
+   * @return QString containing every character in the file name and the path
    */
   QString FileName::original() const {
     return m_d->original(true);
@@ -220,7 +235,7 @@ namespace Isis {
    * @param &extension The new file extension to be added at the end of the file name after all
    * exisiting extensions.
    *
-   * @returns FileName object with added extension
+   * @return FileName object with added extension
    */
   FileName FileName::addExtension(const QString &newExtension) const {
     FileName result = *this;
@@ -241,7 +256,7 @@ namespace Isis {
   /**
    * Removes all extensions in the file name
    *
-   * @returns FileName object with all extensions removed
+   * @return FileName object with all extensions removed
    */
   FileName FileName::removeExtension() const {
     QString attributesStr = attributes();
@@ -260,7 +275,7 @@ namespace Isis {
    *
    * @param &extension The new file extension to replace any current file extensions with
    *
-   * @returns FileName object with all existing extensions replaced by the new extension
+   * @return FileName object with all existing extensions replaced by the new extension
    */
   FileName FileName::setExtension(const QString &newExtension) const {
     FileName result = *this;
@@ -276,7 +291,7 @@ namespace Isis {
    * Checks to see if a file name is versioned by date or numerically. Returns true if file is
    * versioned by date or numerically; returns false otherwise.
    *
-   * @returns Boolean
+   * @return Boolean
    */
   bool FileName::isVersioned() const {
     validateVersioningState();
@@ -288,7 +303,7 @@ namespace Isis {
    * Checks if the file name is versioned numerically. Returns true if the file is versioned
    * numerically; returns false otherwise.
    *
-   * @returns Boolean
+   * @return Boolean
    */
   bool FileName::isNumericallyVersioned() const {
     return FileName(expanded()).name().contains("?");
@@ -298,7 +313,7 @@ namespace Isis {
    * Checks if the file name is versioned by date. Returns true if the file is versioned
    * by date; returns false otherwise.
    *
-   * @returns Boolean
+   * @return Boolean
    */
   bool FileName::isDateVersioned() const {
     return FileName(expanded()).name().contains(QRegExp("\\{.*\\}"));
@@ -308,7 +323,7 @@ namespace Isis {
    * Searches the directory specified in the file name for the highest version of the file name.
    * Returns a FileName object with the file name changed to reflect the highest version.
    *
-   * @returns FileName object
+   * @return FileName object
    */
   FileName FileName::highestVersion() const {
     validateVersioningState();
@@ -341,7 +356,7 @@ namespace Isis {
    * newest version will be the current date. If the file is versioned numerically, the newest
    * version will be the current version plus one.
    *
-   * @returns FileName object with the new version file name.
+   * @return FileName object with the new version file name.
    *
    * @throws Isis::IException::Unknown
    */
@@ -391,7 +406,7 @@ namespace Isis {
    *
    * @param versionNumber number to version the new FileName object
    *
-   * @returns FileName object with the new version file name.
+   * @return FileName object with the new version file name.
    *
    * @throws Isis::IException::Unknown
    */
@@ -431,7 +446,7 @@ namespace Isis {
    *
    * @param versionDate QDate to version the new FileName object
    *
-   * @returns FileName object with the new version file name.
+   * @return FileName object with the new version file name.
    *
    */
   FileName FileName::version(QDate versionDate) const {
@@ -444,7 +459,7 @@ namespace Isis {
    * Returns true if the file exists; false otherwise.
    * If the file is a symlink that points to a nonexistent file, false is returned.
    *
-   * @returns Boolean
+   * @return Boolean
    */
   bool FileName::fileExists() const {
     return QFileInfo(expanded()).exists();
@@ -453,13 +468,14 @@ namespace Isis {
   /**
    * Returns the path of the file's parent directory as a QDir object
    *
-   * @returns QDir
    * <pre>
    *   for a full file specification of:
    *    "/tmp/Peaks.cub+Bsq"
    *   dir() gives:
    *    "/tmp/"
    * </pre>
+   *
+   * @return QDir
    */
   QDir FileName::dir() const {
     return QFileInfo(expanded()).dir();
@@ -470,7 +486,7 @@ namespace Isis {
    *
    * @param templateFileName the file name used to create the temporary file.
    *
-   * @returns FileName object created using the temporary file
+   * @return FileName object created using the temporary file
    *
    * @throws Isis::IException::Io
    */
@@ -502,13 +518,14 @@ namespace Isis {
    * with any Isis Preferences or environment variables indicated by $, changed to what they
    * represent.
    *
-   * @returns QString
    * <pre>
    *   for a full file specification of:
    *    "$ISISROOT/tmp/Peaks.cub+Bsq"
    *   toString() gives:
    *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
    * </pre>
+   *
+   * @return QString
    */
   QString FileName::toString() const {
     return expanded();
@@ -518,10 +535,9 @@ namespace Isis {
    * Clears the current contents of the FileName object and reinitializes it with
    * the argument.
    *
-   * @returns void
-   *
    * @param rhs FileName to replace the current contents of the object.
    *
+   * @return void
    */
   FileName &FileName::operator=(const FileName &rhs) {
     m_d = rhs.m_d;
@@ -532,9 +548,9 @@ namespace Isis {
    * Compares equality of two FileName objects. Returns true if the two objects are equal
    * and false otherwise.
    *
-   * @returns Boolean
-   *
    * @param rhs FileName to compare the current FileName object to.
+   *
+   * @return Boolean
    */
   bool FileName::operator==(const FileName &rhs) {
     QString expandedOfThis = expanded();
@@ -560,9 +576,9 @@ namespace Isis {
    * Compares equality of two FileName objects. Returns false if the two objects are equal
    * and true otherwise.
    *
-   * @returns Boolean
-   *
    * @param rhs FileName to compare the current FileName object to.
+   *
+   * @return Boolean
    */
   bool FileName::operator!=(const FileName &rhs) {
     return !(*this == rhs);
@@ -572,7 +588,7 @@ namespace Isis {
    * This looks through the directory of the file and checks for the highest version date of
    * the file that is versioned date.
    *
-   * @returns QDate
+   * @return QDate
    */
   QDate FileName::highestVersionDate() const {
     QString fileQDatePattern = fileNameQDatePattern();
@@ -635,7 +651,7 @@ namespace Isis {
    * This looks through the directory of the file and checks for the highest version number of
    * the file that is versioned numerically.
    *
-   * @returns long
+   * @return long
    */
   long FileName::highestVersionNum() const {
     QString file = FileName(expanded()).name();
@@ -674,7 +690,7 @@ namespace Isis {
 
   /**
    * This verifies the class invariant when using versioning - that the FileName is in an acceptable
-   *     state to find file version numbers.
+   * state to find file version numbers.
    */
   void FileName::validateVersioningState() const {
     QString file = QFileInfo(expanded()).fileName();
@@ -722,7 +738,7 @@ namespace Isis {
    * This changes the files format. Specifically quotes everything not in {} with single quotes
    * and removes the {} from the file name.
    *
-   * @returns QString
+   * @return QString
    */
   QString FileName::fileNameQDatePattern() const {
     // We need to quote everything not in {} with single quotes.
@@ -752,7 +768,7 @@ namespace Isis {
    * This returns a QPair of the text (before, after) a version number in a file. Before being
    * the text before the version number and after being the text after the version number.
    *
-   * @returns QPair
+   * @return QPair
    */
   QPair<QString, QString> FileName::splitNameAroundVersionNum() const {
     QString file = FileName(expanded()).name();
@@ -770,7 +786,9 @@ namespace Isis {
     return QPair<QString, QString>(before, after);
   }
 
-   //! Data constructor, creates a new Data object.
+   /**
+    * Data constructor, creates a new Data object.
+    */
   FileName::Data::Data() {
     m_originalFileNameString = NULL;
     m_expandedFileNameString = NULL;
@@ -781,6 +799,7 @@ namespace Isis {
 
   /**
    * Data copy constructor, creates a copy of a Data object.
+   *
    * @param &other Data object to copy
    */
   FileName::Data::Data(const Data &other) : QSharedData(other) {
@@ -791,7 +810,9 @@ namespace Isis {
     m_expandedFileNameString = new QString(*other.m_expandedFileNameString);
   }
 
-  //! Destroys the Data object.
+  /**
+   * Destroys the Data object.
+   */
   FileName::Data::~Data() {
     delete m_originalFileNameString;
     m_originalFileNameString = NULL;
@@ -805,9 +826,9 @@ namespace Isis {
    * parameter includeAttributes determines if the returned file name has the variables
    * included.
    *
-   * @returns Qstring
-   *
    * @param includeAttributes boolean to represent whether the attricubtes should be included.
+   *
+   * @return Qstring
    */
   QString FileName::Data::original(bool includeAttributes) const {
     QString result = *m_originalFileNameString;
@@ -900,9 +921,9 @@ namespace Isis {
    *  parameter includeAttributes determines if the returned file name has the variables
    * included.
    *
-   * @returns Qstring
-   *
    * @param includeAttributes boolean to represent whether the attricubtes should be included.
+   *
+   * @return Qstring
    */
   QString FileName::Data::expanded(bool includeAttributes) const {
     QString result = *m_expandedFileNameString;

--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -50,11 +50,7 @@ namespace Isis {
   /**
    * Constructs a FileName object using a char pointer as a file name.
    *
-<<<<<<< HEAD
    * @param file char pointer representing new filename
-=======
-   * @param *fileName char pointer representing new filename
->>>>>>> 1a09013a7b3d9d1750e5709b9ee5ce2c50d352bb
    */
   FileName::FileName(const char *file) {
     m_d = new Data;
@@ -64,11 +60,7 @@ namespace Isis {
   /**
    * Constructs a FileName object using a QString as a file name.
    *
-<<<<<<< HEAD
    * @param file Qstring representing new filename
-=======
-   * @param &fileName Qstring representing new filename
->>>>>>> 1a09013a7b3d9d1750e5709b9ee5ce2c50d352bb
    */
   FileName::FileName(const QString &file) {
     m_d = new Data;
@@ -240,11 +232,7 @@ namespace Isis {
    * Adds a new extension to the file name. If the current extension is the same as the
    * new extension it will return an unchanged FileName object.
    *
-<<<<<<< HEAD
    * @param newExtension The new file extension to be added at the end of the file name after all
-=======
-   * @param &extension The new file extension to be added at the end of the file name after all
->>>>>>> 1a09013a7b3d9d1750e5709b9ee5ce2c50d352bb
    * exisiting extensions.
    *
    * @return FileName object with added extension
@@ -285,11 +273,7 @@ namespace Isis {
   /**
    * Sets all current file extensions to a new extension in the file name.
    *
-<<<<<<< HEAD
    * @param newExtension The new file extension to replace any current file extensions with
-=======
-   * @param &extension The new file extension to replace any current file extensions with
->>>>>>> 1a09013a7b3d9d1750e5709b9ee5ce2c50d352bb
    *
    * @return FileName object with all existing extensions replaced by the new extension
    */

--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -40,41 +40,90 @@ using namespace std;
 
 namespace Isis {
 
+  //! Constructs an empty FileName object.
   FileName::FileName() {
     m_d = new Data;
   }
 
-
+  /**
+   * Constructs a FileName object using a char pointer as a file name.
+   * @param *fileName char pointer representing new filename
+   */
   FileName::FileName(const char *file) {
     m_d = new Data;
     m_d->setOriginal(file);
   }
 
-
+  /**
+   * Constructs a FileName object using a QString as a file name.
+   * @param &fileName Qstring representing new filename
+   */
   FileName::FileName(const QString &file) {
     m_d = new Data;
     m_d->setOriginal(file);
   }
 
-
+  //! Copy Constructor, creates a copy of a FileName object.
+  /**
+   * Constructs a copy of a FileName object using another FileName object.
+   * @param &other FileName object to copy.
+   */
   FileName::FileName(const FileName &other) : m_d(other.m_d) {
   }
 
-
+  //! Destroys the FileName object.
   FileName::~FileName() {
   }
 
-
+  /**
+   * Returns the path of the original file name. For *nix operating
+   * systems this includes everything up to but not including the
+   * last slash "/". For filenames created without any slashes
+   * the current working directory will be returned.
+   *
+   * @returns QString of the path portion of the original filename.
+   * <pre>
+   *   for a full file specification of:
+   *    "/home/me/img/picture.jpg"
+   *   originalPath() gives:
+   *    "/home/me/img"
+   * </pre>
+   */
   QString FileName::originalPath() const {
     return QFileInfo(m_d->original(false)).path();
   }
 
-
+  /**
+   * Returns the path of the file name. For *nix operating
+   * systems this includes everything up to but not including the
+   * last slash "/". For filenames created without any slashes
+   * the current working directory will be returned.
+   *
+   * @returns QString of the path portion of the filename.
+   * <pre>
+   *   for a full file specification of:
+   *    "/home/me/img/picture.jpg"
+   *   path() gives:
+   *    "/home/me/img"
+   * </pre>
+   */
   QString FileName::path() const {
     return QFileInfo(expanded()).path();
   }
 
-
+  /**
+   * Returns a QString of the attributes in a filename, attributes are expected to be of type
+   * CubeAttributeInput or CubeAttributeOutput. Filenames without any attributes return an
+   * empty QString.
+   *
+   * @returns QString of the attributes specified in the filename.
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub+Bsq"
+   *   attributes() gives:
+   *    "Bsq"
+   * </pre>
+   */
   QString FileName::attributes() const {
     QString result;
     QString fileNameWithAttribs = QFileInfo(m_d->original(true)).fileName();
@@ -87,32 +136,93 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Returns the name of the file without the path and without extensions.
+   *
+   * @returns QString containing every character excluding the path and all extensions.
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub.gz"
+   *   baseName() gives:
+   *    "Peaks"
+   * </pre>
+   */
   QString FileName::baseName() const {
     return QFileInfo(m_d->original(false)).completeBaseName();
   }
 
-
+  /**
+   * Returns the name of the file excluding the path and the attributes in the file name.
+   *
+   * @returns QString containing every character in the file name exluding the path and attributes
+   * of the file.
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub+Bsq"
+   *   name() gives:
+   *    "Peaks.cub"
+   * </pre>
+   */
   QString FileName::name() const {
     return QFileInfo(m_d->original(false)).fileName();
   }
 
-
+  /**
+   * Returns the last extension of the file name.
+   *
+   * @returns QString containing every character in the file name after the last "." character.
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub.gz"
+   *   extension() gives:
+   *    "gz"
+   * </pre>
+   */
   QString FileName::extension() const {
     return QFileInfo(m_d->original(false)).suffix();
   }
 
-
+  /**
+   * Returns a QString of the full file name including the file path, excluding the attributes.
+   * Any Isis Preferences or environment variables indicated by $, are changed to what they
+   * represent.
+   *
+   * @returns QString
+   * <pre>
+   *   for a full file specification of:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   *   expanded() gives:
+   *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
+   * </pre>
+   */
   QString FileName::expanded() const {
     return m_d->expanded(false);
   }
 
-
+  /**
+   * Returns the full file name including the file path
+   *
+   * @returns QString containing every character in the file name and the path
+   * <pre>
+   *   for a full file specification of:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   *   original() gives:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   * </pre>
+   */
   QString FileName::original() const {
     return m_d->original(true);
   }
 
-
+  /**
+   * Adds a new extension to the file name. If the current extension is the same as the
+   * new extension it will return an unchanged FileName object.
+   *
+   * @param &extension The new file extension to be added at the end of the file name after all
+   * exisiting extensions.
+   *
+   * @returns FileName object with added extension
+   */
   FileName FileName::addExtension(const QString &newExtension) const {
     FileName result = *this;
 
@@ -129,7 +239,11 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Removes all extensions in the file name
+   *
+   * @returns FileName object with all extensions removed
+   */
   FileName FileName::removeExtension() const {
     QString attributesStr = attributes();
 
@@ -142,7 +256,13 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Sets all current file extensions to a new extension in the file name.
+   *
+   * @param &extension The new file extension to replace any current file extensions with
+   *
+   * @returns FileName object with all existing extensions replaced by the new extension
+   */
   FileName FileName::setExtension(const QString &newExtension) const {
     FileName result = *this;
 
@@ -153,24 +273,44 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Checks to see if a file name is versioned by date or numerically. Returns true if file is
+   * versioned by date or numerically; returns false otherwise.
+   *
+   * @returns Boolean
+   */
   bool FileName::isVersioned() const {
     validateVersioningState();
 
     return isNumericallyVersioned() || isDateVersioned();
   }
 
-
+  /**
+   * Checks if the file name is versioned numerically. Returns true if the file is versioned
+   * numerically; returns false otherwise.
+   *
+   * @returns Boolean
+   */
   bool FileName::isNumericallyVersioned() const {
     return FileName(expanded()).name().contains("?");
   }
 
-
+  /**
+   * Checks if the file name is versioned by date. Returns true if the file is versioned
+   * by date; returns false otherwise.
+   *
+   * @returns Boolean
+   */
   bool FileName::isDateVersioned() const {
     return FileName(expanded()).name().contains(QRegExp("\\{.*\\}"));
   }
 
-
+  /**
+   * Searches the directory specified in the file name for the highest version of the file name.
+   * Returns a FileName object with the file name changed to reflect the highest version.
+   *
+   * @returns FileName object
+   */
   FileName FileName::highestVersion() const {
     validateVersioningState();
 
@@ -197,7 +337,15 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Updates the file name to be the latest version. If the file is versioned by date the
+   * newest version will be the current date. If the file is versioned numerically, the newest
+   * version will be the current version plus one.
+   *
+   * @returns FileName object with the new version file name.
+   *
+   * @throws Isis::IException::Unknown
+   */
   FileName FileName::newVersion() const {
     validateVersioningState();
 
@@ -238,7 +386,16 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Returns a FileName object of the same file name but versioned numerically by the
+   * number passed in as a parameter.
+   *
+   * @param versionNumber number to version the new FileName object
+   *
+   * @returns FileName object with the new version file name.
+   *
+   * @throws Isis::IException::Unknown
+   */
   FileName FileName::version(long versionNumber) const {
     QString file = FileName(expanded()).name();
 
@@ -269,24 +426,55 @@ namespace Isis {
     return FileName(originalPath() + "/" + file);
   }
 
-
+  /**
+   * Returns a FileName object of the same file name but versioned by the
+   * date passed in as a parameter.
+   *
+   * @param versionDate QDate to version the new FileName object
+   *
+   * @returns FileName object with the new version file name.
+   *
+   */
   FileName FileName::version(QDate versionDate) const {
     QString newName = versionDate.toString(fileNameQDatePattern());
 
     return FileName(originalPath() + "/" + newName);
   }
 
-
+  /**
+   * Returns true if the file exists; false otherwise.
+   * If the file is a symlink that points to a nonexistent file, false is returned.
+   *
+   * @returns Boolean
+   */
   bool FileName::fileExists() const {
     return QFileInfo(expanded()).exists();
   }
 
-
+  /**
+   * Returns the path of the file's parent directory as a QDir object
+   *
+   * @returns QDir
+   * <pre>
+   *   for a full file specification of:
+   *    "/tmp/Peaks.cub+Bsq"
+   *   dir() gives:
+   *    "/tmp/"
+   * </pre>
+   */
   QDir FileName::dir() const {
     return QFileInfo(expanded()).dir();
   }
 
-
+  /**
+   * Creates a temporary file and returns a FileName object created using the temporary file.
+   *
+   * @param templateFileName the file name used to create the temporary file.
+   *
+   * @returns FileName object created using the temporary file
+   *
+   * @throws Isis::IException::Io
+   */
   FileName FileName::createTempFile(FileName templateFileName) {
     QString preppedFileName = QString("%1/%2XXXXXX.%3").arg(templateFileName.path())
         .arg(templateFileName.baseName()).arg(templateFileName.extension());
@@ -310,18 +498,45 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Returns a QString of the full file name including the file path, excluding the attributes
+   * with any Isis Preferences or environment variables indicated by $, changed to what they
+   * represent.
+   *
+   * @returns QString
+   * <pre>
+   *   for a full file specification of:
+   *    "$ISISROOT/tmp/Peaks.cub+Bsq"
+   *   toString() gives:
+   *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
+   * </pre>
+   */
   QString FileName::toString() const {
     return expanded();
   }
 
-
+  /**
+   * Clears the current contents of the FileName object and reinitializes it with
+   * the argument.
+   *
+   * @returns void
+   *
+   * @param rhs FileName to replace the current contents of the object.
+   *
+   */
   FileName &FileName::operator=(const FileName &rhs) {
     m_d = rhs.m_d;
     return *this;
   }
 
-
+  /**
+   * Compares equality of two FileName objects. Returns true if the two objects are equal
+   * and false otherwise.
+   *
+   * @returns Boolean
+   *
+   * @param rhs FileName to compare the current FileName object to.
+   */
   bool FileName::operator==(const FileName &rhs) {
     QString expandedOfThis = expanded();
     QString canonicalOfThis = QFileInfo(expandedOfThis).canonicalFilePath();
@@ -342,12 +557,24 @@ namespace Isis {
     return equal;
   }
 
-
+  /**
+   * Compares equality of two FileName objects. Returns false if the two objects are equal
+   * and true otherwise.
+   *
+   * @returns Boolean
+   *
+   * @param rhs FileName to compare the current FileName object to.
+   */
   bool FileName::operator!=(const FileName &rhs) {
     return !(*this == rhs);
   }
 
-
+  /**
+   * This looks through the directory of the file and checks for the highest version date of
+   * the file that is versioned date.
+   *
+   * @returns QDate
+   */
   QDate FileName::highestVersionDate() const {
     QString fileQDatePattern = fileNameQDatePattern();
 
@@ -405,7 +632,12 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * This looks through the directory of the file and checks for the highest version number of
+   * the file that is versioned numerically.
+   *
+   * @returns long
+   */
   long FileName::highestVersionNum() const {
     QString file = FileName(expanded()).name();
     int result = 0;
@@ -441,7 +673,10 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * This verifies the class invariant when using versioning - that the FileName is in an acceptable
+   *     state to find file version numbers.
+   */
   void FileName::validateVersioningState() const {
     QString file = QFileInfo(expanded()).fileName();
 
@@ -484,6 +719,12 @@ namespace Isis {
     }
   }
 
+  /**
+   * This changes the files format. Specifically quotes everything not in {} with single quotes
+   * and removes the {} from the file name.
+   *
+   * @returns QString
+   */
   QString FileName::fileNameQDatePattern() const {
     // We need to quote everything not in {} with single quotes.
     QString file = FileName(expanded()).name();
@@ -508,7 +749,12 @@ namespace Isis {
     return file;
   }
 
-
+  /**
+   * This returns a QPair of the text (before, after) a version number in a file. Before being
+   * the text before the version number and after being the text after the version number.
+   *
+   * @returns QPair
+   */
   QPair<QString, QString> FileName::splitNameAroundVersionNum() const {
     QString file = FileName(expanded()).name();
     QString before;
@@ -525,7 +771,7 @@ namespace Isis {
     return QPair<QString, QString>(before, after);
   }
 
-
+   //! Data constructor, creates a new Data object.
   FileName::Data::Data() {
     m_originalFileNameString = NULL;
     m_expandedFileNameString = NULL;
@@ -534,7 +780,10 @@ namespace Isis {
     m_expandedFileNameString = new QString;
   }
 
-
+  /**
+   * Data copy constructor, creates a copy of a Data object.
+   * @param &other Data object to copy
+   */
   FileName::Data::Data(const Data &other) : QSharedData(other) {
     m_originalFileNameString = NULL;
     m_expandedFileNameString = NULL;
@@ -543,7 +792,7 @@ namespace Isis {
     m_expandedFileNameString = new QString(*other.m_expandedFileNameString);
   }
 
-
+  //! Destroys the Data object.
   FileName::Data::~Data() {
     delete m_originalFileNameString;
     m_originalFileNameString = NULL;
@@ -552,7 +801,15 @@ namespace Isis {
     m_expandedFileNameString = NULL;
   }
 
-
+  /**
+   * Returns the original file name, stored in m_originalFileNameString. Boolean
+   * parameter includeAttributes determines if the returned file name has the variables
+   * included.
+   *
+   * @returns Qstring
+   *
+   * @param includeAttributes boolean to represent whether the attricubtes should be included.
+   */
   QString FileName::Data::original(bool includeAttributes) const {
     QString result = *m_originalFileNameString;
 
@@ -567,7 +824,13 @@ namespace Isis {
     return result;
   }
 
-
+  /**
+   * Sets the original file name, stored in m_originalFileNameString. QString parameter
+   * is the new file name to store in m_originalFileNameString. The expanded verison is also
+   * set and stored in m_expandedFileNameString when this method is called.
+   *
+   * @param originalStr the new file name
+   */
   void FileName::Data::setOriginal(const QString &originalStr) {
     *m_originalFileNameString = originalStr;
 
@@ -633,7 +896,15 @@ namespace Isis {
     *m_expandedFileNameString = expandedStr;
   }
 
-
+  /**
+   * Returns the expanded file name, stored in m_expandedFileNameString. Boolean
+   *  parameter includeAttributes determines if the returned file name has the variables
+   * included.
+   *
+   * @returns Qstring
+   *
+   * @param includeAttributes boolean to represent whether the attricubtes should be included.
+   */
   QString FileName::Data::expanded(bool includeAttributes) const {
     QString result = *m_expandedFileNameString;
 

--- a/isis/src/base/objs/FileName/FileName.h
+++ b/isis/src/base/objs/FileName/FileName.h
@@ -108,383 +108,62 @@ namespace Isis {
    *                           ISIS coding standards and removed include for std::string.
    *   @history 2016-06-21 Kris Becker - Properly forward declare QPair as struct not class
    *   @history 2017-04-21 Cole Neubauer - Updated documentation for the class Fixes #4121
+   *   @history 2018-04-06 Kaitlyn Lee - Moved method documentation to cpp file and
+   *                           updated it for consistency. Fixes #5230.
+
    */
   class FileName {
     public:
-      //! Constructs an empty FileName object.
+      // Constructors
       FileName();
-      /**
-       * Constructs a FileName object using a char pointer as a file name.
-       * @param *fileName char pointer representing new filename
-       */
       FileName(const char *fileName);
-      /**
-       * Constructs a FileName object using a QString as a file name.
-       * @param &fileName Qstring representing new filename
-       */
       FileName(const QString &fileName);
-      //! Copy Constructor, creates a copy of a FileName object.
-      /**
-       * Constructs a copy of a FileName object using another FileName object.
-       * @param &other FileName object to copy.
-       */
+
+      // Copy Constructor, creates a copy of a FileName object.
       FileName(const FileName &other);
-      //! Destroys the FileName object.
+
+      // Destroys the FileName Object
       ~FileName();
 
-
-      /**
-       * Returns the path of the original file name. For *nix operating
-       * systems this includes everything up to but not including the
-       * last slash "/". For filenames created without any slashes
-       * the current working directory will be returned.
-       *
-       * @returns QString of the path portion of the original filename.
-       * <pre>
-       *   for a full file specification of:
-       *    "/home/me/img/picture.jpg"
-       *   originalPath() gives:
-       *    "/home/me/img"
-       * </pre>
-       */
+      // Methods
       QString originalPath() const;
-
-
-      /**
-       * Returns the path of the file name. For *nix operating
-       * systems this includes everything up to but not including the
-       * last slash "/". For filenames created without any slashes
-       * the current working directory will be returned.
-       *
-       * @returns QString of the path portion of the filename.
-       * <pre>
-       *   for a full file specification of:
-       *    "/home/me/img/picture.jpg"
-       *   path() gives:
-       *    "/home/me/img"
-       * </pre>
-       */
       QString path() const;
-
-
-      /**
-       * Returns a QString of the attributes in a filename, attributes are expected to be of type
-       * CubeAttributeInput or CubeAttributeOutput. Filenames without any attributes return an
-       * empty QString.
-       *
-       * @returns QString of the attributes specified in the filename.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub+Bsq"
-       *   attributes() gives:
-       *    "Bsq"
-       * </pre>
-       */
       QString attributes() const;
-
-
-      /**
-       * Returns the name of the file without the path and without extensions.
-       *
-       * @returns QString containing every character excluding the path and all extensions.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub.gz"
-       *   baseName() gives:
-       *    "Peaks"
-       * </pre>
-       */
       QString baseName() const;
-
-
-      /**
-       * Returns the name of the file excluding the path and the attributes in the file name.
-       *
-       * @returns QString containing every character in the file name exluding the path and attributes
-       * of the file.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub+Bsq"
-       *   name() gives:
-       *    "Peaks.cub"
-       * </pre>
-       */
       QString name() const;
-
-
-      /**
-       * Returns the last extension of the file name.
-       *
-       * @returns QString containing every character in the file name after the last "." character.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub.gz"
-       *   extension() gives:
-       *    "gz"
-       * </pre>
-       */
       QString extension() const;
-
-
-      /**
-       * Returns a QString of the full file name including the file path, excluding the attributes.
-       * Any Isis Preferences or environment variables indicated by $, are changed to what they
-       * represent.
-       *
-       * @returns QString
-       * <pre>
-       *   for a full file specification of:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       *   expanded() gives:
-       *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
-       * </pre>
-       */
       QString expanded() const;
-
-
-      /**
-       * Returns the full file name including the file path
-       *
-       * @returns QString containing every character in the file name and the path
-       * <pre>
-       *   for a full file specification of:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       *   original() gives:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       * </pre>
-       */
       QString original() const;
 
-
-      /**
-       * Adds a new extension to the file name. If the current extension is the same as the
-       * new extension it will return an unchanged FileName object.
-       *
-       * @param &extension The new file extension to be added at the end of the file name after all
-       * exisiting extensions.
-       *
-       * @returns FileName object with added extension
-       */
       FileName addExtension(const QString &extension) const;
-
-
-      /**
-       * Removes all extensions in the file name
-       *
-       * @returns FileName object with all extensions removed
-       */
       FileName removeExtension() const;
-
-
-      /**
-       * Sets all current file extensions to a new extension in the file name.
-       *
-       * @param &extension The new file extension to replace any current file extensions with
-       *
-       * @returns FileName object with all existing extensions replaced by the new extension
-       */
       FileName setExtension(const QString &extension) const;
 
-
-      /**
-       * Checks to see if a file name is versioned by date or numerically. Returns true if file is
-       * versioned by date or numerically; returns false otherwise.
-       *
-       * @returns Boolean
-       */
       bool isVersioned() const;
-
-
-      /**
-       * Checks if the file name is versioned numerically. Returns true if the file is versioned
-       * numerically; returns false otherwise.
-       *
-       * @returns Boolean
-       */
       bool isNumericallyVersioned() const;
-
-
-      /**
-       * Checks if the file name is versioned by date. Returns true if the file is versioned
-       * by date; returns false otherwise.
-       *
-       * @returns Boolean
-       */
       bool isDateVersioned() const;
 
-
-      /**
-       * Searches the directory specified in the file name for the highest version of the file name.
-       * Returns a FileName object with the file name changed to reflect the highest version.
-       *
-       * @returns FileName object
-       */
       FileName highestVersion() const;
-
-
-      /**
-       * Updates the file name to be the latest version. If the file is versioned by date the
-       * newest version will be the current date. If the file is versioned numerically, the newest
-       * version will be the current version plus one.
-       *
-       * @returns FileName object with the new version file name.
-       *
-       * @throws Isis::IException::Unknown
-       */
       FileName newVersion() const;
-
-
-      /**
-       * Returns a FileName object of the same file name but versioned numerically by the
-       * number passed in as a parameter.
-       *
-       * @param versionNumber number to version the new FileName object
-       *
-       * @returns FileName object with the new version file name.
-       *
-       * @throws Isis::IException::Unknown
-       */
       FileName version(long versionNumber) const;
-
-
-      /**
-       * Returns a FileName object of the same file name but versioned by the
-       * date passed in as a parameter.
-       *
-       * @param versionDate QDate to version the new FileName object
-       *
-       * @returns FileName object with the new version file name.
-       *
-       */
       FileName version(QDate versionDate) const;
 
-
-      /**
-       * Returns true if the file exists; false otherwise.
-       * If the file is a symlink that points to a nonexistent file, false is returned.
-       *
-       * @returns Boolean
-       */
       bool fileExists() const;
-
-
-      /**
-       * Returns the path of the file's parent directory as a QDir object
-       *
-       * @returns QDir
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub+Bsq"
-       *   dir() gives:
-       *    "/tmp/"
-       * </pre>
-       */
       QDir dir() const;
-
-
-      /**
-       * Creates a temporary file and returns a FileName object created using the temporary file.
-       *
-       * @param templateFileName the file name used to create the temporary file.
-       *
-       * @returns FileName object created using the temporary file
-       *
-       * @throws Isis::IException::Io
-       */
       static FileName createTempFile(FileName templateFileName = "$TEMPORARY/temp");
-
-
-      /**
-       * Returns a QString of the full file name including the file path, excluding the attributes
-       * with any Isis Preferences or environment variables indicated by $, changed to what they
-       * represent.
-       *
-       * @returns QString
-       * <pre>
-       *   for a full file specification of:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       *   toString() gives:
-       *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
-       * </pre>
-       */
       QString toString() const;
-
-
-      /**
-       * Clears the current contents of the FileName object and reinitializes it with
-       * the argument.
-       *
-       * @returns void
-       *
-       * @param rhs FileName to replace the current contents of the object.
-       *
-       */
       FileName &operator=(const FileName &rhs);
-
-
-      /**
-       * Compares equality of two FileName objects. Returns true if the two objects are equal
-       * and false otherwise.
-       *
-       * @returns Boolean
-       *
-       * @param rhs FileName to compare the current FileName object to.
-       */
       bool operator==(const FileName &rhs);
-
-
-      /**
-       * Compares equality of two FileName objects. Returns false if the two objects are equal
-       * and true otherwise.
-       *
-       * @returns Boolean
-       *
-       * @param rhs FileName to compare the current FileName object to.
-       */
       bool operator!=(const FileName &rhs);
 
 
     private:
-      /**
-       * This looks through the directory of the file and checks for the highest version date of
-       * the file that is versioned date.
-       *
-       * @returns QDate
-       */
+
       QDate highestVersionDate() const;
-
-
-      /**
-       * This looks through the directory of the file and checks for the highest version number of
-       * the file that is versioned numerically.
-       *
-       * @returns long
-       */
       long highestVersionNum() const;
-
-
-      /**
-       * This verifies the class invariant when using versioning - that the FileName is in an acceptable
-       *     state to find file version numbers.
-       */
       void validateVersioningState() const;
-
-     /**
-      * This changes the files format. Specifically quotes everything not in {} with single quotes
-      * and removes the {} from the file name.
-      *
-      * @returns QString
-      */
       QString fileNameQDatePattern() const;
-
-     /**
-      * This returns a QPair of the text (before, after) a version number in a file. Before being
-      * the text before the version number and after being the text after the version number.
-      *
-      * @returns QPair
-      */
       QPair<QString, QString> splitNameAroundVersionNum() const;
-
 
     private:
       /**
@@ -496,65 +175,31 @@ namespace Isis {
        */
       class Data : public QSharedData {
         public:
-          //! Data constructor, creates a new Data object.
+
+          // Constructors
           Data();
 
-
-          /**
-           * Data copy constructor, creates a copy of a Data object.
-           * @param &other Data object to copy
-           */
+          // Copy Constructor, creates a copy of a Data object.
           Data(const Data &other);
 
-
-          //! Destroys the Data object.
+          // Destroys the Data Object
           ~Data();
 
-
-         /**
-          * Returns the original file name, stored in m_originalFileNameString. Boolean
-          * parameter includeAttributes determines if the returned file name has the variables
-          * included.
-          *
-          * @returns Qstring
-          *
-          * @param includeAttributes boolean to represent whether the attricubtes should be included.
-          */
+          // Methods
           QString original(bool includeAttributes) const;
-
-
-         /**
-          * Sets the original file name, stored in m_originalFileNameString. QString parameter
-          * is the new file name to store in m_originalFileNameString. The expanded verison is also
-          * set and stored in m_expandedFileNameString when this method is called.
-          *
-          * @param originalStr the new file name
-          */
           void setOriginal(const QString &originalStr);
-
-
-         /**
-          * Returns the expanded file name, stored in m_expandedFileNameString. Boolean
-          *  parameter includeAttributes determines if the returned file name has the variables
-          * included.
-          *
-          * @returns Qstring
-          *
-          * @param includeAttributes boolean to represent whether the attricubtes should be included.
-          */
           QString expanded(bool includeAttributes) const;
 
-
         private:
-          //! Holds the original file name.
+          // Holds the original file name.
           QString *m_originalFileNameString;
 
 
-          //! Holds the expanded file name.
+          // Holds the expanded file name.
           QString *m_expandedFileNameString;
       };
 
-      //! @see QSharedDataPointer
+      // @see QSharedDataPointer
       QSharedDataPointer<Data> m_d;
   };
 };

--- a/isis/src/base/objs/FileName/FileName.h
+++ b/isis/src/base/objs/FileName/FileName.h
@@ -108,6 +108,9 @@ namespace Isis {
    *                           ISIS coding standards and removed include for std::string.
    *   @history 2016-06-21 Kris Becker - Properly forward declare QPair as struct not class
    *   @history 2017-04-21 Cole Neubauer - Updated documentation for the class Fixes #4121
+   *   @history 2018-04-06 Kaitlyn Lee - Moved method documentation to cpp file and
+   *                           updated it for consistency. Fixes #5230.
+
    */
   class FileName {
     public:
@@ -116,10 +119,10 @@ namespace Isis {
       FileName(const char *fileName);
       FileName(const QString &fileName);
 
-      //! Copy Constructor, creates a copy of a FileName object.
+      // Copy Constructor, creates a copy of a FileName object.
       FileName(const FileName &other);
 
-      //! Destroys the FileName Object
+      // Destroys the FileName Object
       ~FileName();
 
       // Methods
@@ -173,13 +176,13 @@ namespace Isis {
       class Data : public QSharedData {
         public:
 
-          //Constructors
+          // Constructors
           Data();
 
-          //! Copy Constructor, creates a copy of a Data object.
+          // Copy Constructor, creates a copy of a Data object.
           Data(const Data &other);
 
-          //! Destroys the Data Object
+          // Destroys the Data Object
           ~Data();
 
           // Methods
@@ -188,15 +191,15 @@ namespace Isis {
           QString expanded(bool includeAttributes) const;
 
         private:
-          //! Holds the original file name.
+          // Holds the original file name.
           QString *m_originalFileNameString;
 
 
-          //! Holds the expanded file name.
+          // Holds the expanded file name.
           QString *m_expandedFileNameString;
       };
 
-      //! @see QSharedDataPointer
+      // @see QSharedDataPointer
       QSharedDataPointer<Data> m_d;
   };
 };

--- a/isis/src/base/objs/FileName/FileName.h
+++ b/isis/src/base/objs/FileName/FileName.h
@@ -111,378 +111,79 @@ namespace Isis {
    */
   class FileName {
     public:
-      //! Constructs an empty FileName object.
+
       FileName();
-      /**
-       * Constructs a FileName object using a char pointer as a file name.
-       * @param *fileName char pointer representing new filename
-       */
+
       FileName(const char *fileName);
-      /**
-       * Constructs a FileName object using a QString as a file name.
-       * @param &fileName Qstring representing new filename
-       */
+
       FileName(const QString &fileName);
-      //! Copy Constructor, creates a copy of a FileName object.
-      /**
-       * Constructs a copy of a FileName object using another FileName object.
-       * @param &other FileName object to copy.
-       */
+
       FileName(const FileName &other);
-      //! Destroys the FileName object.
+
       ~FileName();
 
-
-      /**
-       * Returns the path of the original file name. For *nix operating
-       * systems this includes everything up to but not including the
-       * last slash "/". For filenames created without any slashes
-       * the current working directory will be returned.
-       *
-       * @returns QString of the path portion of the original filename.
-       * <pre>
-       *   for a full file specification of:
-       *    "/home/me/img/picture.jpg"
-       *   originalPath() gives:
-       *    "/home/me/img"
-       * </pre>
-       */
       QString originalPath() const;
 
-
-      /**
-       * Returns the path of the file name. For *nix operating
-       * systems this includes everything up to but not including the
-       * last slash "/". For filenames created without any slashes
-       * the current working directory will be returned.
-       *
-       * @returns QString of the path portion of the filename.
-       * <pre>
-       *   for a full file specification of:
-       *    "/home/me/img/picture.jpg"
-       *   path() gives:
-       *    "/home/me/img"
-       * </pre>
-       */
       QString path() const;
 
-
-      /**
-       * Returns a QString of the attributes in a filename, attributes are expected to be of type
-       * CubeAttributeInput or CubeAttributeOutput. Filenames without any attributes return an
-       * empty QString.
-       *
-       * @returns QString of the attributes specified in the filename.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub+Bsq"
-       *   attributes() gives:
-       *    "Bsq"
-       * </pre>
-       */
       QString attributes() const;
 
-
-      /**
-       * Returns the name of the file without the path and without extensions.
-       *
-       * @returns QString containing every character excluding the path and all extensions.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub.gz"
-       *   baseName() gives:
-       *    "Peaks"
-       * </pre>
-       */
       QString baseName() const;
 
-
-      /**
-       * Returns the name of the file excluding the path and the attributes in the file name.
-       *
-       * @returns QString containing every character in the file name exluding the path and attributes
-       * of the file.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub+Bsq"
-       *   name() gives:
-       *    "Peaks.cub"
-       * </pre>
-       */
       QString name() const;
 
-
-      /**
-       * Returns the last extension of the file name.
-       *
-       * @returns QString containing every character in the file name after the last "." character.
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub.gz"
-       *   extension() gives:
-       *    "gz"
-       * </pre>
-       */
       QString extension() const;
 
-
-      /**
-       * Returns a QString of the full file name including the file path, excluding the attributes.
-       * Any Isis Preferences or environment variables indicated by $, are changed to what they
-       * represent.
-       *
-       * @returns QString
-       * <pre>
-       *   for a full file specification of:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       *   expanded() gives:
-       *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
-       * </pre>
-       */
       QString expanded() const;
 
-
-      /**
-       * Returns the full file name including the file path
-       *
-       * @returns QString containing every character in the file name and the path
-       * <pre>
-       *   for a full file specification of:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       *   original() gives:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       * </pre>
-       */
       QString original() const;
 
-
-      /**
-       * Adds a new extension to the file name. If the current extension is the same as the
-       * new extension it will return an unchanged FileName object.
-       *
-       * @param &extension The new file extension to be added at the end of the file name after all
-       * exisiting extensions.
-       *
-       * @returns FileName object with added extension
-       */
       FileName addExtension(const QString &extension) const;
 
-
-      /**
-       * Removes all extensions in the file name
-       *
-       * @returns FileName object with all extensions removed
-       */
       FileName removeExtension() const;
 
-
-      /**
-       * Sets all current file extensions to a new extension in the file name.
-       *
-       * @param &extension The new file extension to replace any current file extensions with
-       *
-       * @returns FileName object with all existing extensions replaced by the new extension
-       */
       FileName setExtension(const QString &extension) const;
 
-
-      /**
-       * Checks to see if a file name is versioned by date or numerically. Returns true if file is
-       * versioned by date or numerically; returns false otherwise.
-       *
-       * @returns Boolean
-       */
       bool isVersioned() const;
 
-
-      /**
-       * Checks if the file name is versioned numerically. Returns true if the file is versioned
-       * numerically; returns false otherwise.
-       *
-       * @returns Boolean
-       */
       bool isNumericallyVersioned() const;
 
-
-      /**
-       * Checks if the file name is versioned by date. Returns true if the file is versioned
-       * by date; returns false otherwise.
-       *
-       * @returns Boolean
-       */
       bool isDateVersioned() const;
 
-
-      /**
-       * Searches the directory specified in the file name for the highest version of the file name.
-       * Returns a FileName object with the file name changed to reflect the highest version.
-       *
-       * @returns FileName object
-       */
       FileName highestVersion() const;
 
-
-      /**
-       * Updates the file name to be the latest version. If the file is versioned by date the
-       * newest version will be the current date. If the file is versioned numerically, the newest
-       * version will be the current version plus one.
-       *
-       * @returns FileName object with the new version file name.
-       *
-       * @throws Isis::IException::Unknown
-       */
       FileName newVersion() const;
 
-
-      /**
-       * Returns a FileName object of the same file name but versioned numerically by the
-       * number passed in as a parameter.
-       *
-       * @param versionNumber number to version the new FileName object
-       *
-       * @returns FileName object with the new version file name.
-       *
-       * @throws Isis::IException::Unknown
-       */
       FileName version(long versionNumber) const;
 
-
-      /**
-       * Returns a FileName object of the same file name but versioned by the
-       * date passed in as a parameter.
-       *
-       * @param versionDate QDate to version the new FileName object
-       *
-       * @returns FileName object with the new version file name.
-       *
-       */
       FileName version(QDate versionDate) const;
 
-
-      /**
-       * Returns true if the file exists; false otherwise.
-       * If the file is a symlink that points to a nonexistent file, false is returned.
-       *
-       * @returns Boolean
-       */
       bool fileExists() const;
 
-
-      /**
-       * Returns the path of the file's parent directory as a QDir object
-       *
-       * @returns QDir
-       * <pre>
-       *   for a full file specification of:
-       *    "/tmp/Peaks.cub+Bsq"
-       *   dir() gives:
-       *    "/tmp/"
-       * </pre>
-       */
       QDir dir() const;
 
-
-      /**
-       * Creates a temporary file and returns a FileName object created using the temporary file.
-       *
-       * @param templateFileName the file name used to create the temporary file.
-       *
-       * @returns FileName object created using the temporary file
-       *
-       * @throws Isis::IException::Io
-       */
       static FileName createTempFile(FileName templateFileName = "$TEMPORARY/temp");
 
-
-      /**
-       * Returns a QString of the full file name including the file path, excluding the attributes
-       * with any Isis Preferences or environment variables indicated by $, changed to what they
-       * represent.
-       *
-       * @returns QString
-       * <pre>
-       *   for a full file specification of:
-       *    "$ISISROOT/tmp/Peaks.cub+Bsq"
-       *   toString() gives:
-       *    "/usgs/pkgs/isis3/isis/tmp/Peaks.cub"
-       * </pre>
-       */
       QString toString() const;
 
-
-      /**
-       * Clears the current contents of the FileName object and reinitializes it with
-       * the argument.
-       *
-       * @returns void
-       *
-       * @param rhs FileName to replace the current contents of the object.
-       *
-       */
       FileName &operator=(const FileName &rhs);
 
-
-      /**
-       * Compares equality of two FileName objects. Returns true if the two objects are equal
-       * and false otherwise.
-       *
-       * @returns Boolean
-       *
-       * @param rhs FileName to compare the current FileName object to.
-       */
       bool operator==(const FileName &rhs);
 
-
-      /**
-       * Compares equality of two FileName objects. Returns false if the two objects are equal
-       * and true otherwise.
-       *
-       * @returns Boolean
-       *
-       * @param rhs FileName to compare the current FileName object to.
-       */
       bool operator!=(const FileName &rhs);
 
 
     private:
-      /**
-       * This looks through the directory of the file and checks for the highest version date of
-       * the file that is versioned date.
-       *
-       * @returns QDate
-       */
+
       QDate highestVersionDate() const;
 
-
-      /**
-       * This looks through the directory of the file and checks for the highest version number of
-       * the file that is versioned numerically.
-       *
-       * @returns long
-       */
       long highestVersionNum() const;
 
-
-      /**
-       * This verifies the class invariant when using versioning - that the FileName is in an acceptable
-       *     state to find file version numbers.
-       */
       void validateVersioningState() const;
 
-     /**
-      * This changes the files format. Specifically quotes everything not in {} with single quotes
-      * and removes the {} from the file name.
-      *
-      * @returns QString
-      */
       QString fileNameQDatePattern() const;
 
-     /**
-      * This returns a QPair of the text (before, after) a version number in a file. Before being
-      * the text before the version number and after being the text after the version number.
-      *
-      * @returns QPair
-      */
+
       QPair<QString, QString> splitNameAroundVersionNum() const;
 
 
@@ -496,54 +197,18 @@ namespace Isis {
        */
       class Data : public QSharedData {
         public:
-          //! Data constructor, creates a new Data object.
+
           Data();
 
-
-          /**
-           * Data copy constructor, creates a copy of a Data object.
-           * @param &other Data object to copy
-           */
           Data(const Data &other);
 
-
-          //! Destroys the Data object.
           ~Data();
 
-
-         /**
-          * Returns the original file name, stored in m_originalFileNameString. Boolean
-          * parameter includeAttributes determines if the returned file name has the variables
-          * included.
-          *
-          * @returns Qstring
-          *
-          * @param includeAttributes boolean to represent whether the attricubtes should be included.
-          */
           QString original(bool includeAttributes) const;
 
-
-         /**
-          * Sets the original file name, stored in m_originalFileNameString. QString parameter
-          * is the new file name to store in m_originalFileNameString. The expanded verison is also
-          * set and stored in m_expandedFileNameString when this method is called.
-          *
-          * @param originalStr the new file name
-          */
           void setOriginal(const QString &originalStr);
 
-
-         /**
-          * Returns the expanded file name, stored in m_expandedFileNameString. Boolean
-          *  parameter includeAttributes determines if the returned file name has the variables
-          * included.
-          *
-          * @returns Qstring
-          *
-          * @param includeAttributes boolean to represent whether the attricubtes should be included.
-          */
           QString expanded(bool includeAttributes) const;
-
 
         private:
           //! Holds the original file name.

--- a/isis/src/base/objs/FileName/FileName.h
+++ b/isis/src/base/objs/FileName/FileName.h
@@ -111,81 +111,56 @@ namespace Isis {
    */
   class FileName {
     public:
-
+      // Constructors
       FileName();
-
       FileName(const char *fileName);
-
       FileName(const QString &fileName);
 
+      //! Copy Constructor, creates a copy of a FileName object.
       FileName(const FileName &other);
 
+      //! Destroys the FileName Object
       ~FileName();
 
+      // Methods
       QString originalPath() const;
-
       QString path() const;
-
       QString attributes() const;
-
       QString baseName() const;
-
       QString name() const;
-
       QString extension() const;
-
       QString expanded() const;
-
       QString original() const;
 
       FileName addExtension(const QString &extension) const;
-
       FileName removeExtension() const;
-
       FileName setExtension(const QString &extension) const;
 
       bool isVersioned() const;
-
       bool isNumericallyVersioned() const;
-
       bool isDateVersioned() const;
 
       FileName highestVersion() const;
-
       FileName newVersion() const;
-
       FileName version(long versionNumber) const;
-
       FileName version(QDate versionDate) const;
 
       bool fileExists() const;
-
       QDir dir() const;
-
       static FileName createTempFile(FileName templateFileName = "$TEMPORARY/temp");
-
       QString toString() const;
-
       FileName &operator=(const FileName &rhs);
-
       bool operator==(const FileName &rhs);
-
       bool operator!=(const FileName &rhs);
 
 
     private:
 
       QDate highestVersionDate() const;
-
       long highestVersionNum() const;
-
       void validateVersioningState() const;
-
       QString fileNameQDatePattern() const;
-
-
       QPair<QString, QString> splitNameAroundVersionNum() const;
-
 
     private:
       /**
@@ -198,16 +173,18 @@ namespace Isis {
       class Data : public QSharedData {
         public:
 
+          //Constructors
           Data();
 
+          //! Copy Constructor, creates a copy of a Data object.
           Data(const Data &other);
 
+          //! Destroys the Data Object
           ~Data();
 
+          // Methods
           QString original(bool includeAttributes) const;
-
           void setOriginal(const QString &originalStr);
-
           QString expanded(bool includeAttributes) const;
 
         private:


### PR DESCRIPTION
The method documentation was inside of the h file, instead of the cpp file. I also made some changes to the documentation to make sure everything was consistent.