### PR TITLE
Added subwindow support to Rosetta OSIRIS camera model

### DIFF
--- a/isis/src/rosetta/objs/RosettaOsirisCamera/RosettaOsirisCamera.h
+++ b/isis/src/rosetta/objs/RosettaOsirisCamera/RosettaOsirisCamera.h
@@ -39,7 +39,7 @@ namespace Isis {
    * @internal
    *   @history 2015-05-21 Sasha Brownsberger - Original Version.
    *   @history 2017-06-02 Jesse Mapel - Added a distortion map Fixes #4496.
-   *   @history 2017-04-11 Jesse Mapel - Added subwindowing.
+   *   @history 2017-04-11 Jesse Mapel - Added subwindowing. Fixes #5394.
    */
   class RosettaOsirisCamera : public FramingCamera {
     public:

--- a/isis/src/rosetta/objs/RosettaOsirisCamera/RosettaOsirisCamera.h
+++ b/isis/src/rosetta/objs/RosettaOsirisCamera/RosettaOsirisCamera.h
@@ -29,7 +29,7 @@
 
 namespace Isis {
   /**
-   * This is the camera model for the Osiris NAC Framing Camera 
+   * This is the camera model for the Osiris NAC Framing Camera
    *
    * @ingroup SpiceInstrumentsAndCameras
    * @ingroup Rosetta
@@ -39,6 +39,7 @@ namespace Isis {
    * @internal
    *   @history 2015-05-21 Sasha Brownsberger - Original Version.
    *   @history 2017-06-02 Jesse Mapel - Added a distortion map Fixes #4496.
+   *   @history 2017-04-11 Jesse Mapel - Added subwindowing.
    */
   class RosettaOsirisCamera : public FramingCamera {
     public:
@@ -48,17 +49,17 @@ namespace Isis {
       //! Destroys the NewHorizonsLorriCamera object
       ~RosettaOsirisCamera() {};
 
-    /** 
-     * Reimplemented from FrameCamera 
-     *  
+    /**
+     * Reimplemented from FrameCamera
+     *
      * @author Stuart Sides
      *
      * @internal
      * @history modified Sasha Brownsberger (2015/05/21)
-     * 
+     *
      * @param time Start time of the observation
      * @param exposureDuration The exposure duration of the observation
-     * 
+     *
      * @return std::pair<iTime,iTime> The start and end times of the observation
      */
       virtual std::pair <iTime, iTime> ShutterOpenCloseTimes(double time,
@@ -66,23 +67,23 @@ namespace Isis {
 
       /**
        * CK frame ID -  - Instrument Code from spacit run on CK
-       *  
-       * @return @b int The appropriate instrument code for the "Camera-matrix" 
+       *
+       * @return @b int The appropriate instrument code for the "Camera-matrix"
        *         Kernel Frame ID
        */
-      virtual int CkFrameId() const { return (-226000); } //Code for Rosetta orbitter; no specific code for Osiris in ck files.  
+      virtual int CkFrameId() const { return (-226000); } //Code for Rosetta orbitter; no specific code for Osiris in ck files.
 
-      /** 
+      /**
        * CK Reference ID - J2000
-       * 
+       *
        * @return @b int The appropriate instrument code for the "Camera-matrix"
        *         Kernel Reference ID
        */
       virtual int CkReferenceId() const { return (1); }
 
-      /** 
+      /**
        * SPK Reference ID - J2000
-       * 
+       *
        * @return @b int The appropriate instrument code for the Spacecraft
        *         Kernel Reference ID
        */


### PR DESCRIPTION
There is also a change to the IAK for the WAC that is not currently in the data area, but it resolves a different problem.