### PR TITLE
Added missing @author/@internal/@history tags to header files.

### DIFF
--- a/isis/src/qisis/objs/ProgressBar/ProgressBar.h
+++ b/isis/src/qisis/objs/ProgressBar/ProgressBar.h
@@ -4,10 +4,11 @@
 #include <QProgressBar>
 
 namespace Isis {
-  /**
-   * @brief QProgressBar with customizable text
+  /**   
    *
    * @author ????-??-?? Steven Lambright
+   * @internal ????-??-?? Steven Lambright - QProgressBar with customizable text
+   *
    *                            
    */
 

--- a/isis/src/qisis/objs/SortFilterProxyModel/SortFilterProxyModel.h
+++ b/isis/src/qisis/objs/SortFilterProxyModel/SortFilterProxyModel.h
@@ -35,16 +35,13 @@ class QVariant;
 
 namespace Isis {
 
-  /**
-   * @brief A proxy class for filtering data within the JigsawSetupDialog
-   *    Bundle Observation Solve Settings (BOSS) tab.
-   *   
-   * @ingroup
+  /**  
    *
    * @author 2018-06-18 Tyler Wilson
    *
    * @internal
-   *   @history 2018-06-18 Tyler Wilson - Original version.
+   *   @history 2018-06-18 Tyler Wilson - Original version. A proxy class for filtering data
+   *   within the JigsawSetupDialog Bundle Observation Solve Settings (BOSS) tab.
    */
   
    class ProjectItem;

--- a/isis/src/qisis/objs/SubTreeProxyModel/SubTreeProxyModel.h
+++ b/isis/src/qisis/objs/SubTreeProxyModel/SubTreeProxyModel.h
@@ -13,6 +13,14 @@ class QVariant;
 
 namespace Isis {
   
+/**
+ *
+ * @author ????-??-?? Ian Humphrey
+ * @internal ????-??-?? Ian Humphrey
+ *
+ *
+ */
+
   class SubTreeProxyModel : public QIdentityProxyModel {
     Q_OBJECT
 

--- a/isis/src/qisis/objs/Template/Template.h
+++ b/isis/src/qisis/objs/Template/Template.h
@@ -34,11 +34,12 @@
    class FileName;
    class Project;
 
-   /**
-    * This represents an ISIS template in a project-based GUI interface.
-    * This encapsulates ideas about a template such as it's filename and import name.
-    *
+   /**   
     * @author 2017-11-01 Christopher Combs
+    * @internal
+    *   @history - 2017-11-01 Christopher Combs -  This represents an ISIS template in a
+    *                         project-based GUI interface.  This encapsulates ideas about a
+    *                         template such as it's filename and import name.
     */
    class Template : public QObject {
      Q_OBJECT
@@ -59,13 +60,13 @@
      void updateFileName(Project * project);
 
    private:
-     /**
-      * Nested class used to write the Template object information to an XML file for the
-      * purpose of saving and restoring the state of the project.
-      *
+     /**     
       * @author 2012-??-?? Steven Lambright
       *
       * @internal
+      *   @history 2012-??-?? Steven Lambright -  Nested class used to write the Template object
+      *                             information to an XML file for the purpose of saving and
+      *                             restoring the state of the project.
       */
      class XmlHandler : public XmlStackedHandler {
        public:

--- a/isis/src/qisis/objs/TemplateList/TemplateList.h
+++ b/isis/src/qisis/objs/TemplateList/TemplateList.h
@@ -34,11 +34,13 @@
 
  namespace Isis {
 
-   /**
-    * Maintains a list of Templates so that templates can easily be copied from one Project to
-    * another, saved to disk, or deleted from disk. Adapted from ControlList.
+   /**    
     *
     * @author 2017-11-01 Christopher Combs
+    * @internal
+    *   @history 2017-11-01 Christopher Combs - Maintains a list of Templates so that templates
+    *     can easily be copied from one Project to another, saved to disk, or deleted from disk.
+    *     Adapted from ControlList.
     */
    class TemplateList : public QObject, public QList<Template *> {
      Q_OBJECT
@@ -67,6 +69,14 @@
        QString m_type;
 
        class XmlHandler : public XmlStackedHandler {
+         /**
+          *
+          * @author 2017-11-01 Christopher Combs
+          * @internal
+          *   @history 2017-11-01 Christopher Combs - Maintains a list of Templates so that templates
+          *     can easily be copied from one Project to another, saved to disk, or deleted from disk.
+          *     Adapted from ControlList.
+          */
          public:
            XmlHandler(TemplateList *templateList, Project *project);
 


### PR DESCRIPTION
The isis3mgr script createReleaseNotesXML expects @author/@internal/@history entries in front of class declarations, and when it doesn't find them or when they are in the wrong order it will throw a warning.  This fixes:  https://isis.astrogeology.usgs.gov/fixit/issues/5462