### PR TITLE
Ipce

### DIFF
--- a/isis/src/qisis/apps/ipce/ControlNetTool.cpp
+++ b/isis/src/qisis/apps/ipce/ControlNetTool.cpp
@@ -1,0 +1,1 @@
+../../objs/ControlNetTool/ControlNetTool.cpp

--- a/isis/src/qisis/apps/ipce/ipce.cpp
+++ b/isis/src/qisis/apps/ipce/ipce.cpp
@@ -26,6 +26,7 @@
 #include <QLocale>
 #include <QTranslator>
 
+#include "FileName.h"
 #include "Gui.h"
 #include "IException.h"
 #include "IpceMainWindow.h"
@@ -39,10 +40,19 @@ int main(int argc, char *argv[]) {
   Gui::checkX11();
 
   try {
+
+    // Add the Qt plugin directory to the library path
+    FileName qtpluginpath("$ISISROOT/3rdParty/plugins");
+    QCoreApplication::addLibraryPath(qtpluginpath.expanded());
+
     QApplication *app = new QIsisApplication(argc, argv);
     QApplication::setApplicationName("ipce");
 
     IpceMainWindow *mainWindow = new IpceMainWindow();
+
+    //  For OSX, had problems with cneteditor view because it has it's own menus, caused the
+    //  menubar on OSX to lockup
+    QCoreApplication::setAttribute(Qt::AA_DontUseNativeMenuBar, true);
 
     // We do not want a showMaximized call, as that will negate the settings read during the main
     // window's initialization. References #4358.

--- a/isis/src/qisis/objs/ControlNetTool/ControlNetTool.cpp
+++ b/isis/src/qisis/objs/ControlNetTool/ControlNetTool.cpp
@@ -35,7 +35,8 @@ using namespace std;
 
 namespace Isis {
   /**
-   * ControlNet (Qnet) tool - Handles mouse button actions and drawing control points on viewports
+   * ControlNet tool - Handles mouse button actions and drawing control points on viewports in the
+   * CubeDnView for the ipce application. 
    *
    * @param parent Pointer to the parent widget for the ControlNet tool
    *

--- a/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.cpp
+++ b/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.cpp
@@ -710,7 +710,6 @@ namespace Isis {
   FileName ControlPointEditWidget::findGroundFile() {
 
     FileName groundFile(m_editPoint->GetAprioriSurfacePointSourceFile());
-
     if (m_changeAllGroundLocation) {
       QFileInfo oldFile(groundFile.expanded());
       QFileInfo newFile(m_newGroundDir, oldFile.fileName());
@@ -1028,7 +1027,7 @@ namespace Isis {
 
     Camera *cam;
     for (int i = 0; i < m_serialNumberList->size(); i++) {
-//    if (m_serialNumberList->serialNumber(i) == m_groundSN) continue;
+      if (m_serialNumberList->serialNumber(i) == m_groundSN) continue;
       cam = m_controlNet->Camera(i);
       if (cam->SetUniversalGround(latitude, longitude)) {
         //  Make sure point is within image boundary
@@ -1246,9 +1245,7 @@ namespace Isis {
       }
 
       // emit a signal to alert user to save when exiting
-      qDebug()<<"ControlPointEditWidget before cnetModified signal";
       emit cnetModified();
-      qDebug()<<"ControlPointEditWidget after cnetModified signal";
       emit saveControlNet();
 
       if (m_editPoint != NULL) {

--- a/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.h
+++ b/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.h
@@ -49,7 +49,7 @@ namespace Isis {
   class UniversalGroundMap;
 
   /**
-   * @brief Gui for editing ControlPoint
+   * @brief Gui for editing ControlPoints in ipce application
    *
    * @ingroup Visualization Tools
    *
@@ -85,6 +85,9 @@ namespace Isis {
    *   @history 2018-03-30 Tracie Sucharski - Save Control in addition to the control net and use
    *                           Control to write the control net so Control can keep track of the
    *                           modification state of the control net.
+   *   @history 2018-04-25 Tracie Sucharski - Fix bug when creating a control point from CubeDnView
+   *                           or FootprintView if a ground source exists in the serial number list.
+   *                           Fixes #5399.
    */
   class ControlPointEditWidget : public QWidget {
     Q_OBJECT

--- a/isis/src/qisis/objs/Directory/ImportImagesWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/ImportImagesWorkOrder.cpp
@@ -412,7 +412,9 @@ namespace Isis {
           projectImage->relocateDnData(FileName(destination).name());
         }
 
-        //  Set new ecub to readOnly
+        //  Set new ecub to readOnly.  When closing cube, the labels were being re-written because
+        // the cube was read/write. This caused a segfault when imported large number of images
+        // because of a label template file being opened too many times. 
         projectImage->reopen();
 
         delete input;

--- a/isis/src/qisis/objs/Project/Project.cpp
+++ b/isis/src/qisis/objs/Project/Project.cpp
@@ -2855,7 +2855,7 @@ namespace Isis {
       else if (localName == "imageList") {
         m_imageLists.append(new ImageList(m_project, reader()));
       }
-      else if (localName == "shapeLists") {
+      else if (localName == "shapeList") {
         m_shapeLists.append(new ShapeList(m_project, reader()));
       }
       else if (localName == "templateList") {

--- a/isis/src/qisis/objs/Project/Project.h
+++ b/isis/src/qisis/objs/Project/Project.h
@@ -250,6 +250,9 @@ namespace Isis {
    *                           to the new project, so this had to be done in
    *                           Control::copyToNewProjectRoot.  If simply saving current projct,
    *                           the write is done here in the save method.
+   *  @history 2018-04-25 Tracie Sucharski - Fixed typo in XmlHandler::startElement reading
+   *                           imported shapes from a project which caused the shapes to be put in
+   *                           the wrong place on the project tree. Fixes #5274.
    *  
    */
   class Project : public QObject {


### PR DESCRIPTION
Fixed #5274-Reading saved project with multiple imported shapes incorrectly put all shapes on the last import node on project tree.
Fixed #5399-Fixed seg fault when attempting to create new control point after previously loading a constrained or fixed point in the Control Point Editor.