### PR TITLE
Removed Z from end of StartTime on re-ingested cubes

### DIFF
--- a/isis/src/base/objs/iTime/iTime.cpp
+++ b/isis/src/base/objs/iTime/iTime.cpp
@@ -47,29 +47,19 @@ namespace Isis {
   }
 
   /**
-   * Constructs a iTime object and initializes it to the time from the argument.
-   *  
-   * This constructor will (temporarily) strip the Z off of the end of an input UTC-formatted time 
-   * if it is present. This time format is used by PDS4, but not presently supported by NAIF calls, 
-   * in particular str2et_c, which is used by this class.  
+   * Constructs a iTime object and initializes it to the time from the argument.  
    *  
    * @param time A time string formatted in standard UTC or similar format.
-   *             Example:"2000/12/31 23:59:01.6789" or "2000-12-31T23:59:01.6789" or
-   *             "2000-12-31T23:59:01.6789Z"
+   *             Example:"2000/12/31 23:59:01.6789" or "2000-12-31T23:59:01.6789"
    */
   iTime::iTime(const QString &time) {
     LoadLeapSecondKernel();
-    
-    QString tempTime = time; 
-    if (QString::compare(time.at(time.size() - 1), "Z", Qt::CaseInsensitive) == 0) {
-      tempTime = time.left(time.size() - 1);
-    }
 
     NaifStatus::CheckErrors();
 
     // Convert the time string to a double ephemeris time
     SpiceDouble et;
-    str2et_c(tempTime.toLatin1().data(), &et);
+    str2et_c(time.toLatin1().data(), &et);
 
     p_et = et;
     NaifStatus::CheckErrors();

--- a/isis/src/base/objs/iTime/iTime.h
+++ b/isis/src/base/objs/iTime/iTime.h
@@ -72,8 +72,6 @@ namespace Isis {
    *           were signaled. References #2248.
    *  @history 2018-03-15 Adam Goins - Removed deprecated function iTime::UnloadLeapSecondKernel().
    *                          Fixes #5325.
-   *  @history 2018-05-11 Kristin Berry and Makayla Shepherd - Added UTC time format that ends in Z,
-   *                          as this format is used by PDS4 (and the TGO CaSSIS mission.) 
    */
   class iTime {
     public:

--- a/isis/src/base/objs/iTime/iTime.truth
+++ b/isis/src/base/objs/iTime/iTime.truth
@@ -18,25 +18,6 @@ Unit test for iTime
    Et          = 94781765.3
    UTC         = 2003-01-02T12:15:01.1234
 
-  Test of date = 2003/01/02 12:15:01.1234Z
-   Year        = 2003
-   Year        = 2003
-   Month       = 1
-   Month       = 1
-   Day         = 2
-   Day         = 2
-   Hour        = 12
-   Hour        = 12
-   Minute      = 15
-   Minute      = 15
-   Second      = 1.1234
-   Second      = 1.1234
-   Day of Year = 2
-   Day of Year = 2
-   Et          = 94781765.307363
-   Et          = 94781765.3
-   UTC         = 2003-01-02T12:15:01.1234
-
   Test of date = 2000-12-31T23:59:01.6789
    Year        = 2000
    Year        = 2000

--- a/isis/src/base/objs/iTime/unitTest.cpp
+++ b/isis/src/base/objs/iTime/unitTest.cpp
@@ -40,35 +40,6 @@ int main(int argc, char *argv[]) {
   catch(IException &error) {
     error.print();
   }
-  
-  
-  try {
-    cout << endl;
-    cout << setprecision(9);
-    QString test = "2003/01/02 12:15:01.1234Z";
-    iTime *time = new iTime(test);
-    cout << "  Test of date = " << test << endl;
-    cout << "   Year        = " << time->YearString() << endl;
-    cout << "   Year        = " << time->Year() << endl;
-    cout << "   Month       = " << time->MonthString() << endl;
-    cout << "   Month       = " << time->Month() << endl;
-    cout << "   Day         = " << time->DayString() << endl;
-    cout << "   Day         = " << time->Day() << endl;
-    cout << "   Hour        = " << time->HourString() << endl;
-    cout << "   Hour        = " << time->Hour() << endl;
-    cout << "   Minute      = " << time->MinuteString() << endl;
-    cout << "   Minute      = " << time->Minute() << endl;
-    cout << "   Second      = " << time->SecondString() << endl;
-    cout << "   Second      = " << time->Second() << endl;
-    cout << "   Day of Year = " << time->DayOfYearString() << endl;
-    cout << "   Day of Year = " << time->DayOfYear() << endl;
-    cout << "   Et          = " << time->EtString() << endl;
-    cout << "   Et          = " << time->Et() << endl;
-    cout << "   UTC         = " << time->UTC() << endl;
-  }
-  catch(IException &error) {
-    error.print();
-  }
 
 
   double saveEt = 0.0;

--- a/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
@@ -216,8 +216,14 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
   subXlater.Auto(*(outputLabel));
 
   // Create YearDoy keyword in Archive group
-  iTime stime(outputLabel->findGroup("Instrument", Pvl::Traverse)["StartTime"][0]);
-
+  PvlKeyword *startTime = &outputLabel->findGroup("Instrument", Pvl::Traverse)["StartTime"];
+  QString startTimeString = startTime[0];
+  if (QString::compare(startTimeString.at(startTimeString.size() - 1), "Z", Qt::CaseInsensitive) == 0){
+    startTimeString = startTimeString.left(startTimeString.length() - 1);
+    startTime->setValue(startTimeString);
+  }
+  iTime stime(startTimeString);
+  
   PvlGroup &archive = outputLabel->findGroup("Archive", Pvl::Traverse);
                                                   
   PvlKeyword yeardoy("YearDoy", toString(stime.Year()*1000 + stime.DayOfYear()));

--- a/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
@@ -215,7 +215,7 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
   archiveXlater.Auto(*(outputLabel));
   subXlater.Auto(*(outputLabel));
 
-  // Create YearDoy keyword in Archive group
+  // Remove trailing "Z" from PDS4 .xml (on re-ingestion) and create YearDoy keyword in Archive group
   PvlKeyword *startTime = &outputLabel->findGroup("Instrument", Pvl::Traverse)["StartTime"];
   QString startTimeString = startTime[0];
   if (QString::compare(startTimeString.at(startTimeString.size() - 1), "Z", Qt::CaseInsensitive) == 0){

--- a/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.xml
+++ b/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.xml
@@ -115,6 +115,10 @@
     <change name="Kristin Berry and Makayla Shepherd" date="2018-05-15">
      Updated to ingest Mapping groups from images have been exported using tgocassisrdrgen. Fixes #5418.
     </change>
+    <change name="Summer Stapleton" date="2018-05-22">
+      Stripped the "Z" from the StartTime value in the "Instrument" group to handle re-ingestion 
+      of PDS4 compliant .xml files.
+    </change>
   </history>
 
   <category>


### PR DESCRIPTION
Would this potentially make recent changes to iTime obsolete as any ingestion program will need to handle this individually anyway?

And should I create a redmine ticket for this one? (I wasn't sure what to reference in the history comment without a ticket number...)