### PR TITLE
Somehow the newDockAvailable signal got added twice to Directory.h. T…

### DIFF
--- a/isis/src/qisis/objs/Directory/Directory.h
+++ b/isis/src/qisis/objs/Directory/Directory.h
@@ -364,7 +364,6 @@ namespace Isis {
       void newWarning();
       void newDockAvailable(QMainWindow *newWidget);
       void newWidgetAvailable(QWidget *newWidget);
-      void newDockAvailable(QMainWindow *newWidget);
 
       void viewClosed(QWidget *widget);
 


### PR DESCRIPTION
…his simply removes it.