### PR TITLE
Updated cube tolerances in the photomet test useDem

### DIFF
--- a/isis/src/base/apps/photomet/tsts/useDem/Makefile
+++ b/isis/src/base/apps/photomet/tsts/useDem/Makefile
@@ -1,7 +1,7 @@
 APPNAME = photomet
 
-angleSourceDemUsedemFalse.cub.TOLERANCE = 0.0005
-angleSourceDemUsedemTrue.cub.TOLERANCE = 0.0005
+angleSourceDemUsedemFalse.cub.TOLERANCE = 0.001
+angleSourceDemUsedemTrue.cub.TOLERANCE = 0.001
 
 include $(ISISROOT)/make/isismake.tsts
 


### PR DESCRIPTION
Stuart and I had changed the dem the test was using because it was 32 gb and was not located in our test data area. Truth data for Mac was checked in and the output for prog25 is not very different. Just needed to update the tolerances.