### PR TITLE
Updated the pvl.DIFF's of the dawn test's input to ignore the InstrumentPointing keyword. Fixes #5379

### DIFF
--- a/isis/src/control/apps/sumspice/sumspice.xml
+++ b/isis/src/control/apps/sumspice/sumspice.xml
@@ -314,6 +314,10 @@ sumspice from=st_2395699394_v.lev0.cub sumfile=N2395699394.SUM  update=spice sum
       Changed pvl.DIFF of input for hayabusa app test to ignore file names. Allows test to pass when
       not using default data area. Fixes #4738.
     </change>
+    <change name="Kaitlyn Lee" date="2018-04-08">
+      Updated the pvl.DIFF's of the input for the dawn test to ignore the 
+      InstrumentPointing keyword. Fixes #5379.
+    </change>
   </history>
 
   <category>


### PR DESCRIPTION
sumpsice's dawn test was failing because the InstrumentPointing keyword was not being ignored. 