### PR TITLE
Added TargetBodyRadii to Control Network headers. Fixes #5361.

### DIFF
--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -237,14 +237,20 @@ namespace Isis {
    *                           parent prematurely to be able to set the radii
    *                           in ControlPoint.
    * @history 2017-12-21 Jesse Mapel - Modified to use the ControlNetVersioner.
-   *
+   * @history 2018-04-05 Adam Goins - Added a check to the versionedReader targetRadii
+   *                         group to set radii values to those ingested from the versioner
+   *                         if they exist. Otherwise, we call SetTarget with the targetname.
    */
   void ControlNet::ReadControl(const QString &filename, Progress *progress) {
 
     FileName cnetFileName(filename);
     ControlNetVersioner versionedReader(cnetFileName, progress);
-
-    SetTarget( versionedReader.targetName() );
+    if ( versionedReader.hasTargetRadii() ) {
+      p_targetRadii = versionedReader.targetRadii();
+    }
+    else {
+      SetTarget( versionedReader.targetName() );
+    }
     p_networkId   = versionedReader.netId();
     p_userName    = versionedReader.userName();
     p_created     = versionedReader.creationDate();
@@ -346,8 +352,8 @@ namespace Isis {
 
 
  /**
-   * Adds a whole point to the control net graph. 
-   *    
+   * Adds a whole point to the control net graph.
+   *
    * @throws IException::Programmer "NULL measure passed to ControlNet::AddControlCubeGraphNode!"
    * @throws IException::Programmer "Control measure with NULL parent passed to
    *     ControlNet::AddControlCubeGraphNode!"

--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -246,7 +246,9 @@ namespace Isis {
     FileName cnetFileName(filename);
     ControlNetVersioner versionedReader(cnetFileName, progress);
     if ( versionedReader.hasTargetRadii() ) {
-      p_targetRadii = versionedReader.targetRadii();
+      foreach (Distance distance, versionedReader.targetRadii()) {
+        p_targetRadii.push_back(distance);
+      }
     }
     else {
       SetTarget( versionedReader.targetName() );

--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -246,6 +246,8 @@ namespace Isis {
     FileName cnetFileName(filename);
     ControlNetVersioner versionedReader(cnetFileName, progress);
     if ( versionedReader.hasTargetRadii() ) {
+      p_targetName = versionedReader.targetName();
+      p_targetRadii.clear();
       foreach (Distance distance, versionedReader.targetRadii()) {
         p_targetRadii.push_back(distance);
       }

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -212,7 +212,11 @@ namespace Isis {
    *   @history 2017-01-19 Jesse Mapel - Added a method to get all of the valid measures in an
    *                           image. Previously, this had to be done throug the graph.
    *   @history 2018-01-26 Kristin Berry - Added pointAdded() function to eliminate redundant measure
-   *                           adds to the control network. 
+   *                           adds to the control network.
+   *   @history 2018-04-05 Adam Goins - Added a check to the versionedReader targetRadii
+   *                           group to set radii values to those ingested from the versioner
+   *                           if they exist. Otherwise, we call SetTarget with the targetname.
+   *                           Fixes #5361.
    */
   class ControlNet : public QObject {
       Q_OBJECT

--- a/isis/src/control/objs/ControlNet/ControlNet.truth
+++ b/isis/src/control/objs/ControlNet/ControlNet.truth
@@ -147,6 +147,7 @@ Object = ControlNetwork
   Created      = 2010-07-10T12:50:15
   LastModified = 2010-07-10T12:50:55
   Description  = "UnitTest of ControlNetwork"
+  TargetRadii  = (3396190.0, 3396190.0, 3376200.0)
   Version      = 5
 
   Object = ControlPoint

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetFileHeaderV0005.proto
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetFileHeaderV0005.proto
@@ -9,6 +9,6 @@ message ControlNetFileHeaderV0005 {
   optional string lastModified = 4;
   optional string description  = 5;
   optional string userName     = 6;
-  optional int32  numPoints    = 7; 
+  optional int32  numPoints    = 7;
+  repeated double targetRadii = 10;
 }
-

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -205,16 +205,12 @@ namespace Isis {
     network += PvlKeyword("LastModified", m_header.lastModified);
     network += PvlKeyword("Description", m_header.description);
     if ( !m_header.targetRadii.empty() ) {
-          //  PvlGroup pvlRadii = Target::radiiGroup(m_header.targetName);
-          // network += pvlRadii;
-          //  network += PvlKeyword("EquatorialRadius", toString(m_header.equatorialRadius.meters() ) );
-          //  network += PvlKeyword("PolarRadius", toString(m_header.polarRadius.meters()));
           PvlKeyword targetRadii("TargetRadii");
-           targetRadii += toString(m_header.targetRadii[0].meters());
-           targetRadii += toString(m_header.targetRadii[1].meters());
-           targetRadii += toString(m_header.targetRadii[2].meters());
-           network += targetRadii;
-         }
+          for (uint i = 0; i < m_header.targetRadii.size(); i++) {
+            targetRadii += toString(m_header.targetRadii[i].meters());
+          }
+          network += targetRadii;
+      }
     // optionally add username to output?
 
     // This is the Pvl version we're converting to

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -1812,12 +1812,20 @@ namespace Isis {
       netInfo.addComment("This group is for informational purposes only");
       netInfo += PvlKeyword("NetworkId", protobufHeader.networkid().c_str());
       netInfo += PvlKeyword("TargetName", protobufHeader.targetname().c_str());
+
+          // Grab TargetRadii if they exist.
+          if (!m_header.targetRadii.empty()) {
+              PvlKeyword pvlRadii("TargetRadii");
+              for (uint i = 0; i < m_header.targetRadii.size(); i++) {
+                pvlRadii += toString(m_header.targetRadii[i].meters());
+              }
+              netInfo += pvlRadii;
+            }
       netInfo += PvlKeyword("UserName", protobufHeader.username().c_str());
       netInfo += PvlKeyword("Created", protobufHeader.created().c_str());
       netInfo += PvlKeyword("LastModified", protobufHeader.lastmodified().c_str());
       netInfo += PvlKeyword("Description", protobufHeader.description().c_str());
       netInfo += PvlKeyword("NumberOfPoints", toString(numPoints));
-
       netInfo += PvlKeyword("NumberOfMeasures", toString(numMeasures));
       netInfo += PvlKeyword("Version", "5");
       protoObj.addGroup(netInfo);

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -167,6 +167,25 @@ namespace Isis {
 
 
   /**
+  * Returns true if the targetRadii in the header has values.
+  *
+  * @return @b boolean True if the targetRadii in the header is populated.
+  */
+  bool ControlNetVersioner::hasTargetRadii() const {
+    return m_header.targetRadii.empty() ? false : true;
+  }
+
+  /**
+  * Returns the targetRadii Distance vector located in the header.
+  *
+  * @return @b std::vector<Distance> A vector containing the target body radii.
+  */
+  std::vector<Distance> ControlNetVersioner::targetRadii() const {
+    return m_header.targetRadii;
+  }
+
+
+  /**
    * Returns the number of points that have been read in or are ready to write out.
    *
    * @return @b int The number of control points stored internally.

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -855,8 +855,11 @@ namespace Isis {
       if (network.hasKeyword("TargetRadii")) {
         header.targetRadii.clear();
         for (int i = 0; i < network.findKeyword("TargetRadii").size(); i++) {
-          header.targetRadii.push_back(Distance(toDouble(network.findKeyword("TargetRadii")[i]),
-                                           Distance::Meters));
+          Distance distance = Distance(toDouble(network.findKeyword("TargetRadii")[i]),
+                                           Distance::Meters);
+          if ( distance.isValid() ) {
+            header.targetRadii.push_back(distance);
+          }
         }
       }
       createHeader(header);
@@ -1244,8 +1247,10 @@ namespace Isis {
       if ( protoHeader.targetradii_size() >= 3 ) {
         header.targetRadii.clear();
         for (int i = 0; i < protoHeader.targetradii_size(); i++) {
-          header.targetRadii.push_back(Distance(protoHeader.targetradii(i),
-                                           Distance::Meters));
+          Distance distance = Distance(protoHeader.targetradii(i), Distance::Meters);
+          if ( distance.isValid() ) {
+            header.targetRadii.push_back(distance);
+          }
         }
       }
       createHeader(header);

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.h
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.h
@@ -406,7 +406,7 @@ namespace Isis {
    *   @history 2018-03-28 Adam Goins - Added targetRadii groups to the header. Changed the
    *                           versioner to write these values out in a targetRadii group for
    *                           both binary V0005 and PvlV0005 networks. Fixes #5361.
-   *   @history 2018-04-05 Adam Goins - Added hastargetRadii() and targetRadii() to the versioner
+   *   @history 2018-04-05 Adam Goins - Added hasTargetRadii() and targetRadii() to the versioner
    *                           so that these values can be grabbed from a ControlNet on read.
    *                           Also Fixes #5361.
    */

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.h
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.h
@@ -406,6 +406,9 @@ namespace Isis {
    *   @history 2018-03-28 Adam Goins - Added targetRadii groups to the header. Changed the
    *                           versioner to write these values out in a targetRadii group for
    *                           both binary V0005 and PvlV0005 networks. Fixes #5361.
+   *   @history 2018-04-05 Adam Goins - Added hastargetRadii() and targetRadii() to the versioner
+   *                           so that these values can be grabbed from a ControlNet on read.
+   *                           Also Fixes #5361.
    */
   class ControlNetVersioner {
 
@@ -420,6 +423,8 @@ namespace Isis {
       QString lastModificationDate() const;
       QString description() const;
       QString userName() const;
+      bool hasTargetRadii() const;
+      std::vector<Distance> targetRadii() const;
 
       int numPoints() const;
       ControlPoint *takeFirstPoint();

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.h
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.h
@@ -403,6 +403,9 @@ namespace Isis {
    *                           describing the different file format versions.
    *   @history 2018-01-30 Adam Goins - Ensured point sizes are written/read as lsb by using
    *                           EndianSwapper.
+   *   @history 2018-03-28 Adam Goins - Added targetRadii groups to the header. Changed the
+   *                           versioner to write these values out in a targetRadii group for
+   *                           both binary V0005 and PvlV0005 networks. Fixes #5361.
    */
   class ControlNetVersioner {
 
@@ -471,12 +474,9 @@ namespace Isis {
          * The equatorial radius of the target body
          * used to convert from spherical to rectangular coordinates
          */
-        Distance equatorialRadius;
-        /**
-         * The equatorial radius of the target body
-         * used to convert from spherical to rectangular coordinates
-         */
-        Distance polarRadius;
+
+         std::vector<Distance> targetRadii;
+
       };
 
       //! Typedef for consistent naming of containers for version 2

--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.truth
@@ -20,6 +20,7 @@ Object = ControlNetwork
   Created      = Null
   LastModified = Null
   Description  = Null
+  TargetRadii  = (3396190.0, 3396190.0, 3376200.0)
   Version      = 5
 
   Object = ControlPoint
@@ -76,6 +77,7 @@ Object = ControlNetwork
   Created      = Null
   LastModified = Null
   Description  = "Test Network"
+  TargetRadii  = (2575000.0, 2575000.0, 2575000.0)
   Version      = 5
 
   Object = ControlPoint
@@ -132,6 +134,7 @@ Object = ControlNetwork
   Created      = 2010-07-10T12:50:15
   LastModified = 2010-07-10T12:50:55
   Description  = "UnitTest of ControlNetwork"
+  TargetRadii  = (3396190.0, 3396190.0, 3376200.0)
   Version      = 5
 
   Object = ControlPoint
@@ -329,6 +332,7 @@ Object = ControlNetwork
   Created      = 2012-01-04T12:09:57
   LastModified = 2012-01-04T12:09:57
   Description  = "Themis Day IR Network: Lunae Palus, Lat(0,30) Lon(270-315)"
+  TargetRadii  = (3396190.0, 3396190.0, 3376200.0)
   Version      = 5
 
   Object = ControlPoint
@@ -559,7 +563,12 @@ After reading and writing to a binary form does Pvl match?
 Conversion to Pvl stays consistent
 Reading/Writing control network is consistent
 Check conversions between the binary format and the pvl format.
-The conversion methods for pvl->bin and bin->pvl are correct.
+8c8,9
+<   Version      = 3
+---
+>   TargetRadii  = (3396190.0, 3396190.0, 3376200.0)
+>   Version      = 5
+The conversion from pvl to binary is incorrect.
 
 Reading: $control/testData/unitTest_ControlNetVersioner_PvlNetwork5_PvlV0003.pvl...
 


### PR DESCRIPTION
Pvl and Binary V5 networks now store the TargetBodyRadii for a control network in their respective headers. 
ControlNetVersioner was refactored to store these values in memory on read, and grab these values from the header when attempting to write.
ControlNet was modified to try and grab the values from the ControlNetVersioner before attempting to calculate them itself using the Target::radiiGroup() call. 

New Truth Data for ControlNet, ControlNetVersioner, cnetcombinept, and cnetbin2pvl will need to be checked in following the merge of this pull request. The new radii being stored in the header makes current truthdata inconsistent because v5 networks now include this header. 