### PR TITLE
Fixed distortion model not being applied error

### DIFF
--- a/isis/src/tgo/objs/TgoCassisCamera/TgoCassisDistortionMap.cpp
+++ b/isis/src/tgo/objs/TgoCassisCamera/TgoCassisDistortionMap.cpp
@@ -54,7 +54,6 @@ namespace Isis {
       m_A2_dist.push_back(p_camera->getDouble(od + "A2_DIST", i));
       m_A3_dist.push_back(p_camera->getDouble(od + "A3_DIST", i));
     }
-
     m_pixelPitch = p_camera->getDouble("INS" + toString(naifIkCode) + "_PIXEL_PITCH");
     m_width  = p_camera->getDouble("INS" + toString(naifIkCode) + "_FILTER_SAMPLES");
     m_height = p_camera->getDouble("INS" + toString(naifIkCode) + "_FILTER_LINES");
@@ -114,13 +113,16 @@ namespace Isis {
     // 
     // So, whenever x or y are too far from center or divider is near zero,
     // return the given inputs
-    if ( qFuzzyCompare(divider + 1.0,  1.0) == 0
+    
+    double epsilon = 0.0005;
+    if ( (abs(divider) < epsilon) 
          || dx < -0.5*m_pixelPitch*m_width  - 0.2
          || dx >  0.5*m_pixelPitch*m_width  + 0.2
          || dy < -0.5*m_pixelPitch*m_height - 0.2
          || dy >  0.5*m_pixelPitch*m_height + 0.2 ) {
       p_undistortedFocalPlaneX = dx;
       p_undistortedFocalPlaneY = dy;
+
       return true;
     }
 
@@ -130,6 +132,7 @@ namespace Isis {
 
     p_undistortedFocalPlaneX = ux;
     p_undistortedFocalPlaneY = uy;
+
     return true;
   }
 
@@ -179,13 +182,16 @@ namespace Isis {
     // 
     // So, whenever x or y are too far from center or divider is near zero,
     // return the given inputs
-    if ( qFuzzyCompare(divider + 1.0,  1.0) == 0
+
+    double epsilon = 0.0005;
+    if ( (abs(divider) < epsilon)
          || ux < -0.5*m_pixelPitch*m_width  - 0.2
          || ux >  0.5*m_pixelPitch*m_width  + 0.2
          || uy < -0.5*m_pixelPitch*m_height - 0.2
          || uy >  0.5*m_pixelPitch*m_height + 0.2 ) {
       p_focalPlaneX = ux;
       p_focalPlaneY = uy;
+
       return true;
     }
 
@@ -195,6 +201,7 @@ namespace Isis {
 
     p_focalPlaneX = dx;
     p_focalPlaneY = dy;
+    std::cout << "Difference ux-dx, uy-dy: " << ux-dx << ", " <<uy-dy << std::endl; 
     return true;
   }
 

--- a/isis/src/tgo/objs/TgoCassisCamera/TgoCassisDistortionMap.h
+++ b/isis/src/tgo/objs/TgoCassisCamera/TgoCassisDistortionMap.h
@@ -52,6 +52,9 @@ namespace Isis {
    *   @history 2017-09-18 Jeannie Backer - Added check to verify that values
    *                           passed into SetFocalPlane and SetUndistortedFocalPlane
    *                           are within valid range. References #5155
+   *   @history 2018-06-14 Kristin Berry - Switched from using qFuzzyCompare to
+   *                           abs(val) < epsilon for comparison to fix "distortion
+   *                           model not being applied" error. 
    */
   class TgoCassisDistortionMap : public CameraDistortionMap {
     public:


### PR DESCRIPTION
The distortion model was never being applied because of a "if divider is too close to zero, don't apply the distortion model" check that was always true. That is, the divider was always being identified as too close to zero, so the distortion model was never applied. 

I fixed this by switching from using `qFuzzyCompare` to using `abs(divider) < epsilon`, which I arbitrarily set to 0.005 <--- this may not be a good value, I don't know. Looking for feedback on this. 