### PR TITLE
Added an option to kerneldbgen to specify SPICE time coverage level. Fixes #5410.

### DIFF
--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
@@ -40,7 +40,8 @@ const char *SpiceDbGen::calForm = "YYYY MON DD HR:MN:SC.###### TDB ::TDB";
 */
 SpiceDbGen::SpiceDbGen(QString type) {
   p_type = type;
-//  calForm = "YYYY MON DD HR:MN:SC.### TDB ::TDB";
+  m_coverageLevel = "SEGMENT"; // default
+  //  calForm = "YYYY MON DD HR:MN:SC.### TDB ::TDB";
 }
 
 
@@ -156,6 +157,17 @@ QStringList SpiceDbGen::GetFiles(FileName location, QString filter) {
 
 
 /**
+ * Sets the desired time coverage level of the Spice database. 
+ * 
+ * @param level The desired time coverage level. May be either Segment or 
+ *              Interval.  
+ */
+void SpiceDbGen::setCoverageLevel(QString level) {
+  m_coverageLevel = level; 
+}
+
+
+/**
   * Format a single kernel file to include the file.
   *
   * @param fileIn   The file name being added
@@ -227,10 +239,16 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
         SPICEDOUBLE_CELL(cover, 200000);
         ssize_c(0, &cover);
         ssize_c(200000, &cover);
-        ckcov_c(tmp.toLatin1().data(), body, SPICEFALSE, "SEGMENT", 0.0, "TDB", &cover);
+
+        // A SPICE SEGMENT is composed of SPICE INTERVALS, and is a more coarse measurement
+        if (QString::compare(m_coverageLevel, "SEGMENT", Qt::CaseInsensitive) == 0 ) {
+          ckcov_c(tmp.toLatin1().data(), body, SPICEFALSE, "SEGMENT", 0.0, "TDB", &cover); 
+        }
+        else {
+          ckcov_c(tmp.toLatin1().data(), body, SPICEFALSE, "INTERVAL", 0.0, "TDB", &cover);
+        }
 
         NaifStatus::CheckErrors();
-
         result = FormatIntervals(cover, currFile, startOffset, endOffset);
       }
     }

--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
@@ -240,7 +240,7 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
         ssize_c(0, &cover);
         ssize_c(200000, &cover);
 
-        // A SPICE SEGMENT is composed of SPICE INTERVALS, and is a more coarse measurement
+        // A SPICE SEGMENT is composed of SPICE INTERVALS
         if (QString::compare(m_coverageLevel, "SEGMENT", Qt::CaseInsensitive) == 0 ) {
           ckcov_c(tmp.toLatin1().data(), body, SPICEFALSE, "SEGMENT", 0.0, "TDB", &cover); 
         }

--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.h
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.h
@@ -57,6 +57,7 @@ class SpiceDbGen {
                            std::vector<QString> & filter, double startOffset, double endOffset);
     void FurnishDependencies(QList<Isis::FileName> sclks, QList<Isis::FileName> fks,
                              QList<Isis::FileName> extras);
+    void setCoverageLevel(QString level); 
 
   private:
     QStringList GetFiles(Isis::FileName location, QString filter);
@@ -65,6 +66,7 @@ class SpiceDbGen {
     Isis::PvlGroup GetIntervals(SpiceCell &cover);
     //private instance variables
     QString p_type;
+    QString m_coverageLevel; 
     static const char *calForm;
 };
 

--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.h
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.h
@@ -47,6 +47,11 @@
  *   @history 2013-02-15 Steven Lambright - Added support for extra kernel dependencies
  *   @history 2018-01-10 Christopher Combs - Added passing startOffset and endOffset to allow
  *                           the passing of time offsets to to FormatIntervals. Fixes #5272.
+ *   @history 2018-05-09 Kristin Berry - Added information about the Spice time coverage level
+ *                            to this class: m_coverageLevel, setCoverageLevel, and this class will
+ *                            now select spice "time intervals" at the level specified. This is
+ *                            either a SPICE Segment (coarse) or a SPICE interval (fine.)
+ *                            Fixes #5410. 
  *
  */
 class SpiceDbGen {
@@ -66,7 +71,7 @@ class SpiceDbGen {
     Isis::PvlGroup GetIntervals(SpiceCell &cover);
     //private instance variables
     QString p_type;
-    QString m_coverageLevel; 
+    QString m_coverageLevel; //! The time coverage level of the database: INTERVAL or SEGMENT
     static const char *calForm;
 };
 

--- a/isis/src/system/apps/kerneldbgen/kerneldbgen.cpp
+++ b/isis/src/system/apps/kerneldbgen/kerneldbgen.cpp
@@ -15,19 +15,19 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   PvlGroup dependency("Dependencies");
 
-  //create the database writer based on the kernel type
+  // Create the database writer based on the kernel type
   SpiceDbGen sdg(ui.GetString("TYPE"));
 
-  //Load the SCLK. If it exists, add its location to the dependency group
-  //If there is none, set a flag so that no file is searched for
+  // Load the SCLK. If it exists, add its location to the dependency group
+  // If there is none, set a flag so that no file is searched for
   QList<FileName> sclkFiles = evaluateDependencies(dependency, "SpacecraftClockKernel", "SCLK");
   QList<FileName> lskFiles = evaluateDependencies(dependency, "LeapsecondKernel", "LSK");
   QList<FileName> extraFiles = evaluateDependencies(dependency, "ExtraKernel", "EXTRA");
 
   sdg.FurnishDependencies(sclkFiles, lskFiles, extraFiles);
 
-  //Determine the type of kernel that the user wants a database for. This will
-  //eventually become the name of the object in the output PVL
+  // Determine the type of kernel that the user wants a database for. This will
+  // eventually become the name of the object in the output PVL
   QString kernelType;
   if (ui.GetString("TYPE") == "CK") {
     kernelType = "SpacecraftPointing";
@@ -36,6 +36,18 @@ void IsisMain() {
     kernelType = "SpacecraftPosition";
   }
   PvlObject selections(kernelType);
+
+  // Specify whether to use SPICE segments (made up of SPICE intervals) 
+  // or SPICE intervals for the SPICE database. Naif referes to this as "coverage level" 
+  QString coverageLevel; 
+  if (ui.GetString("LEVEL") == "SEGMENT") {
+    coverageLevel = "SEGMENT"; 
+  }
+  else if (ui.GetString("LEVEL") == "INTERVAL") {
+    coverageLevel = "INTERVAL"; 
+  }
+  // add to Pvl? 
+  sdg.setCoverageLevel(coverageLevel); 
 
   selections += PvlKeyword("RunTime", iTime::CurrentLocalTime());
   selections.addGroup(dependency);

--- a/isis/src/system/apps/kerneldbgen/kerneldbgen.cpp
+++ b/isis/src/system/apps/kerneldbgen/kerneldbgen.cpp
@@ -46,7 +46,6 @@ void IsisMain() {
   else if (ui.GetString("LEVEL") == "INTERVAL") {
     coverageLevel = "INTERVAL"; 
   }
-  // add to Pvl? 
   sdg.setCoverageLevel(coverageLevel); 
 
   selections += PvlKeyword("RunTime", iTime::CurrentLocalTime());

--- a/isis/src/system/apps/kerneldbgen/kerneldbgen.xml
+++ b/isis/src/system/apps/kerneldbgen/kerneldbgen.xml
@@ -152,6 +152,10 @@
       Added STARTOFFSET and ENDOFFSET parameters to allow for slight editing to start and end times.
       Fixes #5272.
     </change>
+    <change name="Kristin Berry" date="2018-05-09">
+      Added option to specify the time coverage level to be used for the generated database. SPICE segements are made up of SPICE intervals. 
+      Segments (the only old option) are now the default, but interval can be selected if needed. 
+    </change>
   </history>
 
   <groups>
@@ -217,6 +221,37 @@
               <item>NADIRDIR</item>
               -->
             </exclusions>
+          </option>
+        </list>
+      </parameter>
+    </group>
+    <group name="Coverage Level">
+      <parameter name="LEVEL">
+        <type>string</type>
+        <default>
+          <item>SEGMENT</item>
+        </default>
+        <brief>
+           The level of time-granularity for the time-coverage interval to be output to the SPICE database. 
+        </brief>
+        <description>
+        </description>
+        <list>
+          <option value="SEGMENT">
+            <brief>
+              SPICE Segment             
+            </brief>
+            <description>
+              The coarsest level of time granularity, a SPICE segment is composed of SPICE intervals.              
+            </description>
+          </option>
+          <option value="INTERVAL">
+            <brief>
+              SPICE Interval 
+            </brief>
+            <description>
+              A finer level of time granularity. 
+            </description>
           </option>
         </list>
       </parameter>

--- a/isis/src/system/apps/kerneldbgen/kerneldbgen.xml
+++ b/isis/src/system/apps/kerneldbgen/kerneldbgen.xml
@@ -153,8 +153,8 @@
       Fixes #5272.
     </change>
     <change name="Kristin Berry" date="2018-05-09">
-      Added option to specify the time coverage level to be used for the generated database. SPICE segements are made up of SPICE intervals. 
-      Segments (the only old option) are now the default, but interval can be selected if needed. 
+      Added the LEVEL=(SEGMENT*, INTERVAL) option to specify the time coverage level to be used for the generated database. SPICE segements are made up of SPICE intervals. 
+      Segments (the only option in the past) are now the default, but interval can be selected if needed. Fixes #5410. 
     </change>
   </history>
 

--- a/isis/src/system/apps/kerneldbgen/tsts/coverageLevel/Makefile
+++ b/isis/src/system/apps/kerneldbgen/tsts/coverageLevel/Makefile
@@ -1,0 +1,38 @@
+# Coverage Level Test for kerneldbgen
+#
+# This test creates an output database file from the kernel in the input file
+# that follow the given filter for reconstructed ck file name patterns. A database
+# is output with time coverage at the SPICE segment level and at the SPICE interval 
+# level. (There will be one output entry for the spice segment, and several for the
+# SPICE interval because a SPICE segment is composed of SPICE intervals.) 
+#
+# After the output PVL is created, when compared, the DIFF file indicates to
+# ignore RunTime and File.  The File keyword is ignored since, depending on 
+# where the test is run, files may have different paths. These paths can not be 
+# removed since they may be long enough to take up multiple lines.
+# 
+# This test uses files from the TGO CaSSIS mission, as this is where the problem
+# was identified. 
+#
+# history 2018-05-09 Kristin Berry - Added test for newly added time coverage 
+#                                    LEVEL=(SEGMENT*, INTERVAL) option. See #5410
+APPNAME = kerneldbgen
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	# Default output level=segment
+	$(APPNAME) to=$(OUTPUT)/kernel_segment.db.pvl \
+	  type=CK \
+	  recondir=$(INPUT) \
+	  reconfilter='em16_tgo_sc_??m_*.bc' \
+	  sclk=\$$tgo/kernels/sclk/em16_tgo_step_????????.tsc \
+          lsk=\$$base/kernels/lsk/naif0012.tls > /dev/null; 
+
+	# Output with level=interval, needed for CaSSIS kernels and potentially other type-6 kernels
+	$(APPNAME) to=$(OUTPUT)/kernel_interval.db.pvl \
+	  type=CK \
+	  level=INTERVAL \
+	  recondir=$(INPUT) \
+	  reconfilter='em16_tgo_sc_??m_*.bc' \
+ 	  sclk=\$$tgo/kernels/sclk/em16_tgo_step_????????.tsc \
+          lsk=\$$base/kernels/lsk/naif0012.tls > /dev/null;


### PR DESCRIPTION
There is no unit test update included because the `SpiceDbGen` class lives with the `kerneldbgen` app, not inside `$ISISROOT/src/*/objs`. 