### PR TITLE
Fix for OpenGL error on Conda Build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,6 @@ dependencies:
   - bzip2==1.0.6=1
   - cmake==3.9.1=0
   - cspice==66-0
-  - curl==7.55.1=0
   - doxygen==1.8.14=0
   - eigen==3.3.3=0
   - embree==2.14.0=0

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -209,7 +209,9 @@ find_package(Qt5 COMPONENTS
                 WebChannel
                 Widgets
                 Xml
-                XmlPatterns REQUIRED)
+                XmlPatterns
+                # Search this path explicitly for MacOS OpenGL Framework
+                PATHS /System/Library/Frameworks/ REQUIRED)
 
 # Some of these will have non-traditional installs with version numbers in the paths in v007
 # For these, we pass in a version number, and use it in the path suffix
@@ -424,10 +426,10 @@ add_custom_target(docs COMMAND ${CMAKE_COMMAND}
                   -P ${CMAKE_MODULE_PATH}/BuildDocs.cmake)
 
 # Add custom build target to copy modified header files to the build/incs directory.
-# ALL is specified so that the target is added to the default build target, i.e. the copy command 
+# ALL is specified so that the target is added to the default build target, i.e. the copy command
 # will be executed when running "ninja install"
 # On a clean build, all files will be copied over.
-add_custom_target(incs ALL COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+add_custom_target(incs ALL COMMAND ${CMAKE_COMMAND} -E copy_if_different
   ${CMAKE_SOURCE_DIR}/src/*/objs/*/*.h ${CMAKE_SOURCE_DIR}/src/*/objs/*/*.hpp ${CMAKE_BINARY_DIR}/inc)
 add_dependencies(isis3 incs)
 


### PR DESCRIPTION
It seems the issue was in the CMake scripts that ship with Qt. They find the incorrect version of OpenGL, most likely a bug on Qt's end as the version found isn't the library but rather the directory of the framework, hence the error. The solution is to add the PATH option with the default system location for OpenGL on MacOS machines. 

The package is uploaded to Anaconda under the USGS-Astro channel, probably worth having someone other than myself test it. 

~Also this should be squashed and merged for obvious reasons.~ Squashed locally and pushed. 
