### PR TITLE
Removed absolute path in csv2table errors test

### DIFF
--- a/isis/src/base/apps/csv2table/tsts/errors/Makefile
+++ b/isis/src/base/apps/csv2table/tsts/errors/Makefile
@@ -27,4 +27,7 @@ commands:
 	  true; \
 	fi;
 
-	rm $(OUTPUT)/isisTruth.cub;
+	cat $(OUTPUT)/errors.txt | sed 's/\/[^ ]*\/input\///g' \
+	    > $(OUTPUT)/clean_errors.txt;
+
+	rm $(OUTPUT)/isisTruth.cub $(OUTPUT)/errors.txt;


### PR DESCRIPTION
the errors test for csv2table is failing because the error messages have absolute file paths in them. Added a regex to strip out everything except the final file.