### PR TITLE
Added support for additional apriori sigmas in updateBundleObservationSolveSettings

### DIFF
--- a/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.cpp
@@ -381,7 +381,7 @@ namespace Isis {
                                            bool solvePolynomialOverExisting,
                                            double anglesAprioriSigma,
                                            double angularVelocityAprioriSigma,
-                                           double angularAccelerationAprioriSigma) {
+                                           double angularAccelerationAprioriSigma,QList<double> * additionalPointingSigmas) {
 
     // automatically set the solve option and ck degree to the user entered values
     m_instrumentPointingSolveOption = option;
@@ -433,6 +433,16 @@ namespace Isis {
         }
       }
     }
+
+    if (additionalPointingSigmas) {
+      for (int i=0;i < additionalPointingSigmas->count();i++) {         
+          m_anglesAprioriSigma.append(additionalPointingSigmas->value(i));
+      }
+    }
+
+
+
+
 
     m_solveTwist = solveTwist; // dependent on solve option???
 
@@ -622,14 +632,14 @@ namespace Isis {
    * @param velocityAprioriSigma A priori velocity sigma
    * @param accelerationAprioriSigma A priori acceleration sigma
    */
-  void BundleObservationSolveSettings::setInstrumentPositionSettings(
-                                           InstrumentPositionSolveOption option,
+  void BundleObservationSolveSettings::setInstrumentPositionSettings(InstrumentPositionSolveOption option,
                                            int spkDegree,
                                            int spkSolveDegree,
                                            bool positionOverHermite,
                                            double positionAprioriSigma,
                                            double velocityAprioriSigma,
-                                           double accelerationAprioriSigma) {
+                                           double accelerationAprioriSigma,
+                                           QList<double> *additionalPositionSigmas) {
     // automatically set the solve option and spk degree to the user entered values
     m_instrumentPositionSolveOption = option;
 
@@ -677,6 +687,12 @@ namespace Isis {
             m_positionAprioriSigma.append(Isis::Null);
           }
         }
+      }
+    }
+
+    if (additionalPositionSigmas) {
+      for (int i=0;i < additionalPositionSigmas->count();i++) {
+          m_positionAprioriSigma.append(additionalPositionSigmas->value(i));
       }
     }
 

--- a/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.h
@@ -78,7 +78,10 @@ namespace Isis {
    *   @history 2018-06-21 Ian Humphrey - Added removeObservationNumber() to be able to remove an
    *                           observation number from a BundleObservationSolveSettings.
    *                           References #497.
-   *
+   *   @history 2018-06-26 Tyler Wilson - Added support for adding an arbitrary number of
+   *                           additional apriori sigma values in setInstrumentPositionSettings/
+   *                           setInstrumentPointingSettings beyond position/velocity/acceleration.
+   *                           References #497.
    *
    *   @todo Figure out why solve degree and num coefficients does not match solve option.
    *   @todo Determine whether xml stuff needs a Project pointer.
@@ -128,7 +131,8 @@ class BundleObservationSolveSettings {
                                          bool solvePolynomialOverExisting = false,
                                          double anglesAprioriSigma = -1.0,
                                          double angularVelocityAprioriSigma = -1.0,
-                                         double angularAccelerationAprioriSigma = -1.0);
+                                         double angularAccelerationAprioriSigma = -1.0,
+                                         QList<double> * additionalPointingSigmas=nullptr);
       InstrumentPointingSolveOption instrumentPointingSolveOption() const;
       bool solveTwist() const;
       int ckDegree() const;
@@ -159,7 +163,8 @@ class BundleObservationSolveSettings {
                                          bool positionOverHermite = false,
                                          double positionAprioriSigma = -1.0,
                                          double velocityAprioriSigma = -1.0,
-                                         double accelerationAprioriSigma = -1.0);
+                                         double accelerationAprioriSigma = -1.0,
+                                         QList<double> * additionalPositionSigmas=nullptr);
       InstrumentPositionSolveOption instrumentPositionSolveOption() const;
       int spkDegree() const;
       int spkSolveDegree() const;

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -902,10 +902,12 @@ namespace Isis {
 
 
       boss.setInstrumentPositionSettings(positionSolvingOption,spkDegree,spkSolveDegree,positionOverHermite,
-                                         positionAprioriSigma,velocityAprioriSigma,accelerationAprioriSigma);
+                                         positionAprioriSigma,velocityAprioriSigma,accelerationAprioriSigma,
+                                         &additionalPositionCoefficients);
 
       boss.setInstrumentPointingSettings(pointSolvingOption,solveTwist,ckDegree,ckSolveDegree,solvePolynomialOverExisting,
-                                         anglesAprioriSigma,angularVelocityAprioriSigma,angularAccelerationAprioriSigma);
+                                         anglesAprioriSigma,angularVelocityAprioriSigma,angularAccelerationAprioriSigma,
+                                         &additionalAngularCoefficients);
 
       //What if multiple instrument IDs are represented?
       boss.setInstrumentId("");
@@ -925,7 +927,7 @@ namespace Isis {
           if (projItem->isImage() ) {
             Image * img = projItem->data().value<Image *>();
             boss.addObservationNumber(img->serialNumber() );
-            //qDebug() << "serial num:  " << img->serialNumber();
+
           }
         }
 

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.h
@@ -77,6 +77,10 @@ namespace Isis {
    *                           updateBundleObservationSolveSettings(BundleObservationSolveSettings &) 
    *                           which grabs BOSS settings from the JSD BOSS tab for selected images 
    *                           in the BOSS QTreeView and saves them in a BOSS object. 
+   *   @history 2018-06-26 Tyler Wilson - Added support in
+   *                           updateBundleObservationSolveSettings(BundleObservationSolveSettings &)
+   *                           for the user to set an arbitrary number of position/pointing Apriori
+   *                           Sigma values beyond position/velocity/acceleration.  References #497.
    */
 
   class JigsawSetupDialog : public QDialog {


### PR DESCRIPTION
Prior to this, the additional apriori sigmas were being read in by updateBundleObservationSolveSettings, but they weren't being sent to the BOSS object the function is modifying.  Now they are.  This required modifying BundleObservationSolveSettings::setInstrumentPositionSettings/setInstrumentPointingSettings and changing the function signature by adding a default parameter at the end.  The change is backwards compatible and will not break anything.