### PR TITLE
Updated ControlNet and ControlNetVitals to fix problem with numImages…

### DIFF
--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -1381,7 +1381,11 @@ namespace Isis {
    *                         returning a count of only valid measures (Ignore=False).
    */
   int ControlNet::GetNumberOfValidMeasuresInImage(const QString &serialNumber) {
-    return p_cameraValidMeasuresMap[serialNumber];
+    // If SetImage was called, use the map that has been populated with valid measures
+    if (p_cameraList.size() > 0) {
+      return p_cameraValidMeasuresMap[serialNumber];
+    }
+    return GetValidMeasuresInCube(serialNumber).size();     
   }
 
 

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -224,10 +224,10 @@ namespace Isis {
    *                           image. Previously, this had to be done throug the graph.
    *   @history 2018-01-26 Kristin Berry - Added pointAdded() function to eliminate redundant measure
    *                           adds to the control network.
-   *   @history 2018-01-26 Kristin Berry - Removed unused methods and associated code:
+   *   @history 2018-06-10 Kristin Berry - Removed unused methods and associated code:
    *                           MinimumSpanningTree(), GetNodeConnections(), RandomBFS(), Shuffle(),
    *                           CalcBWAndCE(), CubeGraphToString(), getGraphNode(). References #5434
-   *  @history 2018-01-26 Kristin Berry - Updated to use the boost graph library instead of our
+   *   @history 2018-06-10 Kristin Berry - Updated to use the boost graph library instead of our
    *                           custom graph structure ControlCubeGraphNode.
    *   @history 2018-04-05 Adam Goins - Added a check to the versionedReader targetRadii
    *                           group to set radii values to those ingested from the versioner
@@ -245,7 +245,10 @@ namespace Isis {
    *                           These signals exist for the purpose of communication between the
    *                           ControlNetVitals class, and the network that it is observing.
    *                           Fixes #5435.
-
+   *  @history 2018-06-25 Kristin Berry - Updated GetNumberOfValidMeasuresInImage() to use
+   *                           GetValidMeasuresInCube() if SetImage has not yet been called to populate
+   *                           the p_cameraValidMeasuresMap.
+   *
    */
   class ControlNet : public QObject {
       Q_OBJECT

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
@@ -613,9 +613,10 @@ namespace Isis {
 
     QMap<int, int>::const_iterator i = m_imageMeasureCounts.constBegin();
     while (i != m_imageMeasureCounts.constEnd()) {
-      if (i.key() < num ) {
-        count += i.value();
+      if (i.key() >= num ) {
+        break;
       }
+      count += i.value();
       ++i;
     }
     return count;

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
@@ -610,11 +610,13 @@ namespace Isis {
    */
   int ControlNetVitals::numImagesBelowMeasureThreshold(int num) {
     int count = 0;
-    foreach(int measureCount, m_imageMeasureCounts) {
-      if (measureCount > num) {
-        break;
+
+    QMap<int, int>::const_iterator i = m_imageMeasureCounts.constBegin();
+    while (i != m_imageMeasureCounts.constEnd()) {
+      if (i.key() < num ) {
+        count += i.value();
       }
-      count += m_imageMeasureCounts[measureCount];
+      ++i;
     }
     return count;
   }
@@ -753,7 +755,9 @@ namespace Isis {
   QList<QString> ControlNetVitals::getImagesBelowMeasureThreshold(int num) {
     QList<QString> imagesBelowThreshold;
     foreach(QString serial, m_controlNet->GetCubeSerials()) {
-      if (m_controlNet->GetMeasuresInCube(serial).size() < num) imagesBelowThreshold.append(serial);
+      if (m_controlNet->GetValidMeasuresInCube(serial).size() < num) {
+        imagesBelowThreshold.append(serial);
+      }
     }
     return imagesBelowThreshold;
   }

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
@@ -56,6 +56,7 @@ namespace Isis {
   *    @history 2018-05-28 Adam Goins - Initial Creation.
   *    @history 2018-06-14 Adam Goins & Jesse Maple - Refactored method calls and Signal/Slot usage.
   *    @history 2018-06-15 Adam Goins - Added documentation.
+  *    @history 2018-06-25 Kristin Berry - Fixed problem with getImagesBelowMeasureThreshold()
   */
   class ControlNetVitals : public QObject {
     Q_OBJECT

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.truth
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.truth
@@ -3,8 +3,8 @@ Testing Control Net Vitals
 Loading Network
 Calculating Network Vitals
 Network ID: "LROC_NAC_LRPAIR_AUTO"
-Network Status: "Healthy!"
-Status Details: "This network is healthy."
+Network Status: "Weak!"
+Status Details: "This network has 4 image(s) with less than 3 measures\n"
 Network has additional islands? no
 Number of islands in network: 1
 Serials in island  0
@@ -54,7 +54,7 @@ Number of free points in network: 75
 Number of points without measures: 0
 Number of points with less than 3 measures: 0
 Number of images without measures: 0
-Number of images with less than 2 measures: 0
+Number of images with less than 2 measures: 1
 Number of images with less 75 percent hull coverage: 0
 Testing getters...
 

--- a/isis/src/control/objs/ControlNetVitals/unitTest.cpp
+++ b/isis/src/control/objs/ControlNetVitals/unitTest.cpp
@@ -13,6 +13,13 @@
 using namespace Isis;
 using namespace std;
 
+/**
+ * Unit test for ControlNetVitals class 
+ *  
+ * @author 2018-06-18 Adam Goins
+ * @internal
+ *   @history 2018-06-22 Kristin Berry - Upated after fix to numImagesBelowMeasureThreshold()
+ */
 int main() {
   try {
     Preference::Preferences(true);
@@ -84,11 +91,8 @@ int main() {
     assert(pointsWithoutMeasures == netVitals.getPointsBelowMeasureThreshold(1).size());
     assert(pointsBelowMeasures == netVitals.getPointsBelowMeasureThreshold(3).size());
     assert(imagesWithoutMeasures == netVitals.getImagesBelowMeasureThreshold(1).size());
-    // fix this
-    // std::cout << imagesBelowMeasures << "    " << netVitals.getImagesBelowMeasureThreshold(2).size() << std::endl;
-    // assert(imagesBelowMeasures == netVitals.getImagesBelowMeasureThreshold(2).size());
+    assert(imagesBelowMeasures == netVitals.getImagesBelowMeasureThreshold(2).size());
     assert(numImagesBelowHull == netVitals.getImagesBelowHullTolerance().size());
-
 
     qDebug() << "\nTesting signal/slots...";
     ControlPoint *testPoint = new ControlPoint;


### PR DESCRIPTION
…BelowMeasureThreshold not matching getImagesBelowMeasureThreshold. 

I verified using cneteditor that the number of images with < n measures matched the updated results in the unitTest