### PR TITLE
Changed boost edge bundled property to work without c++11 in ControlNet.

### DIFF
--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -415,7 +415,8 @@ namespace Isis {
       };
 
       struct Connection {
-        int strength = 0;
+        int strength;
+        Connection() : strength(0) {}
       };
 
       typedef boost::adjacency_list<boost::setS,


### PR DESCRIPTION
This fixes the build warnings we're seeing on mac.