### PR TITLE
Cleanup Tasks for ipceCnetHealth

### DIFF
--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
@@ -24,7 +24,6 @@
 
 #include <QList>
 #include <QStringList>
-#include <QPoint>
 
 #include "Application.h"
 #include "Camera.h"

--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.h
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.h
@@ -231,6 +231,16 @@ namespace Isis {
         MeasureLocked
       };
 
+
+      /**
+       * @brief Control Measure Modification Types
+       *
+       *  This enum is designed to represent the different types of modifications that can be
+       *  made to a ControlMeasure.
+       *
+       * IgnoredModified means that the Control Measure had it's IGNORED flag changed.
+       *
+       */
       enum ModType {
         IgnoredModified
       };

--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -129,10 +129,29 @@ namespace Isis {
   }
 
 
+  /**
+   * This method is a wrapper to emit the measureModified() signal and is called whenever a change
+   * is made to a Control Measure.
+   *
+   * @param measure The ControlMeasure* that was modified.
+   * @param type The ControlMeasure::ModType indicating which modification occured.
+   * @param oldValue The oldValue before the change.
+   * @param newValue The new value that the change incorporated.
+   */
   void ControlNet::emitMeasureModified(ControlMeasure *measure, ControlMeasure::ModType type, QVariant oldValue, QVariant newValue) {
     emit measureModified(measure, type, oldValue, newValue);
   }
 
+
+  /**
+   * This method is a wrapper to emit the pointModified() signal and is called whenever a change
+   * is made to a Control Point.
+   *
+   * @param point The ControlPoint* that was modified.
+   * @param type The ControlPoint::ModType indicating which modification occured.
+   * @param oldValue The oldValue before the change.
+   * @param newValue The new value that the change incorporated.
+   */
   void ControlNet::emitPointModified(ControlPoint *point, ControlPoint::ModType type, QVariant oldValue, QVariant newValue) {
     emit pointModified(point, type, oldValue, newValue);
   }
@@ -827,6 +846,10 @@ namespace Isis {
   }
 
 
+
+  /**
+   * This method is a wrapper to emit the networkStructureModified() signal.
+   */
   void ControlNet::emitNetworkStructureModified() {
     emit networkStructureModified();
   }

