### PR TITLE
Converted crop to a threaded object which can be called.

### DIFF
--- a/isis/src/base/apps/crop/crop.cpp
+++ b/isis/src/base/apps/crop/crop.cpp
@@ -1,32 +1,15 @@
 #include "Isis.h"
 
-#include <cmath>
+//#include <cmath>
 
-#include "Cube.h"
-#include "ProcessByLine.h"
-#include "SpecialPixel.h"
-#include "LineManager.h"
-#include "FileName.h"
-#include "IException.h"
-#include "Projection.h"
-#include "AlphaCube.h"
-#include "Table.h"
-#include "SubArea.h"
+#include "CropApp.h"
+
 
 using namespace std;
 using namespace Isis;
 
-// Globals and prototypes
-int ss, sl, sb;
-int ns, nl, nb;
-int sinc, linc;
-Cube *cube = NULL;
-LineManager *in = NULL;
-
-void crop(Buffer &out);
-
 void IsisMain() {
-  ProcessByLine p;
+
 
   // Open the input cube
   UserInterface &ui = Application::GetUserInterface();
@@ -36,18 +19,28 @@ void IsisMain() {
   cube->setVirtualBands(inAtt.bands());
   from = ui.GetFileName("FROM");
   cube->open(from);
+  bool propspice =false;
 
   // Determine the sub-area to extract
   ss = ui.GetInteger("SAMPLE");
   sl = ui.GetInteger("LINE");
   sb = 1;
 
-  int origns = cube->sampleCount();
-  int orignl = cube->lineCount();
-  int es = cube->sampleCount();
-  if (ui.WasEntered("NSAMPLES")) es = ss + ui.GetInteger("NSAMPLES") - 1;
-  int el = cube->lineCount();
-  if (ui.WasEntered("NLINES")) el = sl + ui.GetInteger("NLINES") - 1;
+
+  int ns;
+  int nl;
+  if (ui.WasEntered("NSAMPLES"))
+    ns = ui.GetInteger("NSAMPLES");
+  else
+    ns = -1;
+
+  if (ui.WasEntered("NLINESS"))
+    nl = ui.GetInteger("LINES");
+  else
+    nl = -1;
+
+
+
   int eb = cube->bandCount();
 
   sinc = ui.GetInteger("SINC");
@@ -81,143 +74,15 @@ void IsisMain() {
     throw IException(IException::User, msg, _FILEINFO_);
   }
 
-  // Determine the size of the output cube and then set the output image size
-  ns = ceil((double)(es - ss + 1) / sinc);
-  nl = ceil((double)(el - sl + 1) / linc);
-  nb = eb;
-  //if (ns == 0) ns = 1;
-  //if (nl == 0) nl = 1;
-  es = ss + (ns - 1) * sinc;
-  el = sl + (nl - 1) * linc;
-
-  // Allocate the output file and make sure things get propogated nicely
-  p.SetInputCube("FROM");
-  p.PropagateTables(false);
-  Cube *ocube = p.SetOutputCube("TO", ns, nl, nb);
-  p.ClearInputCubes();
-
-  // propagate tables manually
-  Pvl &inLabels = *cube->label();
-
-  // Loop through the labels looking for object = Table
-  for(int labelObj = 0; labelObj < inLabels.objects(); labelObj++) {
-    PvlObject &obj = inLabels.object(labelObj);
-
-    if(obj.name() != "Table") continue;
-
-    // If we're not propagating spice data, dont propagate the following tables...
-    if(!ui.GetBoolean("PROPSPICE")) {
-      if((IString)obj["Name"][0] == "InstrumentPointing") continue;
-      if((IString)obj["Name"][0] == "InstrumentPosition") continue;
-      if((IString)obj["Name"][0] == "BodyRotation") continue;
-      if((IString)obj["Name"][0] == "SunPosition") continue;
-    }
-
-    // Read the table into a table object
-    Table table(obj["Name"], from);
-
-    // We are not going to bother with line/sample associations; they apply
-    //   only to the alpha cube at this time. I'm leaving this code here for the
-    //   equations in case we try our hand at modifying these tables at a later date.
-
-    /* Deal with associations, sample first
-    if(table.IsSampleAssociated()) {
-      int numDeleted = 0;
-      for(int samp = 0; samp < cube->sampleCount(); samp++) {
-        // This tests checks to see if we would include this sample.
-        //   samp - (ss-1)) / sinc must be a whole number less than ns.
-        if((samp - (ss-1)) % sinc != 0 || (samp - (ss-1)) / sinc >= ns || (samp - (ss-1)) < 0) {
-          table.Delete(samp-numDeleted);
-          numDeleted ++;
-        }
-      }
-    }
-
-    // Deal with line association
-    if(table.IsLineAssociated()) {
-      int numDeleted = 0;
-      for(int line = 0; line < cube->lineCount(); line++) {
-        // This tests checks to see if we would include this line.
-        //   line - (sl-1)) / linc must be a whole number less than nl.
-        if((line - (sl-1)) % linc != 0 || (line - (sl-1)) / linc >= nl || (line - (sl-1)) < 0) {
-          table.Delete(line-numDeleted);
-          numDeleted ++;
-        }
-      }
-    }*/
-
-    // Write the table
-    ocube->write(table);
+  if (ui.GetBoolean("PROPSPICE") ) {
+    propsice = true;
   }
 
-  Pvl &outLabels = *ocube->label();
-  if(!ui.GetBoolean("PROPSPICE") && outLabels.findObject("IsisCube").hasGroup("Kernels")) {
-    PvlGroup &kerns = outLabels.findObject("IsisCube").findGroup("Kernels");
 
-    QString tryKey = "NaifIkCode";
-    if(kerns.hasKeyword("NaifFrameCode")) {
-      tryKey = "NaifFrameCode";
-    }
-
-    if(kerns.hasKeyword(tryKey)) {
-      PvlKeyword ikCode = kerns[tryKey];
-      kerns = PvlGroup("Kernels");
-      kerns += ikCode;
-    }
-  }
-
-  // Create a buffer for reading the input cube
-  in = new LineManager(*cube);
-
-  // Crop the input cube
-  p.StartProcess(crop);
-
-  delete in;
-  in = NULL;
-
-  // Construct a label with the results
-  PvlGroup results("Results");
-  results += PvlKeyword("InputLines", toString(orignl));
-  results += PvlKeyword("InputSamples", toString(origns));
-  results += PvlKeyword("StartingLine", toString(sl));
-  results += PvlKeyword("StartingSample", toString(ss));
-  results += PvlKeyword("EndingLine", toString(el));
-  results += PvlKeyword("EndingSample", toString(es));
-  results += PvlKeyword("LineIncrement", toString(linc));
-  results += PvlKeyword("SampleIncrement", toString(sinc));
-  results += PvlKeyword("OutputLines", toString(nl));
-  results += PvlKeyword("OutputSamples", toString(ns));
-
-  // Update the Mapping, Instrument, and AlphaCube groups in the output
-  // cube label
-  SubArea *s;
-  s = new SubArea;
-  s->SetSubArea(orignl, origns, sl, ss, el, es, linc, sinc);
-  s->UpdateLabel(cube, ocube, results);
-  delete s;
-  s = NULL;
-
-  // Cleanup
-  p.EndProcess();
-  cube->close();
-  delete cube;
-  cube = NULL;
+  CropApp *capp = new CropApp(from,to,ss,ns,sinc,sl,nl,linc,propspice,cube);
+  capp->start();
 
   // Write the results to the log
-  Application::Log(results);
+  //Application::Log(results);
 }
 
-// Line processing routine
-void crop(Buffer &out) {
-  // Read the input line
-  int iline = sl + (out.Line() - 1) * linc;
-  in->SetLine(iline, sb);
-  cube->read(*in);
-
-  // Loop and move appropriate samples
-  for(int i = 0; i < out.size(); i++) {
-    out[i] = (*in)[(ss - 1) + i * sinc];
-  }
-
-  if(out.Line() == nl) sb++;
-}

--- a/isis/src/base/apps/crop/crop.cpp
+++ b/isis/src/base/apps/crop/crop.cpp
@@ -36,7 +36,7 @@ void IsisMain() {
   else
     ns = -1;
 
-  if (ui.WasEntered("NLINESS"))
+  if (ui.WasEntered("NLINES"))
     nl = ui.GetInteger("LINES");
   else
     nl = -1;

--- a/isis/src/base/apps/crop/crop.cpp
+++ b/isis/src/base/apps/crop/crop.cpp
@@ -14,7 +14,7 @@ void IsisMain() {
   // Open the input cube
   UserInterface &ui = Application::GetUserInterface();
   QString from = ui.GetAsString("FROM");
-  QString to = ui.GetAsString("FROM");
+  QString to = ui.GetAsString("TO");
   CubeAttributeInput inAtt(from);
   Cube *cube = new Cube();
   cube->setVirtualBands(inAtt.bands());
@@ -83,8 +83,8 @@ void IsisMain() {
   }
 
 
-  CropApp *capp = new CropApp(from,to,ss,ns,sinc,sl,nl,linc,propspice,cube);
-  //capp->start();
+  CropApp *capp = new CropApp(from,to,ss,ns,sinc,sl,nl,linc,propspice);
+  capp->start();
 
   // Write the results to the log
   //Application::Log(results);

--- a/isis/src/base/apps/crop/crop.cpp
+++ b/isis/src/base/apps/crop/crop.cpp
@@ -14,17 +14,19 @@ void IsisMain() {
   // Open the input cube
   UserInterface &ui = Application::GetUserInterface();
   QString from = ui.GetAsString("FROM");
+  QString to = ui.GetAsString("FROM");
   CubeAttributeInput inAtt(from);
-  cube = new Cube();
+  Cube *cube = new Cube();
   cube->setVirtualBands(inAtt.bands());
   from = ui.GetFileName("FROM");
   cube->open(from);
   bool propspice =false;
 
   // Determine the sub-area to extract
-  ss = ui.GetInteger("SAMPLE");
-  sl = ui.GetInteger("LINE");
-  sb = 1;
+
+  int ss = ui.GetInteger("SAMPLE");
+  int sl = ui.GetInteger("LINE");
+  //int sb = 1;
 
 
   int ns;
@@ -41,10 +43,12 @@ void IsisMain() {
 
 
 
-  int eb = cube->bandCount();
+  int es = cube->sampleCount();
+  int el = cube->lineCount();
+  //int eb = cube->bandCount();
 
-  sinc = ui.GetInteger("SINC");
-  linc = ui.GetInteger("LINC");
+  int sinc = ui.GetInteger("SINC");
+  int linc = ui.GetInteger("LINC");
 
   // Make sure starting positions fall within the cube
   if (ss > cube->sampleCount()) {
@@ -75,7 +79,7 @@ void IsisMain() {
   }
 
   if (ui.GetBoolean("PROPSPICE") ) {
-    propsice = true;
+    propspice = true;
   }
 
 

--- a/isis/src/base/apps/crop/crop.cpp
+++ b/isis/src/base/apps/crop/crop.cpp
@@ -84,7 +84,7 @@ void IsisMain() {
 
 
   CropApp *capp = new CropApp(from,to,ss,ns,sinc,sl,nl,linc,propspice,cube);
-  capp->start();
+  //capp->start();
 
   // Write the results to the log
   //Application::Log(results);

--- a/isis/src/base/objs/CropApp/CropApp.cpp
+++ b/isis/src/base/objs/CropApp/CropApp.cpp
@@ -1,0 +1,229 @@
+#include "CropApp.h"
+
+#include <QString>
+#include <QThread>
+
+#include <cmath>
+
+#include "Cube.h"
+#include "ProcessByLine.h"
+#include "SpecialPixel.h"
+#include "LineManager.h"
+#include "FileName.h"
+#include "IException.h"
+#include "Projection.h"
+#include "AlphaCube.h"
+#include "Table.h"
+#include "SubArea.h"
+
+using namespace std;
+using namespace Isis;
+
+namespace Isis {
+
+
+int cropper::m_sline= -1;
+int cropper::m_linc=-1;
+int cropper::m_sband=-1;
+int cropper::m_ssample=-1;
+int cropper::m_sinc=-1;
+Cube * cropper::m_cube=NULL;
+LineManager * cropper::m_in = NULL;
+
+int cropper::m_osamples =-1;
+int cropper::m_olines=-1;
+int cropper::m_obands=-1;
+
+QString cropper::m_outputCubeName="";
+bool cropper::m_propspice = false;
+
+
+         CropApp::CropApp(QString &from, QString &to, int ssample,int nsamples,
+                          int sinc, int sline,int nlines,int linc,bool propspice){
+
+            m_fromCube =from;
+            m_toCube = to;
+            m_ssample = ssample;
+            m_nsamples = nsamples;
+            m_sinc = sinc;
+            m_sline = sline;
+            m_nlines = nlines;
+            m_linc = linc;
+            m_propspice = propspice;
+            m_sband = 1;
+            m_in = NULL;
+            m_cube = NULL;
+
+
+            CubeAttributeInput inAtt(from);
+            m_cube = new Cube();
+            m_cube->setVirtualBands(inAtt.bands());
+            m_cube->open(from);
+
+
+            cropper *crop = new cropper(ssample,nsamples,sinc,
+                                          sline,nlines,linc,propspice,to,m_cube);
+            crop->moveToThread(&cropThread);
+
+            connect(&cropThread, &QThread::finished,crop, &QObject::deleteLater);
+            connect(this, &CropApp::operate, crop, &cropper::cropit);
+            connect(crop, &cropper::resultReady, this, &CropApp::handleResults);
+            cropThread.start();
+
+
+
+         }
+
+         void CropApp::handleResults() {
+
+         }
+
+
+  cropper::cropper(int ssample,int nsamples,
+          int sinc, int sline,int nlines,int linc,bool propspice,QString to,Cube *cube){
+
+
+          m_sline= sline;
+          m_linc= linc;
+          m_sband=1;
+          m_ssample=ssample;
+          m_sinc=sinc;
+          m_cube=cube;
+          m_outputCubeName=to;
+          m_propspice = propspice;
+
+
+  }
+        void cropper::crop(Buffer &out) {
+        // Read the input line
+        int iline = m_sline + (out.Line() - 1) * m_linc;
+        m_in->SetLine(iline, m_sband);
+        m_cube->read(*m_in);
+
+        // Loop and move appropriate samples
+        for(int i = 0; i < out.size(); i++) {
+          out[i] = (*m_in)[(m_ssample - 1) + i * m_sinc];
+        }
+
+        if(out.Line() == m_olines) m_sband++;
+
+        }
+
+        void cropper::cropit(QString &from, QString &to, int ssample,int nsamples,
+                      int sinc, int sline,
+                      int nlines,int linc,bool propspice,Cube *cube) {
+
+             ProcessByLine p;
+
+             int origns = cube->sampleCount();
+             int orignl = cube->lineCount();
+             int es = cube->sampleCount();
+             int el = cube->lineCount();
+             int eb = cube->bandCount();
+             if (nsamples !=-1) {
+               es = ssample + nsamples -1;
+             }
+
+             if (nlines != -1) {
+               el = sline + nlines -1;
+             }
+
+             m_osamples = ceil((double)(es - m_ssample + 1) / m_sinc);
+             m_olines = ceil((double)(el - m_sline + 1) / m_linc);
+             m_obands = eb;
+
+             es = m_ssample + (m_osamples - 1) * m_sinc;
+             el = m_sline + (m_olines - 1) * m_linc;
+
+             p.SetInputCube(cube);
+             p.PropagateTables(false);
+             CubeAttributeOutput outAtt(to);
+             Cube * ocube = p.SetOutputCube(m_outputCubeName,outAtt,m_osamples,m_olines,m_obands);
+
+             p.ClearInputCubes();
+
+           // propagate tables manually
+           Pvl &inLabels = *cube->label();
+
+           // Loop through the labels looking for object = Table
+           for(int labelObj = 0; labelObj < inLabels.objects(); labelObj++) {
+             PvlObject &obj = inLabels.object(labelObj);
+
+             if(obj.name() != "Table") continue;
+
+             // If we're not propagating spice data, dont propagate the following tables...
+             if( propspice ) {
+               if((IString)obj["Name"][0] == "InstrumentPointing") continue;
+               if((IString)obj["Name"][0] == "InstrumentPosition") continue;
+               if((IString)obj["Name"][0] == "BodyRotation") continue;
+               if((IString)obj["Name"][0] == "SunPosition") continue;
+             }
+
+             // Read the table into a table object
+             Table table(obj["Name"], from);
+
+             // Write the table
+             ocube->write(table);
+           }
+
+           Pvl &outLabels = *ocube->label();
+           if(! propspice && outLabels.findObject("IsisCube").hasGroup("Kernels")) {
+             PvlGroup &kerns = outLabels.findObject("IsisCube").findGroup("Kernels");
+
+             QString tryKey = "NaifIkCode";
+             if(kerns.hasKeyword("NaifFrameCode")) {
+               tryKey = "NaifFrameCode";
+             }
+
+             if(kerns.hasKeyword(tryKey)) {
+               PvlKeyword ikCode = kerns[tryKey];
+               kerns = PvlGroup("Kernels");
+               kerns += ikCode;
+             }
+           }
+
+           // Create a buffer for reading the input cube
+           LineManager * m_in = new LineManager(*cube);
+
+           // Crop the input cube
+           p.StartProcess(this->crop);
+
+           delete m_in;
+           m_in = NULL;
+
+           // Construct a label with the results
+           PvlGroup results("Results");
+           results += PvlKeyword("InputLines", toString(orignl));
+           results += PvlKeyword("InputSamples", toString(origns));
+           results += PvlKeyword("StartingLine", toString(m_sline));
+           results += PvlKeyword("StartingSample", toString(m_ssample));
+           results += PvlKeyword("EndingLine", toString(el));
+           results += PvlKeyword("EndingSample", toString(es));
+           results += PvlKeyword("LineIncrement", toString(m_linc));
+           results += PvlKeyword("SampleIncrement", toString(m_sinc));
+           results += PvlKeyword("OutputLines", toString(m_olines));
+           results += PvlKeyword("OutputSamples", toString(m_osamples));
+
+           // Update the Mapping, Instrument, and AlphaCube groups in the output
+           // cube label
+           SubArea *s;
+           s = new SubArea;
+           s->SetSubArea(orignl, origns, m_sline, m_ssample, el, es, m_linc, m_sinc);
+           s->UpdateLabel(cube, ocube, results);
+           delete s;
+           s = NULL;
+
+           // Cleanup
+           p.EndProcess();
+           cube->close();
+           delete cube;
+           cube = NULL;
+
+
+           QString result;
+
+           emit resultReady(result);
+
+          }//end cropit
+
+}

--- a/isis/src/base/objs/CropApp/CropApp.cpp
+++ b/isis/src/base/objs/CropApp/CropApp.cpp
@@ -2,6 +2,7 @@
 
 #include <QString>
 #include <QThread>
+#include <QDebug>
 
 #include <cmath>
 
@@ -39,7 +40,7 @@ bool cropper::m_propspice = false;
 
 
          CropApp::CropApp(QString &from, QString &to, int ssample,int nsamples,
-                          int sinc, int sline,int nlines,int linc,bool propspice){
+                          int sinc, int sline,int nlines,int linc,bool propspice,Cube *cube){
 
             m_fromCube =from;
             m_toCube = to;
@@ -54,11 +55,10 @@ bool cropper::m_propspice = false;
             m_in = NULL;
             m_cube = NULL;
 
-
-            CubeAttributeInput inAtt(from);
-            m_cube = new Cube();
-            m_cube->setVirtualBands(inAtt.bands());
-            m_cube->open(from);
+            //CubeAttributeInput inAtt(from);
+            //m_cube = new Cube();
+            //m_cube->setVirtualBands(inAtt.bands());
+            //m_cube->open(from);
 
 
             cropper *crop = new cropper(ssample,nsamples,sinc,
@@ -70,11 +70,20 @@ bool cropper::m_propspice = false;
             connect(crop, &cropper::resultReady, this, &CropApp::handleResults);
             cropThread.start();
 
+         }
+
+         void start() {
+
+
+          emit (operate (from,to,m_ssample,m_nsamples,
+                       m_sinc,m_sline,m_nlines,m_linc,m_propspice,m_cube));
 
 
          }
 
          void CropApp::handleResults() {
+           qDebug() << "Results are handled here.";
+
 
          }
 

--- a/isis/src/base/objs/CropApp/CropApp.cpp
+++ b/isis/src/base/objs/CropApp/CropApp.cpp
@@ -72,10 +72,10 @@ bool cropper::m_propspice = false;
 
          }
 
-         void start() {
+         void CropApp::start() {
 
 
-          emit (operate (from,to,m_ssample,m_nsamples,
+          emit (operate (m_fromCube,m_toCube,m_ssample,m_nsamples,
                        m_sinc,m_sline,m_nlines,m_linc,m_propspice,m_cube));
 
 

--- a/isis/src/base/objs/CropApp/CropApp.h
+++ b/isis/src/base/objs/CropApp/CropApp.h
@@ -79,6 +79,8 @@ public slots:
               int sinc, int sline,
               int nlines,int linc,bool propspice,Cube *cube);
 
+   void cropit();
+
 
 
 

--- a/isis/src/base/objs/CropApp/CropApp.h
+++ b/isis/src/base/objs/CropApp/CropApp.h
@@ -17,10 +17,11 @@ class CropApp: public QObject {
     Q_OBJECT
     public:
 
-    CropApp(QString &from, QString &to, int ssample = 1,int nsamples = -1,int sinc=1,
-             int sline =1,int nlines=-1,int linc=1,bool propspice=true);
+    CropApp(QString &from, QString &to, int ssample = 1, int nsamples = -1, int sinc=1,
+             int sline =1, int nlines=-1, int linc=1, bool propspice=true, Cube *cube);
 
     public slots:
+    void start();
     void handleResults();
 
     signals:

--- a/isis/src/base/objs/CropApp/CropApp.h
+++ b/isis/src/base/objs/CropApp/CropApp.h
@@ -18,7 +18,7 @@ class CropApp: public QObject {
     public:
 
     CropApp(QString &from, QString &to, int ssample = 1, int nsamples = -1, int sinc=1,
-             int sline =1, int nlines=-1, int linc=1, bool propspice=true, Cube *cube);
+             int sline =1, int nlines=-1, int linc=1, bool propspice=true, Cube *cube=NULL);
 
     public slots:
     void start();

--- a/isis/src/base/objs/CropApp/CropApp.h
+++ b/isis/src/base/objs/CropApp/CropApp.h
@@ -18,7 +18,7 @@ class CropApp: public QObject {
     public:
 
     CropApp(QString &from, QString &to, int ssample = 1, int nsamples = -1, int sinc=1,
-             int sline =1, int nlines=-1, int linc=1, bool propspice=true, Cube *cube=NULL);
+             int sline =1, int nlines=-1, int linc=1, bool propspice=true);
 
     public slots:
     void start();
@@ -68,8 +68,8 @@ public:
   static bool m_propspice;
   static LineManager *m_in;
 
-  cropper(int ssample,int nsamples,
-          int sinc, int sline,int nlines,int linc,bool propspice,QString to,Cube *cube);
+  cropper(int ssample, int nsamples,
+          int sinc, int sline, int nlines, int linc, bool propspice, QString to, QString from);
 
    static void crop(Buffer &out);
 

--- a/isis/src/base/objs/CropApp/CropApp.h
+++ b/isis/src/base/objs/CropApp/CropApp.h
@@ -1,0 +1,94 @@
+#ifndef CropApp_h
+#define CropApp_h
+#include <QObject>
+#include <QString>
+#include <QThread>
+
+namespace Isis{
+
+
+class Buffer;
+class Cube;
+class LineManager;
+
+class CropApp: public QObject {
+
+
+    Q_OBJECT
+    public:
+
+    CropApp(QString &from, QString &to, int ssample = 1,int nsamples = -1,int sinc=1,
+             int sline =1,int nlines=-1,int linc=1,bool propspice=true);
+
+    public slots:
+    void handleResults();
+
+    signals:
+
+    void operate(QString &from, QString &to, int ssample = 1,int nsamples = -1,int sinc=1,
+                 int sline =1,int nlines=-1,int linc=1,bool propspice=true,Cube *cube=NULL);
+
+
+    private:
+
+    QThread cropThread;
+
+    QString m_fromCube;
+    QString m_toCube;
+    int m_ssample;
+    int m_nsamples;
+    int m_sinc;
+    int m_sline;
+    int m_nlines;
+    int m_linc;
+    int m_sband;
+    LineManager *m_in;
+    Cube * m_cube;
+    bool m_propspice;
+
+
+    };
+
+class cropper:public QObject{
+
+Q_OBJECT
+public:
+
+  static int m_sline;
+  static int m_linc;
+  static int m_sband;
+  static int m_ssample;
+  static int m_sinc;
+  static int m_osamples;
+  static int m_olines;
+  static int m_obands;
+  static Cube *m_cube;
+  static QString m_outputCubeName;
+  static bool m_propspice;
+  static LineManager *m_in;
+
+  cropper(int ssample,int nsamples,
+          int sinc, int sline,int nlines,int linc,bool propspice,QString to,Cube *cube);
+
+   static void crop(Buffer &out);
+
+
+public slots:
+  void cropit(QString &from, QString &to, int ssample,int nsamples,
+              int sinc, int sline,
+              int nlines,int linc,bool propspice,Cube *cube);
+
+
+
+
+
+signals:
+  void resultReady(const QString &result);
+
+
+};
+
+}
+
+
+#endif

--- a/isis/src/base/objs/CropApp/unitTest.cpp
+++ b/isis/src/base/objs/CropApp/unitTest.cpp
@@ -1,0 +1,361 @@
+#include <iostream>
+#include <iomanip>
+#include <limits>
+
+#include <QDebug>
+
+#include "Angle.h"
+#include "Constants.h"
+#include "IException.h"
+#include "Preference.h"
+#include "SpecialPixel.h"
+
+using namespace Isis;
+using namespace std;
+
+class MyAngle : public Isis::Angle {
+public:
+  MyAngle(double angle, Angle::Units unit) : Isis::Angle(angle, unit) {}
+
+  void TestUnitWrapValue() {
+    cerr << "  Degree wrap value = " << unitWrapValue(Angle::Degrees) << endl;
+    cerr << "  Radian wrap value = " << unitWrapValue(Angle::Radians) << endl;
+  }
+
+  void setAngle(const double& angleValue, const Units& unit) {
+    Angle::setAngle(angleValue, unit);
+    cerr << "angle set to " << angle(unit) << endl;
+  }
+
+};
+
+
+int main(int argc, char *argv[]) {
+  Isis::Preference::Preferences(true);
+  cerr << setprecision(9);
+
+  cerr << "UnitTest for Angle" << endl << endl;
+  cerr << "Testing constructors" << endl;
+
+  try {
+    Angle angle;
+    cerr << "  Default constructor - valid?:  " << angle.isValid() <<
+      " values: " << angle.radians() << " and " << angle.degrees() <<
+      endl;
+    cerr << "  " << angle.toString() << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(Isis::Null, Angle::Degrees);
+    cerr << "  Null input and degree output:  " << angle.degrees() <<
+      " degrees" <<endl;
+    cerr << "  Valid? " << angle.isValid() << endl;
+    cerr << "  " << angle.toString() << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(30., Angle::Degrees );
+    cerr << "  Degree input and radian output:  " << angle.radians() <<
+      " radians" << endl;
+    cerr << "  Valid? " << angle.isValid() << endl;
+    cerr << "  " << angle.toString() << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(30. * PI / 180., Angle::Radians );
+    cerr << "  Radian input and degree output:  " << angle.degrees() <<
+      " degrees" <<endl;
+    cerr << "  " << angle.toString(false) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(30., Angle::Degrees );
+    Angle angleCopy(angle);
+    cerr <<"  Copy constructor:  " << angleCopy.degrees() << " degrees" <<
+        endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  cerr << endl << "Testing mutators" << endl;
+
+  try {
+    Angle angle(30., Angle::Degrees );
+    angle.setDegrees(180);
+    cerr <<"  setDegrees:  " << angle.degrees() << " degrees" <<
+        endl;
+    angle.setRadians(PI);
+    cerr <<"  setRadians:  " << angle.radians() << " radians" <<
+        endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  cerr << endl << "Testing operators" << endl;
+
+  try {
+    Angle angle(45.0, Angle::Degrees);
+    qDebug() << "  QDebug operator:  " << angle;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(30., Angle::Degrees );
+    angle = Angle(45., Angle::Degrees);
+    cerr << "  Assignment operator:  " << angle.degrees() << " degrees" <<
+        endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    Angle angle2(60., Angle::Degrees );
+    angle1 = angle1 + angle2;
+    // Begin with 30 degrees and end with 30 degrees
+    cerr << "  + and - operators..." << endl;
+    cerr << "    angle + angle: " << angle1.degrees() << " degrees" <<endl;
+    angle1 += angle2;
+    cerr << "    angle += angle: " << angle1.degrees() << " degrees" <<endl;
+    angle1 -= angle2;
+    cerr << "    angle -= angle: " << angle1.degrees() << " degrees" <<endl;
+    angle1 = angle1 - angle2;
+    cerr << "    angle - angle: " << angle1.degrees() << " degrees" <<endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(30., Angle::Degrees );
+    // Begin with 30 degrees and end with 30 degrees
+    cerr << "  * and / operators..." << endl;
+    angle = 2. * angle;
+    cerr << "    double * angle: " << angle.degrees() << " degrees" <<endl;
+    angle *= 2;
+    cerr << "    angle *= double: " << angle.degrees() << " degrees" <<endl;
+    angle /= 2;
+    cerr << "    angle /= double: " << angle.degrees() << " degrees" <<endl;
+    angle = angle / 2;
+    cerr << "    angle / double: " << angle.degrees() << " degrees" <<endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  cerr << endl << "Testing logical operators" << endl;
+
+  try {
+    Angle angle1(30., Angle::Degrees);
+    Angle angle2(45., Angle::Degrees);
+    cerr << "  angle1 == angle2?  " << (angle1 == angle2) << endl;
+    cerr << "  angle1 == angle2?  " << (Angle() == Angle()) << endl;
+    cerr << "  angle1 == angle2?  " << (Angle() == angle2) <<endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    Angle angle2(45., Angle::Degrees);
+    cerr << "  angle1 <  angle2?  ";
+    cerr << (angle1 < angle2) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    Angle angle2(45., Angle::Degrees);
+    //Angle epsilon((double)numeric_limits<float>::epsilon(), Angle::Degrees);//1.1920929e-07
+    Angle epsilon(1.1920929e-12, Angle::Degrees);//1.1920929e-07
+    cerr << "  angle1 <  (angle1 + epsilon)?  ";
+    cerr << (angle1 < angle1 + epsilon) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    Angle angle2(45., Angle::Degrees);
+    Angle epsilon(1.1920929e-12, Angle::Degrees);
+    cerr << "  angle2 >  (angle2 - epsilon)?  ";
+    cerr << (angle2 > angle2 - epsilon) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    Angle angle2(45., Angle::Degrees);
+    cerr << "  angle1 <= angle2?  ";
+    cerr << (angle1 <= angle2) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    cout << "  angle1 <  angle2?  ";
+    cerr << (angle1 < Angle());
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    cout << "  angle1 <  angle2?  ";
+    cerr  << (Angle() < angle1);
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    cerr << "  angle1 <=  angle2?  ";
+    cerr << (Angle() <= angle1);
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    Angle angle2(45., Angle::Degrees);
+    cerr << "  angle1 >  angle2?  ";
+    cerr << (angle1 > angle2) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    cerr << "  angle1 >  angle2?  ";
+    cerr << (angle1 > Angle()) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    Angle angle2(45., Angle::Degrees);
+    cerr << "  angle1 >= angle2?  ";
+    cerr << (angle1 >= angle2) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle1(30., Angle::Degrees );
+    cerr << "  angle1 >= angle2?  ";
+    cerr << (angle1 >= Angle()) << endl;
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  cerr << endl << "Testing protected methods" << endl;
+
+  try {
+    MyAngle angle(30., Angle::Degrees);
+    angle.TestUnitWrapValue();
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    MyAngle angle(0., Angle::Degrees);
+    cerr << "  Degree ";
+    angle.setAngle(60., Angle::Degrees);
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    MyAngle angle(0., Angle::Radians);
+    cerr << "  Radian ";
+    angle.setAngle(.5, Angle::Degrees);
+  }
+  catch(Isis::IException &e) {
+    e.print();
+  }
+
+  //Test Angle::Angle(QString):
+  try {
+    Angle angle(QString("-70 15 30.125"));
+    cerr << angle.toString() << endl;
+  }
+  catch (Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(QString("  +70  30 11     "));
+    cerr << angle.toString() << endl;
+  }
+  catch (Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(QString("100"));
+    cerr << angle.toString() << endl;
+  }
+  catch (Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(QString("70 11"));
+    cerr << angle.toString() << endl;
+  }
+  catch (Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(QString("this 79 should 00 fail 0.111"));
+    cerr << angle.toString() << endl;
+  }
+  catch (Isis::IException &e) {
+    e.print();
+  }
+
+  try {
+    Angle angle(QString("100 00 00"));
+    cerr << angle.toString() << endl;
+  }
+  catch (Isis::IException &e) {
+    e.print();
+  }
+
+}

--- a/isis/src/base/objs/ProcessByBrick/ProcessByBrick.cpp
+++ b/isis/src/base/objs/ProcessByBrick/ProcessByBrick.cpp
@@ -456,8 +456,8 @@ void ProcessByBrick::SetOutputRequirements(int outputRequirements) {
     bool haveInput = PrepProcessCubeInPlace(&cube, &brick);
 
     // Loop and let the app programmer work with the bricks
-    p_progress->SetMaximumSteps(brick->Bricks());
-    p_progress->CheckStatus();
+    //p_progress->SetMaximumSteps(brick->Bricks());
+    //p_progress->CheckStatus();
 
     for (brick->begin(); !brick->end(); (*brick)++) {
       if (haveInput) 
@@ -470,7 +470,7 @@ void ProcessByBrick::SetOutputRequirements(int outputRequirements) {
         cube->write(*brick);
       }
 
-      p_progress->CheckStatus();
+      //p_progress->CheckStatus();
     }
 
     delete brick;


### PR DESCRIPTION
I converted the ISIS3 crop application to an ISIS3 CropApp class. The functionality of the application is moved to a single thread.  The purpose of the original application is now to validate parameters that are passed into the class encapsulating the logic of the application.  This will make it easier for testing/debugging because now they are separate modules of logic instead of being co-mingled.  Validation of parameters in some ISIS3 applications can also be quite complex and non-trivial, so this is a good thing.

I have kept the code logic as simple as possible so that it can be easily replicated across applications.  Hopefully following this blueprint we can finally get rid of ProgramLauncher and pipeline (two of the touchiest applications within ISIS3).