### PR TITLE
Added support for binary CK based body reference frames. Fixes #5408

### DIFF
--- a/isis/src/base/objs/ProcessImport/ProcessImport.h
+++ b/isis/src/base/objs/ProcessImport/ProcessImport.h
@@ -150,8 +150,19 @@ namespace Isis {
    *                           imports. Brought code closer to coding standards.
    *   @history 2016-04-21 Makayla Shepherd - Added UnsignedWord pixel type handling.
    *   @history 2017-05-29 Kristin Berry - Added support for data trailers in BIP files and fixed
-   *                            a typo so that DataTrailerBytes() will return the correct value.
-   *                            References #3888.
+   *                           a typo so that DataTrailerBytes() will return the correct value.
+   *                           References #3888.
+   *   @history 2018-05-01 Jesse Mapel - Changed data suffix and prefix in BIP files. Previously,
+   *                           data suffixes and prefixes were for each band before/after each line.
+   *                           Now, data suffixes and prefixes are before/after each sample. For a
+   *                           RGB, 3-band image with n samples a line of data was previously
+   *                           | Header | R prefix | G prefix | B prefix | R 1 | G 1 | B 1| ...
+   *                           | R n | G n | B n| R suffix | G suffix | B suffix | Trailer |. Now
+   *                           it is | Header | Prefix 1 | R 1 | G 1 | B 1 | Suffix 1 | ...
+   *                           | Prefix n | R n | G n | B n | Suffix n | Trailer |. This change
+   *                           was made to accomodate Rosetta VIRTIS-m calibrated data files and
+   *                           has no impact on other supported BIP files.
+   *                           Fixes #5398.
    *
    */
   class ProcessImport : public Isis::Process {

--- a/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
+++ b/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
@@ -149,7 +149,7 @@ namespace Isis {
     p_timeBias = rotToCopy.p_timeBias;
 
     p_et = rotToCopy.p_et;
-    p_quaternion = rotToCopy.p_quaternion; 
+    p_quaternion = rotToCopy.p_quaternion;
     p_matrixSet = rotToCopy.p_matrixSet;
     p_source = rotToCopy.p_source;
     p_axisP = rotToCopy.p_axisP;
@@ -159,8 +159,8 @@ namespace Isis {
     p_timeScale = rotToCopy.p_timeScale;
     p_degreeApplied = rotToCopy.p_degreeApplied;
 
-//    for (std::vector<double>::size_type i = 0; i < rotToCopy.p_coefficients[0].size(); i++) 
-    for (int i = 0; i < 3; i++) 
+//    for (std::vector<double>::size_type i = 0; i < rotToCopy.p_coefficients[0].size(); i++)
+    for (int i = 0; i < 3; i++)
       p_coefficients[i] = rotToCopy.p_coefficients[i];
 
     p_noOverride = rotToCopy.p_noOverride;
@@ -180,43 +180,43 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Destructor for SpiceRotation object.
-   */ 
-  SpiceRotation::~SpiceRotation() { 
+   */
+  SpiceRotation::~SpiceRotation() {
   }
 
 
-  /** 
+  /**
    * Change the frame to the given frame code.  This method has no effect if
-   * spice is cached. 
+   * spice is cached.
    *
-   * @param frameCode The integer-valued frame code 
-   */ 
+   * @param frameCode The integer-valued frame code
+   */
   void SpiceRotation::SetFrame(int frameCode) {
     p_constantFrames[0] = frameCode;
   }
 
 
-  /** 
-   * Accessor method that returns the frame code. This is the first value of the 
-   * constant frames member variable. 
-   *  
-   * @return @b int An integer value indicating the frame code. 
-   */ 
+  /**
+   * Accessor method that returns the frame code. This is the first value of the
+   * constant frames member variable.
+   *
+   * @return @b int An integer value indicating the frame code.
+   */
   int SpiceRotation::Frame() {
     return p_constantFrames[0];
   }
 
 
-  /** 
+  /**
    * Apply a time bias when invoking SetEphemerisTime method.
    *
    * The bias is used only when reading from NAIF kernels.  It is added to the
    * ephermeris time passed into SetEphemerisTime and then the body
    * position is read from the NAIF kernels and returned.  When the cache
-   * is loaded from a table the bias is ignored as it is assumed to have 
-   * already been applied.  If this method is never called the default bias is 
+   * is loaded from a table the bias is ignored as it is assumed to have
+   * already been applied.  If this method is never called the default bias is
    * 0.0 seconds.
    *
    * @param timeBias time bias in seconds
@@ -226,7 +226,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the J2000 to reference frame quaternion at given time.
    *
    * This method returns the J2000 to reference frame rotational matrix at a
@@ -280,11 +280,11 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Accessor method to get current ephemeris time.
    *
    * @return @b double The current ephemeris time.
-   */ 
+   */
   double SpiceRotation::EphemerisTime() const {
     return p_et;
   }
@@ -301,16 +301,16 @@ namespace Isis {
 
 
   /**
-   * Set the downsize status to minimize cache. 
+   * Set the downsize status to minimize cache.
    *
-   * @param status The DownsizeStatus enumeration value. 
-   */ 
+   * @param status The DownsizeStatus enumeration value.
+   */
   void SpiceRotation::MinimizeCache(DownsizeStatus status) {
     p_minimizeCache = status;
   }
 
 
-  /** 
+  /**
    * Cache J2000 rotation quaternion over a time range.
    *
    * This method will load an internal cache with frames over a time
@@ -384,7 +384,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Cache J2000 to frame rotation for a time.
    *
    * This method will load an internal cache with a rotation for a single
@@ -402,7 +402,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Cache J2000 rotations using a table file.
    *
    * This method will load either an internal cache with rotations (quaternions)
@@ -423,7 +423,7 @@ namespace Isis {
    * @param table   An ISIS table blob containing valid J2000 to reference
    *                quaternion/time values
    *
-   * @throws IException::Programmer "Expecting either three, five, or eight fields in the 
+   * @throws IException::Programmer "Expecting either three, five, or eight fields in the
    *                                 SpiceRotation table"
    */
   void SpiceRotation::LoadCache(Table &table) {
@@ -476,7 +476,7 @@ namespace Isis {
       p_fullCacheSize = toInt(table.Label().findKeyword("CkTableOriginalSize")[0]);
     }
 
-    // Load FrameTypeCode from labels if available and the planetary constants keywords 
+    // Load FrameTypeCode from labels if available and the planetary constants keywords
     if (table.Label().hasKeyword("FrameTypeCode")) {
       m_frameType = (FrameType) toInt(table.Label().findKeyword("FrameTypeCode")[0]);
     }
@@ -582,7 +582,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Cache J2000 rotation over existing cached time range using polynomials
    *
    * This method will reload an internal cache with matrices
@@ -601,7 +601,7 @@ namespace Isis {
       p_cacheTime.clear();
       p_cache.clear();
 
-      // Clear the angular velocity cache if we can calculate it instead.  It can't be calculated 
+      // Clear the angular velocity cache if we can calculate it instead.  It can't be calculated
       //  for functions of degree 0 (framing cameras), so keep the original av.  It is better than
       //  nothing.
       if (p_degree > 0 && p_cacheAv.size() > 1)  p_cacheAv.clear();
@@ -644,7 +644,7 @@ namespace Isis {
         if (p_hasAngularVelocity) p_cacheAv.push_back(tempRot.AngularVelocity());
       }
     }
-    else { //(p_source < PolyFunction) 
+    else { //(p_source < PolyFunction)
       QString msg = "The SpiceRotation has not yet been fit to a function";
       throw IException(IException::Programmer, msg, _FILEINFO_);
     }
@@ -657,7 +657,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return a table with J2000 to reference rotations.
    *
    * Return a table containing the cached pointing with the given
@@ -668,7 +668,7 @@ namespace Isis {
    *
    * @throws IException::Programmer "Only cached rotations can be returned as a line cache of
    *                                 quaternions and time"
-   * 
+   *
    * @return @b Table Table with given name that contains the cached pointing
    */
   Table SpiceRotation::LineCache(const QString &tableName) {
@@ -685,7 +685,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return a table with J2000 to reference rotations.
    *
    * Return a table containing the cached pointing with the given
@@ -703,7 +703,7 @@ namespace Isis {
    * @param tableName    Name of the table to create and return
    *
    * @throws IException::Programmer "To create table source of data must be either Memcache or
-   *                                 PolyFunction" 
+   *                                 PolyFunction"
    *
    * @return @b Table Table with given name that contains the cached pointing
    */
@@ -812,8 +812,8 @@ namespace Isis {
   }
 
 
-  /** 
-   * Initialize planetary orientation constants from Spice PCK 
+  /**
+   * Initialize planetary orientation constants from Spice PCK
    *
    * Retrieve planetary orientation constants from a Spice PCK and store them in the class.
    *
@@ -825,12 +825,12 @@ namespace Isis {
 
     // Retrieve the frame class from Naif.  We distinguish PCK types into text PCK,
     // binary PCK, and PCK not referenced to J2000.  Isis binary PCK can
-    // not be used to solve for target body orientation because of the variety and 
+    // not be used to solve for target body orientation because of the variety and
     // complexity models used with binary PCK.  Currently ISIS does not solve for
     // target body orientation on bodies not referenced to J2000, but it could be
     // changed to handle that case.
     checkForBinaryPck();
-    
+
     if (m_frameType == PCK) {
       // Make sure the reference frame is J2000.  We will need to modify FrameTrace and
       // the pck methods in this class to handle this case.  At the time this method was
@@ -848,13 +848,13 @@ namespace Isis {
       if (found) {
         // Go get the frame name if it is not the default J2000
         SpiceDouble relativeFrameCode;
-        bodvcd_c(centerBodyCode, "CONSTANTS_REF_FRAME", 1, 
+        bodvcd_c(centerBodyCode, "CONSTANTS_REF_FRAME", 1,
                         &numReturned, &relativeFrameCode);
-      } 
+      }
 
       if (!found || relativeFrameCode == 1) {  // We only work with J2000 relative frames for now
 
-        // Make sure the standard coefficients are available for the body code by 
+        // Make sure the standard coefficients are available for the body code by
         // checking for ra
         naifKeyword = "BODY" + toString(centerBodyCode) + "_POLE_RA" ;
         dtpool_c(naifKeyword.toLatin1().data(), &found, &numExpected, &naifType);
@@ -891,6 +891,11 @@ namespace Isis {
             // Get the barycenter (bc) linear coefficients first (2 for each period).
             // Then we can get the maximum expected coefficients.
             SpiceInt bcCode = centerBodyCode/100;  // Ex: bc code for Jupiter (599) & its moons is 5
+            // For comets, ID codes between 1000000 and 2000000, the precession terms just
+            // use the body code.
+            if (centerBodyCode > 1000000 && centerBodyCode < 2000000) {
+              bcCode = centerBodyCode;
+            }
             naifKeyword = "BODY" + toString(bcCode) + "_NUT_PREC_ANGLES" ;
             dtpool_c(naifKeyword.toLatin1().data(), &found, &numExpected, &naifType);
             std::vector<double>npAngles(numExpected, 0.);
@@ -899,7 +904,7 @@ namespace Isis {
             m_raNutPrec.resize(numExpected, 0.);
             m_decNutPrec.resize(numExpected, 0.);
             m_pmNutPrec.resize(numExpected, 0.);
-            
+
             std::vector<SpiceDouble> angles(numExpected);
             bodvcd_c(centerBodyCode, "NUT_PREC_RA", numExpected,  &numReturned, &m_raNutPrec[0]);
             bodvcd_c(centerBodyCode, "NUT_PREC_DEC", numExpected,  &numReturned, &m_decNutPrec[0]);
@@ -924,7 +929,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Initialize planetary orientation constants from an cube body rotation label
    *
    * Retrieve planetary orientation constants from a cube body rotation label if they are present.
@@ -998,12 +1003,12 @@ namespace Isis {
         m_sysNutPrec1.push_back(Angle(toDouble(labelCoeffs[i]), Angle::Degrees));
       }
     }
- 
+
     NaifStatus::CheckErrors();
   }
 
 
-  /** 
+  /**
    * Add labels to a SpiceRotation table.
    *
    * Return a table containing the labels defining the rotation.
@@ -1052,7 +1057,7 @@ namespace Isis {
 
  // Begin section added 06-20-2015 DAC
     table.Label() += PvlKeyword("FrameTypeCode");
-    table.Label()["FrameTypeCode"].addValue(toString(m_frameType)); 
+    table.Label()["FrameTypeCode"].addValue(toString(m_frameType));
 
     if (m_frameType == PCK) {
       // Write out all the body orientation constants
@@ -1113,7 +1118,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the camera angles at the center time of the observation
    *
    * @return @b vector<double> Camera angles at center time
@@ -1127,9 +1132,9 @@ namespace Isis {
   }
 
 
-  /** 
-   * Return the camera angles (right ascension, declination, and twist) for the 
-   * time-based matrix CJ 
+  /**
+   * Return the camera angles (right ascension, declination, and twist) for the
+   * time-based matrix CJ
    *
    * @param axis3 The rotation axis for the third angle
    * @param axis2 The rotation axis for the second angle
@@ -1154,8 +1159,8 @@ namespace Isis {
 
 
 
-  /** 
-   * Set the rotation angles (phi, delta, and w) for the current time to define the 
+  /**
+   * Set the rotation angles (phi, delta, and w) for the current time to define the
    * time-based matrix CJ. This method was created for unitTests and should not
    * be used otherwise.  It only works for cached data with a cache size of 1.
    *
@@ -1167,54 +1172,54 @@ namespace Isis {
   void SpiceRotation::SetAngles(std::vector<double> angles, int axis3, int axis2, int axis1) {
     eul2m_c(angles[2], angles[1], angles[0], axis3, axis2, axis1, (SpiceDouble (*)[3]) &(p_CJ[0]));
     p_cache[0] = p_CJ;
-    // Reset to get the new values 
+    // Reset to get the new values
     p_et = -DBL_MAX;
     SetEphemerisTime(p_et);
   }
 
 
-  /** 
-   * Accessor method to get the angular velocity 
+  /**
+   * Accessor method to get the angular velocity
    *
    * @return @b vector<double> Angular velocity
-   */ 
+   */
   std::vector<double> SpiceRotation::AngularVelocity() {
     return p_av;
   }
 
 
-  /** 
-   * Accessor method to get the frame chain for the constant part of the 
-   * rotation (ends in target) 
+  /**
+   * Accessor method to get the frame chain for the constant part of the
+   * rotation (ends in target)
    *
-   * @return @b vector<int> The frame chain for the constant part of the rotation. 
-   */ 
+   * @return @b vector<int> The frame chain for the constant part of the rotation.
+   */
   std::vector<int> SpiceRotation::ConstantFrameChain() {
     return p_constantFrames;
   }
 
 
-  /** 
+  /**
    * Accessor method to get the frame chain for the rotation (begins in J2000).
-   * 
+   *
    * @return @b vector<int> The frame chain for the rotation.
-   */ 
+   */
   std::vector<int> SpiceRotation::TimeFrameChain() {
     return p_timeFrames;
   }
 
 
-  /** 
-   * Checks whether the rotation has angular velocities.  
+  /**
+   * Checks whether the rotation has angular velocities.
    *
    * @return @b bool Indicates whether the rotation has angular velocities.
-   */ 
+   */
   bool SpiceRotation::HasAngularVelocity() {
     return p_hasAngularVelocity;
   }
 
 
-  /** 
+  /**
    * Given a direction vector in the reference frame, return a J2000 direction.
    *
    * @param[in] rVec A direction vector in the reference frame
@@ -1223,7 +1228,7 @@ namespace Isis {
    */
   std::vector<double> SpiceRotation::J2000Vector(const std::vector<double> &rVec) {
     NaifStatus::CheckErrors();
-    
+
     std::vector<double> jVec;
 
     if (rVec.size() == 3) {
@@ -1232,7 +1237,7 @@ namespace Isis {
       jVec.resize(3);
       mtxv_c(TJ, (SpiceDouble *) &rVec[0], (SpiceDouble *) &jVec[0]);
     }
-    
+
     else if (rVec.size() == 6) {
       // See Naif routine frmchg for the format of the state matrix.  The constant rotation, TC,
       // has a derivative with respect to time of I.
@@ -1257,7 +1262,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the coefficients used to calculate the target body pole ra
    *
    * Return the coefficients used to calculate the target body right
@@ -1267,7 +1272,7 @@ namespace Isis {
    * right ascension (usually the same as the most recent IAU Report)
    * the trignometric terms to account for nutation/precession need to
    * be added.
-   * 
+   *
    * pole ra = ra0 + ra1*T + ra2*T**2 + sum(racoef[i]i*sin(angle[i]))
    *
    * @return @b vector<double> A vector of length 3 containing the pole ra coefficients
@@ -1277,7 +1282,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the coefficients used to calculate the target body pole dec
    *
    * Return the coefficients used to calculate the target body declination
@@ -1287,7 +1292,7 @@ namespace Isis {
    * declination (usually the same as the most recent IAU Report)
    * the trignometric terms to account for nutation/precession need to
    * be added.
-   * 
+   *
    * pole dec = dec0 + dec1*T + dec2*T**2 + sum(racoef[i]i*sin(angle[i]))
    *
    * @return @b vector<double> A vector of length 3 containing the pole declination coefficients.
@@ -1297,16 +1302,16 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the coefficients used to calculate the target body prime meridian
    *
    * Return the coefficients used to calculate the target body prime
    * meridian without nutation/precession.  The model is a standard
-   * quadratic polynomial in time in days from the standard epoch 
+   * quadratic polynomial in time in days from the standard epoch
    * (usually J2000).  To match the Naif PCK prime meridian, (usually
    * the same as the most recent IAU Report) the trignometric terms
    * to account for nutation/precession need to be added.
-   * 
+   *
    * pm = pm0 + pm1*d + pm2*d**2 + sum(pmcoef[i]i*sin(angle[i]))
    *
    * @return @b vector<double> A vector of length 3 containing the prime meridian coefficients.
@@ -1316,7 +1321,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the coefficients used to calculate the target body pole ra nut/prec coefficients
    *
    * Return the coefficients used to calculate the target body right
@@ -1324,7 +1329,7 @@ namespace Isis {
    * sum of the products of the coefficients returned by this method
    * with the sin of the corresponding angles associated with the
    * barycenter related to the target body.
-   * 
+   *
    * pole ra = ra0 + ra1*T + ra2*T**2 + sum(raCoef[i]i*sin(angle[i]))
    *
    * @return @b vector<double> A vector containing the pole ra nut/prec coefficients.
@@ -1334,14 +1339,14 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the coefficients used to calculate the target body pole dec nut/prec coefficients
    *
    * Return the coefficients used to calculate the target body declination
-   * nutation/precession contribution.  The model is the sum of the products 
-   * of the coefficients returned by this method with the sin of the corresponding 
+   * nutation/precession contribution.  The model is the sum of the products
+   * of the coefficients returned by this method with the sin of the corresponding
    * angles associated with the barycenter related to the target body.
-   * 
+   *
    * pole dec = dec0 + dec1*T + dec2*T**2 + sum(decCoef[i]i*sin(angle[i]))
    *
    * @return @b vector<double> A vector containing the pole dec nut/prec coeffcients.
@@ -1351,14 +1356,14 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the coefficients used to calculate the target body pm nut/prec coefficients
    *
    * Return the coefficients used to calculate the target body prime meridian
-   * nutation/precession contribution.  The model is the sum of the products 
-   * of the coefficients returned by this method with the sin of the corresponding 
+   * nutation/precession contribution.  The model is the sum of the products
+   * of the coefficients returned by this method with the sin of the corresponding
    * angles associated with the barycenter related to the target body.
-   * 
+   *
    * prime meridian = pm0 + pm1*T + pm2*d**2 + sum(pmCoef[i]i*sin(angle[i]))
    *
    * @return @b vector<double> A vector containing the pm nut/prec coeffcients.
@@ -1368,14 +1373,14 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the constants used to calculate the target body system nut/prec angles
    *
    * Return the constant terms used to calculate the target body system (barycenter)
    * nutation/precession angles (periods).  The model for the angles is linear in
-   * time in Julian centuries since the standard epoch (usually J2000). 
+   * time in Julian centuries since the standard epoch (usually J2000).
    * angles associated with the barycenter related to the target body.
-   *  
+   *
    * angle[i] = constant[i] + coef[i]*T
    *
    * @return @b vector<Angle> A vector containing the system nut/prec constant terms.
@@ -1385,15 +1390,15 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the coefficients used to calculate the target body system nut/prec angles
    *
-   * Return the linear coefficients used to calculate the target body system 
-   * (barycenter) nutation/precession angles (periods).  The model for the 
-   * angles is linear in time in Julian centuries since the standard epoch 
-   * (usually J2000). angles associated with the barycenter related to the 
+   * Return the linear coefficients used to calculate the target body system
+   * (barycenter) nutation/precession angles (periods).  The model for the
+   * angles is linear in time in Julian centuries since the standard epoch
+   * (usually J2000). angles associated with the barycenter related to the
    * target body.
-   *  
+   *
    * angle[i] = constant[i] + coef[i]*T
    *
    * @return @b vector<Angle> A vector containing the system nut/prec linear coefficients.
@@ -1403,9 +1408,9 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Given a direction vector in the reference frame, compute the derivative
-   * with respect to one of the coefficients in the angle polynomial fit 
+   * with respect to one of the coefficients in the angle polynomial fit
    * equation of a vector rotated from the reference frame to J2000.
    * TODO - merge this method with ToReferencePartial
    *
@@ -1416,14 +1421,14 @@ namespace Isis {
    * @throws IException::User "Body rotation uses a binary PCK. Solutions for this model are not
    *                           supported"
    * @throws IException::User "Body rotation uses a PCK not referenced to J2000. Solutions for this
-   *                           model are not supported" 
+   *                           model are not supported"
    * @throws IException::User "Solutions are not supported for this frame type."
    *
-   * @return @b vector<double>   A direction vector rotated by derivative 
+   * @return @b vector<double>   A direction vector rotated by derivative
    *                             of reference to J2000 rotation.
    */
-  std::vector<double> SpiceRotation::toJ2000Partial(const std::vector<double> &lookT, 
-                                                    SpiceRotation::PartialType partialVar, 
+  std::vector<double> SpiceRotation::toJ2000Partial(const std::vector<double> &lookT,
+                                                    SpiceRotation::PartialType partialVar,
                                                     int coeffIndex) {
     NaifStatus::CheckErrors();
 
@@ -1459,7 +1464,7 @@ namespace Isis {
        break;
      case NOTJ2000PCK:
        msg = "Body rotation uses a PCK not referenced to J2000. "
-             "Solutions for this model are not supported";    
+             "Solutions for this model are not supported";
        throw IException(IException::User, msg, _FILEINFO_);
        break;
      default:
@@ -1497,7 +1502,7 @@ namespace Isis {
     double dTJ[3][3];
     mxm_c((SpiceDouble *) &p_TC[0], dCJ[0], dTJ);
 
-    // Finally rotate the target vector with the transpose of the 
+    // Finally rotate the target vector with the transpose of the
     // derivative matrix, dTJ to get a J2000 vector
     std::vector<double> lookdJ(3);
 
@@ -1508,7 +1513,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Given a direction vector in J2000, return a reference frame direction.
    *
    * @param[in] jVec A direction vector in J2000
@@ -1543,7 +1548,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the coefficients of a polynomial fit to each
    * of the three camera angles for the time period covered by the
    * cache, angle = a + bt + ct**2, where t = (time - p_baseTime)/ p_timeScale.
@@ -1691,7 +1696,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the coefficients of a polynomial fit to each of the
    * three camera angles for the time period covered by the
    * cache, angle = c0 + c1*t + c2*t**2 + ... + cn*t**n,
@@ -1745,10 +1750,10 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the coefficients of a polynomial fit to each
    * of the three planet angles for the time period covered by the
-   * cache, ra = ra0 + ra1*t + ra2*t**2 + raTrig, 
+   * cache, ra = ra0 + ra1*t + ra2*t**2 + raTrig,
    *            dec = dec0 + dec1*t + dec2*t**2 + decTrig,
    *            pm = pm0 + pm1*d + pm2*t**2 + pmTrig,
    * where t = time / (seconds per day). for time = et
@@ -1764,7 +1769,7 @@ namespace Isis {
    */
   void SpiceRotation::usePckPolynomial() {
 
-    // Check to see if rotation is already stored as a polynomial 
+    // Check to see if rotation is already stored as a polynomial
     if (p_source == PckPolyFunction) {
       p_hasAngularVelocity = true;
       return;
@@ -1780,7 +1785,7 @@ namespace Isis {
     // Set the scales
     p_dscale =  0.000011574074074;   // seconds to days conversion
     p_tscale = 3.1688087814029D-10; // seconds to Julian centuries conversion
-    //Set the quadratic part of the equations  
+    //Set the quadratic part of the equations
     //TODO consider just hard coding this part in evaluate
     Isis::PolynomialUnivariate functionRa(p_degree);  // Basis function fit to target body pole ra
     Isis::PolynomialUnivariate functionDec(p_degree);  // Basis function fit to target body pole dec
@@ -1793,7 +1798,7 @@ namespace Isis {
 
     int numNutPrec = p_sysNutPrec0.size;
     if (numNutPrec > 0) {
-      // Set the trigonometric part of the equation 
+      // Set the trigonometric part of the equation
       Isis::TrigBasis functionRaNutPrec("raNutPrec", Isis::TrigBasis::Sin, numNutPrec);
       Isis::TrigBasis functionRaNutPrec("decNutPrec", Isis::TrigBasis::Cos, numNutPrec);
       Isis::TrigBasis functionRaNutPrec("pmNutPrec", Isis::TrigBasis::Sin, numNutPrec);
@@ -1811,9 +1816,9 @@ namespace Isis {
     */
 
     // Set the flag indicating p_degree has been applied to the planet angles, the
-    // coefficients of the polynomials have been saved, and the cache reloaded from  
+    // coefficients of the polynomials have been saved, and the cache reloaded from
     // TODO cache reloaded???
-    // the polynomials.  
+    // the polynomials.
     // ****At least for the planet angles, I don't think we want to reload the cache until just
     // before we write out the table
     p_degreeApplied = true;
@@ -1823,10 +1828,10 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the coefficients of a polynomial fit to each
    * of the three planet angles for the time period covered by the
-   * cache, ra = ra0 + ra1*t + ra2*t**2 + raTrig, 
+   * cache, ra = ra0 + ra1*t + ra2*t**2 + raTrig,
    *            dec = dec0 + dec1*t + dec2*t**2 + decTrig,
    *            pm = pm0 + pm1*d + pm2*t**2 + pmTrig,
    * where t = time / (seconds per day). for time = et
@@ -1853,7 +1858,7 @@ namespace Isis {
     // Apply new function parameters
     setEphemerisTimePckPolyFunction();
   }
-                               
+
 
   /**
    * Return the coefficients of a polynomial fit to each of the
@@ -1939,7 +1944,7 @@ namespace Isis {
    *
    * @param coeffIndex The index of the coefficient to differentiate
    *
-   * @throws IException::Programmer "Unable to evaluate the derivative of the SPICE rotation fit 
+   * @throws IException::Programmer "Unable to evaluate the derivative of the SPICE rotation fit
    *                                 polynomial for the given coefficient index. Index is negative
    *                                 or exceeds degree of polynomial"
    *
@@ -1974,7 +1979,7 @@ namespace Isis {
    * @param partialVar Variable derivative is to be with respect to
    * @param coeffIndex The index of the coefficient to differentiate
    *
-   * @throws IException::Programmer "Unable to evaluate the derivative of the SPICE rotation fit 
+   * @throws IException::Programmer "Unable to evaluate the derivative of the SPICE rotation fit
    *                                 polynomial for the given coefficient index. Index is negative
    *                                 or exceeds degree of polynomial"
    *
@@ -1983,7 +1988,7 @@ namespace Isis {
   double SpiceRotation::DPckPolynomial(SpiceRotation::PartialType partialVar,
                                        const int coeffIndex) {
     const double p_dayScale = 86400; // number of seconds in a day
- // Number of 24 hour days in a Julian century = 36525    
+ // Number of 24 hour days in a Julian century = 36525
     const double p_centScale = p_dayScale * 36525;
     double time = 0.;
 
@@ -2104,7 +2109,7 @@ namespace Isis {
     double dTJ[3][3];
     mxm_c((SpiceDouble *) &p_TC[0], dCJ[0], dTJ);
 
-    // Finally rotate the J2000 vector with the derivative matrix, dTJ to 
+    // Finally rotate the J2000 vector with the derivative matrix, dTJ to
     // get the vector in the targeted reference frame.
     std::vector<double> lookdT(3);
 
@@ -2115,7 +2120,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Wrap the input angle to keep it within 2pi radians of the angle to compare.
    *
    * @param[in]  compareAngle Look vector in J2000 frame
@@ -2139,7 +2144,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the degree of the polynomials to be fit to the
    * three camera angles for the time period covered by the
    * cache, angle = c0 + c1*t + c2*t**2 + ... + cn*t**n,
@@ -2195,8 +2200,8 @@ namespace Isis {
   }
 
 
-  /** 
-   * Accessor method to get the rotation frame type. 
+  /**
+   * Accessor method to get the rotation frame type.
    *
    * @return @b SpiceRotation::FrameType The frame type of the rotation.
    */
@@ -2205,8 +2210,8 @@ namespace Isis {
   }
 
 
-  /** 
-   * Accessor method to get the rotation source. 
+  /**
+   * Accessor method to get the rotation source.
    *
    * @return @b SpiceRotation::Source The source of the rotation.
    */
@@ -2216,9 +2221,9 @@ namespace Isis {
 
 
   /**
-   * Resets the source of the rotation to the given value. 
+   * Resets the source of the rotation to the given value.
    *
-   * @param source The rotation source to be set.  
+   * @param source The rotation source to be set.
    */
   void SpiceRotation::SetSource(Source source) {
     p_source = source;
@@ -2227,7 +2232,7 @@ namespace Isis {
 
 
   /**
-   * Accessor method to get the rotation base time. 
+   * Accessor method to get the rotation base time.
    *
    * @return @b double The base time for the rotation.
    */
@@ -2237,7 +2242,7 @@ namespace Isis {
 
 
   /**
-   * Accessor method to get the rotation time scale. 
+   * Accessor method to get the rotation time scale.
    *
    * @return @b double The time scale for the rotation.
    */
@@ -2246,7 +2251,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the axes of rotation for decomposition of a rotation
    * matrix into 3 angles.
    *
@@ -2269,15 +2274,15 @@ namespace Isis {
   }
 
 
-  /** 
-   * Load the time cache.  This method should works with the LoadCache(startTime, endTime, size) 
+  /**
+   * Load the time cache.  This method should works with the LoadCache(startTime, endTime, size)
    * method to load the time cache.
    *
    * @throws IException::Programmer "Full cache size does NOT match cache size in LoadTimeCache --
    *                                 should never happen"
-   * @throws IException::Programmer "Observation crosses segment boundary--unable to interpolate 
+   * @throws IException::Programmer "Observation crosses segment boundary--unable to interpolate
    *                                 pointing"
-   * @throws IException::User "No camera kernels loaded...Unable to determine time cache to 
+   * @throws IException::User "No camera kernels loaded...Unable to determine time cache to
    *                           downsize"
    */
   void SpiceRotation::LoadTimeCache() {
@@ -2311,7 +2316,7 @@ namespace Isis {
       SpiceDouble quats[p_fullCacheSize][4];
       double avvs[p_fullCacheSize][3];// Angular velocity vector
 
-      // We will treat et as the sclock time and avoid converting back and forth 
+      // We will treat et as the sclock time and avoid converting back and forth
      for (int r = 0; r < p_fullCacheSize; r++) {
         timeSclkdp[r] = p_cacheTime[r];
         SpiceDouble CJ[9] = { p_cache[r][0], p_cache[r][1], p_cache[r][2],
@@ -2332,7 +2337,7 @@ namespace Isis {
       SpiceInt intarr[p_fullCacheSize]; // Integer work array
       SpiceInt sizOut = p_fullCacheSize; // Size of downsized cache
 
-      ck3sdn(radTol, avflag, (int *) &sizOut, timeSclkdp, (doublereal *) quats, 
+      ck3sdn(radTol, avflag, (int *) &sizOut, timeSclkdp, (doublereal *) quats,
              (SpiceDouble *) avvs, nints, &cubeStarts, dparr, (int *) intarr);
 
       // Clear full cache and load with downsized version
@@ -2398,7 +2403,7 @@ namespace Isis {
 
         // Don't read type 5 ck here
         if (ic[2] == 5) break;
-//      
+//
         // Check times for type 3 ck segment if spacecraft matches
         if (ic[0] == spCode && ic[2] == 3) {
           sct2e_c((int) spCode / 1000, dc[0], &segStartEt);
@@ -2409,7 +2414,7 @@ namespace Isis {
           // Get times for this segment
           if (currentTime >= segStartEt  &&  currentTime <= segStopEt) {
 
-            // Check for a gap in the time coverage by making sure the time span of the observation 
+            // Check for a gap in the time coverage by making sure the time span of the observation
             //  does not cross a segment unless the next segment starts where the current one ends
             if (observationSpansToNextSegment && currentTime > segStartEt) {
               QString msg = "Observation crosses segment boundary--unable to interpolate pointing";
@@ -2476,7 +2481,7 @@ namespace Isis {
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
-    // Load times according to cache size (body rotations) -- handle first round of type 5 ck case 
+    // Load times according to cache size (body rotations) -- handle first round of type 5 ck case
     //   and multiple ck case --Load a time for every line scan line and downsize later
     if (!timeLoaded) {
       double cacheSlope = 0.0;
@@ -2490,7 +2495,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return full listing (cache) of original time coverage requested.
    *
    * @throws IException::User "Time cache not availabe -- rerun spiceinit"
@@ -2518,7 +2523,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Compute frame trace chain from target frame to J2000
    *
    * @param et Ephemeris time
@@ -2611,7 +2616,7 @@ namespace Isis {
 
       else {
         QString msg = "The frame " + toString(frameCodes[frmidx]) +
-            " has a type " + toString(type) + " not supported by your version of Naif Spicelib." 
+            " has a type " + toString(type) + " not supported by your version of Naif Spicelib."
             + "You need to update.";
         throw IException(IException::Programmer, msg, _FILEINFO_);
 
@@ -2649,7 +2654,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the full rotation TJ as a matrix
    *
    * @return @b vector<double> Returned matrix.
@@ -2664,9 +2669,9 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the constant 3x3 rotation TC matrix as a quaternion.
-   *  
+   *
    * @return @b vector<double> Constant rotation quaternion, TC.
    */
   std::vector<double> SpiceRotation::ConstantRotation() {
@@ -2679,9 +2684,9 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return the constant 3x3 rotation TC matrix as a vector of length 9.
-   *  
+   *
    * @return @b vector<double> Constant rotation matrix, TC.
    */
   std::vector<double> &SpiceRotation::ConstantMatrix() {
@@ -2689,9 +2694,9 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the constant 3x3 rotation TC matrix from a vector of length 9.
-   *  
+   *
    * @param constantMatrix Constant rotation matrix, TC.
    */
   void SpiceRotation::SetConstantMatrix(std::vector<double> constantMatrix) {
@@ -2699,9 +2704,9 @@ namespace Isis {
     return;
   }
 
-  /** 
+  /**
    * Return time-based 3x3 rotation CJ matrix as a quaternion.
-   *  
+   *
    * @return @b vector<double> Time-based rotation quaternion, CJ.
    */
   std::vector<double> SpiceRotation::TimeBasedRotation() {
@@ -2714,9 +2719,9 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Return time-based 3x3 rotation CJ matrix as a vector of length 9.
-   *  
+   *
    * @return @b vector<double> Time-based rotation matrix, CJ.
    */
   std::vector<double> &SpiceRotation::TimeBasedMatrix() {
@@ -2724,9 +2729,9 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Set the time-based 3x3 rotation CJ matrix from a vector of length 9.
-   *  
+   *
    * @param timeBasedMatrix Time-based rotation matrix, TC.
    */
   void SpiceRotation::SetTimeBasedMatrix(std::vector<double> timeBasedMatrix) {
@@ -2735,7 +2740,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Initialize the constant rotation
    *
    * @param et Ephemeris time.
@@ -2752,7 +2757,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Compute the angular velocity from the time-based functions fit to the pointing angles
    * This method computes omega = angular velocity matrix, and extracts the angular velocity.
    * See comments in the Naif Spicelib routine xf2rav_c.c.
@@ -2810,7 +2815,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Compute the derivative of the 3x3 rotation matrix CJ with respect to time.
    * The derivative is computed based on p_CJ (J2000 to first constant frame).
    *
@@ -2877,7 +2882,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Compute & return the rotation matrix that rotates vectors from J2000 to the targeted frame.
    *
    * @return @b vector<double> Returned rotation matrix.
@@ -2900,7 +2905,7 @@ namespace Isis {
       for (int col = 0; col < 3; col++) {
         jcol  =  col + 3;
         // Fill the upper left corner
-        stateTJ[irow*6 + col] = p_TC[vpos] * stateCJ[0][col] + p_TC[vpos+1] * stateCJ[1][col] 
+        stateTJ[irow*6 + col] = p_TC[vpos] * stateCJ[0][col] + p_TC[vpos+1] * stateCJ[1][col]
                                               + p_TC[vpos+2] * stateCJ[2][col];
         // Fill the lower left corner
         stateTJ[row*6 + col]  =  p_TC[vpos] * stateCJ[3][col] + p_TC[vpos+1] * stateCJ[4][col]
@@ -2915,7 +2920,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Extrapolate pointing for a given time assuming a constant angular velocity.
    * The pointing and angular velocity at the current time will be used to
    * extrapolate pointing at the input time.  If angular velocity does not
@@ -2934,7 +2939,7 @@ namespace Isis {
     std::vector<double> CJ(9, 0.0);
     double dmat[3][3];
 
-    // Create a rotation matrix for the axis and magnitude of the angular velocity multiplied by  
+    // Create a rotation matrix for the axis and magnitude of the angular velocity multiplied by
     //   the time difference
     axisar_c((SpiceDouble *) &p_av[0], diffTime*vnorm_c((SpiceDouble *) &p_av[0]), dmat);
 
@@ -2945,7 +2950,7 @@ namespace Isis {
    }
 
 
-   /** 
+   /**
     * Set the full cache time parameters.
     *
     * @param[in]   startTime The earliest time of the full cache coverage
@@ -2960,7 +2965,7 @@ namespace Isis {
    }
 
 
-  /** 
+  /**
    * Check loaded pck to see if any are binary and set frame type to indicate binary pck.
    *
    * This is strictly a local method to be called only when the source is Spice.  Its purpose is
@@ -2971,7 +2976,7 @@ namespace Isis {
     // Get a count of all the loaded kernels
     SpiceInt count;
     ktotal_c("PCK", &count);
-    
+
     // Define some Naif constants
     int FILESIZ = 128;
     int TYPESIZ = 32;
@@ -2981,7 +2986,7 @@ namespace Isis {
     SpiceChar source[SOURCESIZ];
     SpiceInt handle;
     SpiceBoolean found;
-       
+
     // Get the name of each loaded kernel.  The accuracy of this test depends on the use of the
     // "bpc" suffix to name a binary pck.  If a binary bpc does not have the "bpc" suffix, it will not
     // be found by this test.  This test was suggested by Boris Semenov at Naif.
@@ -2994,9 +2999,9 @@ namespace Isis {
       }
     }
   }
-  
 
-  /** 
+
+  /**
    * Set the frame type (m_frameType).
    *
    * This is strictly a local method to be called only when the source is Spice.  Its purpose is
@@ -3012,7 +3017,7 @@ namespace Isis {
     frinfo_c(frameCode, &centerBodyCode, &frameClass, &classId, &found);
 
     if (found) {
-      if (frameClass == 2  ||  centerBodyCode > 0) {
+      if (frameClass == 2  ||  (centerBodyCode > 0 && frameClass != 3)) {
         m_frameType = PCK;
         // Load the PC information while it is available and set member values
         loadPCFromSpice(centerBodyCode);
@@ -3043,7 +3048,7 @@ namespace Isis {
           m_frameType = UNKNOWN;
         }
       }
-    }      
+    }
   }
 
 
@@ -3102,7 +3107,7 @@ namespace Isis {
       SpiceDouble delta[3][3];
       axisar_c(axis, angle * (SpiceDouble)mult, delta);
       mxmt_c((SpiceDouble *) &CJ1[0], delta, (SpiceDouble( *) [3]) &p_CJ[0]);
- 
+
       if (p_hasAngularVelocity) {
         double v1[3], v2[3]; // Vectors surrounding desired time
         vequ_c((SpiceDouble *) &p_cacheAv[cacheIndex][0], v1);
@@ -3154,7 +3159,7 @@ namespace Isis {
    * When setting the ephemeris time, updates the rotation state based on data read directly
    * from NAIF kernels using NAIF Spice routines
    *
-   * @throws IException::Io "[framecode] is an unrecognized reference frame code. Has the mission 
+   * @throws IException::Io "[framecode] is an unrecognized reference frame code. Has the mission
    *                         frames kernel been loaded?"
    * @throws IException::Io "No pointing is availabe at request time for frame code"
    *
@@ -3294,7 +3299,7 @@ namespace Isis {
 
   /**
    * When setting the ephemeris time, updates the rotation state based on a polynomial fit
-   * over spice kernel data. 
+   * over spice kernel data.
    *
    * @see SpiceRotation::SetEphemerisTime
    */
@@ -3308,7 +3313,7 @@ namespace Isis {
     setEphemerisTimePolyFunction();
     std::vector<double> polyAngles(3);
     // The decomposition fails because the angles are outside the valid range for Naif
-    // polyAngles = Angles(p_axis3, p_axis2, p_axis1); 
+    // polyAngles = Angles(p_axis3, p_axis2, p_axis1);
     polyAngles = EvaluatePolyFunction();
     std::vector<double> polyVelocity(3);
     polyVelocity = p_av;
@@ -3358,14 +3363,14 @@ namespace Isis {
     Angle dra = (m_raPole[1] + 2.*m_raPole[2]*centTime) / secondsPerJulianCentury;
     Angle ddec = (m_decPole[1] + 2.*m_decPole[2]*centTime) / secondsPerJulianCentury;
     Angle dpm = (m_pm[1] + 2.*m_pm[2]*dTime) / 86400;
-    
+
     // Now add the nutation/precession (trig part) adjustment to the expression if any
     int numNutPrec = (int) m_raNutPrec.size();
     Angle theta;
     double dtheta;
     double costheta;
     double sintheta;
-    
+
     for (int ia = 0;  ia < numNutPrec; ia++) {
       theta = m_sysNutPrec0[ia] + m_sysNutPrec1[ia]*centTime;
       dtheta = m_sysNutPrec1[ia].degrees() * DEG2RAD;
@@ -3408,7 +3413,7 @@ namespace Isis {
     SpiceDouble angsDangs[6];
     SpiceDouble BJs[6][6];
     vpack_c(w, delta, phi, angsDangs);
-    vpack_c(dw, ddelta, dphi, &angsDangs[3]); 
+    vpack_c(dw, ddelta, dphi, &angsDangs[3]);
     eul2xf_c (angsDangs, p_axis3, p_axis2, p_axis1, BJs);
 
     // Decompose the state matrix to the rotation and its angular velocity

--- a/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
+++ b/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
@@ -891,11 +891,6 @@ namespace Isis {
             // Get the barycenter (bc) linear coefficients first (2 for each period).
             // Then we can get the maximum expected coefficients.
             SpiceInt bcCode = centerBodyCode/100;  // Ex: bc code for Jupiter (599) & its moons is 5
-            // For comets, ID codes between 1000000 and 2000000, the precession terms just
-            // use the body code.
-            if (centerBodyCode > 1000000 && centerBodyCode < 2000000) {
-              bcCode = centerBodyCode;
-            }
             naifKeyword = "BODY" + toString(bcCode) + "_NUT_PREC_ANGLES" ;
             dtpool_c(naifKeyword.toLatin1().data(), &found, &numExpected, &naifType);
             std::vector<double>npAngles(numExpected, 0.);

--- a/isis/src/base/objs/SpiceRotation/SpiceRotation.truth
+++ b/isis/src/base/objs/SpiceRotation/SpiceRotation.truth
@@ -624,6 +624,13 @@ Frame type is binary PCK and cannot be updated
 End of PCK testing
 
 
+Testing CK based body rotation with 67P/Churyumov–Gerasimenko data ...
+Time = 4.6285471e+08
+CJ = 0.93816333 -0.34618155 -0.002810256
+     0.30996014 0.84356223 -0.43855157
+     0.15418909 0.41056193 0.89870163
+
+
 Testing exceptions...
 
 **I/O ERROR** Cannot find [INS-99999_TRANSX] in text kernels.

--- a/isis/src/base/objs/SpiceRotation/unitTest.cpp
+++ b/isis/src/base/objs/SpiceRotation/unitTest.cpp
@@ -37,6 +37,8 @@ int main(int argc, char *argv[]) {
   QString mocbsp(dir + "moc.bsp");
   QString de(dir + "de405.bsp");
   QString pck("/usgs/cpkgs/isis3/data/base/kernels/pck/pck00009.tpc");
+  QString cgFK(dir + "ROS_V29.TF");
+  QString cgCK(dir + "CATT_DV_145_02_______00216.BC");
   //QString mocadd(dir+"mocAddendum.ti");
   QString mocspice(dir + "mocSpiceRotationUnitTest.ti");
   furnsh_c(naif.toLatin1().data());
@@ -47,6 +49,8 @@ int main(int argc, char *argv[]) {
   furnsh_c(de.toLatin1().data());
   furnsh_c(pck.toLatin1().data());
   furnsh_c(mocspice.toLatin1().data());
+  furnsh_c(cgFK.toLatin1().data());
+  furnsh_c(cgCK.toLatin1().data());
 
   double startTime = -69382819.0;
   double endTime = -69382512.0;
@@ -202,7 +206,7 @@ int main(int argc, char *argv[]) {
   lookC.push_back(1.);
   vector<double> lookJ = rot.J2000Vector(lookC);
   // Save a J2000 vector for testing target body partial methods later.
-  vector<double> testLookJ(lookJ);  
+  vector<double> testLookJ(lookJ);
   cout << " For lookJ = " << lookJ[0] << " " << lookJ[1] << " " << lookJ[2] << endl;
   vector<double> dAraLookC(3);
   dAraLookC = rot.ToReferencePartial(lookJ, SpiceRotation::WRT_RightAscension, 0);
@@ -385,11 +389,11 @@ int main(int argc, char *argv[]) {
   // Use Galileo Io image with product id = 21I0165 for testing nutation/precession terms.  Mars has none.
   //  tet = -15839262.24291
   // body frame code for Io = 10023
-  // Use Europa for exercising the code using nutation/precession terms.  Mars has none. 
+  // Use Europa for exercising the code using nutation/precession terms.  Mars has none.
   SpiceRotation targrot1(10014);   //Frame code for Mars
   // SpiceRotation targrotV1(10024);   //Frame code for Europa
   // targrotV1.LoadCache(-646009153.46723, -646009153.46723, 1); // This calls LoadPcFromSpice for Europa
-  SpiceRotation targrotV1(10023);   //Frame code for Io  
+  SpiceRotation targrotV1(10023);   //Frame code for Io
   targrotV1.LoadCache(-15839262.24291, -15839262.24291, 1); // This calls LoadPcFromSpice for Io
   targrot1.LoadCache(startTime, endTime, 2); // This calls LoadPcFromSpice for Mars
   cout << "Test CacheLabel for PCK data..." << endl;
@@ -397,8 +401,8 @@ int main(int argc, char *argv[]) {
   Table pcktabV = targrotV1.Cache("Planetary constants test table"); // This calls CacheLabel
   SpiceRotation targrot(10014);  // Mars
   // SpiceRotation targrotV(10024);  // Europa  --  The results for pm will differ slightly from TrigBasis because of the older PCK
-  SpiceRotation targrotV(10023);  // Io  -- 
-  cout << "Test LoadPCFromTable..." << endl; 
+  SpiceRotation targrotV(10023);  // Io  --
+  cout << "Test LoadPCFromTable..." << endl;
   targrot.LoadCache(pcktab);  // This calls LoadPcFromTable
   targrotV.LoadCache(pcktabV);  // This calls LoadPcFromTable
   // Now get the values
@@ -460,7 +464,7 @@ int main(int argc, char *argv[]) {
   // cout << "    Angles = " << pckanglesV[0]*dpr_c() <<","<< pckanglesV[1]*dpr_c() <<","
   //      << pckanglesV[2]*dpr_c() <<endl <<endl;
   // end Europa test
-  
+
   // For testing Io with the nutation/precession terms and a cache size of 1
   tet = -15839262.24291;  // time et for Io
   ibod = 501; // Io
@@ -471,8 +475,8 @@ int main(int argc, char *argv[]) {
        << pckanglesV[2]*dpr_c() <<endl <<endl;
   // end Io test
 
-  // For testing Mars with more than one value in the cache 
-  cout << endl << "  Mars original SPICE values for target body orientation unadjusted" 
+  // For testing Mars with more than one value in the cache
+  cout << endl << "  Mars original SPICE values for target body orientation unadjusted"
        << endl;
   cout << "  Source = " << targrot.GetSource() << endl;
   for (int i = 0; i < 10; i++) {
@@ -520,18 +524,18 @@ int main(int argc, char *argv[]) {
     cout << "         " << CJ[6] << " " << CJ[7] << " " << CJ[8] << endl;
   }
 
-    // Test angular velocities 
+    // Test angular velocities
   cout << endl << endl << "Testing angular velocity with Io data ..." << endl;
   if (targrotV.HasAngularVelocity()) {
     vector<double> av = targrotV.AngularVelocity();
     cout << "SpiceRotation av = " << av[0] << " " << av[1] << " " << av[2] << endl;
     SpiceDouble tsipm[6][6];
-    sxform_c ( "J2000", "IAU_IO", -15839262.24291, tsipm); 
-    // sxform_c ( "J2000", "IAU_EUROPA", -646009153.46723, tsipm); 
+    sxform_c ( "J2000", "IAU_IO", -15839262.24291, tsipm);
+    // sxform_c ( "J2000", "IAU_EUROPA", -646009153.46723, tsipm);
     SpiceDouble tipm[3][3];
     vector<SpiceDouble> nav(3,0.);
     xf2rav_c (tsipm, tipm, &(nav[0]) );
-    cout << "J2000 to body-fixed Naif av = " << nav[0] << " " << nav[1] << " " << nav[2] << endl; 
+    cout << "J2000 to body-fixed Naif av = " << nav[0] << " " << nav[1] << " " << nav[2] << endl;
   }
   cout << endl;
 
@@ -559,7 +563,7 @@ int main(int argc, char *argv[]) {
        << matchLookJ[1] << " " << matchLookJ[2] << endl;
 
   dLookB = targrot.ToReferencePartial(testLookJ, SpiceRotation::WRT_Twist, 1);
-  cout << endl << " dLookB with respect to rotation rate = " << dLookB[0] << " " << 
+  cout << endl << " dLookB with respect to rotation rate = " << dLookB[0] << " " <<
           dLookB[1] << " " << dLookB[2] << endl;
   //If I apply toJ2000Partial to dLookB, I get back lookJ(x,y,0) with roundoff  -- 05-12-2015 DAC
   matchLookJ = targrot.toJ2000Partial(dLookB, SpiceRotation::WRT_Twist, 1);
@@ -567,7 +571,7 @@ int main(int argc, char *argv[]) {
        << matchLookJ[1] << " " << matchLookJ[2] << endl;
 
   dLookB = targrot.ToReferencePartial(testLookJ, SpiceRotation::WRT_Twist, 0);
-  cout << endl << " dLookB with respect to rotation = " << dLookB[0] << " " << 
+  cout << endl << " dLookB with respect to rotation = " << dLookB[0] << " " <<
           dLookB[1] << " " << dLookB[2] << endl;
   //If I apply toJ2000Partial to dLookB, I get back lookJ(x,y,0) with roundoff  -- 05-12-2015 DAC
   matchLookJ = targrot.toJ2000Partial(dLookB, SpiceRotation::WRT_Twist, 0);
@@ -589,15 +593,28 @@ int main(int argc, char *argv[]) {
   if (frameType == SpiceRotation::BPC)
     cout << "Frame type is binary PCK and cannot be updated" << endl;
 
-  
+
   cout << "End of PCK testing" << endl;
 
-  
+  // Test CK based body rotation
+  cout << endl << endl << "Testing CK based body rotation with 67P/Churyumov–Gerasimenko data ..." << endl;
+
+  SpiceRotation cgRotation(-1000012000);
+  // Test time from Rosetta OSIRIS NAC image n20140901t144253568id30f22
+  double cgTestTime = 462854709.88606;
+  cgRotation.SetEphemerisTime(cgTestTime);
+  vector<double> cgCJ = cgRotation.Matrix();
+  cout << "Time = " << cgRotation.EphemerisTime() << endl;
+  cout << "CJ = " << cgCJ[0] << " " << cgCJ[1] << " " << cgCJ[2] << endl;
+  cout << "     " << cgCJ[3] << " " << cgCJ[4] << " " << cgCJ[5] << endl;
+  cout << "     " << cgCJ[6] << " " << cgCJ[7] << " " << cgCJ[8] << endl;
+
+
   //Test exceptions
   cout << endl << endl << "Testing exceptions..." << endl;
   SpiceRotation testRot(-94031); // MGS_MOC
 
-  // SpiceRotation(frameCode, targetCode) 
+  // SpiceRotation(frameCode, targetCode)
   //     "Cannot find [key] in text kernels
   try {
     cout << endl;
@@ -611,13 +628,13 @@ int main(int argc, char *argv[]) {
   //     "Argument cacheSize must not be less or equal to zero"
   try {
     cout << endl;
-    testRot.LoadCache(10, 20, -1); 
+    testRot.LoadCache(10, 20, -1);
   }
   catch (IException &e) {
     e.print();
   }
 
-  //     "Argument startTime must be less than or equal to endTime"   
+  //     "Argument startTime must be less than or equal to endTime"
   try {
     cout << endl;
     testRot.LoadCache(20, 10, 1);
@@ -639,7 +656,7 @@ int main(int argc, char *argv[]) {
   try {
     cout << endl;
     testRot.LoadCache(startTime, endTime, 2);
-    testRot.LoadCache(startTime, endTime - 1, 2); 
+    testRot.LoadCache(startTime, endTime - 1, 2);
   }
   catch (IException &e) {
     e.print();
@@ -656,7 +673,7 @@ int main(int argc, char *argv[]) {
   }
 
   // LineCache(tableName)
-  //     "Only cached rotations can be returned as a line cache of quaternions and time" 
+  //     "Only cached rotations can be returned as a line cache of quaternions and time"
   try {
     cout << endl;
     SpiceRotation sr(-94031);
@@ -665,7 +682,7 @@ int main(int argc, char *argv[]) {
   catch (IException &e) {
     e.print();
   }
-    
+
   // Cache(tableName)
   //     "To create table source of data must be either Memcache or PolyFunction"
   try {
@@ -690,10 +707,10 @@ int main(int argc, char *argv[]) {
     e.print();
   }
 
-  // DPolynomial(coeffIndex) 
-  //     "Unable to evaluate the derivative of the SPCIE rotation fit 
+  // DPolynomial(coeffIndex)
+  //     "Unable to evaluate the derivative of the SPCIE rotation fit
   //      polynomial for the given coefficient index. Index is negative
-  //      or exceeds degree of polynomial"    
+  //      or exceeds degree of polynomial"
   try {
     cout << endl;
     testRot.DPolynomial(-1);
@@ -703,7 +720,7 @@ int main(int argc, char *argv[]) {
   }
 
   // DPckPolynomial(partialVar, coeffIndex)
-  //     "Unable to evaluate the derivative of the SPCIE rotation fit 
+  //     "Unable to evaluate the derivative of the SPCIE rotation fit
   //      polynomial for the given coefficient index. Index is negative
   //      or exceeds degree of polynomial"
   try {
@@ -731,9 +748,9 @@ int main(int argc, char *argv[]) {
 
   // LoadTimeCache()
   //TODO test its 3 exceptions
-  
+
   // GetFullCacheTime()
-  //    "Time cache not availabe -- rerun spiceinit" 
+  //    "Time cache not availabe -- rerun spiceinit"
   try {
     cout << endl;
     SpiceRotation sr(-94031);
@@ -745,7 +762,7 @@ int main(int argc, char *argv[]) {
 
   // FrameTrace()
   //TODO test its 3 exceptions
-  
+
   // ComputeAv()
   //     "The SpiceRotation pointing angles must be fit to polynomials in order to
   //      compute angular velocity."

--- a/isis/src/rosetta/apps/rosvirtis2isis/rosvirtis2isis.cpp
+++ b/isis/src/rosetta/apps/rosvirtis2isis/rosvirtis2isis.cpp
@@ -89,233 +89,261 @@ void IsisMain ()
     throw IException(IException::Unknown, msg, _FILEINFO_);
   }
 
+  int procLevel = (int) pdsLabel.findKeyword("PROCESSING_LEVEL_ID");
+
   // Override default DataTrailerBytes constructed from PDS header
   // Will this number ever change? Where did this # come from?
-  p.SetDataTrailerBytes(864);
+  if (procLevel == 2) {
+    p.SetDataTrailerBytes(864);
+  }
+  else if ((procLevel == 3)) {
+    p.SetDataTrailerBytes(0);
+    p.SetDataSuffixBytes(4);
+  }
 
   p.StartProcess();
-
-  // Retrieve HK settings file and read in HK values.
-  QList<VirtisHK> hk;
 
   // Get the directory where the Rosetta translation tables are.
   PvlGroup dataDir (Preference::Preferences().findGroup("DataDirectory"));
   QString transDir = (QString) dataDir["Rosetta"] + "/translations/";
 
-  FileName hkTranslationFile = transDir + "virtis_housekeeping.txt";
-  QFile hkFile(hkTranslationFile.toString());
+  if (procLevel == 2) {
 
-  if(!hkFile.open(QIODevice::ReadOnly)) {
-    QString msg = "Unable to open Virtis Housekeeping information file [" +
-                 hkFile.fileName() + "]";
-    throw IException(IException::Io,msg, _FILEINFO_);
-  }
+    // Retrieve HK settings file and read in HK values.
+    QList<VirtisHK> hk;
 
-  QTextStream in(&hkFile);
+    FileName hkTranslationFile = transDir + "virtis_housekeeping.txt";
+    QFile hkFile(hkTranslationFile.toString());
 
-  while(!in.atEnd()) {
-      QString line = in.readLine();
-      QStringList fields = line.split(",");
-      hk.append(VirtisHK(fields[0], fields[1], fields[2], fields[3], fields[4]));
-  }
+    if(!hkFile.open(QIODevice::ReadOnly)) {
+      QString msg = "Unable to open Virtis Housekeeping information file [" +
+                   hkFile.fileName() + "]";
+      throw IException(IException::Io,msg, _FILEINFO_);
+    }
 
-  hkFile.close();
+    QTextStream in(&hkFile);
 
-  // Construct HK (housekeeping) table
-  TableRecord rec;
+    while(!in.atEnd()) {
+        QString line = in.readLine();
+        QStringList fields = line.split(",");
+        hk.append(VirtisHK(fields[0], fields[1], fields[2], fields[3], fields[4]));
+    }
 
-  QList<TableField> tableFields;
+    hkFile.close();
 
-  for (int i=0; i < hk.size(); i++) {
-    tableFields.append(hk[i].tableField());
-  }
+    // Construct HK (housekeeping) table
+    TableRecord rec;
 
-  for (int i=0; i < tableFields.size(); i++) {
-    rec += tableFields[i];
-  }
+    QList<TableField> tableFields;
 
-  Table table("VIRTISHouseKeeping", rec);
+    for (int i=0; i < hk.size(); i++) {
+      tableFields.append(hk[i].tableField());
+    }
 
-  // VIRTIS-M (VIS and IR) Equations
-  // These are adapted from the VIRTIS IDL processing pipeline
-  // and pg. 66-67 of the VIRTIS-EAICD
-  QList<std::vector<double> > equationList;
-  for (int i=0; i < hk.size(); i++) {
-    equationList.append(hk[i].coefficients());
-  }
+    for (int i=0; i < tableFields.size(); i++) {
+      rec += tableFields[i];
+    }
 
-  QList<PolynomialUnivariate> equations;
+    Table table("VIRTISHouseKeeping", rec);
 
-  for (int s=0; s < equationList.size(); s++) {
-    equations.append(PolynomialUnivariate(2, equationList[s]));
-  }
+    // VIRTIS-M (VIS and IR) Equations
+    // These are adapted from the VIRTIS IDL processing pipeline
+    // and pg. 66-67 of the VIRTIS-EAICD
+    QList<std::vector<double> > equationList;
+    for (int i=0; i < hk.size(); i++) {
+      equationList.append(hk[i].coefficients());
+    }
 
-  // Populate the Housekeeping table
-  //
-  // There are 3 categories of VIRTIS HK Values, in terms of converting from input byte to output
-  // value:
-  //
-  // (1) SCET (many-to-one)
-  // (2) Physical Quantities (one-to-one)
-  // (3) Flags or Statistics (one-to-many)
-  //
-  // SCET values are made up of 3 VIRTIS HK 2-byte words. The output value can be calculated
-  // using the translateScet helper function.
-  //
-  // Physical values are made up of 1 VIRTIS HK 2-byte word, which is converted to a physical value
-  // using an equation specified as a series of coefficients in the associated "assets" file.
-  //
-  // For Flags or Statistics Values, 1 VIRTIS HK 2-byte word is associated with several (a varaible
-  // number of) output Flag or Statistics values. These are all treated as special cases.
-  //
-  // Additionally, Sine and Cosine HK Values need to be pre-processed before conversion, but are
-  // otherwise treated as a normal "Physical Quantity" HK.
-  //
-  std::vector< char * > hkData = p.DataTrailer();
-  for (unsigned int i=0; i < hkData.size() ; i++) {
-    const char *hk = hkData.at(i);
-    const unsigned short *uihk = reinterpret_cast<const unsigned short *> (hk);
+    QList<PolynomialUnivariate> equations;
 
-    // Each data trailer can contain multiple 82-word records, but we only need 1 / line
-    int start = 0;
-    int tableNum = 0;
+    for (int s=0; s < equationList.size(); s++) {
+      equations.append(PolynomialUnivariate(2, equationList[s]));
+    }
 
-    // Loop through each 82-word record
-    // Each k is a byteNumber
-    for (int k=0; k<82*2; k=k+2) {
-      int temp = 0;
+    // Populate the Housekeeping table
+    //
+    // There are 3 categories of VIRTIS HK Values, in terms of converting from input byte to output
+    // value:
+    //
+    // (1) SCET (many-to-one)
+    // (2) Physical Quantities (one-to-one)
+    // (3) Flags or Statistics (one-to-many)
+    //
+    // SCET values are made up of 3 VIRTIS HK 2-byte words. The output value can be calculated
+    // using the translateScet helper function.
+    //
+    // Physical values are made up of 1 VIRTIS HK 2-byte word, which is converted to a physical value
+    // using an equation specified as a series of coefficients in the associated "assets" file.
+    //
+    // For Flags or Statistics Values, 1 VIRTIS HK 2-byte word is associated with several (a varaible
+    // number of) output Flag or Statistics values. These are all treated as special cases.
+    //
+    // Additionally, Sine and Cosine HK Values need to be pre-processed before conversion, but are
+    // otherwise treated as a normal "Physical Quantity" HK.
+    //
+    std::vector< char * > hkData = p.DataTrailer();
+    for (unsigned int i=0; i < hkData.size() ; i++) {
+      const char *hk = hkData.at(i);
+      const unsigned short *uihk = reinterpret_cast<const unsigned short *> (hk);
 
-      // Convert non-SCET records (1 two-byte word each) using the appropriate equations
-      if (k !=0 && k!=14 && k!=38 && k!=58 && k!=116) {
-        temp = word(hk[start + k], hk[start+k+1]);
-        if (temp != 65535) {
+      // Each data trailer can contain multiple 82-word records, but we only need 1 / line
+      int start = 0;
+      int tableNum = 0;
 
-          // If Sine or Cosine, pre-process before sending to conversion.
-          if (tableNum == 63) { // SIN
-            int HK_bit = (int) (((unsigned short int) temp) & 4095);
-            int HK_sign = (unsigned short int) (temp/4096.0) & 1;
-            rec[tableNum] = equations[tableNum].Evaluate((HK_sign * 1.0) * (HK_bit * 1.0));
-          } else if (tableNum == 64) { // COS
-            temp = (int) (temp) & 4095;
-            rec[tableNum] = equations[tableNum].Evaluate(temp * 1.0);
-          } else if (tableNum == 2) { // # of Subslices / first seial num 2-3
-            rec[tableNum] = hk[start+k]*1.0;
-            rec[tableNum+1] = hk[start+k+1]*1.0;
-            tableNum++;
-          } // Specical one-to-many cases (Flags or Statistics)
-          else if (tableNum == 4) { // Data Type 4-9
-            rec[tableNum] = (int)(temp/-32768) & 1;
-            rec[tableNum+1] = (int)(temp/16384) & 1;
-            rec[tableNum+2] = (int)(temp/8192) & 1;
-            rec[tableNum+3] = (int)(temp/1024) & 7;
-            rec[tableNum+4] = (int)(temp/256) & 3;
-            rec[tableNum+5] = (int)(temp/1) & 255;
-            tableNum+=5;
-          } else if (tableNum == 12) { // V_MODE 12-14
-            rec[tableNum] = 1.0* ((int)(temp/4096) & 15);
-            rec[tableNum+1] = 1.0* ((int)(temp/64) & 63);
-            rec[tableNum+2] = 1.0* ((int)(temp/1) & 63);
-            tableNum+=2;
-          } else if (tableNum == 15) { //ME_PWR_STAT 15 - 21
-            rec[tableNum] = 1.0* ((int)(temp/1) & 1);
-            rec[tableNum+1] = 1.0* ((int)(temp/2) & 1);
-            rec[tableNum+2] = 1.0* ((int)(temp/4) & 1);
-            rec[tableNum+3] = 1.0* ((int)(temp/8) & 1);
-            rec[tableNum+4] = 1.0* ((int)(temp/16) & 1);
-            rec[tableNum+5] = 1.0* ((int)(temp/32) & 1);
-            rec[tableNum+6] = 1.0* ((int)(temp/-32786) & 1);
-            tableNum+=6;
-          } else if (tableNum == 30){  // M_ECA_STAT 30-31
-            rec[tableNum] = 1.0* ((int)(temp/1) & 1);
-            rec[tableNum+1] = 1.0* ((int)(temp/256) & 1);
-            tableNum++;
-          } else if (tableNum == 32) { // M_COOL_STAT 32-34
-            rec[tableNum] = 1.0* ((int)(temp/1) & 1);
-            rec[tableNum+1] = 1.0* ((int)(temp/16) & 1);
-            rec[tableNum+2] = 1.0* ((int)(temp/256) & 1);
-            tableNum+=2;
-          }
+      // Loop through each 82-word record
+      // Each k is a byteNumber
+      for (int k=0; k<82*2; k=k+2) {
+        int temp = 0;
 
-          else if (tableNum == 65) { // M_VIS_FLAG
-            rec[tableNum] = 1.0* ((int)(temp/1) & 1);
-            rec[tableNum+1] = 1.0* ((int)(temp/2) & 1);
-            rec[tableNum+2] = 1.0* ((int)(temp/4) & 1);
-            rec[tableNum+3] = 1.0* ((int)(temp/8) & 1);
-            rec[tableNum+4] = 1.0* ((int)(temp/16) & 1);
-            rec[tableNum+5] = 1.0* ((int)(temp/256) & 1);
-            tableNum+=5;
-          }
-          else if (tableNum == 91) { //M_IR_LAMP_SHUTTER
-            double lamp1 = 1.0* ((int)(temp/1) & 15);
-            rec[tableNum] = equations[tableNum].Evaluate(lamp1);
-            rec[tableNum+1] = 1.0* ((int)(temp/16) & 1);
-            double lamp2 = 1.0* ((int)(temp/256) & 15);
-            rec[tableNum+2] = equations[tableNum+1].Evaluate(lamp2);
-            rec[tableNum+3] = 1.0* ((int)(temp/4096) & 1);
-            tableNum+=3;
-          }
-          else if (tableNum == 95) { // M_IR_FLAG
-            rec[tableNum] = 1.0* ((int)(temp/1) & 1);
-            rec[tableNum+1] = 1.0* ((int)(temp/2) & 1);
-            rec[tableNum+2] = 1.0* ((int)(temp/4) & 1);
-            rec[tableNum+3] = 1.0* ((int)(temp/8) & 1);
-            rec[tableNum+4] = 1.0* ((int)(temp/16) & 1);
-            rec[tableNum+5] = 1.0* ((int)(temp/32) & 1);
-            rec[tableNum+6] = 1.0* ((int)(temp/64) & 1);
-            rec[tableNum+7] = 1.0* ((int)(temp/512) & 1);
-            rec[tableNum+8] = 1.0* ((int)(temp/4096) & 1);
-            rec[tableNum+9] = 1.0* ((int)(temp/8192) & 1);
-            rec[tableNum+10] = 1.0* ((int)(temp/16384) & 1);
-            tableNum+=10;
+        // Convert non-SCET records (1 two-byte word each) using the appropriate equations
+        if (k !=0 && k!=14 && k!=38 && k!=58 && k!=116) {
+          temp = word(hk[start + k], hk[start+k+1]);
+          if (temp != 65535) {
+
+            // If Sine or Cosine, pre-process before sending to conversion.
+            if (tableNum == 63) { // SIN
+              int HK_bit = (int) (((unsigned short int) temp) & 4095);
+              int HK_sign = (unsigned short int) (temp/4096.0) & 1;
+              rec[tableNum] = equations[tableNum].Evaluate((HK_sign * 1.0) * (HK_bit * 1.0));
+            } else if (tableNum == 64) { // COS
+              temp = (int) (temp) & 4095;
+              rec[tableNum] = equations[tableNum].Evaluate(temp * 1.0);
+            } else if (tableNum == 2) { // # of Subslices / first seial num 2-3
+              rec[tableNum] = hk[start+k]*1.0;
+              rec[tableNum+1] = hk[start+k+1]*1.0;
+              tableNum++;
+            } // Specical one-to-many cases (Flags or Statistics)
+            else if (tableNum == 4) { // Data Type 4-9
+              rec[tableNum] = (int)(temp/-32768) & 1;
+              rec[tableNum+1] = (int)(temp/16384) & 1;
+              rec[tableNum+2] = (int)(temp/8192) & 1;
+              rec[tableNum+3] = (int)(temp/1024) & 7;
+              rec[tableNum+4] = (int)(temp/256) & 3;
+              rec[tableNum+5] = (int)(temp/1) & 255;
+              tableNum+=5;
+            } else if (tableNum == 12) { // V_MODE 12-14
+              rec[tableNum] = 1.0* ((int)(temp/4096) & 15);
+              rec[tableNum+1] = 1.0* ((int)(temp/64) & 63);
+              rec[tableNum+2] = 1.0* ((int)(temp/1) & 63);
+              tableNum+=2;
+            } else if (tableNum == 15) { //ME_PWR_STAT 15 - 21
+              rec[tableNum] = 1.0* ((int)(temp/1) & 1);
+              rec[tableNum+1] = 1.0* ((int)(temp/2) & 1);
+              rec[tableNum+2] = 1.0* ((int)(temp/4) & 1);
+              rec[tableNum+3] = 1.0* ((int)(temp/8) & 1);
+              rec[tableNum+4] = 1.0* ((int)(temp/16) & 1);
+              rec[tableNum+5] = 1.0* ((int)(temp/32) & 1);
+              rec[tableNum+6] = 1.0* ((int)(temp/-32786) & 1);
+              tableNum+=6;
+            } else if (tableNum == 30){  // M_ECA_STAT 30-31
+              rec[tableNum] = 1.0* ((int)(temp/1) & 1);
+              rec[tableNum+1] = 1.0* ((int)(temp/256) & 1);
+              tableNum++;
+            } else if (tableNum == 32) { // M_COOL_STAT 32-34
+              rec[tableNum] = 1.0* ((int)(temp/1) & 1);
+              rec[tableNum+1] = 1.0* ((int)(temp/16) & 1);
+              rec[tableNum+2] = 1.0* ((int)(temp/256) & 1);
+              tableNum+=2;
+            }
+
+            else if (tableNum == 65) { // M_VIS_FLAG
+              rec[tableNum] = 1.0* ((int)(temp/1) & 1);
+              rec[tableNum+1] = 1.0* ((int)(temp/2) & 1);
+              rec[tableNum+2] = 1.0* ((int)(temp/4) & 1);
+              rec[tableNum+3] = 1.0* ((int)(temp/8) & 1);
+              rec[tableNum+4] = 1.0* ((int)(temp/16) & 1);
+              rec[tableNum+5] = 1.0* ((int)(temp/256) & 1);
+              tableNum+=5;
+            }
+            else if (tableNum == 91) { //M_IR_LAMP_SHUTTER
+              double lamp1 = 1.0* ((int)(temp/1) & 15);
+              rec[tableNum] = equations[tableNum].Evaluate(lamp1);
+              rec[tableNum+1] = 1.0* ((int)(temp/16) & 1);
+              double lamp2 = 1.0* ((int)(temp/256) & 15);
+              rec[tableNum+2] = equations[tableNum+1].Evaluate(lamp2);
+              rec[tableNum+3] = 1.0* ((int)(temp/4096) & 1);
+              tableNum+=3;
+            }
+            else if (tableNum == 95) { // M_IR_FLAG
+              rec[tableNum] = 1.0* ((int)(temp/1) & 1);
+              rec[tableNum+1] = 1.0* ((int)(temp/2) & 1);
+              rec[tableNum+2] = 1.0* ((int)(temp/4) & 1);
+              rec[tableNum+3] = 1.0* ((int)(temp/8) & 1);
+              rec[tableNum+4] = 1.0* ((int)(temp/16) & 1);
+              rec[tableNum+5] = 1.0* ((int)(temp/32) & 1);
+              rec[tableNum+6] = 1.0* ((int)(temp/64) & 1);
+              rec[tableNum+7] = 1.0* ((int)(temp/512) & 1);
+              rec[tableNum+8] = 1.0* ((int)(temp/4096) & 1);
+              rec[tableNum+9] = 1.0* ((int)(temp/8192) & 1);
+              rec[tableNum+10] = 1.0* ((int)(temp/16384) & 1);
+              tableNum+=10;
+            }
+            else {
+               // Convert a physical quantity to its output value (1 word -> 1 output physical value)
+               rec[tableNum] = equations[tableNum].Evaluate(temp * 1.0);
+            }
           }
           else {
-             // Convert a physical quantity to its output value (1 word -> 1 output physical value)
-             rec[tableNum] = equations[tableNum].Evaluate(temp * 1.0);
+            rec[tableNum] = 65535.0; // HK Data is Invalid
           }
         }
         else {
-          rec[tableNum] = 65535.0; // HK Data is Invalid
+          // Convert SCET records (3 words -> one output SCET)
+          int uk = k/2;
+  #if 0
+          int word1 = word(hk[start+k], hk[start+k+1]);
+          int word2 = word(hk[start+k+2], hk[start+k+3]);
+          int word3 = word(hk[start+k+4], hk[start+k+5]);
+  #else
+          int word1 = swapb(uihk[uk]);
+          int word2 = swapb(uihk[uk+1]);
+          int word3 = swapb(uihk[uk+2]);
+  #endif
+
+          double result;
+
+          // If any of the words comprising the SCET are invalid, the whole thing is invalid.
+          if (isValid(word1) && isValid(word2) && isValid(word3)) {
+            result = translateScet(word1, word2, word3);
+          }
+          else {
+            result = 65535;
+          }
+
+          // If we don't have a valid SCET, the whole line of HK data is not valid, so we skip it.
+          if (result == 0 || result == 65535) {
+            break;
+          }
+          else{
+            rec[tableNum] = result*1.0;
+          }
+          // We used 3 words
+          k=k+4;
         }
+        tableNum++;
       }
-      else {
-        // Convert SCET records (3 words -> one output SCET)
-        int uk = k/2;
-#if 0
-        int word1 = word(hk[start+k], hk[start+k+1]);
-        int word2 = word(hk[start+k+2], hk[start+k+3]);
-        int word3 = word(hk[start+k+4], hk[start+k+5]);
-#else
-        int word1 = swapb(uihk[uk]);
-        int word2 = swapb(uihk[uk+1]);
-        int word3 = swapb(uihk[uk+2]);
-#endif
-
-        double result;
-
-        // If any of the words comprising the SCET are invalid, the whole thing is invalid.
-        if (isValid(word1) && isValid(word2) && isValid(word3)) {
-          result = translateScet(word1, word2, word3);
-        }
-        else {
-          result = 65535;
-        }
-
-        // If we don't have a valid SCET, the whole line of HK data is not valid, so we skip it.
-        if (result == 0 || result == 65535) {
-          break;
-        }
-        else{
-          rec[tableNum] = result*1.0;
-        }
-        // We used 3 words
-        k=k+4;
-      }
-      tableNum++;
+      table += rec;
     }
-    table += rec;
-  }
 
-  outcube->write(table);
+    outcube->write(table);
+  }
+  else if (procLevel == 3) {
+    std::vector<char *> hkData = p.DataTrailer();
+    TableRecord rec;
+    TableField scETField("dataSCET", TableField::Double);
+    rec += scETField;
+    Table table("VIRTISHouseKeeping", rec);
+    for (unsigned int i=0; i < hkData.size() ; i++) {
+      const char *hk = hkData.at(i);
+      const unsigned short *uihk = reinterpret_cast<const unsigned short *> (hk);
+      int word1 = swapb(uihk[0]);
+      int word2 = swapb(uihk[1]);
+      int word3 = swapb(uihk[2]);
+      rec[0] = translateScet(word1, word2, word3);
+      table += rec;
+    }
+    outcube->write(table);
+  }
 
 
   // Create a PVL to store the translated labels in


### PR DESCRIPTION
This is currently only  used with Rosetta's comet observations.