### PR TITLE
Fixed c++ compiler build warnings on prog28 and prog29

### DIFF
--- a/isis/src/base/objs/AtmosModel/unitTest.cpp
+++ b/isis/src/base/objs/AtmosModel/unitTest.cpp
@@ -411,19 +411,19 @@ int main() {
   try {
     AtmosModel::Ei(0.0); // require x > 0
   }
-  catch(IException e) {
+  catch(IException &e) {
     e.print();
   }
   try {
     AtmosModel::En(1, 0.0); // require (n>=0 & x>0) or (n>1 & x>=0)
   }
-  catch(IException e) {
+  catch(IException &e) {
     e.print();
   }
   try {
     AtmosModel::En(0, -1.0); // require (n>=0 & x>0) or (n>1 & x>=0)
   }
-  catch(IException e) {
+  catch(IException &e) {
     e.print();
   }
 

--- a/isis/src/base/objs/FunctionTools/unitTest.cpp
+++ b/isis/src/base/objs/FunctionTools/unitTest.cpp
@@ -32,19 +32,19 @@ public std::unary_function <double, double> {
 int main() {
 
   QList<double> roots;
-  
+
   /******************Testing realLinearRoots**************************/
   cerr << "Testing realLinearRoots\n";
-  cerr << "Equation: 3*X - 2 = 0.0  One real root\n"; 
+  cerr << "Equation: 3*X - 2 = 0.0  One real root\n";
   roots = FunctionTools::realLinearRoots(3.0,-2.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
   else
     foreach (const double root, roots)
       cerr << root << "  ";
-    
+
   cerr << endl;
-  cerr << "Equation: 0*X - 2 = 0.0  No roots\n"; 
+  cerr << "Equation: 0*X - 2 = 0.0  No roots\n";
   roots = FunctionTools::realLinearRoots(0,2);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -66,7 +66,7 @@ int main() {
   /******************Testing realQuadraticRoots**************************/
   cerr << endl << endl;
   cerr << "Testing realQuadraticRoots\n";
-  cerr << "Equation: 1.0*X^2 + -1.0*X - 2.0 = 0.0  Two real root\n"; 
+  cerr << "Equation: 1.0*X^2 + -1.0*X - 2.0 = 0.0  Two real root\n";
   roots = FunctionTools::realQuadraticRoots(1.0,-1.0,-2.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -75,7 +75,7 @@ int main() {
       cerr << root << "  ";
 
   cerr << endl;
-  cerr << "Equation: 1.0*X^2 + -4.0*X + 4.0 = 0.0  one double root\n"; 
+  cerr << "Equation: 1.0*X^2 + -4.0*X + 4.0 = 0.0  one double root\n";
   roots = FunctionTools::realQuadraticRoots(1.0,-4.0,4.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -85,7 +85,7 @@ int main() {
 
 
   cerr << endl;
-  cerr << "Equation: 0.0*X^2 + -4.0*X + 4.0 = 0.0  linear equation, one real root\n"; 
+  cerr << "Equation: 0.0*X^2 + -4.0*X + 4.0 = 0.0  linear equation, one real root\n";
   roots = FunctionTools::realQuadraticRoots(0.0,-4.0,4.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -94,7 +94,7 @@ int main() {
       cerr << root << "  ";
 
   cerr << endl;
-  cerr << "Equation: 3.0*X^2 + 0.0*X - 12.0 = 0.0  zero linear coeff, two real roots\n"; 
+  cerr << "Equation: 3.0*X^2 + 0.0*X - 12.0 = 0.0  zero linear coeff, two real roots\n";
   roots = FunctionTools::realQuadraticRoots(3.0,0.0,-12.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -103,7 +103,7 @@ int main() {
       cerr << root << "  ";
 
   cerr << endl;
-  cerr << "Equation: 3.0*X^2 + 0.0*X + 0.0 = 0.0  zero linear and const coeff, one double root\n"; 
+  cerr << "Equation: 3.0*X^2 + 0.0*X + 0.0 = 0.0  zero linear and const coeff, one double root\n";
   roots = FunctionTools::realQuadraticRoots(3.0,0.0,0.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -112,7 +112,7 @@ int main() {
       cerr << root << "  ";
 
   cerr << endl;
-  cerr << "Equation: 3.0*X^2 + -3.0*X + 0.0 = 0.0  zero const coeff, two real roots\n"; 
+  cerr << "Equation: 3.0*X^2 + -3.0*X + 0.0 = 0.0  zero const coeff, two real roots\n";
   roots = FunctionTools::realQuadraticRoots(3.0,-3.0,0.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -125,7 +125,7 @@ int main() {
   cerr << endl << endl;
   cerr << "Testing realCubicRoots\n";
   cerr << "Equation: 1.0*x^3 - 3.0*X^2 + 0.0*X + 4.0 = 0.0"
-           "  zero linear coeff, two real roots (one double)\n"; 
+           "  zero linear coeff, two real roots (one double)\n";
   roots = FunctionTools::realCubicRoots(1.0,-3.0,0.0,4.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -136,7 +136,7 @@ int main() {
 
   cerr << endl;
   cerr << "Equation: 1.0*x^3 - 4.0*X^2 + -7.0*X + 10.0 = 0.0"
-           "  three real roots\n"; 
+           "  three real roots\n";
   roots = FunctionTools::realCubicRoots(1.0,-4.0,-7.0,10.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -146,7 +146,7 @@ int main() {
 
   cerr << endl;
   cerr << "Equation: 1.0*x^3 + 1.0*X^2 + -2.0*X - 30.0 = 0.0"
-           "  one real root\n"; 
+           "  one real root\n";
   roots = FunctionTools::realCubicRoots(1.0,1.0,-2.0,-30.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -156,7 +156,7 @@ int main() {
 
   cerr << endl;
   cerr << "Equation: 1.0*x^3 + 0.0*X^2 + 0.0*X - 8.0 = 0.0"
-           "  zero quad and linear coeffs, one real root\n"; 
+           "  zero quad and linear coeffs, one real root\n";
   roots = FunctionTools::realCubicRoots(1.0,0.0,0.0,-8.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -167,7 +167,7 @@ int main() {
   //repeating some tests with non-one leading coefficients
   cerr << endl;
   cerr << "Equation: 2.0*x^3 - 8.0*X^2 + -14.0*X + 20.0 = 0.0"
-           "  three real roots\n"; 
+           "  three real roots\n";
   roots = FunctionTools::realCubicRoots(2.0,-8.0,-14.0,20.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -177,7 +177,7 @@ int main() {
 
   cerr << endl;
   cerr << "Equation: -2.0*x^3 + -2.0*X^2 + 4.0*X + 60.0 = 0.0"
-           "  one real root\n"; 
+           "  one real root\n";
   roots = FunctionTools::realCubicRoots(-2.0,-2.0,4.0,60.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -187,7 +187,7 @@ int main() {
 
   cerr << endl;
   cerr << "Equation: 3.0*x^3 + 0.0*X^2 + 0.0*X - 24.0 = 0.0"
-           "  zero quad and linear coeffs, one real root\n"; 
+           "  zero quad and linear coeffs, one real root\n";
   roots = FunctionTools::realCubicRoots(3.0,0.0,0.0,-24.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -197,7 +197,7 @@ int main() {
 
   cerr << endl;
   cerr << "Equation: -3.0*x^3 + 0.0*X^2 + 0.0*X - 24.0 = 0.0"
-           "  zero quad and linear coeffs, one real root\n"; 
+           "  zero quad and linear coeffs, one real root\n";
   roots = FunctionTools::realCubicRoots(-3.0,0.0,0.0,24.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -210,7 +210,7 @@ int main() {
   //fall backs to less complicated polys
   cerr << endl;
   cerr << "Equation: 0.0*x^3 + 1.0*X^2 + 0.0*X - 4.0 = 0.0"
-           "  fall back to quadratic math, two real roots\n"; 
+           "  fall back to quadratic math, two real roots\n";
   roots = FunctionTools::realCubicRoots(0.0,1.0,0.0,-4.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -220,7 +220,7 @@ int main() {
 
   cerr << endl;
   cerr << "Equation: 0.0*x^3 + 0.0*X^2 + 1.0*X - 4.0 = 0.0"
-           "  fall back to linear math, one real root\n"; 
+           "  fall back to linear math, one real root\n";
   roots = FunctionTools::realCubicRoots(0.0,0.0,1.0,-4.0);
   cerr << "solutions: ";
   if (roots.size() == 0.0) cerr << "Empty Set";
@@ -245,7 +245,7 @@ int main() {
   try {
     FunctionTools::brentsRootFinder(func,point1,point2,1e-6,100,root);
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -261,10 +261,10 @@ int main() {
   try {
     FunctionTools::brentsRootFinder(errorFunc,point1,point2,1e-6,100,root);
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
-  
+
   cerr << endl;
 
   //actually finding a root now
@@ -279,7 +279,7 @@ int main() {
   try {
     FunctionTools::brentsRootFinder(func,point1,point2,1e-6,100,root);
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   cerr << "Root Found: " << root << endl;

--- a/isis/src/base/objs/IdealCamera/unitTest.cpp
+++ b/isis/src/base/objs/IdealCamera/unitTest.cpp
@@ -2,17 +2,17 @@
  * @file
  *
  *   Unless noted otherwise, the portions of Isis written by the USGS are public
- *   domain. See individual third-party library and package descriptions for 
+ *   domain. See individual third-party library and package descriptions for
  *   intellectual property information,user agreements, and related information.
  *
  *   Although Isis has been used by the USGS, no warranty, expressed or implied,
- *   is made by the USGS as to the accuracy and functioning of such software 
- *   and related material nor shall the fact of distribution constitute any such 
- *   warranty, and no responsibility is assumed by the USGS in connection 
+ *   is made by the USGS as to the accuracy and functioning of such software
+ *   and related material nor shall the fact of distribution constitute any such
+ *   warranty, and no responsibility is assumed by the USGS in connection
  *   therewith.
  *
  *   For additional information, launch
- *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see 
+ *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see
  *   the Privacy &amp; Disclaimers page on the Isis website,
  *   http://isis.astrogeology.usgs.gov, and the USGS privacy and disclaimers on
  *   http://www.usgs.gov/privacy.html.
@@ -54,13 +54,13 @@ int main(void) {
       cam = CameraFactory::Create(cube);
       cout << "FileName: " << FileName(files[i]).name() << endl;
       cout << "CK Frame: " << cam->instrumentRotation()->Frame() << endl << endl;
-      
+
       // Test name methods
       cout << "Spacecraft Name Long: " << cam->spacecraftNameLong() << endl;
       cout << "Spacecraft Name Short: " << cam->spacecraftNameShort() << endl;
       cout << "Instrument Name Long: " << cam->instrumentNameLong() << endl;
       cout << "Instrument Name Short: " << cam->instrumentNameShort() << endl << endl;
-      
+
       cout.setf(std::ios::fixed);
       cout << setprecision(9);
 
@@ -105,13 +105,13 @@ int main(void) {
     // Test kernel ID messages
     cout << "Kernel ID error messages: " << endl;
     try{ cam->CkFrameId(); }
-    catch (IException e){ e.print(); }
+    catch (IException &e){ e.print(); }
     try{ cam->CkReferenceId(); }
-    catch (IException e){ e.print(); }
+    catch (IException &e){ e.print(); }
     try{ cam->SpkTargetId(); }
-    catch (IException e){ e.print(); }
+    catch (IException &e){ e.print(); }
     try{ cam->SpkReferenceId(); }
-    catch (IException e){ e.print(); }
+    catch (IException &e){ e.print(); }
     delete cam;
   }
   catch(IException &e) {

--- a/isis/src/base/objs/InfixToPostfix/unitTest.cpp
+++ b/isis/src/base/objs/InfixToPostfix/unitTest.cpp
@@ -54,7 +54,7 @@ int main(int argc, char *argv[]) {
       QString postfix = converter.convert(equations[equation]);
       cout << "   Postfix: '" << postfix << "'" << endl;
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
   }

--- a/isis/src/base/objs/NumericalApproximation/unitTest.cpp
+++ b/isis/src/base/objs/NumericalApproximation/unitTest.cpp
@@ -102,7 +102,7 @@ int main(int argc, char *argv[]) {
     try {
       interp.SetInterpType(NumericalApproximation::InterpType(11));
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     cout << "\t************************************************" << endl;
@@ -131,7 +131,7 @@ int main(int argc, char *argv[]) {
       y.pop_back();
       NumericalApproximation uneven(x, y);
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     cout << "\t************************************************" << endl;
@@ -177,14 +177,14 @@ int main(int argc, char *argv[]) {
       interp2.AddData(0, .8);
       interp2.DomainMinimum();
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     interp2.Reset();
     try { // DATA SET IS LESS THAN MINPOINTS
       interp2.DomainMaximum();
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     interp2.AddData(x, y);
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]) {
     try {
       interp4.Evaluate(.5);
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     interp4.SetCubicClampedEndptDeriv(fstderiv(x[0]), fstderiv(x[x.size()-1]));
@@ -202,14 +202,14 @@ int main(int argc, char *argv[]) {
       interp4.AddData(.9, f(.9));
       interp4.Evaluate(.5);
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try { // CubicClamped DATA SET IS NOT IN ASCENDING ORDER
       interp4.AddData(.5, f(.5));
       interp4.DomainMinimum();
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     // restore interp4 object
@@ -222,7 +222,7 @@ int main(int argc, char *argv[]) {
       interp5.SetInterpType(NumericalApproximation::CubicNatPeriodic);
       interp5.DomainMinimum();
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     interp5.Reset(NumericalApproximation::PolynomialNeville);
@@ -232,7 +232,7 @@ int main(int argc, char *argv[]) {
     try { //  DATA SET SIZE DOESN'T MATCH NUMBER OF DERIVATIVES ADDED
       interp6.AddCubicHermiteDeriv(fstderiv(3));
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     interp6.Reset();
@@ -311,35 +311,35 @@ int main(int argc, char *argv[]) {
     try {
       interp2.Evaluate(.9);
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     // Test outside domain Extrapolate throws exception for GSL
     try {
       interp2.Evaluate(.9, NumericalApproximation::Extrapolate);
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     // Test outside domain Extrapolate throws exception for CubicNeighborhood
     try {
       interp3.Evaluate(.9, NumericalApproximation::Extrapolate);
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     // interp2 IS NOT OF INTERP TYPE polynomial-Neville
     try {
       interp2.PolynomialNevilleErrorEstimate();
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try { // Evaluate() HAS NOT BEEN CALLED
       interp2.SetInterpType(NumericalApproximation::PolynomialNeville);
       interp2.PolynomialNevilleErrorEstimate();
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     // Test Reset() and restore the state of interp2
@@ -398,133 +398,133 @@ int main(int argc, char *argv[]) {
     try {
       interp2.GslFirstDerivative(1.0); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.GslFirstDerivative(0.2); // not GSL supported
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.BackwardFirstDifference(-1.0); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.BackwardFirstDifference(0.01, 2, .1); // steps outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.BackwardFirstDifference(0.1, 4, .01); // no 4pt formula
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.ForwardFirstDifference(-0.01); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.ForwardFirstDifference(0.75, 3, .1); // steps outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.ForwardFirstDifference(0.1, 4, .01); // no 4pt formula
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.CenterFirstDifference(.81); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.CenterFirstDifference(0.01, 5, .1); // steps outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.CenterFirstDifference(0.1, 4, .01); // no 4pt formula
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp1.GslSecondDerivative(1.0); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.GslSecondDerivative(0.8); // not GSL supported
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.BackwardSecondDifference(-1.0); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.BackwardSecondDifference(0.01, 3, .1); // steps outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.BackwardSecondDifference(0.1, 2, .01); // no 2pt formula
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.ForwardSecondDifference(-0.01); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.ForwardSecondDifference(0.75, 3, .1); // steps outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.ForwardSecondDifference(0.1, 2, .01); // no 2pt formula
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.CenterSecondDifference(.81); // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.CenterSecondDifference(0.01, 5, .1); // steps outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       interp3.CenterSecondDifference(0.1, 4, .01); // no 4pt formula
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     //interp2.AddData(x,y);
@@ -572,31 +572,31 @@ int main(int argc, char *argv[]) {
     try {
       cout << interp1.GslIntegral(1.1, 1.0) << endl; // invalid interval
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       cout << interp1.GslIntegral(1.0, 1.1) << endl; // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       cout << interp3.GslIntegral(0.0, 0.8) << endl; // not GSL supported
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       cout << interp1.TrapezoidalRule(.81, .70) << endl; // invalid interval
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     try {
       cout << interp1.TrapezoidalRule(-.1, .70) << endl; // outside domain
     }
-    catch(IException e) {
+    catch(IException &e) {
       e.print();
     }
     cout << "\t************************************************" << endl;

--- a/isis/src/base/objs/ProcessImport/unitTest.cpp
+++ b/isis/src/base/objs/ProcessImport/unitTest.cpp
@@ -78,11 +78,11 @@ void IsisMain() {
   core_cub.StartProcess();
   core_cub.EndProcess();
 
- 
+
 
   ProcessImport suffix_cub;
-  
-  
+
+
   suffix_cub.SetInputFile("$base/testData/30i001ci.qub");
   QString suffixFile = Application::GetUserInterface().GetFileName("SUFFIX_CUBE");
   suffix_cub.SetVAXConvert(true);
@@ -101,11 +101,11 @@ void IsisMain() {
   suffix_cub.SetOrganization(ProcessImport::BSQ);
   suffix_cub.SetOutputCube("SUFFIX_CUBE");
 
-  suffix_cub.SetSuffixOffset(47,46,12,4);  
+  suffix_cub.SetSuffixOffset(47,46,12,4);
 
   suffix_cub.StartProcess();
   suffix_cub.EndProcess();
- 
+
 
 
 
@@ -120,28 +120,28 @@ void IsisMain() {
   try { // Should NOT throw an error
     pNull.SetNull(0.0, 45.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
   try { // Should throw an error
     pNull.SetLRS(35.0, 55.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
   try { // Should NOT throw an error
     pNull.SetLIS(50.0, 52.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
   try { // Should throw an error
     pNull.SetHRS(-10.0, 5.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
@@ -151,35 +151,35 @@ void IsisMain() {
   try { // Should throw an error
     pLRS.SetNull(35.0, 55.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
   try { // Should throw an error
     pNull.SetLIS(0.0, 15.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
   try { // Should throw an error
     pLRS.SetHIS(-10.0, 155.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
   try { // Should NOT throw an error
     pLRS.SetHIS(145.0, 155.0);
   }
-  catch(IException e) {
+  catch(IException &e) {
     cout << e.toString() << endl;
   }
   cout << endl;
 
   cout << "Testing ProcessBil()" << endl;
   ProcessImport p3;
- 
+
   p3.SetInputFile("$base/testData/isisTruth.dat");
   p3.SetBase(0.0);
   p3.SetMultiplier(1.0);

--- a/isis/src/base/objs/TableField/unitTest.cpp
+++ b/isis/src/base/objs/TableField/unitTest.cpp
@@ -224,13 +224,13 @@ int main(int argc, char *argv[]) {
   try {
     cout << int(dblSingletonField) << endl; // try to cast a non-Integer type
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     cout << int(intVectorField3); // try to cast an Integer type with multiple values
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -239,13 +239,13 @@ int main(int argc, char *argv[]) {
   try {
     cout << double(textField); // try to cast a non-Double type
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     cout << double(dblVectorField3); // try to cast a Double type with multiple values
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -254,7 +254,7 @@ int main(int argc, char *argv[]) {
   try {
     cout << QString(realSingletonField); // try to cast a non-Text type
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -263,13 +263,13 @@ int main(int argc, char *argv[]) {
   try {
     cout << float(intSingletonField); // try to cast a non-Real type
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     cout << float(realVectorField3); // try to cast a Real type with multiple values
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -278,7 +278,7 @@ int main(int argc, char *argv[]) {
   try {
     vector<int> error = dblSingletonField; // try to cast a non Integer type
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -287,7 +287,7 @@ int main(int argc, char *argv[]) {
   try {
     vector<double> error = realSingletonField; // try to cast a non Double type
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -296,7 +296,7 @@ int main(int argc, char *argv[]) {
   try {
     vector<float> error = intVectorField3; // try to cast a non Real type
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -306,13 +306,13 @@ int main(int argc, char *argv[]) {
   try {
     realSingletonField = (int) 1; // try to set Real type to non-float value
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     intVectorField3 = (int) 1; // try to set single value to vector Field
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -321,13 +321,13 @@ int main(int argc, char *argv[]) {
   try {
     intSingletonField = (double) 3.14; // try to set Integer type to non-integer value
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     dblVectorField3 = (double) 3.14; // try to set single value to vector Field
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -336,7 +336,7 @@ int main(int argc, char *argv[]) {
   try {
     dblSingletonField = "Error"; // try to set Double type to non-double value
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -345,13 +345,13 @@ int main(int argc, char *argv[]) {
   try {
     textField = (float) 3.14; // try to set Text type to non-string value
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     realVectorField3 = (float) 3.14; // try to set single value to vector Field
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -364,13 +364,13 @@ int main(int argc, char *argv[]) {
   try {
     intVectorField3 = intVector2; // try to set wrong size vector
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     realVectorField3 = intVector2;  // try to set float vector to intVector
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -379,13 +379,13 @@ int main(int argc, char *argv[]) {
   try {
     dblVectorField3 = doubleVector2; // try to set wrong size vector
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     intVectorField3 = doubleVector2;  // try to set int vector to double vector
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
@@ -394,13 +394,13 @@ int main(int argc, char *argv[]) {
   try {
     realVectorField3 = floatVector2;  // try to set wrong size vector
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   try {
     dblVectorField3 = floatVector2;  // try to set double vector to float vector
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
   cout << "----------------------------------------" << endl << endl;

--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0001.cpp
@@ -546,7 +546,7 @@ namespace Isis {
         try {
           value = toDouble(dataKeyword[0]);
         }
-        catch (IException e) {
+        catch (IException &e) {
           QString msg = "Invalid control measure log data value [" + dataKeyword[0] + "]";
           throw IException(e, IException::Io, msg, _FILEINFO_);
         }

--- a/isis/src/control/objs/ControlNetVersioner/ControlPointV0002.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlPointV0002.cpp
@@ -296,7 +296,7 @@ namespace Isis {
         try {
           value = toDouble(dataKeyword[0]);
         }
-        catch (IException e) {
+        catch (IException &e) {
           QString msg = "Invalid control measure log data value [" + dataKeyword[0] + "]";
           throw IException(e, IException::Io, msg, _FILEINFO_);
         }

--- a/isis/src/lro/apps/lromakeflat/lromakeflat.cpp
+++ b/isis/src/lro/apps/lromakeflat/lromakeflat.cpp
@@ -2,9 +2,9 @@
  * @Brief This application creates three flatfield (Sensitivity Non-Uniformity Matrix) cubes used for calibration
  *
  * This application creates three flatfield (Sensitivity Non-Uniformity Matrix) cubes used for calibration.
- * The cubes consist of median, mean, and standard deviation values per pixel. Process varies for the three 
- * cameras this application can be used for but general pixel stacking column approach is the same. The 
- * three camera types are line-scan, push-frame, and framing. Invalid pixel values are changed to Isis::Null. 
+ * The cubes consist of median, mean, and standard deviation values per pixel. Process varies for the three
+ * cameras this application can be used for but general pixel stacking column approach is the same. The
+ * three camera types are line-scan, push-frame, and framing. Invalid pixel values are changed to Isis::Null.
  *
  * The application uses a two step process.
  *
@@ -12,19 +12,19 @@
  *
  * The first part of the process is to stack cube pixels at their respective pixel locations.
  *
- * These stacked pixels are processed to produce the median, mean, and standard deviation values for the 
- * pixel location, and to toss out invalid pixel values.  Normalization can also be done at this time if 
- * images were not normalized prior. The mean is used to normalize images. 
+ * These stacked pixels are processed to produce the median, mean, and standard deviation values for the
+ * pixel location, and to toss out invalid pixel values.  Normalization can also be done at this time if
+ * images were not normalized prior. The mean is used to normalize images.
  *
  * Step #2 - PROCESSING STACKED PIXEL COLUMNS AND TRANSFERRING TO SNU
  *
- * Once pixels have been stacked into pixel columns mean and median averages, and standard devation for that 
+ * Once pixels have been stacked into pixel columns mean and median averages, and standard devation for that
  * pixel location is saved to the SNU matrix (flatfield cubes).
  *
  * Mean
  *  -The summed pixels are divided by the number of pixels.
- * Standard Deviation 
- *  -The mean average is used to calculate the standard deviation. 
+ * Standard Deviation
+ *  -The mean average is used to calculate the standard deviation.
  * Median
  *  -The pixel column is sorted and the median is obtained.
  *
@@ -91,7 +91,7 @@ vector < PvlObject > g_excludedDetails;
    *
    * Computes flatfield image for linescan, pushbroom, and framing
    * Cameras
-   * 
+   *
    * @throws IException::User "Only single band images accepted"
    * @throws IException::User "User selected lines value exceeds number of lines in cube"
    * @throws IException::Programmer "Could not write to output cube"
@@ -100,7 +100,7 @@ vector < PvlObject > g_excludedDetails;
    *
    * @internal
    *   @history 2016-08-17 Victor Silva - New app for lroc adapted from makeflat app
-   *                         
+   *
    */
 void IsisMain() {
 
@@ -115,7 +115,7 @@ void IsisMain() {
   int cubeWidthPixels = 0, frameHeightLines = 0, framesPerCube, frameLineCount;
 
   // Setup Sensitivity Non-uniformity Matrix cubes (flatfielding matrix) and line managers
-  Cube *oStdevCube = NULL, *oMedianCube = NULL, *oMeanCube = NULL; 
+  Cube *oStdevCube = NULL, *oMedianCube = NULL, *oMeanCube = NULL;
   LineManager *oStdevlineMgr = NULL, *oMeanLineMgr = NULL, *oMedianLineMgr = NULL;
 
   // Get some info from first cube in list
@@ -144,7 +144,7 @@ void IsisMain() {
     oLineCount = 1;
     frameLineCount = abs(ui.GetInteger("NUMLINES"));
     if (iLineCount != frameLineCount) {
-      string err = "User selected lines value (" + IString(frameLineCount) + 
+      string err = "User selected lines value (" + IString(frameLineCount) +
          ") exceeds number of lines in cube (" + IString(iLineCount) + ". \n";
       throw IException(IException::User, err, _FILEINFO_);
     }
@@ -192,7 +192,7 @@ void IsisMain() {
       tmp2.open(g_list[listIndex].toString());
       // Only run for cubes with one band
       if (tmp2.bandCount() != 1) {
-        string err = "Warning: This cube has too many bands(" + IString(tmp2.bandCount()) + 
+        string err = "Warning: This cube has too many bands(" + IString(tmp2.bandCount()) +
           " and will be excluded). Only single band images accepted. \n";
         cerr << err << endl;
         exclude(listIndex, err);
@@ -201,7 +201,7 @@ void IsisMain() {
       }
       // Reset frame for every cube in list
       int frame = 0;
-      // Cube line has to match oLine as we are slicing the cubes one line at a time to stack pixels 
+      // Cube line has to match oLine as we are slicing the cubes one line at a time to stack pixels
       for (long cubeLine = oLine; cubeLine <= iLineCount; cubeLine = cubeLine + frameLineCount) {
         LineManager cubeMgr(tmp2);
         cubeMgr.SetLine(cubeLine);
@@ -211,7 +211,7 @@ void IsisMain() {
         for (int column = 0; column < g_sampleCount; column++) {
           pixelVal = cubeMgr[column];
           int frameIndex = listIndex * framesPerCube + frame;
-          // If frame avg is zero, will cause div/zero error. Set pixel to 0? nil?  
+          // If frame avg is zero, will cause div/zero error. Set pixel to 0? nil?
           (normMatrix[listIndex][frame])? pixelVal = (pixelVal/(normMatrix[listIndex][frame])):pixelVal = Isis::Null;
           pixelMatrix[column][frameIndex] = pixelVal;
         }
@@ -239,7 +239,7 @@ void IsisMain() {
       oMeanCube->write(*oMeanLineMgr);
       oMedianCube->write(*oMedianLineMgr);
     }
-    catch (IException e) {
+    catch (IException &e) {
       //cout << "It's no use at this point. Just go. Leave me here. I'll only slow you down.";
       string err = "Could not write to output cube " + IString(FileName(ui.GetFileName("TO")).expanded()) + ".\n";
       throw IException(IException::Programmer, err, _FILEINFO_);
@@ -298,7 +298,7 @@ void IsisMain() {
  * @param int frameHeight size of frame in rows
  * @param long frameLineCount number of lines to make a frame
  * @param long iLineCount number of lines total in cube
- * 
+ *
  * @throws IException::User "This selection will yield less than 1 pixel (width). This is not enough to normalize."
  * @throws IException::User "This percentage will yield less than 1 line. This is not enough to normalize."
  *
@@ -306,7 +306,7 @@ void IsisMain() {
  *
  * @internal
  *   @history 2016-08-17 Victor Silva - New app for lroc adapted from makeflat app
- *   
+ *
  */
 void getCubeListNormalization(Matrix2d &matrix, int cubeWidth, int frameHeight, long frameLineCount, long iLineCount) {
 
@@ -362,11 +362,11 @@ void getCubeListNormalization(Matrix2d &matrix, int cubeWidth, int frameHeight, 
 
 
 /**
- * @brief This function returns the median, mean, and standard deviation for a vector 
+ * @brief This function returns the median, mean, and standard deviation for a vector
  *        of valid pixels
  *
- * It will return Isis::Null if it doesn't find any valid pixels. The function builds 
- * a vector of valid pixels. It also calculates the mean and standard deviation of the 
+ * It will return Isis::Null if it doesn't find any valid pixels. The function builds
+ * a vector of valid pixels. It also calculates the mean and standard deviation of the
  * vector. The function also sorts the vector and finds the median. If there are an even
  * number of valid pixels, it will average (mean) the two middle pixels and return
  * that average as the median. It does not return the median pixel but rather its
@@ -414,7 +414,7 @@ void getVectorStats(vector<double> &inVec, double &mean, double &median, double 
       sum = 0;
       vector <double> v2;
       for(int i = 0; i < v_size; i++ ){
-        if( (abs(tempMean - v1[i])) <= (tempStdev * g_numStdevs) ){  
+        if( (abs(tempMean - v1[i])) <= (tempStdev * g_numStdevs) ){
           v2.push_back(v1[i]);
           sum += v1[i];
         }
@@ -440,10 +440,10 @@ void getVectorStats(vector<double> &inVec, double &mean, double &median, double 
           median = double(v2[medianIndex]);
         }
         v2.clear();
-      } 
+      }
       v1.clear();
-    } 
-  } 
+    }
+  }
 }
 
 
@@ -502,4 +502,3 @@ void exclude(int listIndex, int frame, string reason){
     g_excludedDetails.push_back(exclusion);
   }
 }
-

--- a/isis/src/lro/objs/MiniRF/unitTest.cpp
+++ b/isis/src/lro/objs/MiniRF/unitTest.cpp
@@ -109,25 +109,25 @@ int main(void) {
     try{
       cam->CkFrameId();
     }
-    catch(IException e){
+    catch(IException &e){
        e.print();
     }
     try{
       cam->CkReferenceId();
     }
-    catch (IException e){
+    catch (IException &e){
       e.print();
     }
     try{
       cam->SpkTargetId();
     }
-    catch (IException e){
+    catch (IException &e){
       e.print();
     }
     try{
       cam->SpkReferenceId();
     }
-    catch (IException e){
+    catch (IException &e){
        e.print();
     }
 

--- a/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
+++ b/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
@@ -93,7 +93,7 @@ void IsisMain() {
     }
   }
 
-  catch (IException e) {
+  catch (IException &e) {
       QString msg = "File cannot be read by hrsc2isis, use pds2isis.";
       throw IException(e, IException::User, msg, _FILEINFO_);
   }

--- a/isis/src/mro/apps/hijitreg/HiJitCube.cpp
+++ b/isis/src/mro/apps/hijitreg/HiJitCube.cpp
@@ -281,7 +281,7 @@ namespace Isis {
                         jdata.summing);
       }
     }
-    catch(Exception hiExc) {
+    catch(Exception &hiExc) {
       ostringstream msg;
       msg << "Summing mode (" << jdata.summing
           << ") is illegal (must be > 0) or CPMM number (" << jdata.cpmmNumber

--- a/isis/src/mro/apps/hijitreg/Instrument.cpp
+++ b/isis/src/mro/apps/hijitreg/Instrument.cpp
@@ -390,7 +390,8 @@ namespace UA {
       unsigned int  CPMM,
       unsigned int  binning
     )
-    throw(Out_of_Range, Invalid_Argument) {
+    {
+
       if (CPMM >= CCDS) {
         ostringstream
         message;
@@ -414,7 +415,7 @@ namespace UA {
       return
         (int)rint(CCD_FOCAL_PLANE_X_OFFSETS_MM[CPMM]
                   / (CCD_PIXEL_SIZE_MM * binning));
-    }
 
+  }
   }   //  namespace HiRISE
 }   //  namespace UA

--- a/isis/src/mro/apps/hijitreg/Instrument.hh
+++ b/isis/src/mro/apps/hijitreg/Instrument.hh
@@ -41,7 +41,7 @@ namespace HiRISE
 	characterize the MRO HiRISE instrument.
 <p>
 @author		Bradford Castalia, UA/PIRL
-$Revision: 1.1.1.1 $ 
+$Revision: 1.1.1.1 $
 */
 
 class Instrument
@@ -96,7 +96,7 @@ static const unsigned int
 /**	CPMM numbers associated with each CCD, indexed by CCD sensor array number.
 
 	<b>N.B.</b>: All other arrays in this Instrument class are indexed by
-	CPMM number. 
+	CPMM number.
 
 	@see	#CCD_BY_CPMM
 */
@@ -146,7 +146,7 @@ static const double
 	CCD_FOCAL_PLANE_Y_OFFSETS_MM[];
 
 //!	CCD detector pixel size in millimeters.
-static const double 
+static const double
 	CCD_PIXEL_SIZE_MM;
 
 
@@ -278,7 +278,7 @@ static const char* const
 //!	Exposure operation setup time.
 static const double
 	EXPOSURE_SETUP_MICROS;
-	
+
 //!	Engineering_Header Delta_Line_Time maximum valid value.
 static const unsigned int
 	DELTA_LINE_TIME_MAX;
@@ -399,8 +399,7 @@ static unsigned int calibration_lines_minimum
 	@see	#BINNING_FACTORS
 */
 static int focal_plane_x_offset
-	(unsigned int CPMM, unsigned int binning = 1) 
-	throw (Out_of_Range, Invalid_Argument);
+	(unsigned int CPMM, unsigned int binning = 1) ;
 
 };	//	class Instrument
 

--- a/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
+++ b/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
@@ -1121,7 +1121,7 @@ namespace Isis {
     if(p_blueBuffer && p_blueBuffer->working()){
       return;
     }
-    
+
     viewport()->repaint(rect);
   }
 
@@ -1776,7 +1776,7 @@ namespace Isis {
       e->accept();
     }
     else if ((e->key() == Qt::Key_C) &&
-             QApplication::keyboardModifiers() &&
+             QApplication::keyboardModifiers() &
              Qt::ControlModifier) {
 
       //QString fileName = p_cube->fileName();
@@ -1961,7 +1961,7 @@ namespace Isis {
     viewport()->repaint();
   }
 
-  
+
   void CubeViewport::forgetStretches() {
     for(int stretch = 0; stretch < p_knownStretches->size(); stretch++) {
       if((*p_knownStretches)[stretch]) {

--- a/isis/src/qisis/objs/Directory/ControlHealthMonitorWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/ControlHealthMonitorWorkOrder.cpp
@@ -120,7 +120,7 @@ namespace Isis {
     try {
       project()->directory()->addControlHealthMonitorView();
     }
-    catch (IException e) {
+    catch (IException &e) {
       m_status = WorkOrderFinished;
       QMessageBox::critical(NULL, tr("Error"), tr(e.what()));
     }

--- a/isis/src/qisis/objs/Directory/ImportImagesWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/ImportImagesWorkOrder.cpp
@@ -220,7 +220,7 @@ namespace Isis {
       }
 
     }
-    catch (IException e) {
+    catch (IException &e) {
       QMessageBox::critical(NULL, tr("Error"), tr(e.what()));
     }
     return false;
@@ -289,7 +289,7 @@ namespace Isis {
         project()->setClean(false);
       }
     }
-    catch (IException e) {
+    catch (IException &e) {
         QMessageBox::critical(NULL, tr("Error"), tr(e.what()));
     }
   }
@@ -315,7 +315,7 @@ namespace Isis {
         m_newImages = NULL;
       }
     }
-    catch (IException e) {
+    catch (IException &e) {
       m_status = WorkOrderFinished;
       m_warning.append(e.what());
     }
@@ -414,7 +414,7 @@ namespace Isis {
 
         //  Set new ecub to readOnly.  When closing cube, the labels were being re-written because
         // the cube was read/write. This caused a segfault when imported large number of images
-        // because of a label template file being opened too many times. 
+        // because of a label template file being opened too many times.
         projectImage->reopen();
 
         delete input;
@@ -586,7 +586,7 @@ namespace Isis {
         setInternalData(newInternalData);
       }
     }
-    catch (IException e) {
+    catch (IException &e) {
         QMessageBox::critical(NULL, tr("Error"), tr(e.what()));
     }
   }

--- a/isis/src/qisis/objs/Directory/MatrixViewWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/MatrixViewWorkOrder.cpp
@@ -180,7 +180,7 @@ namespace Isis {
       }
       project()->setClean(false);
     }
-    catch (IException e) {
+    catch (IException &e) {
       m_status = WorkOrderFinished;
       QMessageBox::critical(NULL, tr("Error"), tr(e.what()));
     }

--- a/isis/src/qisis/objs/Directory/SetActiveControlWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/SetActiveControlWorkOrder.cpp
@@ -129,7 +129,7 @@ namespace Isis {
     try {
       project()->setActiveControl(controlList()->at(0)->displayProperties()->displayName());
     }
-    catch (IException e) {
+    catch (IException &e) {
       m_status = WorkOrderFinished;
       QMessageBox::critical(NULL, tr("Error"), tr(e.what()));
     }

--- a/isis/src/qisis/objs/Directory/SetActiveImageListWorkOrder.cpp
+++ b/isis/src/qisis/objs/Directory/SetActiveImageListWorkOrder.cpp
@@ -111,7 +111,7 @@ namespace Isis {
     try {
       project()->setActiveImageList(imageList()->name());
     }
-    catch (IException e) {
+    catch (IException &e) {
       m_status = WorkOrderFinished;
       QMessageBox::critical(NULL, tr("Error"), tr(e.what()));
     }

--- a/isis/src/qisis/objs/Project/Project.cpp
+++ b/isis/src/qisis/objs/Project/Project.cpp
@@ -1754,7 +1754,7 @@ namespace Isis {
           m_activeControl->controlNet()->SetImages(*(activeImageList()->serialNumberList()));
           item->setTextColor(Qt::darkGreen);
       }
-      catch(IException e){
+      catch(IException &e){
           if (previousControl) {
             m_activeControl = previousControl;
             item = directory()->model()->findItemData(m_activeControl->
@@ -1847,7 +1847,7 @@ namespace Isis {
         try {
           activeControl()->controlNet()->SetImages(*(m_activeImageList->serialNumberList()));
         }
-        catch(IException e){
+        catch(IException &e){
           if (previousImageList) {
             m_activeImageList = previousImageList;
             item = directory()->model()->findItemData(m_activeImageList->
@@ -2192,11 +2192,11 @@ namespace Isis {
       if ( !newDestination.isEmpty() ) {
         m_isTemporaryProject = false;
         save( QFileInfo(newDestination + "/").absolutePath() );
-        
+
         // delete the temporary project
         deleteAllProjectFiles();
         relocateProjectRoot(newDestination);
-        
+
         // 2014-03-14 kle This is a lame kludge because we think that relocateProjectRoot is not
         // working properly. For example, when we save a new project and try to view a control net
         // the it thinks it's still in the /tmp area

--- a/isis/src/voyager/apps/voy2isis/voy2isis.cpp
+++ b/isis/src/voyager/apps/voy2isis/voy2isis.cpp
@@ -64,7 +64,7 @@ void IsisMain() {
                        + in.name() + "].", _FILEINFO_);
     }
   }
-  
+
   // Convert the pds file to a cube
   Pvl *pdsLabel = new Pvl();
 
@@ -104,14 +104,14 @@ void IsisMain() {
   try  {
     TranslateVoyagerLabels(*pdsLabel, ocube);
   }
-  catch (IException e) {
+  catch (IException &e) {
     e.print();
   }
 
   ocube->write(*hist);
 
   p.EndProcess();
-  
+
   delete pdsLabel;
   if (tempFile) QFile::remove(temp.expanded());
 }
@@ -448,7 +448,7 @@ void TranslateVoyagerLabels(Pvl &inputLab, Cube *ocube) {
                     + ".template.cub");
   res += PvlKeyword("Status", "Nominal");
   ocube->putGroup(res);
-  NaifStatus::CheckErrors();   
+  NaifStatus::CheckErrors();
 }
 
 


### PR DESCRIPTION
Changes include:  Catching IException as a reference rather than value, 
                              Not using Qt::ControlModifier as a boolean reference, 
                              Removed deprecated dynamic throw() call.

There are special notes for the fixes for the Qt::ControlModifier and throw() warnings in the PR.