### PR TITLE
Modified displayed filename in ControlPointEditorView

### DIFF
--- a/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.cpp
+++ b/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.cpp
@@ -219,8 +219,6 @@ namespace Isis {
     saveMeasureLayout->insertStretch(-1);
 
     m_cnetFileNameLabel = new QLabel("Control Network: " + m_cnetFileName);
-    m_cnetFileNameLabel->setToolTip("Name of opened control network file.");
-    m_cnetFileNameLabel->setWhatsThis("Name of opened control network file.");
 
     m_templateFileNameLabel = new QLabel("Template File: " +
         m_measureEditor->templateFileName());

--- a/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.cpp
+++ b/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.cpp
@@ -589,7 +589,11 @@ namespace Isis {
     m_controlNet = control->controlNet();
     m_cnetFileName = control->fileName();
 
-    m_cnetFileNameLabel->setText("Control Network: " + m_cnetFileName);
+    QStringList cnetDirs = m_cnetFileName.split('/');
+    QString strippedCnetFilename = cnetDirs.value(cnetDirs.length() -1);
+    m_cnetFileNameLabel->setText("Control Network: " + strippedCnetFilename);
+    m_cnetFileNameLabel->setToolTip(m_cnetFileName);
+    m_cnetFileNameLabel->setWhatsThis(m_cnetFileName);
     setWindowTitle("Control Point Editor- Control Network File: " + m_cnetFileName);
 
     emit newControlNetwork(m_controlNet);

--- a/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.h
+++ b/isis/src/qisis/objs/ControlPointEditWidget/ControlPointEditWidget.h
@@ -90,6 +90,8 @@ namespace Isis {
    *                           Fixes #5399.
    *   @history 2018-05-02 Tracie Sucharski - Colorize save buttons properly when creating new
    *                           control point and loading a different control point. 
+   *   @history 2018-06-11 Summer Stapleton - Stripped path from displayed filename of Control 
+   *                           Network and set the tooltip to the full path for easier access.
    */
   class ControlPointEditWidget : public QWidget {
     Q_OBJECT


### PR DESCRIPTION
Stripped path from displayed filename in ControlPointEditorView and set full pathname to tooltip to allow for better readability.