### PR TITLE
JigsawSetupDialog observation solve settings validation

### DIFF
--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -1320,7 +1320,7 @@ namespace Isis {
     }
 
     // FREE is a valid value for the a priori sigma column
-    int free = item->text().compare("FREE", Qt::CaseInsensitive);
+    int free = item->text().simplified().compare("FREE", Qt::CaseInsensitive);
     if (free == 0) {
       item->setText("FREE");
     }

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -1361,14 +1361,18 @@ namespace Isis {
     bool tablesAreValid = true;
     
     // Evaluate both tables; if any value is invalid, the table is invalid
-    const QTableWidget *positionTable = m_ui->positionAprioriSigmaTable;
-
-    for (int i = 0; i < positionTable->rowCount(); i++) {
-      const QTableWidgetItem *item = positionTable->item(i,3);
-      if (item) { 
-        if (item->data(Qt::UserRole).toBool() == false) {
-          tablesAreValid = false;
-          break;
+    QList<const QTableWidget *> tables{m_ui->positionAprioriSigmaTable,
+                                       m_ui->pointingAprioriSigmaTable};
+                                       
+    for (const auto &table : tables) {
+      for (int i = 0; i < table->rowCount(); i++) {
+        // a priori sigma column is column 3
+        const QTableWidgetItem *item = table->item(i,3);
+        if (item) { 
+          if (item->data(Qt::UserRole).toBool() == false) {
+            tablesAreValid = false;
+            break;
+          }
         }
       }
     }

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -110,7 +110,7 @@ namespace Isis {
 
     const QStringList pointingOptions{"NONE", "ANGLES", "VELOCITY", "ACCELERATION", "ALL"};
     m_ui->pointingComboBox->insertItems(0, pointingOptions);
-    m_ui->pointingComboBox->setCurrentIndex(0);
+    m_ui->pointingComboBox->setCurrentIndex(1);
 
     // The degree solve options' minimums are -1 (set in ui file), make the -1's display as N/A
     m_ui->spkSolveDegreeSpinBox->setSpecialValueText("N/A");

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -117,13 +117,19 @@ namespace Isis {
     QStringList tableHeaders;
     tableHeaders << "coefficients" << "description" << "units" << "a priori sigma";
     m_ui->positionAprioriSigmaTable->setHorizontalHeaderLabels(tableHeaders);
+    m_ui->pointingAprioriSigmaTable->setHorizontalHeaderLabels(tableHeaders);
 
+    // Set the default size of the columns
     m_ui->positionAprioriSigmaTable->setColumnWidth(0, fontMetrics().width(tableHeaders.at(0)) + 10);
     m_ui->positionAprioriSigmaTable->setColumnWidth(1, fontMetrics().width(tableHeaders.at(1)) + 10);
     m_ui->positionAprioriSigmaTable->setColumnWidth(2, fontMetrics().width(tableHeaders.at(2)) + 10);
     m_ui->positionAprioriSigmaTable->setColumnWidth(3, fontMetrics().width(tableHeaders.at(3)) + 10);
 
-    m_ui->pointingAprioriSigmaTable->setHorizontalHeaderLabels(tableHeaders);
+    m_ui->pointingAprioriSigmaTable->setColumnWidth(0, fontMetrics().width(tableHeaders.at(0)) + 10);
+    m_ui->pointingAprioriSigmaTable->setColumnWidth(1, fontMetrics().width(tableHeaders.at(1)) + 10);
+    m_ui->pointingAprioriSigmaTable->setColumnWidth(2, fontMetrics().width(tableHeaders.at(2)) + 10);
+    m_ui->pointingAprioriSigmaTable->setColumnWidth(3, fontMetrics().width(tableHeaders.at(3)) + 10);
+
 
     // Add validators to the tables in the observation solve settings tab to validate the a priori
     // sigma items

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -1378,6 +1378,7 @@ namespace Isis {
     }
 
     m_ui->okCloseButtonBox->button(QDialogButtonBox::Ok)->setEnabled(tablesAreValid);
+    m_ui->applySettingsPushButton->setEnabled(tablesAreValid);
   }
 
 

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -1353,23 +1353,18 @@ namespace Isis {
    */
   void JigsawSetupDialog::validateSigmaTables() {
     bool tablesAreValid = true;
+    
     // Evaluate both tables; if any value is invalid, the table is invalid
     const QTableWidget *positionTable = m_ui->positionAprioriSigmaTable;
-    qDebug() << "validating the position table...";
-    qDebug() << "\tnumber of rows: " << positionTable->rowCount();
+
     for (int i = 0; i < positionTable->rowCount(); i++) {
-      qDebug() << "\t\trow " << i;
       const QTableWidgetItem *item = positionTable->item(i,3);
-      qDebug() << "\t\titem: " << item;
-      qDebug() << "\t\tdata: ";
       if (item) { 
-        qDebug() << item->data(Qt::UserRole);
         if (item->data(Qt::UserRole).toBool() == false) {
           tablesAreValid = false;
           break;
         }
       }
-      else qDebug() << "(null)";
     }
 
     m_ui->okCloseButtonBox->button(QDialogButtonBox::Ok)->setEnabled(tablesAreValid);

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
@@ -77,6 +77,10 @@ namespace Isis {
    *                           updateBundleObservationSolveSettings(BundleObservationSolveSettings &) 
    *                           which grabs BOSS settings from the JSD BOSS tab for selected images 
    *                           in the BOSS QTreeView and saves them in a BOSS object. 
+   *   @history 2018-06-27 Ian Humphrey - Added validateSigmaTables() that checks if there are any
+   *                           invalid a priori sigma values whenever an a priori sigma values changes.
+   *                           If any value is invalid, the OK and Apply Settings buttons are disabled
+   *                           until all the a priori sigma values are valid again. References #497.
    */
 
   class JigsawSetupDialog : public QDialog {

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
@@ -76,17 +76,16 @@ namespace Isis {
    *   @history 2018-06-26 Tyler Wilson - Added the function 
    *                           updateBundleObservationSolveSettings(BundleObservationSolveSettings &) 
    *                           which grabs BOSS settings from the JSD BOSS tab for selected images 
-   *                           in the BOSS QTreeView and saves them in a BOSS object. 
-   *   @history 2018-06-27 Ian Humphrey - Added validateSigmaTables() that checks if there are any
-   *                           invalid a priori sigma values whenever an a priori sigma values changes.
-   *                           If any value is invalid, the OK and Apply Settings buttons are disabled
-   *                           until all the a priori sigma values are valid again. References #497.
+   *                           in the BOSS QTreeView and saves them in a BOSS object.
    *   @history 2018-06-26 Tyler Wilson - Added support in
    *                           updateBundleObservationSolveSettings(BundleObservationSolveSettings &)
    *                           for the user to set an arbitrary number of position/pointing Apriori
    *                           Sigma values beyond position/velocity/acceleration.  References #497.
+   *   @history 2018-06-27 Ian Humphrey - Added validateSigmaTables() that checks if there are any
+   *                           invalid a priori sigma values whenever an a priori sigma values changes.
+   *                           If any value is invalid, the OK and Apply Settings buttons are disabled
+   *                           until all the a priori sigma values are valid again. References #497.
    */
-
   class JigsawSetupDialog : public QDialog {
     Q_OBJECT
 

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
@@ -70,6 +70,8 @@ namespace Isis {
    *                           (BOSS) tab for displaying user-selected images from the main Project
    *                           treeview.  All changes were made in the
    *                           createObservationSolveSettingsTreeView() function.  References #497.
+   *   @history 2018-06-25 Ian Humphrey - Implemented the position and pointing a priori sigma
+   *                           tables in the observation solve settings tab. References #497.
    */
 
   class JigsawSetupDialog : public QDialog {
@@ -146,6 +148,7 @@ namespace Isis {
     void on_pointingComboBox_currentIndexChanged(const QString &arg1);
 
     void validateSigmaValue(QTableWidgetItem *);
+    void validateSigmaTables();
     
 
     public slots:


### PR DESCRIPTION
This PR adds OK and Apply Settings button enabling/disabling based on validation of the position and pointing a priori sigma tables in the JigsawSetupDialog's observation solve settings tab.

Now, whenever there is *any* invalid value in either of the tables, the OK and Apply Settings buttons are disabled. When all of the sigmas are valid, the OK and Apply Settings buttons are (re)enabled.

Also, the default sizing of the pointing table matches the default sizing of the position table, and any whitespace is trimmed when checking for FREE validation in the sigma value.