### PR TITLE
Fixed ControlNet not handling ignoring measures correctly

### DIFF
--- a/isis/src/control/apps/cnetwinnow/cnetwinnow.cpp
+++ b/isis/src/control/apps/cnetwinnow/cnetwinnow.cpp
@@ -311,7 +311,6 @@ void IsisMain() {
         measFlag[j] = true;  //test passed
     }
 
-
     //for now it is necessary to set measures to ignor before testing to see if they would split the network
       //this will change when the expected ControlNet::isCriticalMeasure(...) method is written
     for (int j=0; j<measGroup.size(); j++) {
@@ -319,8 +318,12 @@ void IsisMain() {
     }
 
     //if the number of islands has increased the network has split
-    if (net.GetSerialConnections().size() > numInitialIslands) islandFlag = false; //test failed
-    else islandFlag = true; //test passed
+    if (net.GetSerialConnections().size() > numInitialIslands) {
+      islandFlag = false; //test failed
+    }
+    else {
+      islandFlag = true; //test passed
+    }
 
     //again we will temporarily be setting the measure back to unignored
       //this will change when the expected ControlNet::isCriticalMeasure(...) method is written
@@ -375,7 +378,6 @@ void IsisMain() {
   //close the report file
   fclose(guiltyFile);
   fclose(ignoredReport);
-
 
   //save out the winnowed ControlNet
   net.Write(ui.GetFileName("ONET"));

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -247,6 +247,8 @@ namespace Isis {
    *                           Fixes #5435.
    *   @history 2018-06-25 Jesse Mapel - Fixed the incorrect signal being called when adding and
    *                           removing measures. References #5435.
+   *   @history 2018-06-25 Jesse Mapel - Fixed ignoring measures with ignored adjacent measures
+   *                           incorrectly modifying the edge between the two image vertices.
    */
   class ControlNet : public QObject {
       Q_OBJECT

--- a/isis/src/control/objs/ControlNet/ControlNet.truth
+++ b/isis/src/control/objs/ControlNet/ControlNet.truth
@@ -3,43 +3,43 @@ UnitTest for ControlNet ....
 ******* test cube connection graph ************
 testing ignoring measures..............................
 starting graph
-ALPHA ----[p0]---- BRAVO
+ALPHA ----(1) [p0]---- BRAVO
 
 ignore a measure
 
 un-ignore a measure
-ALPHA ----[p0]---- BRAVO
+ALPHA ----(1) [p0]---- BRAVO
 
 testing measure addition to point already in network...
 add point with only 1 measure
-ALPHA ----[p0]---- BRAVO
+ALPHA ----(1) [p0]---- BRAVO
 
 add a measure
-ALPHA ----[p0,p1]---- BRAVO
+ALPHA ----(2) [p0,p1]---- BRAVO
 
 add another measure
-ALPHA ----[p0,p1]---- BRAVO
-ALPHA ----[p1]---- CHARLIE
-BRAVO ----[p1]---- CHARLIE
+ALPHA ----(2) [p0,p1]---- BRAVO
+ALPHA ----(1) [p1]---- CHARLIE
+BRAVO ----(1) [p1]---- CHARLIE
 
 testing setting point to ignored.......................
 ignore p1
-ALPHA ----[p0]---- BRAVO
+ALPHA ----(1) [p0]---- BRAVO
 
 un-ignore p1
-ALPHA ----[p0,p1]---- BRAVO
-ALPHA ----[p1]---- CHARLIE
-BRAVO ----[p1]---- CHARLIE
+ALPHA ----(2) [p0,p1]---- BRAVO
+ALPHA ----(1) [p1]---- CHARLIE
+BRAVO ----(1) [p1]---- CHARLIE
 
 testing measure deletion & addition....................
-ALPHA ----[p1]---- BRAVO
-ALPHA ----[p1]---- CHARLIE
-BRAVO ----[p1]---- CHARLIE
+ALPHA ----(1) [p1]---- BRAVO
+ALPHA ----(1) [p1]---- CHARLIE
+BRAVO ----(1) [p1]---- CHARLIE
 
-ALPHA ----[p1]---- BRAVO
-ALPHA ----[p1]---- CHARLIE
-ALPHA ----[p0]---- DELTA
-BRAVO ----[p1]---- CHARLIE
+ALPHA ----(1) [p1]---- BRAVO
+ALPHA ----(1) [p1]---- CHARLIE
+ALPHA ----(1) [p0]---- DELTA
+BRAVO ----(1) [p1]---- CHARLIE
 
 testing FindClosest....................
 Closest Point ID: p1
@@ -51,7 +51,7 @@ Adjacent Images:
   DELTA
 
 testing point deletion.................................
-ALPHA ----[p0]---- DELTA
+ALPHA ----(1) [p0]---- DELTA
 
 ******* Done testing cube graph ***************
 
@@ -349,7 +349,7 @@ Read/Write of binary files OK.
     BRAVO
     CHARLIE
     DELTA
-ALPHA ----[p0]---- DELTA
+ALPHA ----(1) [p0]---- DELTA
 
 
 Testing getEdgeCount: 1


### PR DESCRIPTION
This fixes the errors in cnetwinnow. I also added the edge strength to the graphToString method in ControlNet because it's very helpful for debugging and ensuring the integrity of the graph.