### PR TITLE
Make this program more pythonic

### DIFF
--- a/isis/scripts/isis3VarInit.py
+++ b/isis/scripts/isis3VarInit.py
@@ -5,56 +5,92 @@ import os
 import sys
 
 ##########################################################################################################
-#   Author:  Tyler Wilson
-#   Date  :  2018-10-05
-#   Description:  This script sets ISISROOT/ISIS3DATA/ISIS3TESTDATA for the user and is executed
-#   within the conda environment created for the ISIS3 installation.
-#   The data directory and test directory are optional command line arguments.  If the user chooses
-#   not to set them, they will both be placed created on the same level as the $ISISROOT directory
-#   within the conda environment.
+#
+#  This work is free of known copyright restrictions.  USGS-authored or produced data, 
+#  information, and software are in the public domain.
+#
+#
+#   Description:  This program builds the shell scripts that define the 
+#       ISISROOT/ISIS3DATA/ISIS3TESTDATA environment variables for the user 
+#       when the ISIS3 conda environment is activated, and clean up when it is
+#       deactivated.
+#
+#       The data directory and test directory are optional command line arguments.  
+#       If the user chooses not to set them, they will both be created in the
+#       $ISISROOT directory.
+#
 #   History:
-#       Author:  Tyler Wilson
+#       Author:  Tyler Wilson, USGS
+#       Date:    2018-10-05
+#       Description: Initial commit.
+#
+#       Author:  Tyler Wilson, USGS
 #       Date:    2018-11-01
 #       Description:  Removed a pair of lines which were causing output errors on Mac OS X and were not
 #                     required anyway.
 #
+#       Author:  Ross Beyer
+#       Date:    2018-11-
+#       Description: Streamlined the program, improved documentation, and made the directory and
+#                    file creation more `pythonic' rather than using system calls.
+#       To the extent possible under law, Ross Beyer has waived all copyright and related or 
+#       neighboring rights to his contribution to this file.  This work is published from
+#       the United States.
+#   
+#
 ##########################################################################################################
 
-parser = argparse.ArgumentParser(description='Usage:  ./isis3VarInit --data_dir <data dir path> --test_dir <test dir path')
-   
-isisroot = '$CONDA_PREFIX'
-data_dir='$CONDA_PREFIX/data'
-testdata_dir='$CONDA_PREFIX/testData'
+# There are still a lot of Python 2 installations out there, and if people don't have
+# their conda environment set up properly, the error message they'll get will be hard
+# to decipher.  This might help:
+assert( sys.version_info >= (3,2) ) # Must be using Python 3.2 or later, is conda set up?
 
-parser.add_argument("--data-dir",default= data_dir,help="ISIS3 Mission Data Directory")
-parser.add_argument("--test-dir",default=testdata_dir,help="ISIS3 Mission Test Data Directory")
 
+# This just wraps and reports on the directory creation:
+def mkdir( p ):
+    if os.path.exists( p ): print( 'Tried to create '+p+', but it already exists.' )
+    else:
+        os.makedirs( p )
+        print( 'Created '+p )
+    return
+
+
+# Set up and then parse the command line:
+parser = argparse.ArgumentParser( description='This program builds shell scripts that define ISIS3 environment variables during conda environment activation and deactivation, and creates some directories.' )
+
+parser.add_argument('-d','--data-dir', 
+                    default=os.environ['CONDA_PREFIX']+'/data',
+                    help='ISIS3 Data Directory, default: %(default)s' )
+parser.add_argument('-t','--test-dir',
+                    default=os.environ['CONDA_PREFIX']+'/testData',
+                    help='ISIS3 Test Data Directory, default: %(default)s')
 args=parser.parse_args()
-if (data_dir != args.data_dir):
-    os.system("mkdir -p "+args.data_dir)
-    data_dir = args.data_dir
-else:    
-    os.system("mkdir -p "+data_dir)
 
-if (testdata_dir != args.test_dir):
-    os.system("mkdir -p "+args.test_dir)
-    testdata_dir=args.test_dir
-else:
-    os.system("mkdir -p "+testdata_dir)
+# Create the data directories:
+mkdir( args.data_dir )
+mkdir( args.test_dir )
 
-os.popen('mkdir -p '+isisroot+'/etc/conda/activate.d')
-os.popen('mkdir -p '+isisroot+'/etc/conda/deactivate.d')
+# Create the conda activation and deactivation directories:
+activate_dir   = os.environ['CONDA_PREFIX']+'/etc/conda/activate.d'
+deactivate_dir = os.environ['CONDA_PREFIX']+'/etc/conda/deactivate.d'
 
-os.popen('touch '+isisroot+'/etc/conda/activate.d/env_vars.sh')
-os.popen('touch '+isisroot+'/etc/conda/activate.d/env_vars.sh')
+mkdir( activate_dir )
+mkdir( deactivate_dir )
 
