### PR TITLE
Fixed an edge-case scenario with ProjectItemModel::selectedBossImages()

### DIFF
--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -785,6 +785,16 @@ namespace Isis {
     return QString(m_ui->inputControlNetCombo->currentText());
   }
 
+  
+
+  /**
+   * @brief updateBundleObservationSolveSettings:  This function sets the parameters of
+   * a BundleObservationSolveSettings object by reading user settings from the BOSS
+   * tab, as well as reading in the selected images on the BOSS QTreeView these
+   * BOSS settings are to be applied to.
+   * @param BundleObservationSolveSettings &boss The object which stores user-specified
+   * settings from the BOSS tab.
+   */
   void JigsawSetupDialog::updateBundleObservationSolveSettings(BundleObservationSolveSettings &boss)
     {
 

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
@@ -13,6 +13,7 @@ class QItemSelection;
 class QTableWidgetItem;
 
 namespace Isis {
+  class BundleObservationSolveSettings;
   class Project;
   class ProjectItem;
   class Control;
@@ -156,10 +157,11 @@ namespace Isis {
 
 
     private:
-    void makeReadOnly()    ;
+    void makeReadOnly();
     void fillFromSettings(const BundleSettingsQsp settings);
     void showTargetParametersGroupBox();
     void hideTargetParametersGroupBox();
+    void updateBundleObservationSolveSettings(BundleObservationSolveSettings &boss);
 
     void createObservationSolveSettingsTreeView();
 

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
@@ -73,6 +73,10 @@ namespace Isis {
    *                           createObservationSolveSettingsTreeView() function.  References #497.
    *   @history 2018-06-25 Ian Humphrey - Implemented the position and pointing a priori sigma
    *                           tables in the observation solve settings tab. References #497.
+   *   @history 2018-06-26 Tyler Wilson - Added the function 
+   *                           updateBundleObservationSolveSettings(BundleObservationSolveSettings &) 
+   *                           which grabs BOSS settings from the JSD BOSS tab for selected images 
+   *                           in the BOSS QTreeView and saves them in a BOSS object. 
    */
 
   class JigsawSetupDialog : public QDialog {

--- a/isis/src/qisis/objs/ProjectItemModel/ProjectItemModel.h
+++ b/isis/src/qisis/objs/ProjectItemModel/ProjectItemModel.h
@@ -134,7 +134,11 @@ namespace Isis {
    *                           refinement of selectedItems and is used by the JigsawSetupDialog
    *                           Bundle Observation Solve Settings (BOSS) tab when displaying a
    *                           subset of user-selected images.  References #497
-   *
+   *   @history 2018-06-24 Tyler Wilson - Fixed an edge-case scenario in the selection criteria for
+   *                           selectedBOSSImages().   If a user selected an image list and some
+   *                           (but not all) of the images within that list, the function returned
+   *                           all of the images in the list and not just the selected ones.
+   *                           References #497.
    */
   class ProjectItemModel : public QStandardItemModel {
 


### PR DESCRIPTION
There was a problem with the selection criteria in ProjectItemModel.  When a user clicks on an image list, but also selects some but not all of the images in the image list, selectedBossImages() was returning all of the images in the image list.  This PR fixes that problem.