### PR TITLE
Update isis3VarInit.py

### DIFF
--- a/isis/scripts/isis3VarInit.py
+++ b/isis/scripts/isis3VarInit.py
@@ -45,15 +45,12 @@ else:
 os.popen('mkdir -p '+isisroot+'/etc/conda/activate.d')
 os.popen('mkdir -p '+isisroot+'/etc/conda/deactivate.d')
 
-os.popen('touch '+isisroot+'/etc/conda/activate.d/env_vars.sh')
-os.popen('touch '+isisroot+'/etc/conda/activate.d/env_vars.sh')
-
-os.popen("echo '#!/bin/sh' >> "+isisroot+ "/etc/conda/activate.d/env_vars.sh")
+os.popen("echo '#!/bin/sh' > "+isisroot+ "/etc/conda/activate.d/env_vars.sh")
 os.popen("echo 'export ISISROOT="+isisroot+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
 os.popen("echo 'export ISIS3DATA="+data_dir+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
 os.popen("echo 'export ISIS3TESTDATA="+testdata_dir+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
 
-os.popen("echo '#!/bin/sh' >> "+isisroot+ "/etc/conda/deactivate.d/env_vars.sh")
+os.popen("echo '#!/bin/sh' > "+isisroot+ "/etc/conda/deactivate.d/env_vars.sh")
 os.popen("echo 'unset ISISROOT' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
 os.popen("echo 'unset ISIS3DATA' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
 os.popen("echo 'unset ISIS3TESTDATA' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")


### PR DESCRIPTION
Unnecessary 'touch'ing, the '>' redirect will create the file if it doesn't exist.
Also, the first redirect should be the single '>'.  Otherwise, multiple runs of this program will continue appending to these files.  They still work, its just a lot of setting and unsetting for no good reason.