### PR TITLE
Tweaked ControlNetVitals to keep island computation and counting in sync

### DIFF
--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -401,6 +401,7 @@ namespace Isis {
         newImage.serial = sn;
         ImageVertex newVertex = boost::add_vertex(newImage, m_controlGraph);
         m_vertexMap.insert(sn, newVertex);
+        emit networkModified(GraphModified);
       }
     }
 
@@ -422,20 +423,19 @@ namespace Isis {
           }
         }
       }
-      emit newMeasure(measure);
     }
     emit newPoint(point);
   }
 
 
   /**
-   * In the ControlNet graph: adds an edge between the verticies associated with the two serial 
-   * numbers provided. Or, if the edge already exists, increments the strength of the edge.  
-   * 
+   * In the ControlNet graph: adds an edge between the verticies associated with the two serial
+   * numbers provided. Or, if the edge already exists, increments the strength of the edge.
+   *
    * @param sourceSerial The first serial to be connected by the edge
    * @param targetSerial The second serial number to be connected by the edge
-   *  
-   * @return bool true if a new edge was added, false otherwise.  
+   *
+   * @return bool true if a new edge was added, false otherwise.
   */
   bool ControlNet::addEdge(QString sourceSerial, QString targetSerial) {
     // If the edge doesn't already exist, this adds and returns the edge.
@@ -446,20 +446,23 @@ namespace Isis {
 
     boost::tie(connection, edgeAdded) = boost::add_edge(m_vertexMap[sourceSerial],
                                                         m_vertexMap[targetSerial],
-                                                        m_controlGraph); 
+                                                        m_controlGraph);
     m_controlGraph[connection].strength++;
-    return edgeAdded; 
+    if (edgeAdded) {
+      emit networkModified(GraphModified);
+    }
+    return edgeAdded;
   }
 
 
   /**
-   * In the ControlNet graph, decrements the strength on the edge between the two serial numbers. 
-   * This is called when the ControlMeasures that connect these images are deleted or ignored. 
-   * If it is the last measure connecting two verticies (serial numbers) the edge is removed.  
-   * 
-   * @param sourceSerial The first serial number defining the end of the edge to have its strength 
+   * In the ControlNet graph, decrements the strength on the edge between the two serial numbers.
+   * This is called when the ControlMeasures that connect these images are deleted or ignored.
+   * If it is the last measure connecting two verticies (serial numbers) the edge is removed.
+   *
+   * @param sourceSerial The first serial number defining the end of the edge to have its strength
    *                     decremented or be removed.
-   * @param targetSerial The second serial number defining the other end of the edge to have its 
+   * @param targetSerial The second serial number defining the other end of the edge to have its
    *                     strength decremented or be removed.
    * @return bool true if the edge is removed, otherwise false
    */
@@ -475,6 +478,7 @@ namespace Isis {
         boost::remove_edge(m_vertexMap[sourceSerial],
                            m_vertexMap[targetSerial],
                            m_controlGraph);
+        emit networkModified(GraphModified);
 
         return true;
       }
@@ -599,6 +603,7 @@ namespace Isis {
       newImage.serial = serial;
       ImageVertex newVertex = boost::add_vertex(newImage, m_controlGraph);
       m_vertexMap.insert(serial, newVertex);
+      emit networkModified(GraphModified);
     }
 
     m_controlGraph[m_vertexMap[serial]].measures[measure->Parent()] = measure;
@@ -613,10 +618,7 @@ namespace Isis {
 
 
           if (QString::compare(sn, serial) != 0) {
-            bool edgeAdded = addEdge(serial, sn);
-            if (edgeAdded) {
-              emit networkModified(GraphModified);
-            }
+            addEdge(serial, sn);
           }
         }
       }
@@ -658,7 +660,7 @@ namespace Isis {
           msg += targetSerial + "]";
           throw IException(IException::Programmer, msg, _FILEINFO_);
         }
-        addEdge(sourceSerial, targetSerial); 
+        addEdge(sourceSerial, targetSerial);
       }
     }
   }
@@ -718,11 +720,7 @@ namespace Isis {
           QString sn = cm->GetCubeSerialNumber();
 
           if (QString::compare(sn, serial) != 0) {
-            bool edgeAdded = addEdge(serial, sn); 
-
-            if (edgeAdded) {
-              emit networkModified(GraphModified);
-            }
+            addEdge(serial, sn);
           }
         }
       }
