### PR TITLE
Fix to "points not showing up in qnet" problem

### DIFF
--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -764,7 +764,6 @@ namespace Isis {
     // Conceptually, I think this belongs in measureIgnored, but it isn't done
     // for the old graph.
     m_controlGraph[m_vertexMap[serial]].measures.remove(measure->Parent());
-
   }
 
 
@@ -1819,7 +1818,6 @@ namespace Isis {
     std::swap(points, other.points);
     std::swap(pointIds, other.pointIds);
     m_controlGraph.swap(other.m_controlGraph);
-    std::swap(m_vertexMap, other.m_vertexMap);
     std::swap(m_mutex, other.m_mutex);
     std::swap(p_targetName, other.p_targetName);
     std::swap(p_networkId, other.p_networkId);
@@ -1833,7 +1831,7 @@ namespace Isis {
     std::swap(p_cameraList, other.p_cameraList);
     std::swap(p_targetRadii, other.p_targetRadii);
 
-    // points have parent pointers that need updated too...
+    // points have parent pointers that need to be updated too...
     QHashIterator< QString, ControlPoint * > i(*points);
     while (i.hasNext()) {
       i.next().value()->parentNetwork = this;
@@ -1860,6 +1858,14 @@ namespace Isis {
       // copy & swap
       ControlNet copy(other);
       swap(copy);
+    }
+
+    m_vertexMap.clear();
+    VertexIterator v, vend;
+    for (boost::tie(v, vend) = vertices(m_controlGraph); v != vend; ++v) {
+      ImageVertex imVertex = *v;
+      QString serialNum = m_controlGraph[*v].serial;
+      m_vertexMap[serialNum] = imVertex;
     }
 
     return *this;

--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -1841,6 +1841,15 @@ namespace Isis {
     while (i2.hasNext()) {
       i2.next().value()->parentNetwork = &other;
     }
+
+    m_vertexMap.clear();
+    VertexIterator v, vend;
+    for (boost::tie(v, vend) = vertices(m_controlGraph); v != vend; ++v) {
+      ImageVertex imVertex = *v;
+      QString serialNum = m_controlGraph[*v].serial;
+      m_vertexMap[serialNum] = imVertex;
+    }
+
     emit networkModified(ControlNet::Swapped);
   }
 
@@ -1858,14 +1867,6 @@ namespace Isis {
       // copy & swap
       ControlNet copy(other);
       swap(copy);
-    }
-
-    m_vertexMap.clear();
-    VertexIterator v, vend;
-    for (boost::tie(v, vend) = vertices(m_controlGraph); v != vend; ++v) {
-      ImageVertex imVertex = *v;
-      QString serialNum = m_controlGraph[*v].serial;
-      m_vertexMap[serialNum] = imVertex;
     }
 
     return *this;

--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -1850,6 +1850,14 @@ namespace Isis {
       m_vertexMap[serialNum] = imVertex;
     }
 
+    other.m_vertexMap.clear();
+    VertexIterator v2, vend2;
+    for (boost::tie(v2, vend2) = vertices(other.m_controlGraph); v2 != vend2; ++v2) {
+      ImageVertex imVertex = *v2;
+      QString serialNum = other.m_controlGraph[*v2].serial;
+      other.m_vertexMap[serialNum] = imVertex;
+    }
+
     emit networkModified(ControlNet::Swapped);
   }
 

--- a/isis/src/control/objs/ControlNet/ControlNet.cpp
+++ b/isis/src/control/objs/ControlNet/ControlNet.cpp
@@ -61,7 +61,6 @@ namespace Isis {
     p_modified = Application::DateTime();
   }
 
-
   ControlNet::ControlNet(const ControlNet &other) {
 
     nullify();
@@ -394,7 +393,6 @@ namespace Isis {
     // Make sure there is a node for every measure
     for (int i = 0; i < point->GetNumMeasures(); i++) {
       QString sn = point->GetMeasure(i)->GetCubeSerialNumber();
-
       // If the graph doesn't have the sn, add a node for it
       if (!m_vertexMap.contains(sn)) {
         Image newImage;
@@ -1820,6 +1818,8 @@ namespace Isis {
   void ControlNet::swap(ControlNet &other) {
     std::swap(points, other.points);
     std::swap(pointIds, other.pointIds);
+    m_controlGraph.swap(other.m_controlGraph);
+    std::swap(m_vertexMap, other.m_vertexMap);
     std::swap(m_mutex, other.m_mutex);
     std::swap(p_targetName, other.p_targetName);
     std::swap(p_networkId, other.p_networkId);
@@ -1843,9 +1843,7 @@ namespace Isis {
     while (i2.hasNext()) {
       i2.next().value()->parentNetwork = &other;
     }
-
     emit networkModified(ControlNet::Swapped);
-
   }
 
 

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -257,6 +257,7 @@ namespace Isis {
    *   @history 2018-07-06 Jesse Mapel - Modified addEdge and removeEdge to always emit a graph
    *                           modified signal if an edge is added or removed. Added graph
    *                           modified signal when a vertex is added.
+   *   @history 2018-07-22 Kristin Berry - Updated swap to include the graph and vertex map.
    */
   class ControlNet : public QObject {
       Q_OBJECT

--- a/isis/src/control/objs/ControlNet/ControlNet.h
+++ b/isis/src/control/objs/ControlNet/ControlNet.h
@@ -437,8 +437,8 @@ namespace Isis {
 
       //! Used to define the edges of the graph.
       struct Connection {
-        int strength;
         Connection() : strength(0) {}
+        int strength;
       };
 
       //! Defines the graph type as an undirected graph that uses Images for verticies,
@@ -461,6 +461,7 @@ namespace Isis {
 
       //! Iterates over adjacent verticies
       typedef boost::graph_traits<Network>::adjacency_iterator AdjacencyIterator;
+      typedef boost::graph_traits<Network>::vertex_iterator VertexIterator;
 
       QHash<QString, ImageVertex> m_vertexMap; //! The serial number -> vertex hash used by the graph
       Network m_controlGraph; //! The ControlNet graph


### PR DESCRIPTION
After merging the control net changes from ipce into dev, control measures no longer appeared in cubes opened in qnet. This PR fixes this issue. 

This was tested by Ethan. 