### PR TITLE
Fixing the clean state of project on load 

### DIFF
--- a/isis/src/qisis/objs/Project/Project.cpp
+++ b/isis/src/qisis/objs/Project/Project.cpp
@@ -1388,6 +1388,7 @@ namespace Isis {
     m_isOpen = true;
     // TODO: TLS 2018-06-07  Why writeSettings here?
     //writeSettings();
+    setClean(true);
     emit projectLoaded(this);
   }
 


### PR DESCRIPTION
This was related to the window change events I established earlier in the sprint