### PR TITLE
Changed the behavior of BundleSettings::observationSolveSettings(...)

### DIFF
--- a/isis/src/control/objs/BundleSettings/BundleSettings.cpp
+++ b/isis/src/control/objs/BundleSettings/BundleSettings.cpp
@@ -450,14 +450,17 @@ namespace Isis {
   BundleObservationSolveSettings
       BundleSettings::observationSolveSettings(QString observationNumber) const {
 
+    BundleObservationSolveSettings defaultSolveSettings;
+
     for (int i = 0; i < numberSolveSettings(); i++) {
       if (m_observationSolveSettings[i].observationNumbers().contains(observationNumber)) {
         return m_observationSolveSettings[i];
       }
     }
-    QString msg = "Unable to find BundleObservationSolveSettings for observation number ["
-                  + observationNumber + "].";
-    throw IException(IException::Unknown, msg, _FILEINFO_);
+    return defaultSolveSettings;
+    //QString msg = "Unable to find BundleObservationSolveSettings for observation number ["
+    //              + observationNumber + "].";
+   // throw IException(IException::Unknown, msg, _FILEINFO_);
   }
 
 

--- a/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
+++ b/isis/src/qisis/objs/JigsawSetupDialog/JigsawSetupDialog.cpp
@@ -485,8 +485,27 @@ namespace Isis {
 
     }
 
-    m_bundleSettings->setObservationSolveOptions(settings->observationSolveSettings());
+    // If we click setup after changing image selection in the project tree, not all images will
+    // have solve settings. Here we add those images and their default settings to the list
+    QList<BundleObservationSolveSettings> defaultSettings = m_bundleSettings->observationSolveSettings();
+    QList<BundleObservationSolveSettings> fillSettings = settings->observationSolveSettings();
 
+    for (auto &solveSettings : defaultSettings) {      
+      // Remove any images from defaultSettings that exist in fillSettings
+      foreach (QString observationNumber, solveSettings.observationNumbers()) {
+        // The method will return a default with no obs numbers if none are found
+        if (settings->observationSolveSettings(observationNumber).observationNumbers().isEmpty()) {
+          solveSettings.removeObservationNumber(observationNumber);
+        }
+      }
+      // Append leftover defaultSettings
+      if (!solveSettings.observationNumbers().isEmpty()) {
+        fillSettings.append(solveSettings);
+      }
+    }
+
+    m_bundleSettings->setObservationSolveOptions(fillSettings);
+    
     update();
 
   }


### PR DESCRIPTION
In the BOSS selection tree of the JSD , if you select a second group of images after applying BOSS settings to an initial group of images,  an error comes up that says "Unable to find BundleObservationSolveSettings."  and the GUI will not let you set BOSS settings for the second group of images.  This PR fixes that by changing the behavior of  BundleSettings::observationSolveSettings(QString observationNumber) by just returning a default BOSS object instead of throwing an exception.  