### PR TITLE
(DO NOT MERGE) Turn off useQuantizedAabbCompression in BulletDskShape

### DIFF
--- a/isis/src/base/objs/BulletDskShape/BulletDskShape.cpp
+++ b/isis/src/base/objs/BulletDskShape/BulletDskShape.cpp
@@ -232,8 +232,8 @@ namespace Isis {
       btAssert ( pindex[i] < v_vertices );
     }
 
-    bool useQuantizedAabbCompression = true;
-    // bool useQuantizedAabbCompression = false;
+    // bool useQuantizedAabbCompression = true;
+    bool useQuantizedAabbCompression = false;
     btBvhTriangleMeshShape *v_triShape = new btBvhTriangleMeshShape(m_mesh.data(), 
                                                                     useQuantizedAabbCompression);
     v_triShape->setUserPointer(this);

--- a/isis/src/base/objs/BulletDskShape/BulletDskShape.h
+++ b/isis/src/base/objs/BulletDskShape/BulletDskShape.h
@@ -38,6 +38,8 @@ namespace Isis {
  * @author 2017-03-17 Kris Becker 
  * @internal 
  *   @history 2017-03-17  Kris Becker  Original Version
+ *   @history 2018-08-24  Kristin Berry - Set useQuantizedAabbCompression = false to fix segfault
+ *                          in a spiceinit test under cmake. 
  */
   class BulletDskShape : public BulletTargetShape {
     public:


### PR DESCRIPTION
This fixes the segfaults that occur in the parts of the raytracing cat test and spiceinit app test that use the Bullet library. This may be a temporary fix as it would be much better to be able to continue using the compression, but I was unable to figure out how to do this for now.  