### PR TITLE
Save button is enabled after editing a control network in the CnetEditor widget of IPCE

### DIFF
--- a/isis/src/qisis/objs/Project/Project.cpp
+++ b/isis/src/qisis/objs/Project/Project.cpp
@@ -540,7 +540,7 @@ namespace Isis {
             tempDir.removeRecursively();
           }
         }
-        
+
         projectXml.close();
       }
 
@@ -569,7 +569,7 @@ namespace Isis {
     m_guiCameras->clear();
     m_bundleSolutionInfo->clear();
     m_workOrderHistory->clear();
-    
+
     directory()->clean();
     setClean(true);
   }
@@ -948,7 +948,7 @@ namespace Isis {
   void Project::addImages(ImageList newImages) {
     imagesReady(newImages);
 
-    //  The each 
+    //  The each
     emit guiCamerasAdded(m_guiCameras);
     emit targetsAdded(m_targets);
   }
@@ -1564,8 +1564,8 @@ namespace Isis {
 
 
   /**
-   * Get the top-level folder of the new project. This is where the project is opened from/saved to. 
-   * This is set when a Save As operation is in progress. 
+   * Get the top-level folder of the new project. This is where the project is opened from/saved to.
+   * This is set when a Save As operation is in progress.
    */
   QString Project::newProjectRoot() const {
     return m_newProjectRoot;
@@ -1708,7 +1708,7 @@ namespace Isis {
    *
    */
   void Project::setActiveControl(QString displayName) {
-    Control *previousControl = m_activeControl; 
+    Control *previousControl = m_activeControl;
     if (m_activeControl) {
 
       // If the current active control has been modified, ask user if they want to save or discard
@@ -1776,10 +1776,10 @@ namespace Isis {
    *
    * @description Returns the active control (control network) for views which need to operate on
    * the same control, ie. Footprint2dView, CubeDnView, ControlPointEditView.
-   * IMPORTANT:  Returns NULL if no active Control. 
-   *  
+   * IMPORTANT:  Returns NULL if no active Control.
+   *
    * @return @b Control * Returns the active Control if set, otherwise returns NULL
-   *  
+   *
    * @internal
    *   @history 2016-06-23 Tracie Sucharski - Original version.
    *   @history 2017-05-17 Tracie Sucharski - If no active control set & there is only one control
@@ -1803,8 +1803,8 @@ namespace Isis {
 
 
   void Project::activeControlModified() {
-
     m_activeControl->setModified(true);
+    setClean(false);
   }
 
 
@@ -1870,9 +1870,9 @@ namespace Isis {
    * @brief  Returns the active ImageList
    *
    * Returns the active ImageList for views which need to operate on the
-   * same list of images, ie. Footprint2dView, CubeDnView, ControlPointEditView. 
-   * IMPORTANT:  Returns NULL if active ImageList is not set and a default cannot be set if there 
-   *             are multiple image lists in the project. 
+   * same list of images, ie. Footprint2dView, CubeDnView, ControlPointEditView.
+   * IMPORTANT:  Returns NULL if active ImageList is not set and a default cannot be set if there
+   *             are multiple image lists in the project.
    *
    * @internal
    *   @history 2016-06-23 Tracie Sucharski - Original version.
@@ -1883,7 +1883,7 @@ namespace Isis {
 
     if (!m_activeImageList && m_images->count() == 1) {
       QString imageList = m_images->at(0)->name();
-      
+
       setActiveImageList(imageList);
     }
     return m_activeImageList;
@@ -2348,7 +2348,7 @@ namespace Isis {
 
     //  For now set the member variable rather than calling setName which emits signal and updates
     //  ProjectItemModel & the project name on the tree.  This will be updated when the new project
-    //  is opened.  
+    //  is opened.
     m_name = newPath.name();
 
     QFile projectSettingsFile(newPath.toString() + "/project.xml");
@@ -2619,12 +2619,12 @@ namespace Isis {
 
 
   /**
-   * Add images to the id map which are not under the projects main data area, the Images node on 
-   * the project tree, such as the images under bundle results.  This is an interim solution since 
-   * the Project and model/view does not seem to be properly handling data which is not on the main 
-   * data part of the project tree. 
-   *  
-   * @param ImagesList of images 
+   * Add images to the id map which are not under the projects main data area, the Images node on
+   * the project tree, such as the images under bundle results.  This is an interim solution since
+   * the Project and model/view does not seem to be properly handling data which is not on the main
+   * data part of the project tree.
+   *
+   * @param ImagesList of images
    */
   void Project::addImagesToIdMap(ImageList images) {
 

--- a/isis/src/qisis/objs/Project/Project.h
+++ b/isis/src/qisis/objs/Project/Project.h
@@ -253,7 +253,9 @@ namespace Isis {
    *  @history 2018-04-25 Tracie Sucharski - Fixed typo in XmlHandler::startElement reading
    *                           imported shapes from a project which caused the shapes to be put in
    *                           the wrong place on the project tree. Fixes #5274.
-   *  
+   *  @history 2018-06-06 Kaitlyn Lee - activeControlModified() calls setClean(false) to enable the save
+   *                           button when the active control net is modified, i.e. a point is modified.
+   *
    */
   class Project : public QObject {
     Q_OBJECT


### PR DESCRIPTION
If editing a point in CnetEditor, the project can now be saved and saves the changes made to the control network.