### PR TITLE
Added 4-byte unsigned integer special pixel vals to  SpecialPixel.h

### DIFF
--- a/isis/src/base/objs/Blobber/Blobber.cpp
+++ b/isis/src/base/objs/Blobber/Blobber.cpp
@@ -241,4 +241,18 @@ namespace Isis {
 
   }
 
+
+  double Blobber::int2ToDouble(unsigned int value) const {
+    if (value == NULLUI4) return NULL8;
+    else if (value == LOW_REPR_SATUI4) return LOW_REPR_SAT8;
+    else if (value == LOW_INSTR_SATUI4) return LOW_INSTR_SAT8;
+    else if (value == HIGH_INSTR_SATUI4) return HIGH_INSTR_SAT8;
+    else if (value == HIGH_REPR_SATUI4) return HIGH_REPR_SAT8;
+    else return value;
+
+  }
+
+
+
+
 }  //  end namespace Isis

--- a/isis/src/base/objs/Blobber/Blobber.h
+++ b/isis/src/base/objs/Blobber/Blobber.h
@@ -108,6 +108,8 @@ namespace Isis {
    *                           coding standards. Added padding to control
    *                           statements. References #1169.
    *   @history 2017-08-30 Summer Stapleton - Updated documentation. References #4807.
+   *   @history 2018-07-20 Tyler Wilson - Overloaded the int2Double function so it can handle
+   *                       special pixel types for 4-byte unsigned integers.  References #971.
    */
   class Blobber {
     public:
@@ -262,6 +264,7 @@ namespace Isis {
 //  Low/level I/O and conversion methods
       void loadDouble(Table &tbl);
       void loadInteger(Table &tbl);
+      double int2ToDouble(unsigned int value) const;
       double int2ToDouble(int value) const;
   };
 };

--- a/isis/src/base/objs/Cube/CubeIoHandler.cpp
+++ b/isis/src/base/objs/Cube/CubeIoHandler.cpp
@@ -1508,6 +1508,40 @@ namespace Isis {
               ((unsigned short *)buffersRawBuf)[bufferIndex] = raw;
             }
 
+            else if(m_pixelType == UnsignedInteger) {
+
+              unsigned int raw = ((unsigned int *)chunkBuf)[chunkIndex];
+              if(m_byteSwapper)
+                raw = m_byteSwapper->Uint32_t(&raw);
+
+              if(raw >= VALID_MINUI4) {
+                bufferVal = (double) raw * m_multiplier + m_base;
+              }
+              else if (raw > VALID_MAXUI4) {
+                if(raw == HIGH_INSTR_SATUI4)
+                  bufferVal = HIGH_INSTR_SAT8;
+                else if(raw == HIGH_REPR_SATUI4)
+                  bufferVal = HIGH_REPR_SAT8;
+                else
+                  bufferVal = LOW_REPR_SAT8;
+              }
+              else {
+                if(raw == NULLUI4)
+                  bufferVal = NULL8;
+                else if(raw == LOW_INSTR_SATUI4)
+                  bufferVal = LOW_INSTR_SAT8;
+                else if(raw == LOW_REPR_SATUI4)
+                  bufferVal = LOW_REPR_SAT8;
+                else
+                  bufferVal = LOW_REPR_SAT8;
+              }
+
+              ((unsigned int *)buffersRawBuf)[bufferIndex] = raw;
+
+
+
+            }
+
             else if(m_pixelType == UnsignedByte) {
               unsigned char raw = ((unsigned char *)chunkBuf)[chunkIndex];
 
@@ -1626,6 +1660,7 @@ namespace Isis {
               ((float *)chunkBuf)[chunkIndex] =
                   m_byteSwapper ? m_byteSwapper->Float(&raw) : raw;
             }
+
             else if(m_pixelType == SignedWord) {
               short raw;
 
@@ -1670,6 +1705,55 @@ namespace Isis {
               ((short *)chunkBuf)[chunkIndex] =
                   m_byteSwapper ? m_byteSwapper->ShortInt(&raw) : raw;
             }
+
+            else if(m_pixelType == UnsignedInteger) {
+
+              unsigned int raw;
+
+              if(bufferVal >= VALID_MINUI4) {
+                double filePixelValueDbl = (bufferVal - m_base) /
+                    m_multiplier;
+                if(filePixelValueDbl < VALID_MINUI4 - 0.5) {
+                  raw = LOW_REPR_SATUI4;
+                }
+                if(filePixelValueDbl > VALID_MAXUI4) {
+                  raw = HIGH_REPR_SATUI4;
+                }
+                else {
+                  unsigned int filePixelValue = (unsigned int)round(filePixelValueDbl);
+
+                  if(filePixelValue < VALID_MINUI4) {
+                    raw = LOW_REPR_SATUI4;
+                  }
+                  else if(filePixelValue > VALID_MAXUI4) {
+                    raw = HIGH_REPR_SATUI4;
+                  }
+                  else {
+                    raw = filePixelValue;
+                  }
+                }
+              }
+              else {
+                if(bufferVal == NULLUI4)
+                  raw = NULLUI4;
+                else if(bufferVal == LOW_INSTR_SATUI4)
+                  raw = LOW_INSTR_SATUI4;
+                else if(bufferVal == LOW_REPR_SATUI4)
+                  raw = LOW_REPR_SATUI4;
+                else if(bufferVal == HIGH_INSTR_SATUI4)
+                  raw = HIGH_INSTR_SATUI4;
+                else if(bufferVal == HIGH_REPR_SATUI4)
+                  raw = HIGH_REPR_SATUI4;
+                else
+                  raw = LOW_REPR_SATUI4;
+              }
+
+              ((unsigned int *)chunkBuf)[chunkIndex] =
+                  m_byteSwapper ? m_byteSwapper->Uint32_t(&raw) : raw;
+
+            }
+
+
             else if(m_pixelType == UnsignedWord) {
               unsigned short raw;
 

--- a/isis/src/base/objs/Cube/CubeIoHandler.h
+++ b/isis/src/base/objs/Cube/CubeIoHandler.h
@@ -116,6 +116,9 @@ namespace Isis {
    *                           implementation causing warnings in clang. Part of OS X 10.11 porting.
    *                           QPair forward declaration now properly claims it as a struct.
    *   @history 2017-09-22 Cole Neubauer - Fixed documentation. References #4807
+   *   @history 2018-07-20 Tyler Wilson - Added support for unsigned integer special pixel values.
+   *                            in functions writeIntoRaw(...) and writeIntoDouble(...)
+   *                            References #971.
    */
   class CubeIoHandler {
     public:

--- a/isis/src/base/objs/ProcessImport/ProcessImport.cpp
+++ b/isis/src/base/objs/ProcessImport/ProcessImport.cpp
@@ -279,7 +279,7 @@ namespace Isis {
 
     if ((type == Isis::Double) || (type == Isis::Real) || (type == Isis::SignedWord) ||
         (type == Isis::UnsignedWord) || (type == Isis::UnsignedByte) ||
-        (type == Isis::SignedInteger)) {
+        (type == Isis::SignedInteger) || type==Isis::UnsignedInteger) {
       p_pixelType = type;
     }
     else {
@@ -1226,6 +1226,11 @@ namespace Isis {
         min = Isis::IVALID_MIN4;
         max = Isis::IVALID_MAX4;
       }
+
+      else if (p_pixelType == Isis::UnsignedInteger) {
+        min = Isis::VALID_MINUI4;
+        max = Isis::VALID_MAXUI4;
+      }
       else if (p_pixelType == Isis::SignedWord) {
         min = Isis::VALID_MIN2 * p_mult[0] + p_base[0];
         max = Isis::VALID_MAX2 * p_mult[0] + p_base[0];
@@ -1480,6 +1485,10 @@ namespace Isis {
             case Isis::SignedInteger:
               (*out)[samp] = (double)swapper.Int((int *)in+samp);
               break;
+
+          case Isis::UnsignedInteger:
+            (*out)[samp] = (double)swapper.Uint32_t((unsigned int *)in+samp);
+            break;
             case Isis::Real:
               if(p_vax_convert) {
                 (*out)[samp]= VAXConversion( (float *)in+samp );
@@ -1733,6 +1742,9 @@ namespace Isis {
             case Isis::SignedInteger:
               (*out)[samp] = (double)swapper.Int((int *)in+samp);
               break;
+          case Isis::UnsignedInteger:
+            (*out)[samp] = (double)swapper.Uint32_t((unsigned int *)in+samp);
+            break;
             case Isis::Real:
               if(p_vax_convert) {
                 (*out)[samp]= VAXConversion( (float *)in+samp );
@@ -1965,7 +1977,10 @@ namespace Isis {
               break;
             case Isis::SignedInteger:
               (*out)[samp] = (double)swapper.Int(&in[bufferIndex]);
-              break;
+              break;            
+          case Isis::UnsignedInteger:
+            (*out)[samp] = (double)swapper.Uint32_t(&in[bufferIndex]);
+            break;
             case Isis::Real:
               if(p_vax_convert) {
                 (*out)[osamp]= VAXConversion(&in[bufferIndex]);

--- a/isis/src/base/objs/ProcessImport/ProcessImport.h
+++ b/isis/src/base/objs/ProcessImport/ProcessImport.h
@@ -163,6 +163,8 @@ namespace Isis {
    *                           was made to accomodate Rosetta VIRTIS-m calibrated data files and
    *                           has no impact on other supported BIP files.
    *                           Fixes #5398.
+   *   @history 208-07-19 Tyler Wilson - Added support for 4-byte UnsignedInteger special pixel
+   *                            values.
    *
    */
   class ProcessImport : public Isis::Process {

--- a/isis/src/base/objs/SpecialPixel/SpecialPixel.h
+++ b/isis/src/base/objs/SpecialPixel/SpecialPixel.h
@@ -76,7 +76,7 @@ namespace Isis {
    *   @history 2016-04-20 Jeannie Backer - Added Janet Barret's changes
    *                           IVALID_MAX4 definition to handle SignedInteger
    *                           imports.
-   *   @history 2018-07-18 Tyler Wilson - Added 4-byte unsigned NULL value. (UINULL4)
+   *   @history 2018-07-18 Tyler Wilson - Added 4-byte unsigned int special pixel values.
    *
    *  @todo 2005-02-15 Kris Becker - finish class documentation
    *
@@ -144,8 +144,8 @@ namespace Isis {
   const int  IVALID_MIN4 = 0xFF7FFFFA;
   const float VALID_MIN4 = (*((const float *) &IVALID_MIN4));
 
+  //const int UINULL4 = 0xFF7FFFFB;
   const int  INULL4 = 0xFF7FFFFB;
-  const unsigned int UINULL4 = (unsigned int)INULL4;
   const float NULL4 = (*((const float *) &INULL4));
 
   const int  ILOW_REPR_SAT4 = 0xFF7FFFFC;
@@ -159,6 +159,7 @@ namespace Isis {
 
   const int  IHIGH_REPR_SAT4 = 0xFF7FFFFF;
   const float HIGH_REPR_SAT4 = (*((const float *) &IHIGH_REPR_SAT4));
+
 
   const float VALID_MAX4 = FLT_MAX;
   const int IVALID_MAX4  = (*((const int *) &VALID_MAX4));
@@ -180,6 +181,16 @@ namespace Isis {
   const unsigned short HIGH_INSTR_SATU2 = ((unsigned short)   65534);
   const unsigned short HIGH_REPR_SATU2  = ((unsigned short)   65535);
   const unsigned short VALID_MAXU2      = ((unsigned short)   65522);
+
+  // 4-byte unsigned special pixel values
+  const unsigned int VALID_MINUI4      = ((unsigned int)       3);
+  const unsigned int NULLUI4           = ((unsigned int)       0);
+  const unsigned int LOW_REPR_SATUI4   = ((unsigned int)       1);
+  const unsigned int LOW_INSTR_SATUI4  = ((unsigned int)       2);
+  const unsigned int HIGH_INSTR_SATUI4 = ((unsigned int)   4294967294);
+  const unsigned int HIGH_REPR_SATUI4  = ((unsigned int)   4294967295);
+  const unsigned int VALID_MAXUI4      = ((unsigned int)   4294967282);
+
 
   // 1-byte special pixel values
   const unsigned char VALID_MIN1      = ((unsigned char) 1);

--- a/isis/src/base/objs/SpecialPixel/SpecialPixel.h
+++ b/isis/src/base/objs/SpecialPixel/SpecialPixel.h
@@ -77,7 +77,7 @@ namespace Isis {
    *                           IVALID_MAX4 definition to handle SignedInteger
    *                           imports.
    *   @history 2018-07-18 Tyler Wilson - Added 4-byte unsigned int special pixel values.
-   *
+   *                           References #971.
    *  @todo 2005-02-15 Kris Becker - finish class documentation
    *
    */
@@ -144,7 +144,7 @@ namespace Isis {
   const int  IVALID_MIN4 = 0xFF7FFFFA;
   const float VALID_MIN4 = (*((const float *) &IVALID_MIN4));
 
-  //const int UINULL4 = 0xFF7FFFFB;
+
   const int  INULL4 = 0xFF7FFFFB;
   const float NULL4 = (*((const float *) &INULL4));
 

--- a/isis/src/base/objs/SpecialPixel/SpecialPixel.h
+++ b/isis/src/base/objs/SpecialPixel/SpecialPixel.h
@@ -76,6 +76,7 @@ namespace Isis {
    *   @history 2016-04-20 Jeannie Backer - Added Janet Barret's changes
    *                           IVALID_MAX4 definition to handle SignedInteger
    *                           imports.
+   *   @history 2018-07-18 Tyler Wilson - Added 4-byte unsigned NULL value. (UINULL4)
    *
    *  @todo 2005-02-15 Kris Becker - finish class documentation
    *
@@ -144,6 +145,7 @@ namespace Isis {
   const float VALID_MIN4 = (*((const float *) &IVALID_MIN4));
 
   const int  INULL4 = 0xFF7FFFFB;
+  const unsigned int UINULL4 = (unsigned int)INULL4;
   const float NULL4 = (*((const float *) &INULL4));
 
   const int  ILOW_REPR_SAT4 = 0xFF7FFFFC;

--- a/isis/src/base/objs/SpecialPixel/SpecialPixel.truth
+++ b/isis/src/base/objs/SpecialPixel/SpecialPixel.truth
@@ -17,6 +17,8 @@ Valid maximum (2 byte):           32767
 
 Valid minimum (4 byte):           -3.40282e+38
 Null (4 byte):                    -3.40282e+38
+INull (4 byte signed int):        ff7ffffb
+UINULL (4 byte unsigned int):     ff7ffffb
 Low Representation (4 byte):      -3.40282e+38
 Low Instrument (4 byte):          -3.40282e+38
 High Representation (4 byte):     -3.40282e+38

--- a/isis/src/base/objs/SpecialPixel/SpecialPixel.truth
+++ b/isis/src/base/objs/SpecialPixel/SpecialPixel.truth
@@ -17,8 +17,6 @@ Valid maximum (2 byte):           32767
 
 Valid minimum (4 byte):           -3.40282e+38
 Null (4 byte):                    -3.40282e+38
-INull (4 byte signed int):        ff7ffffb
-UINULL (4 byte unsigned int):     ff7ffffb
 Low Representation (4 byte):      -3.40282e+38
 Low Instrument (4 byte):          -3.40282e+38
 High Representation (4 byte):     -3.40282e+38

--- a/isis/src/base/objs/SpecialPixel/unitTest.cpp
+++ b/isis/src/base/objs/SpecialPixel/unitTest.cpp
@@ -5,6 +5,8 @@
 #include "SpecialPixel.h"
 #include "Preference.h"
 
+#include <climits>
+
 using namespace Isis;
 using namespace std;
 
@@ -33,6 +35,8 @@ int main(int argc, char *argv[]) {
 
   cout << "Valid minimum (4 byte):           " << Isis::VALID_MIN4 << endl;
   cout << "Null (4 byte):                    " << Isis::NULL4 << endl;
+  cout << "INull (4 byte signed int):        " << hex << Isis::INULL4 << endl;
+  cout << "UINULL (4 byte unsigned int):     " << hex << Isis::UINULL4 << endl;
   cout << "Low Representation (4 byte):      " << Isis::LOW_REPR_SAT4 << endl;
   cout << "Low Instrument (4 byte):          " << Isis::LOW_INSTR_SAT4 << endl;
   cout << "High Representation (4 byte):     " << Isis::HIGH_REPR_SAT4 << endl;
@@ -277,5 +281,14 @@ int main(int argc, char *argv[]) {
     e.print();
   }
   cout << endl;
+
+
+
+
+
+
+
+
+
 }
 

--- a/isis/src/base/objs/SpecialPixel/unitTest.cpp
+++ b/isis/src/base/objs/SpecialPixel/unitTest.cpp
@@ -34,9 +34,7 @@ int main(int argc, char *argv[]) {
   cout << endl;
 
   cout << "Valid minimum (4 byte):           " << Isis::VALID_MIN4 << endl;
-  cout << "Null (4 byte):                    " << Isis::NULL4 << endl;
-  cout << "INull (4 byte signed int):        " << hex << Isis::INULL4 << endl;
-  cout << "UINULL (4 byte unsigned int):     " << hex << Isis::UINULL4 << endl;
+  cout << "Null (4 byte):                    " << Isis::NULL4 << endl; 
   cout << "Low Representation (4 byte):      " << Isis::LOW_REPR_SAT4 << endl;
   cout << "Low Instrument (4 byte):          " << Isis::LOW_INSTR_SAT4 << endl;
   cout << "High Representation (4 byte):     " << Isis::HIGH_REPR_SAT4 << endl;
@@ -53,6 +51,8 @@ int main(int argc, char *argv[]) {
   cout << "High Instrument (8 byte):         " << Isis::HIGH_INSTR_SAT8 << endl;
   cout << "Valid maximum (8 byte):           " << Isis::VALID_MAX8 << endl;
   cout << endl;
+
+
 
   double d = 0.0;
   cout << "Testing 0.0 ... " << endl;
@@ -281,6 +281,7 @@ int main(int argc, char *argv[]) {
     e.print();
   }
   cout << endl;
+
 
 
 


### PR DESCRIPTION
I am emulating what has already been done for 2-byte unsigned shorts to maintain some consistency (even though splitting up the bytes between high and low values is weird).

