### PR TITLE
removed ComputeResidualsMillimeters method and moved computation of f…

### DIFF
--- a/isis/src/base/objs/CameraGroundMap/CameraGroundMap.cpp
+++ b/isis/src/base/objs/CameraGroundMap/CameraGroundMap.cpp
@@ -159,8 +159,8 @@ namespace Isis {
    * class value for m_lookJ is set by this method.
    *
    * @param point Surface point (ground position) 
-   * @param cudx [out] Pointer to computed undistored x focal plane coordinate
-   * @param cudy [out] Pointer to computed undistored y focal plane coordinate
+   * @param cudx [out] Pointer to computed undistorted x focal plane coordinate
+   * @param cudy [out] Pointer to computed undistorted y focal plane coordinate
    *
    * @return @b bool If conversion was successful
    */

--- a/isis/src/base/objs/LidarData/LidarData.h
+++ b/isis/src/base/objs/LidarData/LidarData.h
@@ -38,7 +38,8 @@ namespace Isis {
    *                           apriori variance/covariance matrix, adjusted point coordinates,
    *                           and adjusted variance/covariance matrix to the read and
    *                           write methods. Ref #5343.
-   *  
+   *   @history 2018-06-14 Ken Edmundson - Added typedef for QSharedPointer to LidarData object.
+   *
    */
   class LidarData {
 
@@ -71,5 +72,8 @@ namespace Isis {
       QVector<Isis::Camera *> p_cameraList; //!< Vector of image number to camera
   };
 
-};
+  // typedefs
+  //! Definition for a shared pointer to a LidarData object.
+  typedef QSharedPointer<LidarData> LidarDataQsp;
+}
 #endif

--- a/isis/src/control/objs/ControlPoint/ControlPoint.h
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.h
@@ -495,7 +495,6 @@ namespace Isis {
 
       Status ComputeApriori();
       Status ComputeResiduals();
-      Status ComputeResiduals_Millimeters();
 
       SurfacePoint GetAdjustedSurfacePoint() const;
 

--- a/isis/src/control/objs/ControlPoint/ControlPoint.h
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.h
@@ -343,6 +343,9 @@ namespace Isis {
    *   @history 2018-01-05 Adam Goins - Added HasDateTime() and HasChooserName() methods to allow
    *                           to allow the value of these variables to be read without being
    *                           overriden if they're empty. (Getters override if they're empty).
+   *   @history 2018-06-13 Debbie A. Cook, Ken Edmundson, Removed method
+   *                           ComputeResidualsMillimeters() and added computation of focal plane
+   *                           computedx and computedy to ComputeResiduals method.
    */
   class ControlPoint : public QObject {
 

--- a/isis/src/control/objs/LidarControlPoint/LidarControlPoint.h
+++ b/isis/src/control/objs/LidarControlPoint/LidarControlPoint.h
@@ -61,7 +61,6 @@ namespace Isis {
     double range();
     double sigmaRange();
     iTime time();
-//    QList < QString > snSimultaneous() const;
     QStringList snSimultaneous() const;
     bool isSimultaneous(QString serialNumber);
 


### PR DESCRIPTION
…ocalplane computedx, computedy into the ComputeResiduals method. This removes unneeded computations.