### PR TITLE
Fixed Workspace to accept detached labels with varying file extensions. Fixes #5476

### DIFF
--- a/isis/src/qisis/objs/Workspace/Workspace.cpp
+++ b/isis/src/qisis/objs/Workspace/Workspace.cpp
@@ -332,19 +332,18 @@ namespace Isis {
    *                          relative paths. Fixes # 5177
    */
   void Workspace::addCubeViewport(QString cubename) {
-    
+
     QFileInfo cubeFileName(cubename);
 
     QList<QString> cubesToOpen;
 
-    // If the file is a cub file, we add the path to it to our list of cubes to open.
-    if ( cubeFileName.suffix() == "cub" || cubeFileName.suffix() == "cube" || cubeFileName.suffix() == "lbl") {
-      // cubesToOpen.append(cubeFileName.absoluteFilePath());
-      cubesToOpen.append(cubeFileName.filePath());
-    }
-    else {
-      // If the file received isn't a cube or label, it has to be a cubelist. We read every cube in
-      // the cubelist and append it to the cubesToOpen QList so that we can open them.
+    // We can ingest cubes or cube lists, so we check the extension to see if it's a .lis or .list 
+    // or .txt file and if so, read the file and add every cube listed in it to the cubesToOpen so 
+    // That they can be opened.
+    if (cubeFileName.suffix() == "lis"  || 
+        cubeFileName.suffix() == "list" ||
+        cubeFileName.suffix() == "txt") {
+
       QFile file(cubename);
       file.open(QIODevice::ReadOnly);
 
@@ -356,9 +355,17 @@ namespace Isis {
       }
       file.close();
     }
+
+    // If it doesn't have a .lis, .list, or .txt extension, then it's not a cubelist and should be 
+    // Opened as a cube or detached label.
+    else {
+      cubesToOpen.append(cubeFileName.filePath());
+    }
     
     if (cubesToOpen.size() == 0){
-        QMessageBox::critical((QWidget *)parent(), "Error", "No cubes to open from [" + cubename + "]");
+        QString msg = "No cubes to open from [" + cubename + "]" + 
+		      "\nIf your file is a cube list, the valid extensions are .lis, .list, and .txt";
+	QMessageBox::critical((QWidget *)parent(), "Error", msg);
         return;
     }
 

--- a/isis/src/qisis/objs/Workspace/Workspace.h
+++ b/isis/src/qisis/objs/Workspace/Workspace.h
@@ -81,6 +81,13 @@ namespace Isis {
   *                           Fixes #5099.
   *   @history 2018-04-13 Christopher Combs - Added .lbl files to the list of single-cube file-extensions
   *                           to check before reading a cube list in addCubeViewport. Fixes #5350.
+  *   @history 2018-08-14 Adam Goins - Modified the logic for the addCubeViewport(QString filename) 
+  *                           To only accept .lis, .list, .txt fles as cubelists, otherwise assume
+  *                           it's a cube or a detached label pointing to a cube. This fixes an 
+  *                           issue with detached labels having extensions that aren't .lbl. 
+  *                           If the user provides a cube list under an unlisted extension,
+  *                            they are now provided the valid extensions in the error message. 
+  *                            Fixes #5476.
   */
   class Workspace : public QWidget {
       Q_OBJECT


### PR DESCRIPTION
Changed the logic of Workspace::addCubeViewport(QString filename)

Previously, we checked for a .cub, .cube, or .lbl extension to ingest it as a cube and then assumed it was a cubelist for any other extension. This caused issues with ingesting detached labels such as the one in $ISISDATA/base/testData/isisTruth.cub.org because it didn't have the .lbl extension.

The logic was modified to check the file extension against valid cube list extensions rather than cube extensions so that if a .lis, .list, or .txt is ingested then those are treated as a cubelist and any other extension is assumed to be a cube, or a detached label. 

If an error is thrown during the ingestion process, the error message was updated to display the valid cube list extensions to the user for clarity.

These changes can be found in /work/projects/isis/latest/m05476 and have been built on Fedora 25 for testing.

Fixes #5476.