### PR TITLE
Fix StopTime and SpacecraftClockStopCount in VIRTIS-M Label

### DIFF
--- a/isis/src/rosetta/apps/rosvirtis2isis/rosvirtis2isis.cpp
+++ b/isis/src/rosetta/apps/rosvirtis2isis/rosvirtis2isis.cpp
@@ -108,7 +108,7 @@ void IsisMain ()
   }
 
   double startScet = 0; 
-  double stopScet   = 0; 
+  double stopScet  = 0; 
   p.StartProcess();
 
   // Get the directory where the Rosetta translation tables are.

--- a/isis/src/rosetta/apps/rosvirtis2isis/rosvirtis2isis.cpp
+++ b/isis/src/rosetta/apps/rosvirtis2isis/rosvirtis2isis.cpp
@@ -429,8 +429,8 @@ void IsisMain ()
     PvlKeyword &frameParam = inst["FrameParameter"];
 
     QString stopTime = iTime(et + exposureTime).UTC(); 
-    inst.findKeyword("StopTime).setValue(stopTime); 
-    //TODO: inst.findKeyword("SpacecraftClockStopCount); 
+    inst.findKeyword("StopTime").setValue(stopTime); 
+    inst.findKeyword("SpacecraftClockStopCount").setValue(endSclkString); 
     outcube->putGroup(inst);
 
     // Unload the naif kernels

--- a/isis/src/rosetta/objs/RosettaVirtisCamera/RosettaVirtisCamera.cpp
+++ b/isis/src/rosetta/objs/RosettaVirtisCamera/RosettaVirtisCamera.cpp
@@ -300,26 +300,7 @@ namespace Isis {
      double scet = (double) trec["dataSCET"];
      double lineMidTime;
 
-/*
-SCLK Format
---------------------------------------------------------
-
-     The on-board clock, the conversion for which is provided by this SCLK
-     file, consists of two fields:
-
-          SSSSSSSSSS:FFFFF
-
-     where:
-
-          SSSSSSSSSS -- count of on-board seconds
-
-          FFFFF      -- count of fractions of a second with one fraction
-                        being 1/65536 of a second
-
-
-*/
      QString scetString = toString(scet);
-//     std::cout << "scetString: " << scetString << std::endl; 
 
      // seconds stay the same
      QStringList scetStringList = scetString.split('.');
@@ -335,11 +316,6 @@ SCLK Format
      scetStringList = toString(fractValue).split(".");
 
      scetFinal.append(scetStringList[1].left(5));
-//     std::cout << "final scet value: " << scetFinal << std::endl; 
-
-/*     if (i==0) {
-       setTime(iTime(scetFinal)); 
-     }*/
 
      lineMidTime = getClockTime(scetString, naifSpkCode()).Et();
      m_lineRates.push_back(LineRateChange(lineno,

--- a/isis/src/rosetta/objs/RosettaVirtisCamera/RosettaVirtisCamera.cpp
+++ b/isis/src/rosetta/objs/RosettaVirtisCamera/RosettaVirtisCamera.cpp
@@ -297,27 +297,8 @@ namespace Isis {
    int lineno(1);
    for (int i = 0; i < hktable.Records(); i++) {
      TableRecord &trec = hktable[i];
-     double scet = (double) trec["dataSCET"];
-     double lineMidTime;
-
-     QString scetString = toString(scet);
-
-     // seconds stay the same
-     QStringList scetStringList = scetString.split('.');
-
-     // final format needs to be: SSSSSSSSSS:FFFFF
-
-     //  SSSSSSSSSS:
-     QString scetFinal = scetStringList[0];
-     scetFinal.append(":");
-
-     // FFFFF
-     double fractValue = toDouble(scetStringList[1])/65536.0;
-     scetStringList = toString(fractValue).split(".");
-
-     scetFinal.append(scetStringList[1].left(5));
-
-     lineMidTime = getClockTime(scetString, naifSpkCode()).Et();
+     QString scetString = trec["dataSCET"];
+     double lineMidTime = getClockTime(scetString, naifSpkCode()).Et();
      m_lineRates.push_back(LineRateChange(lineno,
                                           lineStartTime(lineMidTime),
                                           exposureTime()));

--- a/isis/src/rosetta/objs/RosettaVirtisCamera/RosettaVirtisCamera.cpp
+++ b/isis/src/rosetta/objs/RosettaVirtisCamera/RosettaVirtisCamera.cpp
@@ -319,7 +319,7 @@ SCLK Format
 
 */
      QString scetString = toString(scet);
-     std::cout << "scetString: " << scetString << std::endl; 
+//     std::cout << "scetString: " << scetString << std::endl; 
 
      // seconds stay the same
      QStringList scetStringList = scetString.split('.');
@@ -335,7 +335,7 @@ SCLK Format
      scetStringList = toString(fractValue).split(".");
 
      scetFinal.append(scetStringList[1].left(5));
-     std::cout << "final scet value: " << scetFinal << std::endl; 
+//     std::cout << "final scet value: " << scetFinal << std::endl; 
 
 /*     if (i==0) {
        setTime(iTime(scetFinal)); 


### PR DESCRIPTION
Updates the SpacecraftStartClockCount, SpaceCraftStopClockCount, StartTime, and StopTime to be accurate in the labels of ingested Rosetta VIRTIS-M calibrated images. 

Also includes some small updates to the camera model. 

UPDATE: 
In addition to fixing the incorrect scet calculation, now the table attached to the ingested cube contains the (hopefully!) correctly-formatted sclk-strings rather than the scet values right out of idl, as these are more useful to the camera model. 