### PR TITLE
Fix test truthdata for tgo camera ckwriter frame fix.

### DIFF
--- a/isis/src/tgo/objs/TgoCassisCamera/TgoCassisCamera.truth
+++ b/isis/src/tgo/objs/TgoCassisCamera/TgoCassisCamera.truth
@@ -1,9 +1,9 @@
 Unit Test for TgoCassisCamera...
 FileName:  "CAS-MCO-2016-11-22T16.38.39.354-NIR-02036-00.cub"
-CK Frame:  -143420
+CK Frame:  -143410
 
 Kernel IDs: 
-CK Frame ID =  -143420
+CK Frame ID =  -143410
 CK Reference ID =  1
 SPK Target ID =  -143
 SPK Reference ID =  1


### PR DESCRIPTION
This fixes the error in nightly about "CK Frame Id"  not matching. 