--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -692,8 +692,7 @@ namespace Isis {
 
   /**
    * Updates the node for this measure's serial number to
-   * reflect the deletion.  If this is the only measure left in the containing
-   * node, then the node is deleted as well.
+   * reflect the deletion.
    *
    * @param measure The measure removed from the network.
    */
@@ -715,14 +714,6 @@ namespace Isis {
     // for the old graph.
     m_controlGraph[m_vertexMap[serial]].measures.remove(measure->Parent());
 
-
-// We decided in a meeting that we do not want to delete the node when all measures are removed.
-    // If this caused the node to be empty, then delete the node.
-//    if (m_controlGraph[m_vertexMap[serial]].measures.size() <= 0) {
-//      boost::clear_vertex(m_vertexMap[serial], m_controlGraph);
-//      boost::remove_vertex(m_vertexMap[serial], m_controlGraph);
-//      m_vertexMap.remove(serial);
-//    }
   }
 
 
@@ -1375,7 +1366,7 @@ namespace Isis {
     if (p_cameraList.size() > 0) {
       return p_cameraValidMeasuresMap[serialNumber];
     }
-    return GetValidMeasuresInCube(serialNumber).size();     
+    return GetValidMeasuresInCube(serialNumber).size();
   }
 
 

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -259,6 +259,15 @@ namespace Isis {
 
     public:
 
+      /**
+       *  @brief Control Point Modification Types
+       *
+       *  This enum is designed to represent the different types of modifications that can be
+       *  made to a ControlNet.
+       *
+       *  Swapped means the network was swapped with another network (ControlNet::Swap(ControlNet &other)).
+       *  GraphModified means that a vertice or edge was added/removed from the graph..
+       */
       enum ModType {
         Swapped,
         GraphModified

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
@@ -58,7 +58,7 @@ namespace Isis {
   *    @history 2018-06-15 Adam Goins - Added documentation.
   *    @history 2018-06-25 Kristin Berry - Fixed problem with getImagesBelowMeasureThreshold().size()
   *                           not matching numImagesBelowMeasureThreshold(). Fixed a similar
-  *                           problem with numPointsBelowMeasureThreshold(). 
+  *                           problem with numPointsBelowMeasureThreshold().
   */
   class ControlNetVitals : public QObject {
     Q_OBJECT
@@ -122,27 +122,35 @@ namespace Isis {
 
 
     private:
+      //! The Control Network that the vitals class is observing.
       ControlNet *m_controlNet;
 
+      //! The string representing the status of the net. Healthy, Weak, or Broken.
       QString m_status;
+      //! The string providing details into the status of the network.
       QString m_statusDetails;
 
+      //! A QList containing every island in the net. Each island consists of a QList containing
+      //! All cube serials for that island.
       QList< QList< QString > > m_islandList;
 
-      // The measureCount maps track how many points/images have how many measures.
-      // For instance, if I wanted to know how many points have 3 measures I would query
-      // the m_pointMeasureCounts with a key of 3 and it would return how many points
-      // have 3 measures. The same is true for imageMeasureCounts, except for images.
+      //! The measureCount maps track how many points/images have how many measures.
+      //! For instance, if I wanted to know how many points have 3 measures I would query
+      //! the m_pointMeasureCounts with a key of 3 and it would return how many points
+      //! have 3 measures.
       QMap<int, int> m_pointMeasureCounts;
+      //! The same is true for imageMeasureCounts, except for images.
       QMap<int, int> m_imageMeasureCounts;
 
-      // The pointTypeCounts operates in the same fashion as the above two, except
-      // that the key would be the ControlPoint::PointType you're searching for.
-      // For instance, if I wanted to know how many points were fixed I would query
-      // This map at key ControlPoint::Fixed and it would return how many fixed points there are.
+      //! The pointTypeCounts operates in the same fashion as the above two, except
+      //! that the key would be the ControlPoint::PointType you're searching for.
+      //! For instance, if I wanted to know how many points were fixed I would query
+      //!  This map at key ControlPoint::Fixed and it would return how many fixed points there are.
       QMap<ControlPoint::PointType, int> m_pointTypeCounts;
 
+      //! The number of ignored points in the network.
       int m_numPointsIgnored;
+      //! The number of edit locked points in the network.
       int m_numPointsLocked;
   };
 };

--- a/isis/src/control/objs/ControlPoint/ControlPoint.cpp
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.cpp
@@ -321,6 +321,16 @@ namespace Isis {
     return ControlMeasure::Success;
   }
 
+
+  /**
+   * This method is a wrapper to emit the measureModified() signal in the parent network
+   * is called whenever a change is made to a Control Measure.
+   *
+   * @param measure The ControlMeasure* that was modified.
+   * @param type The ControlMeasure::ModType indicating which modification occured.
+   * @param oldValue The oldValue before the change.
+   * @param newValue The new value that the change incorporated.
+   */
   void ControlPoint::emitMeasureModified(ControlMeasure *measure, ControlMeasure::ModType modType, QVariant oldValue, QVariant newValue) {
     if (parentNetwork) {
       parentNetwork->emitMeasureModified(measure, modType, oldValue, newValue);

--- a/isis/src/control/objs/ControlPoint/ControlPoint.h
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.h
@@ -428,6 +428,16 @@ namespace Isis {
 //      ZConstrained = 5;
       };
 
+      /**
+       *  @brief Control Point Modification Types
+       *
+       *  This enum is designed to represent the different types of modifications that can be
+       *  made to a ControlPoint.
+       *
+       *  EditLockModified means that the Control Point had it's edit lock flag changed.
+       *  IgnoredModified means that the Control Measure had it's ignored flag changed.
+       *  TypeModified means that the ControlPoint::PointType for this control point was modified.
+       */
       enum ModType {
         EditLockModified,
         IgnoredModified,


### PR DESCRIPTION
Removed QPoint include in ControlMeasure.cpp
Removed commented out code in ControlNet::MeasureDeleted()

Documented ModType Enums in ControlPoint, Measure, Net.
Documented ControlNetVitals member variables.
