### PR TITLE
Added serialization to the Image class for image observation number.

### DIFF
--- a/isis/src/qisis/objs/Image/Image.cpp
+++ b/isis/src/qisis/objs/Image/Image.cpp
@@ -16,6 +16,7 @@
 #include <geos/io/WKTWriter.h>
 
 #include "Angle.h"
+#include "Camera.h"
 #include "Cube.h"
 #include "CubeAttribute.h"
 #include "DisplayProperties.h"
@@ -53,6 +54,10 @@ namespace Isis {
 
     m_fileName = imageFileName;
 
+    m_observationNumber = ObservationNumber::Compose(*(cube()));
+
+    m_serialNumber = SerialNumber::Compose(*(cube()));
+    
     cube();
 
     initCamStats();
@@ -88,6 +93,8 @@ namespace Isis {
     m_lineResolution = Null;
     m_sampleResolution = Null;
 
+    m_observationNumber = ObservationNumber::Compose(*(cube()));
+
     initCamStats();
 
     try {
@@ -115,6 +122,7 @@ namespace Isis {
     m_displayProperties = NULL;
     m_footprint = NULL;
     m_id = NULL;
+
 
     m_aspectRatio = Null;
     m_resolution = Null;
@@ -280,6 +288,7 @@ namespace Isis {
       m_cube = NULL;
     }
   }
+
 
 
   /**
@@ -600,6 +609,7 @@ namespace Isis {
     stream.writeAttribute("id", m_id->toString());
     stream.writeAttribute("fileName", FileName(m_fileName).name());
     stream.writeAttribute("instrumentId", m_instrumentId);
+    stream.writeAttribute("observationNumber",m_observationNumber);
     stream.writeAttribute("spacecraftName", m_spacecraftName);
 
     if (!IsSpecial(m_aspectRatio) ) {
@@ -825,9 +835,10 @@ namespace Isis {
 
     if (XmlStackedHandler::startElement(namespaceURI, localName, qName, atts)) {
       if (localName == "image") {
-        QString id = atts.value("id");
+        QString id = atts.value("id");     
         QString fileName = atts.value("fileName");
         QString instrumentId = atts.value("instrumentId");
+        QString observationNumber = atts.value("observationNumber");
         QString spacecraftName = atts.value("spacecraftName");
 
         QString aspectRatioStr = atts.value("aspectRatio");
@@ -852,6 +863,10 @@ namespace Isis {
 
         if (!instrumentId.isEmpty()) {
           m_image->m_instrumentId = instrumentId;
+        }
+
+        if (!observationNumber.isEmpty()) {
+          m_image->m_observationNumber = observationNumber;
         }
 
         if (!spacecraftName.isEmpty()) {

--- a/isis/src/qisis/objs/Image/Image.h
+++ b/isis/src/qisis/objs/Image/Image.h
@@ -99,6 +99,8 @@ namespace Isis {
    *                           after the first call to these methods are O(1) and are not
    *                           bottlenecekd by any file I/O that occurs in the Compose()
    *                           methods. References #497.
+   *   @history 2018-07-25 Tyler Wilson - Added serializtion for m_observationNumber.
+   *                           References #497.
    */
 
   class Image : public QObject {


### PR DESCRIPTION
Lacking this ability is an impediment to both sorting images by BOSS in the JSD tab as well as color-coding  to BOSS when loading the project from XML.  