### PR TITLE
Added a central widget to BundleObservationView so the view will open in ipce

### DIFF
--- a/isis/src/qisis/objs/BundleObservationView/BundleObservationView.cpp
+++ b/isis/src/qisis/objs/BundleObservationView/BundleObservationView.cpp
@@ -38,9 +38,9 @@
 
 namespace Isis {
 
-  /** 
+  /**
    * Creates a view showing the CSV or text files from BundleSolutionInfo.
-   * 
+   *
    * @param FileItemQsp fileItem QSharedPointer to the fileItem from the ProjectItemModel
    */
   BundleObservationView::BundleObservationView(FileItemQsp fileItem, QWidget *parent):
@@ -156,9 +156,7 @@ namespace Isis {
     // NOTE: QHeaderView::ResizeToContents does not allow user to resize by dragging column divider
     qtable->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
 
-    QVBoxLayout *layout = new QVBoxLayout;
-    setLayout(layout);
-    layout->addWidget(qtable);
+    setCentralWidget(qtable);
 
     QSizePolicy policy = sizePolicy();
     policy.setHorizontalPolicy(QSizePolicy::Expanding);
@@ -198,10 +196,7 @@ namespace Isis {
 
     file.close();
 
-    QVBoxLayout *layout = new QVBoxLayout;
-    setLayout(layout);
-    layout->addWidget(qText);
-
+    setCentralWidget(qText);
     qText->moveCursor(QTextCursor::Start);
 
     QSizePolicy policy = sizePolicy();
@@ -217,6 +212,3 @@ namespace Isis {
   BundleObservationView::~BundleObservationView() {
   }
 }
-
-
-

--- a/isis/src/qisis/objs/BundleObservationView/BundleObservationView.h
+++ b/isis/src/qisis/objs/BundleObservationView/BundleObservationView.h
@@ -47,6 +47,9 @@ namespace Isis{
    *   @history 2018-04-16 Ken Edmundson - Modified display of residuals.csv to properly show the
    *                           rejected column if there are rejected measures. Also displays
    *                           rejected measure row in red.
+   *   @history 2018-06-06 Kaitlyn Lee - Set a central widget and removed layout (it is not needed
+   *                           after setting a central widget) because AbstractProjectItemView was
+   *                           updated to inherit from QMainWindow.
    */
 
   class BundleObservationView : public AbstractProjectItemView

--- a/isis/src/qisis/objs/Directory/Directory.cpp
+++ b/isis/src/qisis/objs/Directory/Directory.cpp
@@ -631,7 +631,7 @@ namespace Isis {
       result->setObjectName( result->windowTitle() );
     }
 
-    emit newWidgetAvailable(result);
+    emit newDockAvailable(result);
 
     return result;
   }

--- a/isis/src/qisis/objs/Directory/Directory.h
+++ b/isis/src/qisis/objs/Directory/Directory.h
@@ -240,12 +240,14 @@ namespace Isis {
    *                           saved/restored including the ImageFileListWidget. Fixes #5422.
    *   @history 2018-05-30 Kaitlyn Lee - addControlPointEditView() and addCnetEditorView() now emit
    *                           newDockAvailable().
-   *   @history 2018-05-30 Summer Stapleton - updated the emit in addFootprint2DView from 
-   *                           newWidgetAvailable to newDockAvailable to handle new signal from 
+   *   @history 2018-05-30 Summer Stapleton - updated the emit in addFootprint2DView from
+   *                           newWidgetAvailable to newDockAvailable to handle new signal from
    *                           IpceMainWindow. References #5433.
    *   @history 2018-05-30 Tracie Sucharski - Changed for re-factored docked views. Added signal to
    *                           let IpceMainWindow know there is a new view available for docking.
    *                           This needs further work to cleanup and change the mdi interface.
+   *   @history 2018-06-06 Kaitlyn Lee - Changed the emit in addBundleObservationView() from newWidgetAvailable()
+   *                           to newDockAvailable().
    */
   class Directory : public QObject {
     Q_OBJECT


### PR DESCRIPTION
BundleObservationView was never updated after AbstractProjectItemView was modified to inherit from QMainWindow. I set a central widget and emit newDockAvailable() so the view will open in ipce now.