@@ -847,9 +845,7 @@ namespace Isis {
       QString sn = adjacentMeasure->GetCubeSerialNumber();
       if (!adjacentMeasure->IsIgnored() && m_vertexMap.contains(sn)) {
         if (QString::compare(serial, sn) !=0) {
-          if( removeEdge(serial, sn) ) {
-            emit networkModified(GraphModified);
-          }
+          removeEdge(serial, sn);
         }
       }
     }

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -251,10 +251,12 @@ namespace Isis {
    *   @history 2018-06-25 Jesse Mapel - Fixed the incorrect signal being called when adding and
    *                           removing measures. References #5435.
    *   @history 2018-06-29 Kristin Berry - Added addEdge() and removeEdge() functions to make
-   *                           code cleaner. 
+   *                           code cleaner.
    *   @history 2018-06-25 Jesse Mapel - Fixed ignoring measures with ignored adjacent measures
    *                           incorrectly modifying the edge between the two image vertices.
-
+   *   @history 2018-07-06 Jesse Mapel - Modified addEdge and removeEdge to always emit a graph
+   *                           modified signal if an edge is added or removed. Added graph
+   *                           modified signal when a vertex is added.
    */
   class ControlNet : public QObject {
       Q_OBJECT
@@ -393,8 +395,8 @@ namespace Isis {
       void emitMeasureModified(ControlMeasure *measure, ControlMeasure::ModType type, QVariant oldValue, QVariant newValue);
       void emitPointModified(ControlPoint *point, ControlPoint::ModType type, QVariant oldValue, QVariant newValue);
       void pointAdded(ControlPoint *point);
-      bool addEdge(QString sourceSerial, QString targetSerial); 
-      bool removeEdge(QString sourceSerial, QString targetSerial); 
+      bool addEdge(QString sourceSerial, QString targetSerial);
+      bool removeEdge(QString sourceSerial, QString targetSerial);
 
     private: // graphing functions
       /**
@@ -427,41 +429,41 @@ namespace Isis {
 
       //! Used to define the verticies of the graph
       struct Image {
-        QString serial; //! The serial number associated with the image 
+        QString serial; //! The serial number associated with the image
         //! The measures on the image, hashed by pointers to their parent ControlPoints
-        QHash< ControlPoint *, ControlMeasure * > measures; 
+        QHash< ControlPoint *, ControlMeasure * > measures;
       };
 
-      //! Used to define the edges of the graph. 
+      //! Used to define the edges of the graph.
       struct Connection {
         int strength;
         Connection() : strength(0) {}
       };
 
-      //! Defines the graph type as an undirected graph that uses Images for verticies, 
-      //! and Connections for edges. It is defined as an adjacency list with the edge list 
-      //! represented by a set, the and vertex list represented by a list. 
+      //! Defines the graph type as an undirected graph that uses Images for verticies,
+      //! and Connections for edges. It is defined as an adjacency list with the edge list
+      //! represented by a set, the and vertex list represented by a list.
       typedef boost::adjacency_list<boost::setS,
                                     boost::listS,
                                     boost::undirectedS,
                                     Image,
-                                    Connection> Network; 
+                                    Connection> Network;
 
       typedef Network::vertex_descriptor ImageVertex; //! Reprents the verticies of the graph
       typedef Network::edge_descriptor ImageConnection; //! Represents the edges of the graph
 
       //! A map between an ImageVertex and its index
-      typedef std::map<ImageVertex, size_t> VertexIndexMap; 
+      typedef std::map<ImageVertex, size_t> VertexIndexMap;
 
       //! Converts VertexIndexMap into the appropriate form to be used by boost
-      typedef boost::associative_property_map<VertexIndexMap> VertexIndexMapAdaptor; 
+      typedef boost::associative_property_map<VertexIndexMap> VertexIndexMapAdaptor;
 
       //! Iterates over adjacent verticies
-      typedef boost::graph_traits<Network>::adjacency_iterator AdjacencyIterator; 
+      typedef boost::graph_traits<Network>::adjacency_iterator AdjacencyIterator;
 
       QHash<QString, ImageVertex> m_vertexMap; //! The serial number -> vertex hash used by the graph
       Network m_controlGraph; //! The ControlNet graph
-      QStringList *pointIds; 
+      QStringList *pointIds;
       QMutex *m_mutex;
 
       QString p_targetName;            //!< Name of the target

--- a/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
+++ b/isis/src/control/objs/ControlNetVitals/ControlNetVitals.cpp
@@ -142,6 +142,8 @@ namespace Isis {
     else {
       m_pointMeasureCounts[numValidMeasures]++;
     }
+
+    m_numMeasures = m_controlNet->GetNumMeasures();
     validate();
   }
 


### PR DESCRIPTION
The valid measures in image counting is currently not working correctly, but there is not time to fix it right now so it's been documented for work next year.