### PR TITLE
Library update and build preferences

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - bzip2==1.0.6=1
   - cmake==3.9.1=0
   - cspice==66-0
-  - curl==7.55.1=0
+  - curl==7.60.0=0
   - doxygen==1.8.14=0
   - eigen==3.3.3=0
   - embree==2.14.0=0

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -158,6 +158,7 @@ set(thirdPartyCppFlags -Wall
                        -DISIS_LITTLE_ENDIAN=1
                        -Wno-unused-parameter
                        -Wno-overloaded-virtual
+                       -Wno-strict-aliasing
                        -DGMM_USES_SUPERLU
                        -DENABLEJP2K=${JP2KFLAG}
                      )


### PR DESCRIPTION
Updated "broken" curl library from conda-forge and removed strict-aliasing warnings from cmake build mode "Release" to remove warnings from nightly build. This will probably need to be addressed better in the future, but this is to get the build out.