### PR TITLE
Fix problems exporting tgo cassis mosaics

### DIFF
--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -68,9 +68,17 @@ void IsisMain() {
     productId.setValue( ui.GetString("PRODUCTID") );
   }
   else {
-    // Get the observationId from the Archive Group.
-    PvlGroup archiveGroup = label->findObject("IsisCube").findGroup("Archive");
-    QString observationId = archiveGroup.findKeyword("ObservationId")[0];
+    // Get the observationId from the Archive Group, or the Mosaic group, if the input is a mosaic
+    QString observationId; 
+
+    if(label->findObject("IsisCube").hasGroup("Archive")){
+      PvlGroup archiveGroup = label->findObject("IsisCube").findGroup("Archive");
+      observationId = archiveGroup.findKeyword("ObservationId")[0];
+    }
+    else if (label->findObject("IsisCube").hasGroup("Mosaic")) {
+      PvlGroup mosaicGroup = label->findObject("IsisCube").findGroup("Mosaic");
+      observationId = mosaicGroup.findKeyword("ObservationId")[0];
+    }
     productId.setValue(observationId);
   }
 


### PR DESCRIPTION
This fixes a problem that comes up when trying to export a mosaic generated using `tgocassismos` using `tgocassisrdrgen`. (`tgocassisrdrgen` was not looking for the `ObservationId` in the `Mosaic` group in the label of the ISIS3 cube. It was looking for it in the `Archive` group, which does not exist for mosaics.) 