### PR TITLE
Adding appTest for rdrgen for projected images

### DIFF
--- a/isis/src/tgo/apps/tgocassisrdrgen/tsts/mapProjected/Makefile
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tsts/mapProjected/Makefile
@@ -1,0 +1,13 @@
+# This tests exporting a previously projected cube. 
+#
+# @history 2018-05-17 Summer Stapleton - Original version. 
+#
+
+EXPORT = tgocassisrdrgen
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+
+	$(EXPORT) $(TSTARGS) from=$(INPUT)/CAS-MCO-2016-11-26T22.32.23.582-BLU-03009-B1_projected.cub \
+            to=$(OUTPUT)/CAS-MCO-2016-11-26T22.32.23.582-BLU-03009-B1_projected.img > /dev/null;


### PR DESCRIPTION
Test data can be found in /work/users/sgstapleton/testData/tgocassis/mapProjected