### PR TITLE
Removed unneeded LineEquation includes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gtest"]
+	path = gtest
+	url = git@github.com:google/googletest.git

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - bullet==2.86.1=0
   - bz2file==0.98
   - bzip2==1.0.6=1
-  - cmake==3.9.1=0
+  - cmake>=3.10
   - cspice==66=h470a237_3
   - curl==7.60.0=0
   - doxygen==1.8.14=0

--- a/environment_gcc4.yml
+++ b/environment_gcc4.yml
@@ -11,7 +11,7 @@ dependencies:
   - bullet==2.86.1=0
   - bz2file==0.98
   - bzip2==1.0.6=1
-  - cmake==3.9.1=0
+  - cmake>=3.10
   - cspice==66=h470a237_3
   - curl==7.60.0=0
   - doxygen==1.8.14=0

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -347,7 +347,7 @@ if(pybindings)
 
  file(GLOB SIP_GENERATED_SOURCE_FILES ${ISIS_SIP_CODE_DIR}/*.cpp)
  add_library(isispy MODULE ${SIP_GENERATED_SOURCE_FILES})
- target_link_libraries(isispy ${ALLLIBS} gtest ${CMAKE_THREAD_LIBS_INIT})
+ target_link_libraries(isispy ${ALLLIBS})
  target_link_libraries(isispy isis3)
  set_target_properties(isispy PROPERTIES LINK_DEPENDS isis3 INSTALL_RPATH ${CMAKE_INSTALL_PREFIX})
  add_dependencies(isispy sipfiles)

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -5,7 +5,7 @@
 
 # Specify the required version of CMake.  If your machine does not
 #  have this, it should be easy to build from https://cmake.org/download/
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.10)
 
 # Point cmake to our other CMake files.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -16,6 +16,8 @@ include(AddIsisModule)
 include(Utilities)
 include(TestSetup)
 include(InstallThirdParty)
+include(cmake/gtest.cmake)
+include(GoogleTest)
 
 #===============================================================================
 #===============================================================================
@@ -28,15 +30,15 @@ set(PACKAGE            "ISIS")
 set(PACKAGE_NAME       "USGS ISIS")
 
 # Version number
-set(VERSION            "3.5.00.0")
+set(VERSION            "3.6.00.0")
 set(PACKAGE_VERSION    ${VERSION})
 
 # Full name and version number
 set(PACKAGE_STRING     "${PACKAGE_NAME} ${VERSION}")
 
 # Other release information
-set(VERSION_DATE              "2017-04-24")
-set(THIRD_PARTY_LIBS_VERSION  "v007")
+set(VERSION_DATE              "2018-11-09")
+set(THIRD_PARTY_LIBS_VERSION  "v008")
 set(RELEASE_STAGE             "alpha") # (alpha, beta, stable)
 
 # Define to the address where bug reports for this package should be sent.
@@ -245,6 +247,7 @@ find_package(PNG               REQUIRED)
 find_package(Kakadu)
 find_package(Geos    3.5.0     REQUIRED)
 find_package(Armadillo         REQUIRED)
+find_package(Threads)
 
 if(pybindings)
  find_package(Python REQUIRED)
@@ -344,7 +347,7 @@ if(pybindings)
 
  file(GLOB SIP_GENERATED_SOURCE_FILES ${ISIS_SIP_CODE_DIR}/*.cpp)
  add_library(isispy MODULE ${SIP_GENERATED_SOURCE_FILES})
- target_link_libraries(isispy ${ALLLIBS})
+ target_link_libraries(isispy ${ALLLIBS} gtest ${CMAKE_THREAD_LIBS_INIT})
  target_link_libraries(isispy isis3)
  set_target_properties(isispy PROPERTIES LINK_DEPENDS isis3 INSTALL_RPATH ${CMAKE_INSTALL_PREFIX})
  add_dependencies(isispy sipfiles)
@@ -459,3 +462,9 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/scripts         DESTINATION  ${CMAKE_INSTA
 #   the end of this file containing a CMakeLists.txt file which includes all of
 #   the desired post-install commands inside.
 add_subdirectory(cmake)
+option (BUILD_TESTS "Build tests" ON)
+if(BUILD_TESTS)
+  include(CTest)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/isis/cmake/AddIsisModule.cmake
+++ b/isis/cmake/AddIsisModule.cmake
@@ -222,10 +222,10 @@ function(add_isis_module name)
   # - Base module depends on 3rd party libs, other libs also depend on base.
   # - Only the base module gets both a static and shared library.
   if(${name} STREQUAL ${CORE_LIB_NAME})
-    set(reqLibs ${ALLLIBS})
+    set(reqLibs "${ALLLIBS};gtest;${CMAKE_THREAD_LIBS_INIT}")
     set(alsoStatic ON)
   else()
-    set(reqLibs "${CORE_LIB_NAME};${ALLLIBS}")
+    set(reqLibs "${CORE_LIB_NAME};${ALLLIBS};gtest;${CMAKE_THREAD_LIBS_INIT}")
     set(alsoStatic OFF)
   endif()
 

--- a/isis/cmake/AddIsisModule.cmake
+++ b/isis/cmake/AddIsisModule.cmake
@@ -222,10 +222,10 @@ function(add_isis_module name)
   # - Base module depends on 3rd party libs, other libs also depend on base.
   # - Only the base module gets both a static and shared library.
   if(${name} STREQUAL ${CORE_LIB_NAME})
-    set(reqLibs "${ALLLIBS};gtest;${CMAKE_THREAD_LIBS_INIT}")
+    set(reqLibs "${ALLLIBS};gtest;gmock;${CMAKE_THREAD_LIBS_INIT}")
     set(alsoStatic ON)
   else()
-    set(reqLibs "${CORE_LIB_NAME};${ALLLIBS};gtest;${CMAKE_THREAD_LIBS_INIT}")
+    set(reqLibs "${CORE_LIB_NAME};${ALLLIBS};gtest;gmock;${CMAKE_THREAD_LIBS_INIT}")
     set(alsoStatic OFF)
   endif()
 

--- a/isis/cmake/gtest.cmake
+++ b/isis/cmake/gtest.cmake
@@ -1,0 +1,19 @@
+if (NOT TARGET gtest)
+  set(GOOGLETEST_ROOT gtest/googletest CACHE STRING "Google Test source root")
+
+  include_directories(SYSTEM
+      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}
+      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/include
+      )
+
+  set(GOOGLETEST_SOURCES
+      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest-all.cc
+      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest_main.cc
+      )
+
+  foreach(_source ${GOOGLETEST_SOURCES})
+      set_source_files_properties(${_source} PROPERTIES GENERATED 1)
+  endforeach()
+
+  add_library(gtest ${GOOGLETEST_SOURCES})
+endif()

--- a/isis/cmake/gtest.cmake
+++ b/isis/cmake/gtest.cmake
@@ -1,14 +1,14 @@
 if (NOT TARGET gtest)
-  set(GOOGLETEST_ROOT gtest/googletest CACHE STRING "Google Test source root")
+  set(GOOGLETEST_ROOT ${CMAKE_SOURCE_DIR}/../gtest/googletest CACHE STRING "Google Test source root")
 
   include_directories(SYSTEM
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/include
+      ${GOOGLETEST_ROOT}
+      ${GOOGLETEST_ROOT}/include
       )
 
   set(GOOGLETEST_SOURCES
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest-all.cc
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest_main.cc
+      ${GOOGLETEST_ROOT}/src/gtest-all.cc
+      ${GOOGLETEST_ROOT}/src/gtest_main.cc
       )
 
   foreach(_source ${GOOGLETEST_SOURCES})

--- a/isis/cmake/gtest.cmake
+++ b/isis/cmake/gtest.cmake
@@ -17,3 +17,23 @@ if (NOT TARGET gtest)
 
   add_library(gtest ${GOOGLETEST_SOURCES})
 endif()
+
+if (NOT TARGET gmock)
+  set(GOOGLEMOCK_ROOT ${CMAKE_SOURCE_DIR}/../gtest/googlemock CACHE STRING "Google Mock source root")
+
+  include_directories(SYSTEM
+      ${GOOGLEMOCK_ROOT}
+      ${GOOGLEMOCK_ROOT}/include
+      )
+
+  set(GOOGLEMOCK_SOURCES
+      ${GOOGLEMOCK_ROOT}/src/gmock-all.cc
+      ${GOOGLEMOCK_ROOT}/src/gmock_main.cc
+      )
+
+  foreach(_source ${GOOGLEMOCK_SOURCES})
+      set_source_files_properties(${_source} PROPERTIES GENERATED 1)
+  endforeach()
+
+  add_library(gmock ${GOOGLEMOCK_SOURCES})
+endif()

--- a/isis/src/base/apps/appjit/LineScanCameraRotation.cpp
+++ b/isis/src/base/apps/appjit/LineScanCameraRotation.cpp
@@ -8,7 +8,6 @@
 #include "Cube.h"
 #include "LineScanCameraRotation.h"
 #include "Quaternion.h"
-#include "LineEquation.h"
 #include "BasisFunction.h"
 #include "LeastSquares.h"
 #include "BasisFunction.h"

--- a/isis/src/base/apps/appjit/PixelOffset.cpp
+++ b/isis/src/base/apps/appjit/PixelOffset.cpp
@@ -8,7 +8,6 @@
 
 #include "PixelOffset.h"
 #include "TextFile.h"
-#include "LineEquation.h"
 #include "LeastSquares.h"
 #include "BasisFunction.h"
 #include "PolynomialUnivariate.h"

--- a/isis/tests/CMakeLists.txt
+++ b/isis/tests/CMakeLists.txt
@@ -2,10 +2,14 @@ cmake_minimum_required(VERSION 3.10)
 
 add_dependencies(isis3 isis3)
 
+file(GLOB test_source "${CMAKE_SOURCE_DIR}/tests/*.cpp")
+
+
 # Link runISISTests with what we want to test and the GTest and pthread library
 add_executable(runISISTests
-               FileNameTests.cpp)
+               IsisTestMain.cpp
+               ${test_source})
                
 target_link_libraries(runISISTests isis3 ${ALLLIBS} ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
 
-gtest_discover_tests(runISISTests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../tests)
+gtest_discover_tests(runISISTests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/isis/tests/CMakeLists.txt
+++ b/isis/tests/CMakeLists.txt
@@ -1,0 +1,11 @@
+cmake_minimum_required(VERSION 3.10)
+
+add_dependencies(isis3 isis3)
+
+# Link runISISTests with what we want to test and the GTest and pthread library
+add_executable(runISISTests
+               FileNameTests.cpp)
+               
+target_link_libraries(runISISTests isis3 ${ALLLIBS} ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
+
+gtest_discover_tests(runISISTests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/../tests)

--- a/isis/tests/FileNameTests.cpp
+++ b/isis/tests/FileNameTests.cpp
@@ -5,127 +5,175 @@
 #include <gtest/gtest.h>
 
 
-TEST(FileNameTests, OriginalPath) {
+using namespace Isis;
+
+class FileName_Fixture_Versioned : public ::testing::TestWithParam<const char*> {
+  // Intentionally empty
+};
+
+class FileName_Fixture_NotVersioned : public ::testing::TestWithParam<const char*> {
+  // Intentionally empty
+};
+
+
+TEST(FileName, DefaultConstructor) {
+  FileName file;
+  
+//   EXPECT_EQ("", file.originalPath());
+//   EXPECT_EQ("", file.path());
+//   EXPECT_EQ("", file.attributes());
+  EXPECT_EQ("", file.baseName());
+  EXPECT_EQ("", file.name());
+  EXPECT_EQ("", file.extension());
+}
+
+TEST(FileName, OriginalPath) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("/testy/mc/test/face", file.originalPath());
 }
 
-TEST(FileNameTests, Path) {
+TEST(FileName, Path) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("/testy/mc/test/face", file.path());
 }
 
-TEST(FileNameTests, Attributes) {
+TEST(FileName, Attributes) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("", file.attributes());
   
   QString testAtt = "/testy/mc/test/face/test.cub+Bsq";
-  Isis::FileName fileAtt(testAtt);
+  FileName fileAtt(testAtt);
   
   EXPECT_EQ("Bsq", fileAtt.attributes());
 }
 
-TEST(FileNameTests, BaseName) {
+TEST(FileName, BaseName) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("test", file.baseName());
 }
 
-TEST(FileNameTests, Name) {
+TEST(FileName, Name) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("test.cub", file.name());
 }
 
-TEST(FileNameTests, Extension) {
+TEST(FileName, Extension) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("cub", file.extension());
 }
 
-//TODO How is this going to work? Before we used ISISROOT. Will that still work?
+//TODO Waiting for GMock
 
-// TEST(FileNameTests, Expanded) {
-//   QString test = "/testy/mc/test/face/test.cub";
-//   Isis::FileName file(test);
-//   
-//   EXPECT_EQ("cub", file.expanded());
+// TEST(FileName, Expanded) {
 // }
 
-TEST(FileNameTests, Original) {
+TEST(FileName, Original) {
   QString test = "$ISISROOT/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("$ISISROOT/testy/mc/test/face/test.cub", file.original());
 }
 
-TEST(FileNameTests, AddExtension) {
+TEST(FileName, AddExtension) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("txt", file.addExtension(".txt").extension());
 }
 
-TEST(FileNameTests, RemoveExtension) {
+TEST(FileName, RemoveExtension) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   std::cout << file.removeExtension().extension().toStdString() << std::endl;
   EXPECT_EQ("", file.removeExtension().extension());
 }
 
-TEST(FileNameTests, SetExtension) {
+TEST(FileName, SetExtension) {
   QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ("log", file.setExtension("log").extension());
 }
 
-//TODO There are a lot of different tests for versioning. Do we want to replicate them all??
-
-TEST(FileNameTests, isNotVersioned) {
-  QString test = "/testy/mc/test/face/test.cub";
-  Isis::FileName file(test);
-  
-  EXPECT_EQ(false, file.isVersioned());
-}
-
-TEST(FileNameTests, isQuestionMarksNoExtensionVersioned) {
+TEST(FileName, isQuestionMarksNoExtensionVersioned) {
   QString test = "/testy/mc/test/face/test??????";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ(true, file.isVersioned());
 }
 
-TEST(FileNameTests, isQuestionMarksExtensionVersioned) {
+TEST(FileName, isQuestionMarksExtensionVersioned) {
   QString test = "/testy/mc/test/face/test??????.cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ(true, file.isVersioned());
 }
 
-TEST(FileNameTests, isDDMMMYYYVersioned) {
+TEST(FileName, isDDMMMYYYVersioned) {
   QString test = "/testy/mc/test/face/test{ddMMMyyyy}..cub";
-  Isis::FileName file(test);
+  FileName file(test);
   
   EXPECT_EQ(true, file.isVersioned());
 }
 
-//TODO How do we want to deal with test data?
+//TODO Waiting for GMock
 
-// TEST(FileNameTests, HighestVersion) {
-//   QString test = "/testy/mc/test/face/test{ddMMMyyyy}..cub";
-//   Isis::FileName file(test);
-//   
-//   EXPECT_EQ(true, file.isVersioned());
+// TEST(FileName, HighestVersion) {
 // }
 
-//TODO How do we test equal operators?
+// TEST(FileName, NewVersion) {
+// }
+
+// TEST(FileName, Version) {
+// }
+
+TEST(FileName, ToString) {
+  QString test = "/testy/mc/test/face/test.cub";
+  FileName file(test);
+  
+  EXPECT_EQ("/testy/mc/test/face/test.cub", file.toString());
+}
+
+// TODO Waiting for GMock
+// TEST(FileName, EqualOperator) {
+// }
+
+// TEST(FileName, NotEqualOperator) {
+// }
+
+TEST_P(FileName_Fixture_Versioned, IsVersioned) {
+  FileName file(GetParam());
+  
+  EXPECT_TRUE(file.isVersioned());
+}
+
+const char* versionedFiles[] = {"tttt??????", "tttt??????.tmp", "tttt_?.tmp", "??tttt", 
+                                "?tttt000008.tmp", "junk?", "tttt{ddMMMyyyy}.tmp", 
+                                "tt{MMM}tt{dd}yy{yy}.tmp", "tt{d}tt{MMM}.tmp", "tt{d}tt{MMMM}.tmp",
+                                "tt{dd}.tmp", "tttt{dd}.tmp", "$TEMPORARY/{MMM}-{dd}-{yy}_v???.tmp"};
+
+INSTANTIATE_TEST_CASE_P(FileName, FileName_Fixture_Versioned, ::testing::ValuesIn(versionedFiles));
+                                   
+TEST_P(FileName_Fixture_NotVersioned, IsVersioned) {
+  FileName file(GetParam());
+  
+  EXPECT_FALSE(file.isVersioned());
+}
+
+const char* notVersionedFiles[] = {"tttt"};
+//TODO These actually throw errors so they cannot be checked like this
+//"tttt{}.tmp", "ttttt{}.tmp", "??tttt??", "tttt{aaaa}.tmp"};
+
+INSTANTIATE_TEST_CASE_P(FileName, FileName_Fixture_NotVersioned, ::testing::ValuesIn(notVersionedFiles));

--- a/isis/tests/FileNameTests.cpp
+++ b/isis/tests/FileNameTests.cpp
@@ -1,0 +1,18 @@
+#include "FileName.h"
+
+#include <QString>
+
+#include <gtest/gtest.h>
+
+
+TEST(FileNameTests, BaseName) {
+  QString test = "test.log";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("test", file.baseName());
+}
+
+int main(int argc, char **argv) {
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}

--- a/isis/tests/FileNameTests.cpp
+++ b/isis/tests/FileNameTests.cpp
@@ -5,14 +5,127 @@
 #include <gtest/gtest.h>
 
 
+TEST(FileNameTests, OriginalPath) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("/testy/mc/test/face", file.originalPath());
+}
+
+TEST(FileNameTests, Path) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("/testy/mc/test/face", file.path());
+}
+
+TEST(FileNameTests, Attributes) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("", file.attributes());
+  
+  QString testAtt = "/testy/mc/test/face/test.cub+Bsq";
+  Isis::FileName fileAtt(testAtt);
+  
+  EXPECT_EQ("Bsq", fileAtt.attributes());
+}
+
 TEST(FileNameTests, BaseName) {
-  QString test = "test.log";
+  QString test = "/testy/mc/test/face/test.cub";
   Isis::FileName file(test);
   
   EXPECT_EQ("test", file.baseName());
 }
 
-int main(int argc, char **argv) {
-   ::testing::InitGoogleTest(&argc, argv);
-   return RUN_ALL_TESTS();
+TEST(FileNameTests, Name) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("test.cub", file.name());
 }
+
+TEST(FileNameTests, Extension) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("cub", file.extension());
+}
+
+//TODO How is this going to work? Before we used ISISROOT. Will that still work?
+
+// TEST(FileNameTests, Expanded) {
+//   QString test = "/testy/mc/test/face/test.cub";
+//   Isis::FileName file(test);
+//   
+//   EXPECT_EQ("cub", file.expanded());
+// }
+
+TEST(FileNameTests, Original) {
+  QString test = "$ISISROOT/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("$ISISROOT/testy/mc/test/face/test.cub", file.original());
+}
+
+TEST(FileNameTests, AddExtension) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("txt", file.addExtension(".txt").extension());
+}
+
+TEST(FileNameTests, RemoveExtension) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  std::cout << file.removeExtension().extension().toStdString() << std::endl;
+  EXPECT_EQ("", file.removeExtension().extension());
+}
+
+TEST(FileNameTests, SetExtension) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ("log", file.setExtension("log").extension());
+}
+
+//TODO There are a lot of different tests for versioning. Do we want to replicate them all??
+
+TEST(FileNameTests, isNotVersioned) {
+  QString test = "/testy/mc/test/face/test.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ(false, file.isVersioned());
+}
+
+TEST(FileNameTests, isQuestionMarksNoExtensionVersioned) {
+  QString test = "/testy/mc/test/face/test??????";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ(true, file.isVersioned());
+}
+
+TEST(FileNameTests, isQuestionMarksExtensionVersioned) {
+  QString test = "/testy/mc/test/face/test??????.cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ(true, file.isVersioned());
+}
+
+TEST(FileNameTests, isDDMMMYYYVersioned) {
+  QString test = "/testy/mc/test/face/test{ddMMMyyyy}..cub";
+  Isis::FileName file(test);
+  
+  EXPECT_EQ(true, file.isVersioned());
+}
+
+//TODO How do we want to deal with test data?
+
+// TEST(FileNameTests, HighestVersion) {
+//   QString test = "/testy/mc/test/face/test{ddMMMyyyy}..cub";
+//   Isis::FileName file(test);
+//   
+//   EXPECT_EQ(true, file.isVersioned());
+// }
+
+//TODO How do we test equal operators?

--- a/isis/tests/IsisTestMain.cpp
+++ b/isis/tests/IsisTestMain.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}

--- a/isis/tests/PixelTests.cpp
+++ b/isis/tests/PixelTests.cpp
@@ -1,0 +1,481 @@
+#include <gtest/gtest.h>
+
+#include <functional>
+#include <iostream>
+#include <string>
+// #include <tuple>
+#include <utility>
+#include <vector>
+
+#include "Pixel.h"
+#include "SpecialPixel.h"
+
+using namespace Isis;
+
+TEST(Pixel, DefaultConstructor) {
+  Pixel p;
+  EXPECT_EQ(0, p.sample());
+  EXPECT_EQ(0, p.line());
+  EXPECT_EQ(0, p.band());
+  EXPECT_EQ(Isis::Null, p.DN());
+}
+
+TEST(Pixel, Constructor1) {
+  Pixel p(0, 1, 2, 3.0);
+  EXPECT_EQ(0, p.sample());
+  EXPECT_EQ(1, p.line());
+  EXPECT_EQ(2, p.band());
+  EXPECT_DOUBLE_EQ(3.0, p.DN());
+}
+
+TEST(Pixel, CopyConstructor) {
+  Pixel p(0, 1, 2, 3.0);
+  // Note this is equivalent to Pixel copy(p);
+  Pixel copy = p;
+  EXPECT_EQ(0, copy.sample());
+  EXPECT_EQ(1, copy.line());
+  EXPECT_EQ(2, copy.band());
+  EXPECT_DOUBLE_EQ(3.0, copy.DN());
+}
+
+TEST(Pixel, CopyAssignment) {
+  Pixel p(0, 1, 2, 3.0);
+  Pixel copy;
+  copy = p;
+  EXPECT_EQ(0, copy.sample());
+  EXPECT_EQ(1, copy.line());
+  EXPECT_EQ(2, copy.band());
+  EXPECT_DOUBLE_EQ(3.0, copy.DN());
+}
+
+TEST(Pixel, static_To8Bit) {
+  // Zero test
+  EXPECT_EQ(Isis::NULL1, Pixel::To8Bit(0.0));
+  // Negative test
+  EXPECT_EQ(Isis::LOW_REPR_SAT1, Pixel::To8Bit(-1.0));
+  // Trivial positive test
+  EXPECT_EQ(1, Pixel::To8Bit(1.0));
+  // Minimum valid input // Isis::ValidMinimum becomes \0
+  EXPECT_EQ(Isis::LOW_REPR_SAT1, Pixel::To8Bit(Isis::ValidMinimum));
+  // Maximum valid input // Isis::ValidMaximum becomes \xFF (255)
+  EXPECT_EQ(Isis::HIGH_REPR_SAT1, Pixel::To8Bit(Isis::ValidMaximum));
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULL1, Pixel::To8Bit(Isis::Null));
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SAT1, Pixel::To8Bit(Isis::Hrs));
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SAT1, Pixel::To8Bit(Isis::His));
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SAT1, Pixel::To8Bit(Isis::Lrs));
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SAT1, Pixel::To8Bit(Isis::Lis));
+}
+
+TEST(Pixel, To8Bit) {
+  // Zero test
+  EXPECT_EQ(Isis::NULL1, Pixel(1, 2, 3, 0.0).To8Bit());
+  // Negative test
+  EXPECT_EQ(Isis::LOW_REPR_SAT1, Pixel(1, 2, 3, -1.0).To8Bit());
+  // Trivial positive test
+  EXPECT_EQ(1, Pixel(1, 2, 3, 1.0).To8Bit());
+  // Minimum valid input // Isis::ValidMinimum becomes \0
+  EXPECT_EQ(Isis::LOW_REPR_SAT1, Pixel(1, 2, 3, Isis::ValidMinimum).To8Bit());
+  // Maximum valid input // Isis::ValidMaximum becomes \xFF (255)
+  EXPECT_EQ(Isis::HIGH_REPR_SAT1, Pixel(1, 2, 3, Isis::ValidMaximum).To8Bit());
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULL1, Pixel(1, 2, 3, Isis::Null).To8Bit());
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SAT1, Pixel(1, 2, 3, Isis::Hrs).To8Bit());
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SAT1, Pixel(1, 2, 3, Isis::His).To8Bit());
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SAT1, Pixel(1, 2, 3, Isis::Lrs).To8Bit());
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SAT1, Pixel(1, 2, 3, Isis::Lis).To8Bit());
+}
+
+TEST(Pixel, static_To16UBit) {
+  // Zero test
+  EXPECT_EQ(Isis::NULLU2, Pixel::To16UBit(0.0));
+  // Negative test // -1.0 becomes HIGH_REPR_SATU2, not LOW_REPR_SATU2
+  EXPECT_EQ(Isis::HIGH_REPR_SATU2, Pixel::To16UBit(-1.0));
+  // Positive test
+  EXPECT_EQ(1, Pixel::To16UBit(1.0));
+  // Minimum valid input
+  EXPECT_EQ(Isis::LOW_REPR_SATU2, Pixel::To16UBit(Isis::ValidMinimum));
+  // Maximum valid input
+  EXPECT_EQ(Isis::HIGH_REPR_SATU2, Pixel::To16UBit(Isis::ValidMaximum));
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULLU2, Pixel::To16UBit(Isis::Null));
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SATU2, Pixel::To16UBit(Isis::Hrs));
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SATU2, Pixel::To16UBit(Isis::His));
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SATU2, Pixel::To16UBit(Isis::Lrs));
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SATU2, Pixel::To16UBit(Isis::Lis));
+}
+
+TEST(Pixel, To16UBit) {
+  // Zero test
+  EXPECT_EQ(Isis::NULLU2, Pixel(1, 2, 3, 0.0).To16Ubit());
+  // Negative test // -1.0 becomes HIGH_REPR_SATU2, not LOW_REPR_SATU2
+  EXPECT_EQ(Isis::HIGH_REPR_SATU2, Pixel(1, 2, 3, -1.0).To16Ubit());
+  // Positive test
+  EXPECT_EQ(1, Pixel(1, 2, 3, 1.0).To16Ubit());
+  // Minimum valid input
+  EXPECT_EQ(Isis::LOW_REPR_SATU2, Pixel(1, 2, 3, Isis::ValidMinimum).To16Ubit());
+  // Maximum valid input
+  EXPECT_EQ(Isis::HIGH_REPR_SATU2, Pixel(1, 2, 3, Isis::ValidMaximum).To16Ubit());
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULLU2, Pixel(1, 2, 3, Isis::Null).To16Ubit());
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SATU2, Pixel(1, 2, 3, Isis::Hrs).To16Ubit());
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SATU2, Pixel(1, 2, 3, Isis::His).To16Ubit());
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SATU2, Pixel(1, 2, 3, Isis::Lrs).To16Ubit());
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SATU2, Pixel(1 ,2, 3, Isis::Lis).To16Ubit());
+}
+
+TEST(Pixel, static_To16Bit) {
+  // Zero test
+  EXPECT_EQ(0, Pixel::To16Bit(0.0));
+  // Negative test
+  EXPECT_EQ(-1, Pixel::To16Bit(-1.0));
+  // Positive test
+  EXPECT_EQ(1, Pixel::To16Bit(1.0));
+  // Minimum valid input
+  EXPECT_EQ(Isis::LOW_REPR_SAT2, Pixel::To16Bit(Isis::ValidMinimum));
+  // Maximum valid input
+  EXPECT_EQ(Isis::HIGH_REPR_SAT2, Pixel::To16Bit(Isis::ValidMaximum));
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULL2, Pixel::To16Bit(Isis::Null));
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SAT2, Pixel::To16Bit(Isis::Hrs));
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SAT2, Pixel::To16Bit(Isis::His));
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SAT2, Pixel::To16Bit(Isis::Lrs));
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SAT2, Pixel::To16Bit(Isis::Lis));
+}
+
+TEST(Pixel, To16Bit) {
+  // Zero test
+  EXPECT_EQ(0, Pixel(1, 2, 3, 0.0).To16Bit());
+  // Negative test
+  EXPECT_EQ(-1, Pixel(1, 2, 3, -1.0).To16Bit());
+  // Positive test
+  EXPECT_EQ(1, Pixel(1, 2, 3, 1.0).To16Bit());
+  // Minimum valid input
+  EXPECT_EQ(Isis::LOW_REPR_SAT2, Pixel(1, 2, 3, Isis::ValidMinimum).To16Bit());
+  // Maximum valid input
+  EXPECT_EQ(Isis::HIGH_REPR_SAT2, Pixel(1, 2, 3, Isis::ValidMaximum).To16Bit());
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULL2, Pixel(1, 2, 3, Isis::Null).To16Bit());
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SAT2, Pixel(1, 2, 3, Isis::Hrs).To16Bit());
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SAT2, Pixel(1, 2, 3, Isis::His).To16Bit());
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SAT2, Pixel(1, 2, 3, Isis::Lrs).To16Bit());
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SAT2, Pixel(1, 2, 3, Isis::Lis).To16Bit());
+}
+
+TEST(Pixel, static_To32Bit) {
+  // Zero test
+  EXPECT_EQ(0, Pixel::To32Bit(0.0));
+  // Negative test
+  EXPECT_EQ(-1, Pixel::To32Bit(-1.0));
+  // Positive test
+  EXPECT_EQ(1, Pixel::To32Bit(1.0));
+  // Minimum valid input
+  // EXPECT_FLOAT_EQ(Isis::LOW_REPR_SAT4, Pixel::To32Bit(Isis::ValidMinimum));
+  // Maximum valid input // Isis::Maximum becomes inf (not IHIGH_REPR_SAT4)
+  // EXPECT_FLOAT_EQ(Isis::HIGH_REPR_SAT4, Pixel::To32Bit(Isis::ValidMaximum));
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULL4, Pixel::To32Bit(Isis::Null));
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SAT4, Pixel::To32Bit(Isis::Hrs));
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SAT4, Pixel::To32Bit(Isis::His));
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SAT4, Pixel::To32Bit(Isis::Lrs));
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SAT4, Pixel::To32Bit(Isis::Lis));
+}
+
+TEST(Pixel, To32Bit) {
+  // Zero test
+  EXPECT_EQ(0, Pixel(1, 2, 3, 0.0).To32Bit());
+  // Negative test
+  EXPECT_EQ(-1, Pixel(1, 2, 3, -1.0).To32Bit());
+  // Positive test
+  EXPECT_EQ(1, Pixel(1, 2, 3, 1.0).To32Bit());
+  // Minimum valid input
+  // EXPECT_EQ(Isis::LOW_REPR_SAT4, Pixel(1, 2, 3, Isis::ValidMinimum).To32Bit());
+  // Maximum valid input // Isis::Maximum becomes inf (not HIGH_REPR_SAT4)
+  // EXPECT_FLOAT_EQ(Isis::HIGH_REPR_SAT4, Pixel(1, 2, 3, Isis::ValidMaximum).To32Bit());
+  // "Null" pixel
+  EXPECT_EQ(Isis::NULL4, Pixel(1, 2, 3, Isis::Null).To32Bit());
+  // HRS
+  EXPECT_EQ(Isis::HIGH_REPR_SAT4, Pixel(1, 2, 3, Isis::Hrs).To32Bit());
+  // HIS
+  EXPECT_EQ(Isis::HIGH_INSTR_SAT4, Pixel(1, 2, 3, Isis::His).To32Bit());
+  // LRS
+  EXPECT_EQ(Isis::LOW_REPR_SAT4, Pixel(1, 2, 3, Isis::Lrs).To32Bit());
+  // LIS
+  EXPECT_EQ(Isis::LOW_INSTR_SAT4, Pixel(1, 2, 3, Isis::Lis).To32Bit());
+}
+
+TEST(Pixel, static_ToDouble) {
+  // unsigned char
+  unsigned char uc = 0;
+  EXPECT_DOUBLE_EQ(Isis::Null, Pixel::ToDouble(uc));
+
+  // short
+  short s = 0.0;
+  EXPECT_DOUBLE_EQ(0.0, Pixel::ToDouble(s));
+
+  // unsigned short
+  unsigned short us = 0.0;
+  EXPECT_DOUBLE_EQ(Isis::Null, Pixel::ToDouble(us));
+
+  // float
+  float f = 0.0;
+  EXPECT_DOUBLE_EQ(0.0, Pixel::ToDouble(f));
+}
+
+TEST(Pixel, ToDouble) {
+  EXPECT_EQ(0.0, Pixel(1, 2, 3, 0.0).ToDouble());
+}
+
+TEST(Pixel, static_ToFloat) {
+  // unsigned char
+  unsigned char uc = 0;
+  EXPECT_FLOAT_EQ(Isis::NULL4, Pixel::ToFloat(uc));
+
+  // short
+  short s = 0.0;
+  EXPECT_FLOAT_EQ(0.0, Pixel::ToFloat(s));
+
+  // unsigned short
+  unsigned short us = 0.0;
+  EXPECT_FLOAT_EQ(Isis::NULL4, Pixel::ToFloat(us));
+
+  // float
+  float f = 0.0;
+  EXPECT_FLOAT_EQ(0.0, Pixel::ToFloat(f));
+}
+
+TEST(Pixel, ToFloat) {
+  EXPECT_FLOAT_EQ(0.0, Pixel(1, 2, 3, 0.0).ToFloat());
+}
+
+TEST(Pixel, static_IsSpecial) {
+  EXPECT_TRUE(Pixel::IsSpecial(Isis::His));
+  EXPECT_TRUE(Pixel::IsSpecial(Isis::Hrs));
+  EXPECT_TRUE(Pixel::IsSpecial(Isis::Lis));
+  EXPECT_TRUE(Pixel::IsSpecial(Isis::Lrs));
+  EXPECT_TRUE(Pixel::IsSpecial(Isis::Null));
+  EXPECT_FALSE(Pixel::IsSpecial(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsSpecial(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsSpecial) {
+  EXPECT_TRUE(Pixel(1,2,3,Isis::His).IsSpecial());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Hrs).IsSpecial());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Lis).IsSpecial());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Lrs).IsSpecial());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Null).IsSpecial());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsSpecial());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsSpecial());
+}
+
+TEST(Pixel, static_IsValid) {
+  EXPECT_FALSE(Pixel::IsValid(Isis::His));
+  EXPECT_FALSE(Pixel::IsValid(Isis::Hrs));
+  EXPECT_FALSE(Pixel::IsValid(Isis::Lis));
+  EXPECT_FALSE(Pixel::IsValid(Isis::Lrs));
+  EXPECT_FALSE(Pixel::IsValid(Isis::Null));
+  EXPECT_TRUE(Pixel::IsValid(Isis::ValidMaximum));
+  EXPECT_TRUE(Pixel::IsValid(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsValid) {
+  EXPECT_FALSE(Pixel(1,2,3,Isis::His).IsValid());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Hrs).IsValid());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lis).IsValid());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lrs).IsValid());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Null).IsValid());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::ValidMaximum).IsValid());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::ValidMinimum).IsValid());
+}
+
+TEST(Pixel, static_IsNull) {
+  EXPECT_FALSE(Pixel::IsNull(Isis::His));
+  EXPECT_FALSE(Pixel::IsNull(Isis::Hrs));
+  EXPECT_FALSE(Pixel::IsNull(Isis::Lis));
+  EXPECT_FALSE(Pixel::IsNull(Isis::Lrs));
+  EXPECT_TRUE(Pixel::IsNull(Isis::Null));
+  EXPECT_FALSE(Pixel::IsNull(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsNull(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsNull) {
+  EXPECT_FALSE(Pixel(1,2,3,Isis::His).IsNull());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Hrs).IsNull());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lis).IsNull());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lrs).IsNull());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Null).IsNull());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsNull());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsNull());
+}
+
+TEST(Pixel, static_IsHigh) {
+  EXPECT_TRUE (Pixel::IsHigh(Isis::His));
+  EXPECT_TRUE (Pixel::IsHigh(Isis::Hrs));
+  EXPECT_FALSE(Pixel::IsHigh(Isis::Lis));
+  EXPECT_FALSE(Pixel::IsHigh(Isis::Lrs));
+  EXPECT_FALSE(Pixel::IsHigh(Isis::Null));
+  EXPECT_FALSE(Pixel::IsHigh(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsHigh(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsHigh) {
+  EXPECT_TRUE(Pixel(1,2,3,Isis::His).IsHigh());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Hrs).IsHigh());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lis).IsHigh());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lrs).IsHigh());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Null).IsHigh());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsHigh());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsHigh());
+}
+
+TEST(Pixel, static_IsLow) {
+  EXPECT_FALSE(Pixel::IsLow(Isis::His));
+  EXPECT_FALSE(Pixel::IsLow(Isis::Hrs));
+  EXPECT_TRUE(Pixel::IsLow(Isis::Lis));
+  EXPECT_TRUE(Pixel::IsLow(Isis::Lrs));
+  EXPECT_FALSE(Pixel::IsLow(Isis::Null));
+  EXPECT_FALSE(Pixel::IsLow(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsLow(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsLow) {
+  EXPECT_FALSE(Pixel(1,2,3,Isis::His).IsLow());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Hrs).IsLow());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Lis).IsLow());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Lrs).IsLow());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Null).IsLow());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsLow());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsLow());
+}
+
+TEST(Pixel, static_IsHrs) {
+  EXPECT_FALSE(Pixel::IsHrs(Isis::His));
+  EXPECT_TRUE(Pixel::IsHrs(Isis::Hrs));
+  EXPECT_FALSE(Pixel::IsHrs(Isis::Lis));
+  EXPECT_FALSE(Pixel::IsHrs(Isis::Lrs));
+  EXPECT_FALSE(Pixel::IsHrs(Isis::Null));
+  EXPECT_FALSE(Pixel::IsHrs(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsHrs(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsHrs) {
+  EXPECT_FALSE(Pixel(1,2,3,Isis::His).IsHrs());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Hrs).IsHrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lis).IsHrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lrs).IsHrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Null).IsHrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsHrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsHrs());
+}
+
+TEST(Pixel, static_IsHis) {
+  EXPECT_TRUE(Pixel::IsHis(Isis::His));
+  EXPECT_FALSE(Pixel::IsHis(Isis::Hrs));
+  EXPECT_FALSE(Pixel::IsHis(Isis::Lis));
+  EXPECT_FALSE(Pixel::IsHis(Isis::Lrs));
+  EXPECT_FALSE(Pixel::IsHis(Isis::Null));
+  EXPECT_FALSE(Pixel::IsHis(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsHis(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsHis) {
+  EXPECT_TRUE(Pixel(1,2,3,Isis::His).IsHis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Hrs).IsHis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lis).IsHis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lrs).IsHis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Null).IsHis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsHis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsHis());
+}
+
+TEST(Pixel, static_IsLis) {
+  EXPECT_FALSE(Pixel::IsLis(Isis::His));
+  EXPECT_FALSE(Pixel::IsLis(Isis::Hrs));
+  EXPECT_TRUE(Pixel::IsLis(Isis::Lis));
+  EXPECT_FALSE(Pixel::IsLis(Isis::Lrs));
+  EXPECT_FALSE(Pixel::IsLis(Isis::Null));
+  EXPECT_FALSE(Pixel::IsLis(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsLis(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsLis) {
+  EXPECT_FALSE(Pixel(1,2,3,Isis::His).IsLis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Hrs).IsLis());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Lis).IsLis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lrs).IsLis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Null).IsLis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsLis());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsLis());
+}
+
+TEST(Pixel, static_IsLrs) {
+  EXPECT_FALSE(Pixel::IsLrs(Isis::His));
+  EXPECT_FALSE(Pixel::IsLrs(Isis::Hrs));
+  EXPECT_FALSE(Pixel::IsLrs(Isis::Lis));
+  EXPECT_TRUE(Pixel::IsLrs(Isis::Lrs));
+  EXPECT_FALSE(Pixel::IsLrs(Isis::Null));
+  EXPECT_FALSE(Pixel::IsLrs(Isis::ValidMaximum));
+  EXPECT_FALSE(Pixel::IsLrs(Isis::ValidMinimum));
+}
+
+TEST(Pixel, IsLrs) {
+  EXPECT_FALSE(Pixel(1,2,3,Isis::His).IsLrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Hrs).IsLrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Lis).IsLrs());
+  EXPECT_TRUE(Pixel(1,2,3,Isis::Lrs).IsLrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::Null).IsLrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMaximum).IsLrs());
+  EXPECT_FALSE(Pixel(1,2,3,Isis::ValidMinimum).IsLrs());
+}
+
+TEST(Pixel, static_ToString) {
+  EXPECT_EQ(std::string("1"), Pixel::ToString(1.0));
+  EXPECT_EQ(std::string("-1.2"), Pixel::ToString(-1.2));
+  // Special pixels
+  EXPECT_EQ(std::string("His"), Pixel::ToString(Isis::His));
+  EXPECT_EQ(std::string("Hrs"), Pixel::ToString(Isis::Hrs));
+  EXPECT_EQ(std::string("Lis"), Pixel::ToString(Isis::Lis));
+  EXPECT_EQ(std::string("Lrs"), Pixel::ToString(Isis::Lrs));
+  EXPECT_EQ(std::string("Null"), Pixel::ToString(Isis::Null));
+  EXPECT_EQ(std::string("Invalid"), Pixel::ToString(-1.0e+1000));
+}
+
+TEST(Pixel, ToString) {
+  EXPECT_EQ(std::string("1"), Pixel(1,2,3,1.0).ToString());
+  EXPECT_EQ(std::string("-1.2"), Pixel(1,2,3,-1.2).ToString());
+  // Special pixels
+  EXPECT_EQ(std::string("His"), Pixel(1,2,3,Isis::His).ToString());
+  EXPECT_EQ(std::string("Hrs"), Pixel(1,2,3,Isis::Hrs).ToString());
+  EXPECT_EQ(std::string("Lis"), Pixel(1,2,3,Isis::Lis).ToString());
+  EXPECT_EQ(std::string("Lrs"), Pixel(1,2,3,Isis::Lrs).ToString());
+  EXPECT_EQ(std::string("Null"), Pixel(1,2,3,Isis::Null).ToString());
+  EXPECT_EQ(std::string("Invalid"), Pixel(1,2,3,-1.0e+1000).ToString());
+}


### PR DESCRIPTION
Removed unneeded LineEquation.h includes. Noticed that they were no longer used while looking for good unit tests to convert.