### PR TITLE
ddd2isis importing multiband ddd files. Fixes #703

### DIFF
--- a/isis/src/base/apps/ddd2isis/ddd2isis.cpp
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.cpp
@@ -45,7 +45,7 @@ void IsisMain() {
    EndianSwapper swp("MSB");
 
   // Verify that the file is a ddd by reading in the first 4 bytes and
-  // comparing the magic numbers
+  // comparing the magic numbers. The magic number for a ddd file is 1659.
   readBytes.readLong = 0;
   fin.seekg(0);
   fin.read(readBytes.readChars, 4);

--- a/isis/src/base/apps/ddd2isis/ddd2isis.cpp
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.cpp
@@ -130,7 +130,7 @@ void IsisMain() {
   ProcessImport p;
 
   int bitsPerBand = totalBandBits / nBands;
-  if ( ui.WasEntered("TO") ) {         
+  if ( ui.WasEntered("TO") ) {
     switch(bitsPerBand) {
       case 8:
         p.SetPixelType(Isis::UnsignedByte);

--- a/isis/src/base/apps/ddd2isis/ddd2isis.cpp
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.cpp
@@ -91,7 +91,7 @@ void IsisMain() {
   };
 
   // Read bytes 16-19 to get the bit type
-  // Map the bit type to the number of bytes and store in dataTypeBytes
+  // Map the bit type to the number of bytes of that data type
   fin.read(readBytes.readChars, 4);
   readBytes.readFloat = swp.Float(readBytes.readChars);
   int bitType = (int) readBytes.readLong;
@@ -113,6 +113,7 @@ void IsisMain() {
     nOffset = 1024;
   }
 
+  //TO DO: Reword
   PvlGroup results("FileInfo");
   results += PvlKeyword( "NumberOfLines", toString(nLines) );
   results += PvlKeyword( "NumberOfBytesPerLine", toString(nBytes) );
@@ -141,7 +142,7 @@ void IsisMain() {
         p.SetPixelType(Isis::Real);
         break;
       default:
-        IString msg = "Unsupported bit per pixel count [" + IString(totalBandBits) + "]. "; //Do we need this?
+        IString msg = "Unsupported bit per pixel count [" + IString(bitsPerBand) + "]. "; //Do we need this?
         msg += "(Use the raw2isis and crop programs to import the file in case it is ";
         msg += "line or sample interleaved.)";
         throw IException(IException::Io, msg, _FILEINFO_);

--- a/isis/src/base/apps/ddd2isis/ddd2isis.cpp
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.cpp
@@ -44,7 +44,7 @@ void IsisMain() {
    // ddd files are LSB
    EndianSwapper swp("MSB");
 
-  // Verify that the file is a .ddd by reading in the first 4 bytes and
+  // Verify that the file is a ddd by reading in the first 4 bytes and
   // comparing the magic numbers
   readBytes.readLong = 0;
   fin.seekg(0);
@@ -76,7 +76,7 @@ void IsisMain() {
   }
   int totalBandBits = readBytes.readLong;
 
-  // Maps the bit type of the file to the number of bytes
+  // Maps the bit type of the file to the number of bytes of that type
   map<int, int> dataTypes = {
     {1450901768, 1},
     {1450902032, 2},
@@ -99,10 +99,10 @@ void IsisMain() {
   int dataTypeBytes;
   //Old header format has no bit type
   if (bitType == 0) {
-    dataTypeBytes = dataTypes.find( totalBandBits ) -> second;
+    dataTypeBytes = dataTypes.find(totalBandBits) -> second;
   }
-  else{
-    dataTypeBytes = dataTypes.find( bitType ) -> second;
+  else {
+    dataTypeBytes = dataTypes.find(bitType) -> second;
   }
 
   // Read bytes 20-23 to get offset
@@ -141,14 +141,17 @@ void IsisMain() {
         p.SetPixelType(Isis::Real);
         break;
       default:
-        IString msg = "Unsupported bit per pixel count [" + IString(totalBandBits) + "]. ";
+        IString msg = "Unsupported bit per pixel count [" + IString(totalBandBits) + "]. "; //Do we need this?
         msg += "(Use the raw2isis and crop programs to import the file in case it is ";
         msg += "line or sample interleaved.)";
         throw IException(IException::Io, msg, _FILEINFO_);
     }
 
-    // ddd files are pixel interleaved
-    p.SetOrganization(ProcessImport::BIP);
+    // ddd files with more than one band are pixel interleaved
+    // Having one band is similar to BIP, but this is here for clarification
+    if (nBands > 1) {
+      p.SetOrganization(ProcessImport::BIP);
+    }
 
     p.SetDimensions(nSamples, nLines, nBands);
     p.SetFileHeaderBytes(nOffset);

--- a/isis/src/base/apps/ddd2isis/ddd2isis.cpp
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.cpp
@@ -117,7 +117,7 @@ void IsisMain() {
   PvlGroup results("FileInfo");
   results += PvlKeyword( "NumberOfLines", toString(nLines) );
   results += PvlKeyword( "NumberOfBytesPerLine", toString(nBytes) );
-  results += PvlKeyword( "BitType", toString(totalBandBits) );
+  results += PvlKeyword( "BitType", toString(bitType) );
   int nSamples = nBytes / (totalBandBits / 8);
   results += PvlKeyword( "NumberOfSamples", toString(nSamples) );
   int nBands = (totalBandBits / 8) / dataTypeBytes;
@@ -130,7 +130,7 @@ void IsisMain() {
   ProcessImport p;
 
   int bitsPerBand = totalBandBits / nBands;
-  if ( ui.WasEntered("TO") ) {
+  if ( ui.WasEntered("TO") ) {         
     switch(bitsPerBand) {
       case 8:
         p.SetPixelType(Isis::UnsignedByte);
@@ -142,7 +142,7 @@ void IsisMain() {
         p.SetPixelType(Isis::Real);
         break;
       default:
-        IString msg = "Unsupported bit per pixel count [" + IString(bitsPerBand) + "]. "; //Do we need this?
+        IString msg = "Unsupported bit per pixel count [" + IString(bitsPerBand) + "]. "; //Reword?
         msg += "(Use the raw2isis and crop programs to import the file in case it is ";
         msg += "line or sample interleaved.)";
         throw IException(IException::Io, msg, _FILEINFO_);

--- a/isis/src/base/apps/ddd2isis/ddd2isis.cpp
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.cpp
@@ -50,7 +50,7 @@ void IsisMain() {
   fin.seekg(0);
   fin.read(readBytes.readChars, 4);
   if( fin.fail() || fin.eof() ) {
-    string msg = "An error ocurred when reading the input file [" + from + "]";
+    string msg = "Could not read the magic number in the input file [" + from + "]";
     throw IException(IException::Io, msg, _FILEINFO_);
   }
   readBytes.readFloat = swp.Float(readBytes.readChars);
@@ -63,7 +63,7 @@ void IsisMain() {
   // Read bytes 4-7 to get number of lines
   fin.read(readBytes.readChars, 4);
   if( fin.fail() || fin.eof() ) {
-    string msg = "An error ocurred when reading the input file [" + from + "]";
+    string msg = "Could not read the number of lines in the input file [" + from + "]";
     throw IException(IException::Io, msg, _FILEINFO_);
   }
   readBytes.readFloat = swp.Float(readBytes.readChars);
@@ -72,7 +72,7 @@ void IsisMain() {
   // Read bytes 8-11 to get number of bytes
   fin.read(readBytes.readChars, 4);
   if( fin.fail() || fin.eof() ) {
-    string msg = "An error ocurred when reading the input file [" + from + "]";
+    string msg = "Could not read the number of bytes in the input file [" + from + "]";
     throw IException(IException::Io, msg, _FILEINFO_);
   }
   readBytes.readFloat = swp.Float(readBytes.readChars);
@@ -81,7 +81,7 @@ void IsisMain() {
   // Read bytes 12-15 to get the total number of bits out of all the bands
   fin.read(readBytes.readChars, 4);
   if( fin.fail() || fin.eof() ) {
-    string msg = "An error ocurred when reading the input file [" + from + "]";
+    string msg = "Could not read the number of bits in the input file [" + from + "]";
     throw IException(IException::Io, msg, _FILEINFO_);
   }
   readBytes.readFloat = swp.Float(readBytes.readChars);

--- a/isis/src/base/apps/ddd2isis/ddd2isis.xml
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.xml
@@ -30,6 +30,15 @@
       will need to be read in using a combination of the raw2isis and crop
       programs. Fixes #1713.
     </change>
+    <change name="Kaitlyn Lee" date="2018-03-01">
+      We were given a python program that reads in data from a ddd file
+      to use as an example. In the python program, the way they calculate the
+      number of bands is different from the one we previously used. The old
+      formula did the number of total band bits / 8; the formula is now
+      the (number of total band bits / 8) / the number of bytes of the data type
+      of the file's bit type. ddd files are also pixel interleaved, so the program
+      can now process files with multiple bands. Fixes #703.
+    </change>
   </history>
 
   <category>

--- a/isis/src/base/apps/ddd2isis/ddd2isis.xml
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.xml
@@ -7,7 +7,8 @@
   </brief>
 
   <description>
-    This program will import a ddd image into an Isis cube. The ddd format files are created by Malin Space Science Systems.
+    This program will import a ddd image into an Isis cube. The ddd format files
+    are created by Malin Space Science Systems.
   </description>
 
   <history>
@@ -32,12 +33,13 @@
     </change>
     <change name="Kaitlyn Lee" date="2018-03-01">
       We were given a python program that reads in data from a ddd file
-      to use as an example. In the python program, the way they calculate the
-      number of bands is different from the one we previously used. The old
-      formula did the number of total band bits / 8; the formula is now
-      the (number of total band bits / 8) / the number of bytes of the data type
-      of the file's bit type. ddd files are also pixel interleaved, so the program
-      can now process files with multiple bands. Fixes #703.
+      to use as an example. In the python program, the formula they used to
+      calculate the number of bands is different from the one we previously used.
+      The old formula did the number of total band bits / 8; the formula is now
+      (the number of total band bits / 8) / the number of bytes of the data type
+      of the file's bit type. Added the ability to process files with multiple
+      bands. Removed the internal default of the output parameter set to None so
+      that an output file is now requried. Fixes #703.
     </change>
   </history>
 
@@ -64,7 +66,6 @@
       <parameter name="TO">
          <type>cube</type>
          <fileMode>output</fileMode>
-         <internalDefault>None</internalDefault>
          <brief>
            Output Isis cube
          </brief>

--- a/isis/src/base/apps/ddd2isis/tsts/default/Makefile
+++ b/isis/src/base/apps/ddd2isis/tsts/default/Makefile
@@ -4,3 +4,5 @@ include $(ISISROOT)/make/isismake.tsts
 
 commands:
 	$(APPNAME) FROM=$(INPUT)/vis1flat.ddd TO=$(OUTPUT)/vis1flat.cub > /dev/null;
+	$(APPNAME) FROM=$(INPUT)/0023MD0000140000101507C00_DXXX_16b.ddd \
+		TO=$(OUTPUT)/0023MD0000140000101507C00_DXXX_16b.cub > /dev/null;

--- a/isis/src/base/apps/ddd2isis/tsts/errors/Makefile
+++ b/isis/src/base/apps/ddd2isis/tsts/errors/Makefile
@@ -1,0 +1,19 @@
+APPNAME = ddd2isis
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	# TEST: Throws an error when trying to open the file
+	if [ `$(APPNAME) \
+		FROM=$(INPUT)/vis1flat.ddd \
+		TO=$(OUTPUT)/vis1flat.cub \
+		2> $(OUTPUT)/errorTruth.txt > /dev/null` ]; \
+		then true; \
+		fi;
+	# TEST: Throws an error when trying to read from a cub instead of ddd
+	if [ `$(APPNAME) \
+		FROM=$(INPUT)/vis1flat.cub \
+		TO=$(OUTPUT)/vis1flat.cub \
+		2>> $(OUTPUT)/errorTruth.txt > /dev/null` ]; \
+		then true; \
+		fi;


### PR DESCRIPTION
ddd2isis used to not calculate the bit type of a ddd file correctly and would throw an exception if a user would try to import a multiband file. We received a python program that showed us how to correctly calculate the bit type. I also added a few tests and refactored the code.