### PR TITLE
Removed unneeded LineEquation includes

### DIFF
--- a/isis/src/base/apps/appjit/LineScanCameraRotation.cpp
+++ b/isis/src/base/apps/appjit/LineScanCameraRotation.cpp
@@ -8,7 +8,6 @@
 #include "Cube.h"
 #include "LineScanCameraRotation.h"
 #include "Quaternion.h"
-#include "LineEquation.h"
 #include "BasisFunction.h"
 #include "LeastSquares.h"
 #include "BasisFunction.h"

--- a/isis/src/base/apps/appjit/PixelOffset.cpp
+++ b/isis/src/base/apps/appjit/PixelOffset.cpp
@@ -8,7 +8,6 @@
 
 #include "PixelOffset.h"
 #include "TextFile.h"
-#include "LineEquation.h"
 #include "LeastSquares.h"
 #include "BasisFunction.h"
 #include "PolynomialUnivariate.h"


### PR DESCRIPTION
Removed unneeded LineEquation.h includes. Noticed that they were no longer used while looking for good unit tests to convert.

Moved to dev at @jessemapel's request.