### PR TITLE
Added m_numPoints and m_numMeasures member variable to cnetvitals.

### DIFF
--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
@@ -56,8 +56,10 @@ namespace Isis {
 
     m_islandList = m_controlNet->GetSerialConnections();
 
+    m_numPoints = 0;
     m_numPointsIgnored = 0;
     m_numPointsLocked = 0;
+    m_numMeasures = m_controlNet->GetNumMeasures();
 
     m_pointMeasureCounts.clear();
     m_imageMeasureCounts.clear();
@@ -117,7 +119,9 @@ namespace Isis {
    *  @param point The ControlPoint being added to the network.
    */
   void ControlNetVitals::addPoint(ControlPoint *point) {
+
     emitHistoryEntry("Control Point Added", point->GetId(), "", "");
+    m_numPoints++;
 
     if (point->IsIgnored()) {
       m_numPointsIgnored++;
@@ -271,6 +275,7 @@ namespace Isis {
   void ControlNetVitals::deletePoint(ControlPoint *point) {
 
     emitHistoryEntry("Control Point Deleted", point->GetId(), "", "");
+    m_numPoints--;
 
     if (point->IsIgnored()) {
       m_numPointsIgnored--;
@@ -305,6 +310,8 @@ namespace Isis {
    */
   void ControlNetVitals::addMeasure(ControlMeasure *measure) {
     emitHistoryEntry("Control Measure Added", measure->GetCubeSerialNumber(), "", "");
+    m_numMeasures++;
+
 
     ControlPoint *point = measure->Parent();
     if (point) {
@@ -390,7 +397,7 @@ namespace Isis {
   void ControlNetVitals::deleteMeasure(ControlMeasure *measure) {
 
     emitHistoryEntry("Control Measure Deleted", measure->GetCubeSerialNumber(), "", "");
-
+    m_numMeasures--;
 
     ControlPoint *point = measure->Parent();
     if (point) {
@@ -505,7 +512,7 @@ namespace Isis {
    *  @return The number of points in the Control Network.
    */
   int ControlNetVitals::numPoints() {
-    return m_controlNet->GetNumPoints();
+    return m_numPoints;
   }
 
 
@@ -599,7 +606,7 @@ namespace Isis {
    *  @return The number of measures in the Control Network.
    */
   int ControlNetVitals::numMeasures() {
-    return m_controlNet->GetNumMeasures();
+    return m_numMeasures;
   }
 
 

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
@@ -506,8 +506,7 @@ namespace Isis {
 
 
   /**
-   *  This method is designed to return the number of points in the observed Control Network.
-   *  It is a wrapper for the ControlNet::GetNumPoints() call of the observed Control Network.
+   *  This method is designed to return the number of points in the Control Network.
    *
    *  @return The number of points in the Control Network.
    */

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
@@ -58,7 +58,7 @@ namespace Isis {
   *    @history 2018-06-15 Adam Goins - Added documentation.
   *    @history 2018-06-25 Kristin Berry - Fixed problem with getImagesBelowMeasureThreshold().size()
   *                           not matching numImagesBelowMeasureThreshold(). Fixed a similar
-  *                           problem with numPointsBelowMeasureThreshold(). 
+  *                           problem with numPointsBelowMeasureThreshold().
   */
   class ControlNetVitals : public QObject {
     Q_OBJECT
@@ -142,8 +142,10 @@ namespace Isis {
       // This map at key ControlPoint::Fixed and it would return how many fixed points there are.
       QMap<ControlPoint::PointType, int> m_pointTypeCounts;
 
+      int m_numPoints;
       int m_numPointsIgnored;
       int m_numPointsLocked;
+      int m_numMeasures;
   };
 };
 

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.h
@@ -145,16 +145,16 @@ namespace Isis {
       //! The pointTypeCounts operates in the same fashion as the above two, except
       //! that the key would be the ControlPoint::PointType you're searching for.
       //! For instance, if I wanted to know how many points were fixed I would query
-      //!  This map at key ControlPoint::Fixed and it would return how many fixed points there are.
+      //! This map at key ControlPoint::Fixed and it would return how many fixed points there are.
       QMap<ControlPoint::PointType, int> m_pointTypeCounts;
 
-
+      //! The number of points in the network.
       int m_numPoints;
-
       //! The number of ignored points in the network.
       int m_numPointsIgnored;
       //! The number of edit locked points in the network.
       int m_numPointsLocked;
+      //! The number of measures in the network.
       int m_numMeasures;
   };
 };


### PR DESCRIPTION
Made local variables for these values rather than using the getters in ControlNet to reduce coupling with ControlNet and allow for accurate updates for these values.

NOTE: This branch is built off the cubeDn branch on my fork, in which a PR is currently up. That PR needs to be merged before this.