### PR TITLE
Removes the parent widget of a cneteditorview when discarding changes and changing an active control

### DIFF
--- a/isis/src/qisis/apps/ipce/IpceMainWindow.cpp
+++ b/isis/src/qisis/apps/ipce/IpceMainWindow.cpp
@@ -173,7 +173,7 @@ namespace Isis {
     initializeActions();
     createMenus();
     createToolBars();
-    
+
     QStringList args = QCoreApplication::arguments();
 
     if (args.count() == 2) {
@@ -232,8 +232,11 @@ namespace Isis {
    * @param view QWidget* The view to close.
    */
   void IpceMainWindow::removeView(QWidget *view) {
-    view->close();
+    QDockWidget *parentDock = qobject_cast<QDockWidget *>(view->parent());
+    removeDockWidget(parentDock);
+    m_viewDocks.removeAll(parentDock);
     delete view;
+    delete parentDock;
   }
 
 
@@ -261,13 +264,13 @@ namespace Isis {
   }
 
 
-  /** 
-   * This is needed so that the project clean flag is not set to false when move and resize events 
-   * are emitted from ipce.cpp when IpceMainWindow::show() is called. 
-   * The non-spontaneous or internal QShowEvent is only emitted once from ipce.cpp, so the project 
-   * clean flag can be reset. 
-   * 
-   * @param event QShowEvent* 
+  /**
+   * This is needed so that the project clean flag is not set to false when move and resize events
+   * are emitted from ipce.cpp when IpceMainWindow::show() is called.
+   * The non-spontaneous or internal QShowEvent is only emitted once from ipce.cpp, so the project
+   * clean flag can be reset.
+   *
+   * @param event QShowEvent*
    *
    */
   void IpceMainWindow::showEvent(QShowEvent *event) {
@@ -512,7 +515,7 @@ namespace Isis {
       globalSettings.setValue("geometry", QVariant(geometry()));
     }
 
-    globalSettings.setValue("maxThreadCount", m_maxThreadCount); 
+    globalSettings.setValue("maxThreadCount", m_maxThreadCount);
     globalSettings.setValue("maxRecentProjects",m_maxRecentProjects);
 
     globalSettings.beginGroup("recent_projects");
@@ -632,7 +635,7 @@ namespace Isis {
    *   @history Ian Humphrey - Settings are now read on a project name basis. References #4358.
    *   @history Tyler Wilson 2017-11-02 - Settings now read recent projects.  References #4492.
    *   @history Tyler Wilson 2017-11-13 - Commented out a resize call near the end because it
-   *                was messing with the positions of widgets after a project was loaded.  
+   *                was messing with the positions of widgets after a project was loaded.
    *                Fixes #5075.
    *   @history Makayla Shepherd 2018-06-10 - Settings are read from the project root ipce.config.
    *                If that does not exist then we read from .Isis/ipce/ipce.config.
@@ -643,7 +646,7 @@ namespace Isis {
       QString msg = "Cannot read settings with a NULL Project pointer.";
       throw IException(IException::Programmer, msg, _FILEINFO_);
     }
-    
+
     // Set the path of the settings file
     // The default is to assume that the project has an ipce.config in it
     // If the file does not exist then we read settings from .Isis/ipce/ipce.config
@@ -652,13 +655,13 @@ namespace Isis {
     bool isFullScreen = false;
     if (!FileName(filePath).fileExists()) {
       filePath = "$HOME/.Isis/" + appName + "/ipce.config";
-      // If the $HOME/.Isis/ipce/ipce.config does not exist then we want ipce to show up in 
+      // If the $HOME/.Isis/ipce/ipce.config does not exist then we want ipce to show up in
       // in full screen. In other words the default geometry is full screen
       if (!FileName(filePath).fileExists()) {
         isFullScreen = true;
       }
     }
-    
+
     if (project->name() == "Project") {
       setWindowTitle("ipce");
     }
@@ -667,7 +670,7 @@ namespace Isis {
     }
 
     QSettings projectSettings(FileName(filePath).expanded(), QSettings::NativeFormat);
-    
+
     if (!isFullScreen) {
       setGeometry(projectSettings.value("geometry").value<QRect>());
       if (!project->isTemporaryProject()) {
@@ -679,7 +682,7 @@ namespace Isis {
     }
 
     if (project->name() == "Project") {
-      QSettings globalSettings(FileName("$HOME/.Isis/" + appName + "/ipce.config").expanded(), 
+      QSettings globalSettings(FileName("$HOME/.Isis/" + appName + "/ipce.config").expanded(),
                               QSettings::NativeFormat);
 
       QStringList projectNameList;

--- a/isis/src/qisis/apps/ipce/IpceMainWindow.h
+++ b/isis/src/qisis/apps/ipce/IpceMainWindow.h
@@ -152,13 +152,16 @@ namespace Isis {
    *                           views does not always work with this enabled. With this option enabled, the
    *                           type of a view will randomly change and setting its type has no effect.
    *                           Use windowType() to get the type. Also added the toolbar title in the
-   *                           permanent toolbar constructor. 
+   *                           permanent toolbar constructor.
    *   @history 2018-06-22 Tracie Sucharski - Cleanup destruction of dock widgets and the views they
    *                           hold.  Extra destroy slots were causing double deletion of memory.
    *   @history 2018-06-22 Tracie Sucharski - Added a showEvent handler so that the project clean
    *                           state can be reset after the IpceMainWindow::show() causes resize and
    *                           move events which in turn cause the project clean flag to be false
    *                           even though the project has just opened.
+   *   @history 2018-07-09 Kaitlyn Lee - Changed removeView() to delete the parent dock widget. If we do
+   *                           not delete the dock widget, an empty dock widget will remain where the
+   *                           view used to be.
    */
   class IpceMainWindow : public QMainWindow {
       Q_OBJECT

--- a/isis/src/qisis/apps/ipce/IpceMainWindow.h
+++ b/isis/src/qisis/apps/ipce/IpceMainWindow.h
@@ -159,8 +159,9 @@ namespace Isis {
    *                           state can be reset after the IpceMainWindow::show() causes resize and
    *                           move events which in turn cause the project clean flag to be false
    *                           even though the project has just opened.
-   *   @history 2018-07-09 Kaitlyn Lee - Changed removeView() to delete the parent dock widget. If we do
-   *                           not delete the dock widget, an empty dock widget will remain where the
+   *   @history 2018-07-09 Kaitlyn Lee - Added tileViews() and the menu option to tile all docked/undocked
+   *                           and tabbed/untabbed views. Changed removeView() to delete the parent dock widget.
+   *                           If we do not delete the dock widget, an empty dock widget will remain where the
    *                           view used to be.
    */
   class IpceMainWindow : public QMainWindow {

--- a/isis/src/qisis/objs/Directory/Directory.cpp
+++ b/isis/src/qisis/objs/Directory/Directory.cpp
@@ -561,12 +561,10 @@ namespace Isis {
 
   void Directory::newActiveControl(bool newControl) {
 
-//  if (newControl && m_controlPointEditViewWidget) {
-//    bool closed = m_controlPointEditViewWidget->close();
-//    qDebug()<<"Directory::newActiveControl  CPEditor closed = "<<closed;
-//    emit viewClosed(m_controlPointEditViewWidget);
-//    delete m_controlPointEditViewWidget;
-//  }
+    if (newControl && m_controlPointEditViewWidget) {
+     emit viewClosed(m_controlPointEditViewWidget);
+     delete m_controlPointEditViewWidget;
+    }
 
     // If the new active control is the same as what is showing in the cnetEditorWidget, allow
     // editing of control points from the widget, otherwise turnoff from context menu
@@ -601,7 +599,7 @@ namespace Isis {
 
     connect( result, SIGNAL( destroyed(QObject *) ),
              this, SLOT( cleanupBundleObservationViews(QObject *) ) );
-             
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
              m_project, SLOT(setClean(bool)));
 
@@ -665,7 +663,7 @@ namespace Isis {
     // connect destroyed signal to cleanupCnetEditorViewWidgets slot
     connect(result, SIGNAL( destroyed(QObject *) ),
             this, SLOT( cleanupCnetEditorViewWidgets(QObject *) ) );
-            
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
             m_project, SLOT(setClean(bool)));
 
@@ -706,7 +704,7 @@ namespace Isis {
     m_cubeDnViewWidgets.append(result);
     connect( result, SIGNAL( destroyed(QObject *) ),
              this, SLOT( cleanupCubeDnViewWidgets(QObject *) ) );
-   
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
              m_project, SLOT(setClean(bool)));
 
@@ -751,10 +749,10 @@ namespace Isis {
 
     connect(result, SIGNAL(destroyed(QObject *)),
             this, SLOT(cleanupFootprint2DViewWidgets(QObject *)));
-            
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
             m_project, SLOT(setClean(bool)));
-                    
+
     emit newWidgetAvailable(result);
 
     //  Connections between mouse button events from footprint2DView and control point editing
@@ -867,7 +865,7 @@ namespace Isis {
               this, SLOT(makeBackupActiveControl()));
       connect (project(), SIGNAL(activeControlSet(bool)),
               result->controlPointEditWidget(), SLOT(setControlFromActive()));
-               
+
       connect(result, SIGNAL(windowChangeEvent(bool)),
               m_project, SLOT(setClean(bool)));
     }
@@ -902,7 +900,7 @@ namespace Isis {
 
     connect( result, SIGNAL( destroyed(QObject *) ),
              this, SLOT( cleanupMatrixViewWidgets(QObject *) ) );
-             
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
              m_project, SLOT(setClean(bool)));
 
@@ -926,7 +924,7 @@ namespace Isis {
 
     connect( result, SIGNAL( destroyed(QObject *) ),
              this, SLOT( cleanupTargetInfoWidgets(QObject *) ) );
-             
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
              m_project, SLOT(setClean(bool)));
 
@@ -950,7 +948,7 @@ namespace Isis {
 
     connect( result, SIGNAL( destroyed(QObject *) ),
              this, SLOT( cleanupTemplateEditorWidgets(QObject *) ) );
-             
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
              m_project, SLOT(setClean(bool)));
 
@@ -999,7 +997,7 @@ namespace Isis {
 
     connect( result, SIGNAL( destroyed(QObject *) ),
              this, SLOT( cleanupFileListWidgets(QObject *) ) );
-             
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
              m_project, SLOT(setClean(bool)));
 
@@ -1024,7 +1022,7 @@ namespace Isis {
     //  node located on the ProjectTreeView.
     connect(m_projectItemModel, SIGNAL(projectNameEdited(QString)),
             this, SLOT(initiateRenameProjectWorkOrder(QString)));
-            
+
     connect(result, SIGNAL(windowChangeEvent(bool)),
             m_project, SLOT(setClean(bool)));
 

--- a/isis/src/qisis/objs/Directory/Directory.h
+++ b/isis/src/qisis/objs/Directory/Directory.h
@@ -244,14 +244,15 @@ namespace Isis {
    *                           CubeDnView and Footprint2DView, instead of enabling the tool directly.
    *                           Removed  saveActiveControl() since users can save the control
    *                           network with the project save button.
-   *   @history 2018-06-18 Summer Stapleton - Added connection to each view on creation to 
+   *   @history 2018-06-18 Summer Stapleton - Added connection to each view on creation to
    *                           catch a windowChangeEvent on moveEvent or resizeEvent of these views
    *                           to allow for saving of the project at these times. Fixes #5114.
    *   @history 2018-06-07 Adam Goins - Added the addControlHealthMonitorView() method to directory.
    *                           Fixes #5435.
    *   @history 2018-06-19 Adam Goins - Gave the ControlHealthMonitorView() a reference to the
    *                           directory instance rather than the activeControl. Fixes #5435.
-   *
+   *   @history 2018-07-09 Kaitlyn Lee - Uncommented code that closes a ControlPointEditView when a new
+   *                           active control is set.
    */
   class Directory : public QObject {
     Q_OBJECT


### PR DESCRIPTION
When a user makes changes to an active control, but wants to change the active control and discards these changes, the old CnetEditorView used to not be deleted completely. Also, if a ControlPointEditView is open and a user discards changes, the view will close. 