### PR TITLE
Added PRODUCTID parameter to tgocassisrdrgen to allow users to update the product id

### DIFF
--- a/isis/src/tgo/apps/tgocassismos/tgocassismos.cpp
+++ b/isis/src/tgo/apps/tgocassismos/tgocassismos.cpp
@@ -62,7 +62,7 @@ void IsisMain() {
       bandname = bandname.toUpper();
       ProdId = ProdId + "_" + bandname;
     }
-    
+
     bool runXY = true;
 
     //calculate the min and max lon
@@ -173,7 +173,7 @@ void IsisMain() {
     QString startClock;
     QString startTime;
     for(int i = 0; i < (int)clist.size(); i++) {
-      // himos used original label here. 
+      // himos used original label here.
 
       Pvl *origLab = clist[i]->label();
       PvlGroup timegrp = origLab->findGroup("Instrument", Pvl::Traverse);
@@ -213,7 +213,7 @@ void IsisMain() {
 
 
     PvlGroup mos("Mosaic");
-    mos += PvlKeyword("ProductId ", ProdId);
+    mos += PvlKeyword("ObservationId ", ProdId);
 //     mos += PvlKeyword(sourceProductId);
     mos += PvlKeyword("StartTime ", startTime);
     mos += PvlKeyword("SpacecraftClockStartCount ", startClock);
@@ -251,7 +251,7 @@ void CompareLabels(Pvl &pmatch, Pvl &pcomp) {
 //   PvlGroup compgrp = pcomp.findGroup("Archive", Pvl::Traverse);
 //   QString obsMatch = matchgrp["ObservationId"];
 //   QString obsComp = compgrp["ObservationId"];
-// 
+//
 //   if(obsMatch != obsComp) {
 //     QString msg = "Images not from the same observation";
 //     throw IException(IException::User, msg, _FILEINFO_);

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -43,14 +43,14 @@ void IsisMain() {
     throw  IException(IException::User, msg, _FILEINFO_);
   }
 
-  if ( ui.WasEntered("PRODID") ) {
+  if ( ui.WasEntered("PRODUCTID") ) {
     PvlGroup &archiveGroup = label->findObject("IsisCube").findGroup("Archive");
     try {
       PvlKeyword &prodId = archiveGroup.findKeyword("ProductId");
-      prodId.setValue( ui.GetString("PRODID") );
+      prodId.setValue( ui.GetString("PRODUCTID") );
     }
     catch (IException &e) {
-      archiveGroup.addKeyword( PvlKeyword("ProductId", ui.GetString("PRODID")) );
+      archiveGroup.addKeyword( PvlKeyword("ProductId", ui.GetString("PRODUCTID")) );
     }
   }
 

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -47,16 +47,18 @@ void IsisMain() {
   // by the user, set it to the Observation Id.
   // This is added before the translation instead of adding it to the exported xml
   // because of the ease of editing pvl vs xml.
-  PvlGroup &archiveGroup = label->findObject("IsisCube").findGroup("Archive");
+  PvlGroup &instrumentGroup = label->findObject("IsisCube").findGroup("Instrument");
   PvlKeyword productId = PvlKeyword("ProductId");
   if ( ui.WasEntered("PRODUCTID") ) {
     productId.setValue( ui.GetString("PRODUCTID") );
+    instrumentGroup.addKeyword(productId);
+
   }
   else {
-    QString observationId = archiveGroup.findKeyword("ObservationId").QString();
+    QString observationId = instrumentGroup.findKeyword("ObservationId")[0];
     productId.setValue(observationId);
   }
-  archiveGroup.addKeyword(productId);
+  instrumentGroup.addKeyword(productId);
 
   /*
   * Add additional pds label data here

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -43,16 +43,20 @@ void IsisMain() {
     throw  IException(IException::User, msg, _FILEINFO_);
   }
 
+  // Add the ProductId keyword for translation. If a product id is not specified
+  // by the user, set it to the Observation Id.
+  // This is added before the translation instead of adding it to the exported xml
+  // because of the ease of editing pvl vs xml.
+  PvlGroup &archiveGroup = label->findObject("IsisCube").findGroup("Archive");
+  PvlKeyword productId = PvlKeyword("ProductId");
   if ( ui.WasEntered("PRODUCTID") ) {
-    PvlGroup &archiveGroup = label->findObject("IsisCube").findGroup("Archive");
-    try {
-      PvlKeyword &prodId = archiveGroup.findKeyword("ProductId");
-      prodId.setValue( ui.GetString("PRODUCTID") );
-    }
-    catch (IException &e) {
-      archiveGroup.addKeyword( PvlKeyword("ProductId", ui.GetString("PRODUCTID")) );
-    }
+    productId.setValue( ui.GetString("PRODUCTID") );
   }
+  else {
+    QString observationId = archiveGroup.findKeyword("ObservationId").QString();
+    productId.setValue(observationId);
+  }
+  archiveGroup.addKeyword(productId);
 
   /*
   * Add additional pds label data here

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -43,7 +43,18 @@ void IsisMain() {
     throw  IException(IException::User, msg, _FILEINFO_);
   }
 
-/*
+  if ( ui.WasEntered("PRODID")) {
+    PvlGroup &archiveGroup = label->findObject("IsisCube").findGroup("Archive");
+    try {
+      PvlKeyword &prodId = archiveGroup.findKeyword("ProductId");
+      prodId.setValue( ui.GetString("PRODID") );
+    }
+    catch (IException &e) {
+      archiveGroup.addKeyword( PvlKeyword("ProductId", ui.GetString("PRODID")) );
+    }
+  }
+
+  /*
   * Add additional pds label data here
   */
 
@@ -67,8 +78,8 @@ void IsisMain() {
   process.addHistory(historyDescription, historyDate);
 
   ProcessExportPds4::translateUnits(pdsLabel);
-  
+
   QString outFile = ui.GetFileName("TO");
-  
+
   process.WritePds4(outFile);
 }

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -43,7 +43,7 @@ void IsisMain() {
     throw  IException(IException::User, msg, _FILEINFO_);
   }
 
-  if ( ui.WasEntered("PRODID")) {
+  if ( ui.WasEntered("PRODID") ) {
     PvlGroup &archiveGroup = label->findObject("IsisCube").findGroup("Archive");
     try {
       PvlKeyword &prodId = archiveGroup.findKeyword("ProductId");

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
@@ -30,8 +30,8 @@
       Moved code to write out .img and .xml PDS4 data to WritePds4 in ProcessExportPds4.
     </change>
     <change name="Kaitlyn Lee" date="2018-05-16">
-      Added parameter PRODUCTID to set the ProductId keyword. If the keyword does
-      not exist in the label, it will add it.
+      Added parameter PRODUCTID to set the ProductId keyword. If the product id is
+      not specified by the user, set the ProductId keyword to the observation id.
     </change>
   </history>
 

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
@@ -30,7 +30,7 @@
       Moved code to write out .img and .xml PDS4 data to WritePds4 in ProcessExportPds4.
     </change>
     <change name="Kaitlyn Lee" date="2018-05-16">
-      Added parameter PRODID to set the ProductId keyword. If the keyword does
+      Added parameter PRODUCTID to set the ProductId keyword. If the keyword does
       not exist in the label, it will add it.
     </change>
   </history>
@@ -71,9 +71,9 @@
     </group>
 
     <group name="Keywords">
-      <parameter name="PRODID">
+      <parameter name="PRODUCTID">
         <type>string</type>
-        <internalDefault>No Value</internalDefault>
+        <internalDefault>None</internalDefault>
         <brief>
           Poduct ID value
         </brief>

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
@@ -73,6 +73,7 @@
     <group name="Keywords">
       <parameter name="PRODID">
         <type>string</type>
+        <internalDefault>No Value</internalDefault>
         <brief>
           Poduct ID value
         </brief>

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
@@ -23,11 +23,15 @@
       Changed the order that the elements appear in the output label.
     </change>
     <change name="Marjorie Hahn" date="2017-06-05">
-      Added a default test to ensure that if the exported PDS4 data is reingested, 
+      Added a default test to ensure that if the exported PDS4 data is reingested,
       then it is the same as the original cube.
     </change>
     <change name="Marjorie Hahn" date="2017-06-08">
       Moved code to write out .img and .xml PDS4 data to WritePds4 in ProcessExportPds4.
+    </change>
+    <change name="Kaitlyn Lee" date="2018-05-16">
+      Added parameter PRODID to set the ProductId keyword. If the keyword does
+      not exist in the label, it will add it.
     </change>
   </history>
 
@@ -65,5 +69,18 @@
         <filter>*.img</filter>
       </parameter>
     </group>
+
+    <group name="Keywords">
+      <parameter name="PRODID">
+        <type>string</type>
+        <brief>
+          Poduct ID value
+        </brief>
+        <description>
+          Update the default Product ID value.
+        </description>
+      </parameter>
+    </group>
+
   </groups>
 </application>

--- a/isis/src/tgo/apps/tgocassisrdrgen/tsts/default/Makefile
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tsts/default/Makefile
@@ -3,28 +3,24 @@ APPNAME = tgocassisrdrgen
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub \
-	           to=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.img \
+	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.cub \
+	           to=$(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.img \
 		   > /dev/null;
 
 	# Reingest the PDS4 data
-	raw2isis from=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.img \
-	         to=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub \
-	         SAMPLES=2048 \
-	         LINES=254 \
-	         BITTYPE=REAL \
-	         BYTEORDER=LSB \
+	tgocassis2isis from=$(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.xml \
+	         to=$(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.cub \
 		 > /dev/null;
 
 	# Compare the output cube from raw2isis to the original input cube to
 	# ensure that they are identical
-	cubediff from=$(INPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub \
-	         from2=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub \
+	cubediff from=$(INPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.cub \
+	         from2=$(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.cub \
 	         to=$(OUTPUT)/cubediffresults.txt \
 		 > /dev/null;
 
 	$(SED) 's+\Product_Observational.*>+\Product_Observational>+' \
-	       $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.xml \
+	       $(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.xml \
 	       > $(OUTPUT)/templabel1.txt;
 	$(SED) 's+\FSW_HEADER.*>+\FSW_HEADER>+' \
 	       $(OUTPUT)/templabel1.txt \
@@ -34,22 +30,22 @@ commands:
 	       > $(OUTPUT)/templabel3.txt;
 	$(SED) 's+\Modification_Detail.*>+\Modification_Detail>+' \
 	       $(OUTPUT)/templabel3.txt \
-	       > $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.xmlLabel.txt;
+	       > $(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.xmlLabel.txt;
 
 
-	$(RM) $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.xml \
+	$(RM) $(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.xml \
 	      $(OUTPUT)/templabel1.txt \
 	      $(OUTPUT)/templabel2.txt \
 	      $(OUTPUT)/templabel3.txt;
 
 	# Test PRODUCTID parameter with same input
-	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub \
-	           to=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.img \
+	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1.cub \
+	           to=$(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1_modifiedId.img \
 						 PRODUCTID=placeholderId \
 		   > /dev/null;
 
 	$(SED) 's+\Product_Observational.*>+\Product_Observational>+' \
-	       $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.xml \
+	       $(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1_modifiedId.xml \
 	       > $(OUTPUT)/templabel1.txt;
 	$(SED) 's+\FSW_HEADER.*>+\FSW_HEADER>+' \
 	       $(OUTPUT)/templabel1.txt \
@@ -59,10 +55,10 @@ commands:
 	       > $(OUTPUT)/templabel3.txt;
 	$(SED) 's+\Modification_Detail.*>+\Modification_Detail>+' \
 	       $(OUTPUT)/templabel3.txt \
-	       > $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.xmlLabel.txt;
+	       > $(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1_modifiedId.xmlLabel.txt;
 
 
-	$(RM) $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.xml \
+	$(RM) $(OUTPUT)/CAS-MCO-2016-11-22T15.45.50.984-BLU-03000-B1_modifiedId.xml \
 	      $(OUTPUT)/templabel1.txt \
 	      $(OUTPUT)/templabel2.txt \
 	      $(OUTPUT)/templabel3.txt;

--- a/isis/src/tgo/apps/tgocassisrdrgen/tsts/default/Makefile
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tsts/default/Makefile
@@ -2,7 +2,7 @@ APPNAME = tgocassisrdrgen
 
 include $(ISISROOT)/make/isismake.tsts
 
-commands: 
+commands:
 	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub \
 	           to=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.img \
 		   > /dev/null;
@@ -38,6 +38,31 @@ commands:
 
 
 	$(RM) $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.xml \
+	      $(OUTPUT)/templabel1.txt \
+	      $(OUTPUT)/templabel2.txt \
+	      $(OUTPUT)/templabel3.txt;
+
+	# Test PRODUCTID parameter with same input
+	$(APPNAME) from=$(INPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub \
+	           to=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.img \
+						 PRODUCTID=placeholderId \
+		   > /dev/null;
+
+	$(SED) 's+\Product_Observational.*>+\Product_Observational>+' \
+	       $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.xml \
+	       > $(OUTPUT)/templabel1.txt;
+	$(SED) 's+\FSW_HEADER.*>+\FSW_HEADER>+' \
+	       $(OUTPUT)/templabel1.txt \
+	       > $(OUTPUT)/templabel2.txt;
+	$(SED) 's+\PEHK_HEADER.*>+\PEHK_HEADER>+' \
+	       $(OUTPUT)/templabel2.txt \
+	       > $(OUTPUT)/templabel3.txt;
+	$(SED) 's+\Modification_Detail.*>+\Modification_Detail>+' \
+	       $(OUTPUT)/templabel3.txt \
+	       > $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.xmlLabel.txt;
+
+
+	$(RM) $(OUTPUT)/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00_modifiedId.xml \
 	      $(OUTPUT)/templabel1.txt \
 	      $(OUTPUT)/templabel2.txt \
 	      $(OUTPUT)/templabel3.txt;


### PR DESCRIPTION
Users will be able to specify the product id value they want; if they want to update the value. If the input cube does not have the ProductId keyword, we create one, then set the value. Added onto the default test because we are going to use the same input. 