-os.popen("echo '#!/bin/sh' >> "+isisroot+ "/etc/conda/activate.d/env_vars.sh")
-os.popen("echo 'export ISISROOT="+isisroot+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
-os.popen("echo 'export ISIS3DATA="+data_dir+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
-os.popen("echo 'export ISIS3TESTDATA="+testdata_dir+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
+# Write the files that manage the ISIS3 environments:
+activate_vars   =   activate_dir+'/env_vars.sh'
+deactivate_vars = deactivate_dir+'/env_vars.sh'
 
-os.popen("echo '#!/bin/sh' >> "+isisroot+ "/etc/conda/deactivate.d/env_vars.sh")
-os.popen("echo 'unset ISISROOT' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
-os.popen("echo 'unset ISIS3DATA' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
-os.popen("echo 'unset ISIS3TESTDATA' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
+with open( activate_vars, mode='w' ) as a:
+    a.write('#!/bin/sh\n')
+    a.write('export ISISROOT='+      os.environ['CONDA_PREFIX']+'\n')
+    a.write('export ISIS3DATA='+     args.data_dir +'\n')
+    a.write('export ISIS3TESTDATA='+ args.test_dir +'\n')
+print( 'Wrote '+activate_vars )
 
+with open( deactivate_vars, mode='w' ) as d:
+    d.write('#!/bin/sh\n')
+    d.write('unset ISISROOT\n')
+    d.write('unset ISIS3DATA\n')
+    d.write('unset ISIS3TESTDATA\n')
+print( 'Wrote '+deactivate_vars )

--- a/isis/scripts/isis3VarInit.py
+++ b/isis/scripts/isis3VarInit.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+"""This program builds shell scripts that define ISIS3 environment variables during conda environment activation and deactivation, and creates some directories."""
 
 import argparse
 import os
@@ -6,8 +7,10 @@ import sys
 
 ##########################################################################################################
 #
-#  This work is free of known copyright restrictions.  USGS-authored or produced data, 
-#  information, and software are in the public domain.
+#  This work is free and unencumbered software released into the public domain.
+#  In jurisdictions that recognize copyright laws, the author or authors
+#  of this software dedicate any and all copyright interest in the
+#  software to the public domain.
 #
 #
 #   Description:  This program builds the shell scripts that define the 
@@ -30,13 +33,10 @@ import sys
 #                     required anyway.
 #
 #       Author:  Ross Beyer
-#       Date:    2018-11-
+#       Date:    2018-11-19
 #       Description: Streamlined the program, improved documentation, and made the directory and
 #                    file creation more `pythonic' rather than using system calls.
-#       To the extent possible under law, Ross Beyer has waived all copyright and related or 
-#       neighboring rights to his contribution to this file.  This work is published from
-#       the United States.
-#   
+#
 #
 ##########################################################################################################
 
@@ -56,7 +56,7 @@ def mkdir( p ):
 
 
 # Set up and then parse the command line:
-parser = argparse.ArgumentParser( description='This program builds shell scripts that define ISIS3 environment variables during conda environment activation and deactivation, and creates some directories.' )
+parser = argparse.ArgumentParser( description=__doc__ )
 
 parser.add_argument('-d','--data-dir', 
                     default=os.environ['CONDA_PREFIX']+'/data',
@@ -65,33 +65,7 @@ parser.add_argument('-t','--test-dir',
                     default=os.environ['CONDA_PREFIX']+'/testData',
                     help='ISIS3 Test Data Directory, default: %(default)s')
 args=parser.parse_args()
-<<<<<<< HEAD
-=======
-if (data_dir != args.data_dir):
-    os.system("mkdir -p "+args.data_dir)
-    data_dir = args.data_dir
-else:    
-    os.system("mkdir -p "+data_dir)
 
-if (testdata_dir != args.test_dir):
-    os.system("mkdir -p "+args.test_dir)
-    testdata_dir=args.test_dir
-else:
-    os.system("mkdir -p "+testdata_dir)
-
-os.popen('mkdir -p '+isisroot+'/etc/conda/activate.d')
-os.popen('mkdir -p '+isisroot+'/etc/conda/deactivate.d')
-
-os.popen("echo '#!/bin/sh' > "+isisroot+ "/etc/conda/activate.d/env_vars.sh")
-os.popen("echo 'export ISISROOT="+isisroot+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
-os.popen("echo 'export ISIS3DATA="+data_dir+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
-os.popen("echo 'export ISIS3TESTDATA="+testdata_dir+"' >>"+isisroot+"/etc/conda/activate.d/env_vars.sh")
-
-os.popen("echo '#!/bin/sh' > "+isisroot+ "/etc/conda/deactivate.d/env_vars.sh")
-os.popen("echo 'unset ISISROOT' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
-os.popen("echo 'unset ISIS3DATA' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
-os.popen("echo 'unset ISIS3TESTDATA' >>"+isisroot+"/etc/conda/deactivate.d/env_vars.sh")
->>>>>>> upstream/dev
 
 # Create the data directories:
 mkdir( args.data_dir )


### PR DESCRIPTION
Okay, there were two things that I wanted to do here, the first was that the direct system calls seemed unnecessary, when all of that can be accomplished via Python function calls.  I appreciate that this program was meant to be quick and dirty, I get that.  However, this program is one of the first pieces of USGS software that a user runs after installing conda.  The fact that it provided absolutely no feedback about what it was doing, and that its usage statement was actually factually incorrect (it doesn't actually set the environment variables, it just builds the files that conda uses to set them), made me want to fix it.

Also, I wanted to use this to test an idea I had about how to clearly signify that (1) the program itself is in the public domain (because of its USGS origin), and (2) that my updated contribution was also released under the public domain.