### PR TITLE
Cleaned up CubeDnView and Footprint2DView. Fixes #5440 #5389

### DIFF
--- a/isis/src/qisis/apps/ipce/IpceMainWindow.cpp
+++ b/isis/src/qisis/apps/ipce/IpceMainWindow.cpp
@@ -89,8 +89,6 @@ namespace Isis {
     //centralWidget->hide();
     setDockNestingEnabled(true);
 
-    m_activeView = NULL;
-
     try {
       m_directory = new Directory(this);
       connect(m_directory, SIGNAL( newWidgetAvailable(QWidget *) ),
@@ -213,10 +211,10 @@ namespace Isis {
 
 
   /**
-   * @description This slot is connected from Directory::viewClosed(QWidget *) signal.  It will 
+   * @description This slot is connected from Directory::viewClosed(QWidget *) signal.  It will
    * close the given view and delete the view. This was written to handle
-   * 
-   * @param view QWidget* 
+   *
+   * @param view QWidget*
    *
    */
   void IpceMainWindow::removeView(QWidget *view) {
@@ -481,26 +479,14 @@ namespace Isis {
 
   /**
    * Create the tool bars and populates them with QActions from several sources. Actions are taken
-   * from an internal list of QActions and the Directory. 
+   * from an internal list of QActions and the Directory.
    */
   void IpceMainWindow::createToolBars() {
     m_permToolBar = new QToolBar(this);
-    m_activeToolBar = new QToolBar(this);
-    m_toolPad = new QToolBar(this);
-
     QSize iconSize(25, 45);
-
     m_permToolBar->setIconSize(iconSize);
-    m_activeToolBar->setIconSize(iconSize);
-    m_toolPad->setIconSize(iconSize);
-
     m_permToolBar->setObjectName("PermanentToolBar");
-    m_activeToolBar->setObjectName("ActiveToolBar");
-    m_toolPad->setObjectName("ToolPad");
-
     addToolBar(m_permToolBar);
-    addToolBar(m_activeToolBar);
-    addToolBar(m_toolPad);
 
     foreach ( QAction *action, m_directory->permToolBarActions() ) {
       m_permToolBar->addAction(action);
@@ -509,11 +495,11 @@ namespace Isis {
     foreach (QAction *action, m_permToolBarActions) {
       if (action->text() == "&Save Active Control Network") {
         m_permToolBar->addSeparator();
-        m_permToolBar->addAction(action); 
+        m_permToolBar->addAction(action);
         m_permToolBar->addSeparator();
       }
       else {
-        m_permToolBar->addAction(action); 
+        m_permToolBar->addAction(action);
       }
     }
   }

--- a/isis/src/qisis/apps/ipce/IpceMainWindow.h
+++ b/isis/src/qisis/apps/ipce/IpceMainWindow.h
@@ -112,7 +112,7 @@ namespace Isis {
    *                           detached views from the m_detachedViews list appropriately.
    *                           This fixes an issue where a detached view would appear to be
    *                           open even after it has been closed. Fixes #5109.
-   *   @history 2017-11-12  Tyler Wilson - Removed a resize call in readSettings because it 
+   *   @history 2017-11-12  Tyler Wilson - Removed a resize call in readSettings because it
    *                           was screwing up the display of widgets when a project is loaded.
    *                           Also switched the order in which a project is saved.  A project is
    *                           cleared after it is saved, and not before (which had been the previous
@@ -137,7 +137,9 @@ namespace Isis {
    *                           for cleanup because there is no way to get the dock from the view.
    *                           Cleanup connections are made for the views and the docks to ensure
    *                           that cleanup happens for both.  Fixes #5433.
-   *  
+   *   @history 2018-06-13 Kaitlyn Lee - Since views now inherit from QMainWindow, each individual
+   *                           view has its own toolbar, so having an active toolbar and tool pad is
+   *                           not needed.
    */
   class IpceMainWindow : public QMainWindow {
       Q_OBJECT
@@ -197,8 +199,6 @@ namespace Isis {
       static const int m_maxRecentProjects = 5;
 
       QToolBar *m_permToolBar; //!< The toolbar for actions that rarely need to be changed.
-      QToolBar *m_activeToolBar; //<! The toolbar for the actions of the current tool.
-      QToolBar *m_toolPad; //<! The toolbar for the actions that activate tools.
 
       QMenu *m_fileMenu; //!< Menu for the file actions
       QMenu *m_projectMenu; //!< Menu for the project actions
@@ -215,13 +215,9 @@ namespace Isis {
       QList<QAction *> m_helpMenuActions;//!< Internal list of help actions
 
       QList<QAction *> m_permToolBarActions;//!< Internal list of permanent toolbar actions
-      QList<QAction *> m_activeToolBarActions;//!< Internal list of active toolbar actions
-      QList<QAction *> m_toolPadActions;//!< Internal list of toolpad actions
 
       QAction *m_cascadeViewsAction; //!< Action that cascades the mdi area
       QAction *m_tileViewsAction; //!< Action that tiles the mdi area
-
-      AbstractProjectItemView *m_activeView; //!< The active view
   };
 }
 

--- a/isis/src/qisis/objs/CubeDnView/CubeDnView.cpp
+++ b/isis/src/qisis/objs/CubeDnView/CubeDnView.cpp
@@ -236,14 +236,12 @@ namespace Isis {
     zoomTool->activate(true);
   }
 
-
   /**
-   * This is a slot function which is called when directory emits a siganl to
-   * CubeDnView when an active control network is set. It enables the control
-   * network editor tool in the toolpad.
+   * A slot function that is called when directory emits a siganl that an active
+   * control network is set. It enables the control network editor tool in the
+   * toolpad and loads the network.
    */
   void CubeDnView::enableControlNetTool(bool value) {
-
     foreach (QAction * action, m_toolPad->actions()) {
       if (action->objectName() == "ControlNetTool") {
         action->setEnabled(value);
@@ -303,16 +301,6 @@ namespace Isis {
 
     return item->isShape();
   }
-
-  /**
-   * Returns a list of actions for the tool pad.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::toolPadActions() {
-    return m_toolPad->actions();
-  }
-
 
   /**
    * Slot to connect to the currentChanged() signal from a selection

--- a/isis/src/qisis/objs/CubeDnView/CubeDnView.cpp
+++ b/isis/src/qisis/objs/CubeDnView/CubeDnView.cpp
@@ -115,21 +115,11 @@ namespace Isis {
     connect(m_workspace, SIGNAL( cubeViewportAdded(MdiCubeViewport *) ),
             this, SLOT( onCubeViewportAdded(MdiCubeViewport *) ) );
 
-
-    // !!!!!!!   TODO  LOOK AT THIS       !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    // These connections should be at higher level, directory or project???? ::addCubeDnView().
-    Project *activeProject = directory->project();
-    // These connect signals listen to the active project, and if a control network
-    // or list of control networks is added, then the enableControlNetTool() function is called.
-    connect(activeProject, SIGNAL(controlListAdded(ControlList *)), this, SLOT(enableControlNetTool()));
-    connect(activeProject, SIGNAL(controlAdded(Control *)), this, SLOT(enableControlNetTool()));
-
     QSizePolicy policy = sizePolicy();
     policy.setHorizontalPolicy(QSizePolicy::Expanding);
     policy.setVerticalPolicy(QSizePolicy::Expanding);
     setSizePolicy(policy);
   }
-
 
   void CubeDnView::createActions(Directory *directory) {
 
@@ -207,7 +197,6 @@ namespace Isis {
     m_separatorAction = new QAction(this);
     m_separatorAction->setSeparator(true);
 
-    m_fileMenu = menuBar()->addMenu("&File");
     m_viewMenu = menuBar()->addMenu("&View");
     m_optionsMenu = menuBar()->addMenu("&Options");
     m_windowMenu = menuBar()->addMenu("&Window");
@@ -225,10 +214,7 @@ namespace Isis {
         if (!tool->menuName().isEmpty()) {
           QString menuName = tool->menuName();
 
-          if (menuName == "&File") {
-            tool->addTo(m_fileMenu);
-          }
-          else if (menuName == "&View") {
+          if (menuName == "&View") {
             tool->addTo(m_viewMenu);
           }
           else if (menuName == "&Options") {
@@ -252,21 +238,22 @@ namespace Isis {
 
 
   /**
-   * @description enableControlNetTool:  This is a slot function which
-   * is called when the active project emits a signal to the CubeDnView
-   * object after a control network (or a list of control networks)
-   * has been added.  It enables the control network editor tool if it
-   * has been disabled.
+   * This is a slot function which is called when directory emits a siganl to
+   * CubeDnView when an active control network is set. It enables the control
+   * network editor tool in the toolpad.
    */
-  void CubeDnView::enableControlNetTool() {
+  void CubeDnView::enableControlNetTool(bool value) {
 
-    foreach (QAction * action, m_toolPadActions) {
+    foreach (QAction * action, m_toolPad->actions()) {
       if (action->objectName() == "ControlNetTool") {
-        action->setDisabled(false);
+        action->setEnabled(value);
+        if (value) {
+          ControlNetTool *cnetTool = static_cast<ControlNetTool *>(action->parent());
+          cnetTool->loadNetwork();
+        }
       }
     }
   }
-
 
   /**
    * Destructor

--- a/isis/src/qisis/objs/CubeDnView/CubeDnView.cpp
+++ b/isis/src/qisis/objs/CubeDnView/CubeDnView.cpp
@@ -133,7 +133,7 @@ namespace Isis {
 
   void CubeDnView::createActions(Directory *directory) {
 
-    
+
     m_permToolBar = new QToolBar("Standard Tools", this);
     m_permToolBar->setObjectName("permToolBar");
     m_permToolBar->setIconSize(QSize(22, 22));
@@ -296,7 +296,6 @@ namespace Isis {
     AbstractProjectItemView::addItem(item);
   }
 
-
   /**
    * Returns the suggested size
    *
@@ -317,92 +316,6 @@ namespace Isis {
 
     return item->isShape();
   }
-
-
-  /**
-   * Returns a list of actions appropriate for a file menu.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::fileMenuActions() {
-    return m_fileMenu->actions();
-  }
-
-
-  /**
-   * Returns a list of actions appropriate for a project menu.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::projectMenuActions() {
-    return QList<QAction *>();
-  }
-
-  /**
-   * Returns a list of actions appropriate for an edit menu.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::editMenuActions() {
-    return QList<QAction *>();
-  }
-
-
-  /**
-   * Returns a list of actions appropriate for a view menu.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::viewMenuActions() {
-    QList<QAction *> result;
-    result.append( m_viewMenu->actions() );
-    result.append(m_separatorAction);
-    result.append( m_windowMenu->actions() );
-    return result;
-  }
-
-
-  /**
-   * Returns a list of actions appropriate for a settings menu.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::settingsMenuActions() {
-    return m_optionsMenu->actions();
-  }
-
-
-  /**
-   * Returns a list of actions appropriate for a help menu.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::helpMenuActions() {
-    return m_helpMenu->actions();
-  }
-
-
-  /**
-   * Returns a list of actions for the permanent tool bar.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::permToolBarActions() {
-    return m_permToolBar->actions();
-  }
-
-
-  /**
-   * Returns a list of actions for the active tool bar.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> CubeDnView::activeToolBarActions() {
-    QList<QAction *> actions;
-    actions.append(m_activeToolBarAction);
-    return actions;
-  }
-
 
   /**
    * Returns a list of actions for the tool pad.

--- a/isis/src/qisis/objs/CubeDnView/CubeDnView.h
+++ b/isis/src/qisis/objs/CubeDnView/CubeDnView.h
@@ -86,9 +86,12 @@ namespace Isis {
    *                           Workspace of this view is the centralWidget. This needs further work
    *                           to cleanup and fit in with the new docked view interface.git
    *   @history 2018-06-13 Kaitlyn Lee - Since views now inherit from QMainWindow, each individual
-   *                           view has its own toolbar, so having getters that return toolbar actions
-   *                           are unnecessary. Removed methods that returned menu and toolbar actions.
+   *                           view has its own toolbar, so having getters that return toolbar
+   *                           actions to fill the toolbar of the IpceMainWindow are unnecessary.
+   *                           Removed methods that returned menu and toolbar actions.
    *                           toolPadActions() is still needed because it is used in Directory.
+   *                           Removed connections that connected the project and CubeDnView and called
+   *                           enableControlNetTool() because Directory now does this.
    */
   class CubeDnView : public AbstractProjectItemView {
 
@@ -118,7 +121,7 @@ namespace Isis {
 
     public slots:
       void addItem(ProjectItem *item);
-      void enableControlNetTool();
+      void enableControlNetTool(bool value);
 
     private slots:
       void createActions(Directory *directory);
@@ -161,7 +164,6 @@ namespace Isis {
       QMap<Cube *, ProjectItem *> m_cubeItemMap; //!< Maps cubes to their items
       Workspace *m_workspace; //!< The workspace
 
-      QMenu *m_fileMenu; //!< File menu for storing actions
       QMenu *m_viewMenu; //!< View menu for storing actions
       QMenu *m_optionsMenu; //!< Options menu for storing actions
       QMenu *m_windowMenu; //!< Window menu for storing actions
@@ -172,8 +174,6 @@ namespace Isis {
       QToolBar *m_permToolBar; //!< A tool bar for storing actions
       QToolBar *m_activeToolBar; //!< A tool bar for storing actions
       ToolPad *m_toolPad; //!< A tool bar for storing actions
-
-      QList<QAction *> m_toolPadActions; //!< The tool pad actions
   };
 }
 

--- a/isis/src/qisis/objs/CubeDnView/CubeDnView.h
+++ b/isis/src/qisis/objs/CubeDnView/CubeDnView.h
@@ -85,6 +85,10 @@ namespace Isis {
    *                           AbstractProjectItemView now inherits from QMainWindow, so the
    *                           Workspace of this view is the centralWidget. This needs further work
    *                           to cleanup and fit in with the new docked view interface.git
+   *   @history 2018-06-13 Kaitlyn Lee - Since views now inherit from QMainWindow, each individual
+   *                           view has its own toolbar, so having getters that return toolbar actions
+   *                           are unnecessary. Removed methods that returned menu and toolbar actions.
+   *                           toolPadActions() is still needed because it is used in Directory.
    */
   class CubeDnView : public AbstractProjectItemView {
 
@@ -94,15 +98,6 @@ namespace Isis {
       CubeDnView(Directory *directory, QWidget *parent=0);
       ~CubeDnView();
 
-      virtual QList<QAction *> fileMenuActions();
-      virtual QList<QAction *> projectMenuActions();
-      virtual QList<QAction *> editMenuActions();
-      virtual QList<QAction *> viewMenuActions();
-      virtual QList<QAction *> settingsMenuActions();
-      virtual QList<QAction *> helpMenuActions();
-
-      virtual QList<QAction *> permToolBarActions();
-      virtual QList<QAction *> activeToolBarActions();
       virtual QList<QAction *> toolPadActions();
 
       QSize sizeHint() const;
@@ -111,8 +106,6 @@ namespace Isis {
 
       void load(XmlStackedHandlerReader *xmlReader, Project *project);
       void save(QXmlStreamWriter &stream, Project *project, FileName newProjectRoot) const;
-
-
 
     signals:
       void modifyControlPoint(ControlPoint *controlPoint, QString serialNumber);
@@ -180,8 +173,6 @@ namespace Isis {
       QToolBar *m_activeToolBar; //!< A tool bar for storing actions
       ToolPad *m_toolPad; //!< A tool bar for storing actions
 
-      QList<QAction *> m_permToolBarActions; //!< The permanent tool bar actions
-      QWidgetAction *m_activeToolBarAction; //!< Widget of the active tool
       QList<QAction *> m_toolPadActions; //!< The tool pad actions
   };
 }

--- a/isis/src/qisis/objs/CubeDnView/CubeDnView.h
+++ b/isis/src/qisis/objs/CubeDnView/CubeDnView.h
@@ -89,7 +89,6 @@ namespace Isis {
    *                           view has its own toolbar, so having getters that return toolbar
    *                           actions to fill the toolbar of the IpceMainWindow are unnecessary.
    *                           Removed methods that returned menu and toolbar actions.
-   *                           toolPadActions() is still needed because it is used in Directory.
    *                           Removed connections that connected the project and CubeDnView and called
    *                           enableControlNetTool() because Directory now does this.
    */
@@ -100,8 +99,6 @@ namespace Isis {
     public:
       CubeDnView(Directory *directory, QWidget *parent=0);
       ~CubeDnView();
-
-      virtual QList<QAction *> toolPadActions();
 
       QSize sizeHint() const;
 

--- a/isis/src/qisis/objs/Directory/Directory.cpp
+++ b/isis/src/qisis/objs/Directory/Directory.cpp
@@ -718,24 +718,11 @@ namespace Isis {
     connect(this, SIGNAL(redrawMeasures()), result, SIGNAL(redrawMeasures()));
     connect(this, SIGNAL(cnetModified()), result, SIGNAL(redrawMeasures()));
 
-    // Note:  This assumes the Control Net tool is the 1st in the toolpad.
-    // QList<QAction *> toolbar = result->toolPadActions();
-    // QAction* cnetAction = toolbar[0];
-    // ControlNetTool *cnetTool = static_cast<ControlNetTool *>(cnetAction->parent());
-
     connect (project(), SIGNAL(activeControlSet(bool)),
              result, SLOT(enableControlNetTool(bool)));
-    // connect (project(), SIGNAL(activeControlSet(bool)),
-    //          cnetTool, SLOT(loadNetwork()));
-
-    //  If an active control has not been set, make the control net tool inactive
-    // if (!project()->activeControl()) {
-    //   cnetAction->setEnabled(false);
-    // }
 
     return result;
   }
-
 
   /**
    * @brief Add the qmos view widget to the window.
@@ -774,20 +761,8 @@ namespace Isis {
     //  to be drawn with different color/shape.
     connect(this, SIGNAL(redrawMeasures()), result, SIGNAL(redrawMeasures()));
 
-    // Note:  This assumes the Control Net tool is the 4th in the toolpad.
-    // QList<QAction *> toolbar = result->toolPadActions();
-    // QAction* cnetAction = toolbar[3];
-    // MosaicControlNetTool *cnetTool = static_cast<MosaicControlNetTool *>(cnetAction->parent());
-
     connect (project(), SIGNAL(activeControlSet(bool)),
              result, SLOT(enableControlNetTool(bool)));
-    // connect (project(), SIGNAL(activeControlSet(bool)),
-    //          cnetTool, SLOT(loadNetwork()));
-    //
-    // //  Control Net tool will only be active if the project has an active Control.
-    // if (!project()->activeControl()) {
-    //   cnetAction->setEnabled(false);
-    // }
 
     return result;
   }

--- a/isis/src/qisis/objs/Directory/Directory.cpp
+++ b/isis/src/qisis/objs/Directory/Directory.cpp
@@ -535,12 +535,12 @@ namespace Isis {
 
 
   /**
-   * @description This slot was created specifically for the CnetEditorWidgets when user chooses a 
-   * new active control and wants to discard any edits in the old active control.  The only view 
-   * which will not be updated with the new control are any CnetEditorViews showing the old active 
-   * control.  CnetEditorWidget classes do not have the ability to reload a control net, so the 
+   * @description This slot was created specifically for the CnetEditorWidgets when user chooses a
+   * new active control and wants to discard any edits in the old active control.  The only view
+   * which will not be updated with the new control are any CnetEditorViews showing the old active
+   * control.  CnetEditorWidget classes do not have the ability to reload a control net, so the
    * CnetEditor view displaying the old control is removed, then recreated.
-   *  
+   *
    */
   void Directory::reloadActiveControlInCnetEditorView() {
 
@@ -719,19 +719,19 @@ namespace Isis {
     connect(this, SIGNAL(cnetModified()), result, SIGNAL(redrawMeasures()));
 
     // Note:  This assumes the Control Net tool is the 1st in the toolpad.
-    QList<QAction *> toolbar = result->toolPadActions();
-    QAction* cnetAction = toolbar[0];
-    ControlNetTool *cnetTool = static_cast<ControlNetTool *>(cnetAction->parent());
+    // QList<QAction *> toolbar = result->toolPadActions();
+    // QAction* cnetAction = toolbar[0];
+    // ControlNetTool *cnetTool = static_cast<ControlNetTool *>(cnetAction->parent());
 
     connect (project(), SIGNAL(activeControlSet(bool)),
-             cnetAction, SLOT(setEnabled(bool)));
-    connect (project(), SIGNAL(activeControlSet(bool)),
-             cnetTool, SLOT(loadNetwork()));
+             result, SLOT(enableControlNetTool(bool)));
+    // connect (project(), SIGNAL(activeControlSet(bool)),
+    //          cnetTool, SLOT(loadNetwork()));
 
     //  If an active control has not been set, make the control net tool inactive
-    if (!project()->activeControl()) {
-      cnetAction->setEnabled(false);
-    }
+    // if (!project()->activeControl()) {
+    //   cnetAction->setEnabled(false);
+    // }
 
     return result;
   }
@@ -1046,7 +1046,7 @@ namespace Isis {
    * @brief Removes pointers to deleted CnetEditorWidget objects.
    */
   void Directory::cleanupCnetEditorViewWidgets(QObject *obj) {
-    
+
     CnetEditorView *cnetEditorView = static_cast<CnetEditorView *>(obj);
     if (!cnetEditorView) {
       return;
@@ -1055,7 +1055,7 @@ namespace Isis {
     Control *control = m_controlMap.key(cnetEditorView);
     m_controlMap.remove(control, cnetEditorView);
 
-    if ( m_controlMap.count(control) == 0 && project()->activeControl() != control) {      
+    if ( m_controlMap.count(control) == 0 && project()->activeControl() != control) {
       control->closeControlNet();
     }
 
@@ -1065,11 +1065,11 @@ namespace Isis {
 
 
   /**
-   * @description Return true if control is not currently being viewed in a CnetEditorWidget 
-   *  
-   * @param Control * Control used to search current CnetEditorWidgets 
-   *  
-   * @return @b (bool) Returns true if control is currently being viewed in CnetEditorWidget 
+   * @description Return true if control is not currently being viewed in a CnetEditorWidget
+   *
+   * @param Control * Control used to search current CnetEditorWidgets
+   *
+   * @return @b (bool) Returns true if control is currently being viewed in CnetEditorWidget
    */
   bool Directory::controlUsedInCnetEditorWidget(Control *control) {
 

--- a/isis/src/qisis/objs/Directory/Directory.cpp
+++ b/isis/src/qisis/objs/Directory/Directory.cpp
@@ -775,19 +775,19 @@ namespace Isis {
     connect(this, SIGNAL(redrawMeasures()), result, SIGNAL(redrawMeasures()));
 
     // Note:  This assumes the Control Net tool is the 4th in the toolpad.
-    QList<QAction *> toolbar = result->toolPadActions();
-    QAction* cnetAction = toolbar[3];
-    MosaicControlNetTool *cnetTool = static_cast<MosaicControlNetTool *>(cnetAction->parent());
+    // QList<QAction *> toolbar = result->toolPadActions();
+    // QAction* cnetAction = toolbar[3];
+    // MosaicControlNetTool *cnetTool = static_cast<MosaicControlNetTool *>(cnetAction->parent());
 
     connect (project(), SIGNAL(activeControlSet(bool)),
-             cnetAction, SLOT(setEnabled(bool)));
-    connect (project(), SIGNAL(activeControlSet(bool)),
-             cnetTool, SLOT(loadNetwork()));
-
-    //  Control Net tool will only be active if the project has an active Control.
-    if (!project()->activeControl()) {
-      cnetAction->setEnabled(false);
-    }
+             result, SLOT(enableControlNetTool(bool)));
+    // connect (project(), SIGNAL(activeControlSet(bool)),
+    //          cnetTool, SLOT(loadNetwork()));
+    //
+    // //  Control Net tool will only be active if the project has an active Control.
+    // if (!project()->activeControl()) {
+    //   cnetAction->setEnabled(false);
+    // }
 
     return result;
   }

--- a/isis/src/qisis/objs/Directory/Directory.h
+++ b/isis/src/qisis/objs/Directory/Directory.h
@@ -238,6 +238,9 @@ namespace Isis {
    *   @history 2018-05-14 Tracie Sucharski - Serialize Footprint2DView rather than
    *                           MosaicSceneWidget. This will allow all parts of Footprint2DView to be
    *                           saved/restored including the ImageFileListWidget. Fixes #5422.
+   *   @history 2018-06-13 Kaitlyn Lee - The signal activeControlSet() in addCubeDnView() now connects
+   *                           to enableControlNetTool() in CubeDnView, instead of enabling the tool 
+   *                           directly.
    */
   class Directory : public QObject {
     Q_OBJECT

--- a/isis/src/qisis/objs/Directory/Directory.h
+++ b/isis/src/qisis/objs/Directory/Directory.h
@@ -238,9 +238,9 @@ namespace Isis {
    *   @history 2018-05-14 Tracie Sucharski - Serialize Footprint2DView rather than
    *                           MosaicSceneWidget. This will allow all parts of Footprint2DView to be
    *                           saved/restored including the ImageFileListWidget. Fixes #5422.
-   *   @history 2018-06-13 Kaitlyn Lee - The signal activeControlSet() in addCubeDnView() now connects
-   *                           to enableControlNetTool() in CubeDnView, instead of enabling the tool 
-   *                           directly.
+   *   @history 2018-06-13 Kaitlyn Lee - The signal activeControlSet() in addCubeDnView() and
+   *                           addFootprint2DView() now connects to enableControlNetTool() in
+   *                           CubeDnView and Footprint2DView, instead of enabling the tool directly.
    */
   class Directory : public QObject {
     Q_OBJECT

--- a/isis/src/qisis/objs/Directory/ImportControlNetWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/ImportControlNetWorkOrder.cpp
@@ -51,6 +51,7 @@ namespace Isis {
     m_isSynchronous = false;
     m_list = NULL;
     m_watcher = NULL;
+    m_isUndoable = false;
 
     QAction::setText(tr("Import &Control Networks..."));
 
@@ -206,31 +207,13 @@ namespace Isis {
     }
     m_status = WorkOrderFinished;
     m_readProgresses.clear();
-  }
 
-
-  /**
-   * @brief Deletes the control network
-   *
-   * This method deletes the control network from the project. This method is was
-   * renamed from undoSyncRedo() to undoExecution().
-   */
-  void ImportControlNetWorkOrder::undoExecution() {
-    if (m_list && project()->controls().size() > 0 && m_watcher->isFinished()) {
-      // Remove the controls from disk.
-      m_list->deleteFromDisk( project() );
-      // Remove the controls from the model, which updates the tree view.
-      ProjectItem *currentItem =
-          project()->directory()->model()->findItemData( QVariant::fromValue(m_list) );
-      project()->directory()->model()->removeItem(currentItem);
-
-      foreach (Control *control, *m_list) {
-        delete control;
-      }
-      delete m_list;
+    // If one control network was imported, then activeControl() will set the
+    // active control to that control network
+    if (project()->controls().count() == 1) {
+      project()->activeControl();
     }
   }
-
 
   /**
    * CreateControlsFunctor constructor

--- a/isis/src/qisis/objs/Directory/ImportControlNetWorkOrder.h
+++ b/isis/src/qisis/objs/Directory/ImportControlNetWorkOrder.h
@@ -65,6 +65,9 @@ namespace Isis {
    *                           Control is created Fixes #5026
    *   @histroy 2017-10-24 Adam Goins - Removed the undoStack() call that occurred when a
    *                           Failed cnet is imported. Fixes #5186
+   *   @histroy 2018-06-13 Kaitlyn Lee - Removed undoExecution() because we should not want to undo
+   *                           an import. In postExecution(), added the ability to set an active
+   *                           control network when one control network is imported.
    */
   class ImportControlNetWorkOrder : public WorkOrder {
       Q_OBJECT
@@ -80,7 +83,6 @@ namespace Isis {
       void execute();
 
     protected:
-      void undoExecution();
       void postExecution();
 
     private slots:

--- a/isis/src/qisis/objs/Footprint2DView/Footprint2DView.cpp
+++ b/isis/src/qisis/objs/Footprint2DView/Footprint2DView.cpp
@@ -43,6 +43,7 @@
 #include <QWidgetAction>
 #include <QXmlStreamWriter>
 
+#include "ControlNetTool.h"
 #include "ControlPoint.h"
 #include "Cube.h"
 #include "Directory.h"
@@ -50,6 +51,7 @@
 #include "ImageFileListWidget.h"
 #include "MosaicGraphicsView.h"
 #include "MosaicSceneWidget.h"
+#include "MosaicControlNetTool.h"
 #include "Project.h"
 #include "ProjectItem.h"
 #include "ProjectItemModel.h"
@@ -92,14 +94,14 @@ namespace Isis {
 
     connect(m_sceneWidget, SIGNAL(createControlPoint(double, double)),
             this, SIGNAL(createControlPoint(double, double)));
-    
-    connect(m_sceneWidget, SIGNAL(mosCubeClosed(Image *)), 
+
+    connect(m_sceneWidget, SIGNAL(mosCubeClosed(Image *)),
             this, SLOT(onMosItemRemoved(Image *)));
 
     //  Pass on redrawMeasure signal from Directory, so the control measures are redrawn on all
     //  the footprints.
     connect(this, SIGNAL(redrawMeasures()), m_sceneWidget->getScene(), SLOT(update()));
-    
+
     setStatusBar(statusBar);
 
     m_fileListWidget = new ImageFileListWidget(directory);
@@ -115,7 +117,7 @@ namespace Isis {
     imageFileListdock->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
 
     imageFileListdock->setWidget(m_fileListWidget);
-    
+
     addDockWidget(Qt::LeftDockWidgetArea, imageFileListdock, Qt::Vertical);
     setCentralWidget(m_sceneWidget);
 
@@ -135,6 +137,17 @@ namespace Isis {
     m_sceneWidget->addToPermanent(m_permToolBar);
     m_sceneWidget->addTo(m_activeToolBar);
     m_sceneWidget->addTo(m_toolPad);
+
+    // MosaicSceneWidget's default is to have the Control Net Tool enabled.
+    // In ipce, we want it to be disabled if an active control is not set.
+    foreach (QAction * action, m_toolPad->actions()) {
+      if (action->toolTip() == "Control Net (c)") {
+        m_controlNetTool = action;
+      }
+    }
+    if (!directory->project()->activeControl()) {
+      m_controlNetTool->setEnabled(false);
+    }
 
 //  m_activeToolBarAction = new QWidgetAction(this);
 //  m_activeToolBarAction->setDefaultWidget(m_activeToolBar);
@@ -238,11 +251,11 @@ namespace Isis {
     }
   }
 
-  
+
   /**
-   * Slot at removes the mosaic item and corresponding image file list item when a cube is closed 
+   * Slot at removes the mosaic item and corresponding image file list item when a cube is closed
    * using the Close Cube context menu.
-   * 
+   *
    * @param image The image that was closed and needs to be removed
    */
   void Footprint2DView::onMosItemRemoved(Image *image) {
@@ -258,7 +271,7 @@ namespace Isis {
       }
     }
   }
-  
+
 
   /**
    * Slot to connect to the itemRemoved signal from the model. If the item is an image it removes it
@@ -313,37 +326,27 @@ namespace Isis {
     }
   }
 
-
   /**
-   * Returns a list of actions for the permanent tool bar.
-   *
-   * @return @b QList<QAction*> The actions
+   * This is a slot function which is called when directory emits a siganl to
+   * CubeDnView when an active control network is set. It enables the control
+   * network editor tool in the toolpad.
    */
-  QList<QAction *> Footprint2DView::permToolBarActions() {
-    return m_permToolBar->actions();
+  void Footprint2DView::enableControlNetTool(bool value) {
+    m_controlNetTool->setEnabled(value);
+    if (value) {
+      MosaicControlNetTool *cnetTool = static_cast<MosaicControlNetTool *>(m_controlNetTool->parent());
+      cnetTool->loadNetwork();
+    }
   }
 
-
-  /**
-   * Returns a list of actions for the active tool bar.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> Footprint2DView::activeToolBarActions() {
-    QList<QAction *> actions;
-    actions.append(m_activeToolBarAction);
-    return actions;
-  }
-
-
-  /**
-   * Returns a list of actions for the tool pad.
-   *
-   * @return @b QList<QAction*> The actions
-   */
-  QList<QAction *> Footprint2DView::toolPadActions() {
-    return m_toolPad->actions();
-  }
+  // /**
+  //  * Returns a list of actions for the tool pad.
+  //  *
+  //  * @return @b QList<QAction*> The actions
+  //  */
+  // QList<QAction *> Footprint2DView::toolPadActions() {
+  //   return m_toolPad->actions();
+  // }
 
 
   /**
@@ -356,7 +359,7 @@ namespace Isis {
 
 
   /**
-   * @brief Save the footprint view widgets (ImageFileListWidget and MosaicSceneWidget to an XML 
+   * @brief Save the footprint view widgets (ImageFileListWidget and MosaicSceneWidget to an XML
    *        file.
    * @param stream  The XML stream writer
    * @param newProjectRoot The FileName of the project this Directory is attached to.
@@ -432,4 +435,3 @@ namespace Isis {
     return result;
   }
 }
-

--- a/isis/src/qisis/objs/Footprint2DView/Footprint2DView.cpp
+++ b/isis/src/qisis/objs/Footprint2DView/Footprint2DView.cpp
@@ -151,7 +151,6 @@ namespace Isis {
     setAcceptDrops(true);
   }
 
-
   /**
    * Destructor
    */
@@ -321,6 +320,8 @@ namespace Isis {
    * A slot function that is called when directory emits a siganl that an active
    * control network is set. It enables the control network editor tool in the
    * toolpad and loads the network.
+   * TODO 2018-06-14 Kaitlyn Lee - Commented out code that loads the network,
+   * since it does not actually load the network. Left it here to research further.
    */
   void Footprint2DView::enableControlNetTool(bool value) {
     m_controlNetTool->setEnabled(value);

--- a/isis/src/qisis/objs/Footprint2DView/Footprint2DView.cpp
+++ b/isis/src/qisis/objs/Footprint2DView/Footprint2DView.cpp
@@ -121,7 +121,6 @@ namespace Isis {
     addDockWidget(Qt::LeftDockWidgetArea, imageFileListdock, Qt::Vertical);
     setCentralWidget(m_sceneWidget);
 
-
     m_permToolBar = addToolBar("Standard Tools");
     m_permToolBar->setObjectName("permToolBar");
     m_permToolBar->setIconSize(QSize(22, 22));
@@ -149,15 +148,7 @@ namespace Isis {
       m_controlNetTool->setEnabled(false);
     }
 
-//  m_activeToolBarAction = new QWidgetAction(this);
-//  m_activeToolBarAction->setDefaultWidget(m_activeToolBar);
-
     setAcceptDrops(true);
-
-    // QSizePolicy policy = sizePolicy();
-    // policy.setHorizontalPolicy(QSizePolicy::Expanding);
-    // policy.setVerticalPolicy(QSizePolicy::Expanding);
-    // setSizePolicy(policy);
   }
 
 
@@ -327,27 +318,17 @@ namespace Isis {
   }
 
   /**
-   * This is a slot function which is called when directory emits a siganl to
-   * CubeDnView when an active control network is set. It enables the control
-   * network editor tool in the toolpad.
+   * A slot function that is called when directory emits a siganl that an active
+   * control network is set. It enables the control network editor tool in the
+   * toolpad and loads the network.
    */
   void Footprint2DView::enableControlNetTool(bool value) {
     m_controlNetTool->setEnabled(value);
-    if (value) {
-      MosaicControlNetTool *cnetTool = static_cast<MosaicControlNetTool *>(m_controlNetTool->parent());
-      cnetTool->loadNetwork();
-    }
+    // if (value) {
+    //   MosaicControlNetTool *cnetTool = static_cast<MosaicControlNetTool *>(m_controlNetTool->parent());
+    //   cnetTool->loadNetwork();
+    // }
   }
-
-  // /**
-  //  * Returns a list of actions for the tool pad.
-  //  *
-  //  * @return @b QList<QAction*> The actions
-  //  */
-  // QList<QAction *> Footprint2DView::toolPadActions() {
-  //   return m_toolPad->actions();
-  // }
-
 
   /**
    * @brief Loads the Footprint2DView from an XML file.

--- a/isis/src/qisis/objs/Footprint2DView/Footprint2DView.h
+++ b/isis/src/qisis/objs/Footprint2DView/Footprint2DView.h
@@ -72,9 +72,9 @@ namespace Isis {
    *   @history 2018-05-14 Tracie Sucharski - Serialize Footprint2DView rather than
    *                           MosaicSceneWidget. This will allow all parts of Footprint2DView to be
    *                           saved/restored including the ImageFileListWidget. Fixes #5422.
-   *   @history 2018-05-30 Summer Stapleton - updated the view to remove QMainWindow constructor, 
-   *                           include a central widget and to remove layout capacity. This change 
-   *                           was made to adjust to parent class now inheriting from QMainWindow 
+   *   @history 2018-05-30 Summer Stapleton - updated the view to remove QMainWindow constructor,
+   *                           include a central widget and to remove layout capacity. This change
+   *                           was made to adjust to parent class now inheriting from QMainWindow
    *                           instead of QWidget. References #5433.
    *   @history 2018-06-08 Tracie Sucharski - Remove deletion of m_window from destructor. This
    *                           member variable no longer exists.
@@ -88,9 +88,8 @@ namespace Isis {
       ~Footprint2DView();
 
       MosaicSceneWidget *mosaicSceneWidget();
-      virtual QList<QAction *> permToolBarActions();
-      virtual QList<QAction *> activeToolBarActions();
-      virtual QList<QAction *> toolPadActions();
+
+      //virtual QList<QAction *> toolPadActions();
 
       QSize sizeHint() const;
 
@@ -104,6 +103,9 @@ namespace Isis {
 
       void redrawMeasures();
       void controlPointAdded(QString newPointId);
+
+    public slots:
+      void enableControlNetTool(bool value);
 
     protected:
       bool eventFilter(QObject *watched, QEvent *event);
@@ -145,6 +147,8 @@ namespace Isis {
       QToolBar *m_permToolBar; //!< The permanent tool bar
       QToolBar *m_activeToolBar; //!< The active tool bar
       ToolPad *m_toolPad; //!< The tool pad
+
+      QAction *m_controlNetTool;
 
       QWidgetAction *m_activeToolBarAction; //!< Stores the active tool bar
   };

--- a/isis/src/qisis/objs/Footprint2DView/Footprint2DView.h
+++ b/isis/src/qisis/objs/Footprint2DView/Footprint2DView.h
@@ -78,6 +78,15 @@ namespace Isis {
    *                           instead of QWidget. References #5433.
    *   @history 2018-06-08 Tracie Sucharski - Remove deletion of m_window from destructor. This
    *                           member variable no longer exists.
+   *   @history 2018-06-13 Kaitlyn Lee - Since views now inherit from QMainWindow, each individual
+   *                           view has its own toolbar, so having getters that return toolbar
+   *                           actions to fill the toolbar of the IpceMainWindow are unnecessary.
+   *                           Removed methods that returned menu and toolbar actions.
+   *                           Made it so that on default and if there is no active control net,
+   *                           the Control Net Tool will be disabled.
+   *                           Added enableControlNetTool(bool) so when an active control net is set,
+   *                           the tool becomes enabled.
+
    */
   class Footprint2DView : public AbstractProjectItemView {
 
@@ -88,8 +97,6 @@ namespace Isis {
       ~Footprint2DView();
 
       MosaicSceneWidget *mosaicSceneWidget();
-
-      //virtual QList<QAction *> toolPadActions();
 
       QSize sizeHint() const;
 
@@ -148,9 +155,7 @@ namespace Isis {
       QToolBar *m_activeToolBar; //!< The active tool bar
       ToolPad *m_toolPad; //!< The tool pad
 
-      QAction *m_controlNetTool;
-
-      QWidgetAction *m_activeToolBarAction; //!< Stores the active tool bar
+      QAction *m_controlNetTool;  //!< The Control Point Editor Tool
   };
 }
 

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicControlNetTool.h
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicControlNetTool.h
@@ -123,8 +123,6 @@ namespace Isis {
       void displayNewControlPoint(QString pointId);
       void displayChangedControlPoint(QString pointId);
       void displayUponControlPointDeletion();
-      void loadNetwork();
-
 
     protected:
       QAction *getPrimaryAction();
@@ -138,6 +136,7 @@ namespace Isis {
       void displayControlNet();
       void displayConnectivity();
       void closeNetwork();
+      void loadNetwork();
       void randomizeColors();
 
       void objectDestroyed(QObject *);

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicControlNetTool.h
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicControlNetTool.h
@@ -17,7 +17,7 @@ namespace Isis {
 
   /**
    * //TODO: Remove debug printout & comment
-   * //         2016-08-25 Tracie Sucharski - Checking Directory pointer for IPCE code not ideal. 
+   * //         2016-08-25 Tracie Sucharski - Checking Directory pointer for IPCE code not ideal.
    *                           Is there a better design?  This might go away if we emit signals,
    *                           which only IPCE classes would connect to.
    * @brief Handles Control Net displays
@@ -123,6 +123,8 @@ namespace Isis {
       void displayNewControlPoint(QString pointId);
       void displayChangedControlPoint(QString pointId);
       void displayUponControlPointDeletion();
+      void loadNetwork();
+
 
     protected:
       QAction *getPrimaryAction();
@@ -136,7 +138,6 @@ namespace Isis {
       void displayControlNet();
       void displayConnectivity();
       void closeNetwork();
-      void loadNetwork();
       void randomizeColors();
 
       void objectDestroyed(QObject *);
@@ -169,4 +170,3 @@ namespace Isis {
 };
 
 #endif
-


### PR DESCRIPTION
Removed methods that were returning toolbar actions, set an active control on import (when only 1 is being imported, removed undoExecution() when importing a control net, and moved signals from Directory to the two views when an active control network is set.