### PR TITLE
Updated a couple of CaSSIS cat tests 

### DIFF
--- a/isis/src/tgo/tsts/coloredMosaic/Makefile
+++ b/isis/src/tgo/tsts/coloredMosaic/Makefile
@@ -3,6 +3,8 @@
 #
 # @history 2018-02-22 Adam Goins - Original version, many things borrowed from
 #                             uncontrolled single-color cat test.
+#          2018-06-18 Kristin Berry - Updated to use defaultrange=map for the cam2map call so that
+#                             cubeit will get input cubes all of the same size. 
 #
 
 INGEST = tgocassis2isis
@@ -17,7 +19,7 @@ CUBEIT = cubeit
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-  # Ingest Red
+        # Ingest Red
 	$(LS) $(INPUT)/*-RED-*.xml > $(OUTPUT)/redInputs.lis;
 	$(SED) 's/^.*input\///g' $(OUTPUT)/redInputs.lis > $(OUTPUT)/redRelative.lis;
 	$(SED) 's/\.xml//g' $(OUTPUT)/redRelative.lis > $(OUTPUT)/redBasenames.lis;
@@ -67,40 +69,37 @@ commands:
 	# MOSAICS
 	# Create Red Mosaic
 	$(PROJECT) $(TSTARGS) from=$(OUTPUT)/$\$$\1.cub to=$(OUTPUT)/$\$$\1_redEqui.cub \
-            map=$(OUTPUT)/equi.map \
+            map=$(OUTPUT)/equi.map defaultrange=map \
             pixres=mpp resolution=200 -batchlist=$(OUTPUT)/redBasenames.lis > /dev/null;
 	$(LS) $(OUTPUT)/*redEqui.cub > $(OUTPUT)/redMosaic.lis;
 	$(MOSAIC) $(TSTSARGS) fromlist=$(OUTPUT)/redMosaic.lis \
-	    to=$(OUTPUT)/redCassisMosaic.cub;# > /dev/null;
+	    to=$(OUTPUT)/redCassisMosaic.cub > /dev/null;
 
-# Create Blu Mosaic
+        # Create Blu Mosaic
 	$(PROJECT) $(TSTARGS) from=$(OUTPUT)/$\$$\1.cub to=$(OUTPUT)/$\$$\1_bluEqui.cub \
-             map=$(OUTPUT)/equi.map \
+             map=$(OUTPUT)/equi.map defaultrange=map \
              pixres=mpp resolution=200 -batchlist=$(OUTPUT)/bluBasenames.lis > /dev/null;
 	$(LS) $(OUTPUT)/*bluEqui.cub > $(OUTPUT)/bluMosaic.lis;
 	$(MOSAIC) $(TSTSARGS) fromlist=$(OUTPUT)/bluMosaic.lis \
-	    to=$(OUTPUT)/bluCassisMosaic.cub;# \
-	    > /dev/null;
+	    to=$(OUTPUT)/bluCassisMosaic.cub > /dev/null;
 
-# Create Pan Mosaic
+        # Create Pan Mosaic
 	$(PROJECT) $(TSTARGS) from=$(OUTPUT)/$\$$\1.cub to=$(OUTPUT)/$\$$\1_panEqui.cub \
-            map=$(OUTPUT)/equi.map \
+            map=$(OUTPUT)/equi.map defaultrange=map \
             pixres=mpp resolution=200 -batchlist=$(OUTPUT)/panBasenames.lis > /dev/null;
 	$(LS) $(OUTPUT)/*panEqui.cub > $(OUTPUT)/panMosaic.lis;
 	$(MOSAIC) $(TSTSARGS) fromlist=$(OUTPUT)/panMosaic.lis \
-	   to=$(OUTPUT)/panCassisMosaic.cub;# \
-	    > /dev/null;
+	   to=$(OUTPUT)/panCassisMosaic.cub > /dev/null;
 
-# Create Nir Mosaic
+        # Create Nir Mosaic
 	$(PROJECT) $(TSTARGS) from=$(OUTPUT)/$\$$\1.cub to=$(OUTPUT)/$\$$\1_nirEqui.cub \
-             map=$(OUTPUT)/equi.map \
+             map=$(OUTPUT)/equi.map defaultrange=map \
              pixres=mpp resolution=200 -batchlist=$(OUTPUT)/nirBasenames.lis > /dev/null;
 	$(LS) $(OUTPUT)/*nirEqui.cub > $(OUTPUT)/nirMosaic.lis;
 	$(MOSAIC) $(TSTSARGS) fromlist=$(OUTPUT)/nirMosaic.lis \
-	    to=$(OUTPUT)/nirCassisMosaic.cub;# \
-	    > /dev/null;
+	    to=$(OUTPUT)/nirCassisMosaic.cub > /dev/null;
 
-# Create full color mos
+        # Create full color mos
 	$(LS) $(OUTPUT)/*CassisMosaic.cub > $(OUTPUT)/mosaicList.lis;
 	$(CUBEIT) fromlist=$(OUTPUT)/mosaicList.lis to=$(OUTPUT)/coloredMosaic.cub > /dev/null;
 	$(EXPORT) $(TSTSARGS) from=$(OUTPUT)/coloredMosaic.cub to=$(OUTPUT)/coloredMosaic \
@@ -116,21 +115,21 @@ commands:
 	       > $(OUTPUT)/tempLabel3.txt;
 	$(SED) 's+\modification_date.*>+\modification_date>+' \
 	       $(OUTPUT)/tempLabel3.txt \
-	       > $(OUTPUT)/tempLabel4.txt
+	       > $(OUTPUT)/tempLabel4.txt;
 	$(SED) 's+\ISIS version.*<+\ISIS version.<+' \
 	       $(OUTPUT)/tempLabel4.txt \
                > $(OUTPUT)/coloredMosaic.xmlLabel.txt;
 
 	# Cleanup
-#	$(RM) $(OUTPUT)/coloredMosaic.xml;
-#	$(RM) $(OUTPUT)/tempLabel1.txt;
-#	$(RM) $(OUTPUT)/tempLabel2.txt;
-#	$(RM) $(OUTPUT)/tempLabel3.txt;
-#	$(RM) $(OUTPUT)/tempLabel4.txt;
-#	$(RM) $(OUTPUT)/*.lis;
-#	$(RM) $(OUTPUT)/CAS-MCO*.cub;
-#	$(RM) $(OUTPUT)/bluCassisMosaic.cub;
-#	$(RM) $(OUTPUT)/nirCassisMosaic.cub;
-#	$(RM) $(OUTPUT)/panCassisMosaic.cub;
-#	$(RM) $(OUTPUT)/redCassisMosaic.cub;
-#	$(MV) $(OUTPUT)/equi.map $(OUTPUT)/equi.pvl
+	$(RM) $(OUTPUT)/coloredMosaic.xml;
+	$(RM) $(OUTPUT)/tempLabel1.txt;
+	$(RM) $(OUTPUT)/tempLabel2.txt;
+	$(RM) $(OUTPUT)/tempLabel3.txt;
+	$(RM) $(OUTPUT)/tempLabel4.txt;
+	$(RM) $(OUTPUT)/*.lis;
+	$(RM) $(OUTPUT)/CAS-MCO*.cub;
+	$(RM) $(OUTPUT)/bluCassisMosaic.cub;
+	$(RM) $(OUTPUT)/nirCassisMosaic.cub;
+	$(RM) $(OUTPUT)/panCassisMosaic.cub;
+	$(RM) $(OUTPUT)/redCassisMosaic.cub;
+	$(MV) $(OUTPUT)/equi.map $(OUTPUT)/equi.pvl;

--- a/isis/src/tgo/tsts/uncontrolledSingleColorMosaic/Makefile
+++ b/isis/src/tgo/tsts/uncontrolledSingleColorMosaic/Makefile
@@ -3,17 +3,17 @@
 #
 # @history 2017-02-13 Kristin Berry - Original version, many things borrowed from 
 #                             singleFrameletProjection cat test. 
+#          2018-06-16 Kristin Berry - Upated to use tgocassismos and tgocassisrdrgen.
 #
 
 INGEST = tgocassis2isis
 SPICE = spiceinit
 MAPFILE = mosrange
 PROJECT = cam2map
-MOSAIC = automos
-EXPORT = isis2pds
+MOSAIC = tgocassismos
+EXPORT = tgocassisrdrgen
 
 include $(ISISROOT)/make/isismake.tsts
-
 
 commands:
 	$(LS) $(INPUT)/*.xml > $(OUTPUT)/inputs.lis;
@@ -29,10 +29,9 @@ commands:
              map=$(OUTPUT)/equi.map \
              pixres=mpp resolution=200 -batchlist=$(OUTPUT)/basenames.lis > /dev/null;
 	$(LS) $(OUTPUT)/*equi.cub > $(OUTPUT)/mosaic.lis;
-	$(MOSAIC) $(TSTSARGS) fromlist=$(OUTPUT)/mosaic.lis mosaic=$(OUTPUT)/cassisMosaic.cub > /dev/null;
+	$(MOSAIC) $(TSTSARGS) fromlist=$(OUTPUT)/mosaic.lis to=$(OUTPUT)/cassisMosaic.cub > /dev/null;
 
-	$(EXPORT) $(TSTSARGS) from=$(OUTPUT)/cassisMosaic.cub to=$(OUTPUT)/cassisMosaic \
-             pdsversion=pds4 > /dev/null;
+	$(EXPORT) $(TSTSARGS) from=$(OUTPUT)/cassisMosaic.cub to=$(OUTPUT)/cassisMosaic.img > /dev/null;
 	$(SED) 's+\Product_Observational.*>+\Product_Observational>+' \
                $(OUTPUT)/cassisMosaic.xml \
 	       > $(OUTPUT)/tempLabel1.txt;
@@ -49,7 +48,7 @@ commands:
 	       $(OUTPUT)/tempLabel4.txt \
                > $(OUTPUT)/cassisMosaic.xmlLabel.txt;
 	catlab from=$(OUTPUT)/cassisMosaic.cub \
-	       to=$(OUTPUT)/cassisMosaic.pvl >& /dev/null;
+	       to=$(OUTPUT)/cassisMosaic.pvl > /dev/null;
 
 	# Cleanup
 	$(MV) $(OUTPUT)/equi.map $(OUTPUT)/equi.pvl


### PR DESCRIPTION
(1) `coloredMosaic` was failing because `cam2map` didn't use the mapfile to set the output size, so `cubeit` was receiving input cubes of different sizes.

(2) Updated `uncontrolledSingleColor` mosaic to use tgo-specific applications.