### PR TITLE
Fix tgo errors: error about ObservationId not existing in the Image PVL Group.

### DIFF
--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -68,9 +68,12 @@ void IsisMain() {
     productId.setValue( ui.GetString("PRODUCTID") );
   }
   else {
-    QString observationId = targetGroup.findKeyword("ObservationId")[0];
+    // Get the observationId from the Archive Group.
+    PvlGroup archiveGroup = label->findObject("IsisCube").findGroup("Archive");
+    QString observationId = archiveGroup.findKeyword("ObservationId")[0];
     productId.setValue(observationId);
   }
+
   targetGroup.addKeyword(productId);  
   logicalId += productId[0];
   process.setLogicalId(logicalId);


### PR DESCRIPTION
Fix error about ObservationId not existing in the Image PVL Group in tgocassisrdrgen. (The ObservationId was moved to the Archive group.)