### PR TITLE
Replaced the newDockAvailable signal in Directory.h

### DIFF
--- a/isis/src/qisis/objs/Directory/Directory.h
+++ b/isis/src/qisis/objs/Directory/Directory.h
@@ -364,6 +364,7 @@ namespace Isis {
     signals:
       void directoryCleaned();
       void newWarning();
+      void newDockAvailable(QMainWindow *newWidget);
       void newWidgetAvailable(QWidget *newWidget);
 
       void viewClosed(QWidget *widget);


### PR DESCRIPTION
It was missed that the last PR merge erased it somehow.