### PR TITLE
Fixed numPointsBelowMeasureThreshold() to return the correct value

### DIFF
--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
@@ -568,15 +568,19 @@ namespace Isis {
    *  @return The number of points with number of measures less than the threshold.
    */
   int ControlNetVitals::numPointsBelowMeasureThreshold(int num) {
-    // int count = 0;
-    // foreach(int measureCount, m_pointMeasureCounts) {
-    //   if (measureCount >= num) {
-    //     continue;
-    //   }
-    //   count += m_pointMeasureCounts[measureCount];
-    // }
-    // return count;
-    return getPointsBelowMeasureThreshold(num).size();
+    int count = 0;
+
+    QMap<int, int>::const_iterator i = m_pointMeasureCounts.constBegin();
+    while (i != m_pointMeasureCounts.constEnd()) {
+      if (i.key() >= num ) {
+        break;
+      }
+      count += i.value();
+      ++i;
+    }
+
+    return count;
+    //return getPointsBelowMeasureThreshold(num).size();
   }
 
 

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
@@ -580,7 +580,6 @@ namespace Isis {
     }
 
     return count;
-    //return getPointsBelowMeasureThreshold(num).size();
   }
 
 

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
@@ -56,7 +56,9 @@ namespace Isis {
   *    @history 2018-05-28 Adam Goins - Initial Creation.
   *    @history 2018-06-14 Adam Goins & Jesse Maple - Refactored method calls and Signal/Slot usage.
   *    @history 2018-06-15 Adam Goins - Added documentation.
-  *    @history 2018-06-25 Kristin Berry - Fixed problem with getImagesBelowMeasureThreshold()
+  *    @history 2018-06-25 Kristin Berry - Fixed problem with getImagesBelowMeasureThreshold().size()
+  *                           not matching numImagesBelowMeasureThreshold(). Fixed a similar
+  *                           problem with numPointsBelowMeasureThreshold(). 
   */
   class ControlNetVitals : public QObject {
     Q_OBJECT


### PR DESCRIPTION
This had the same error (the foreach is over values, not keys) as numImagesBelowMeasureThreshold()