### PR TITLE
Removed debug cout from Least Squares

### DIFF
--- a/isis/src/base/objs/LeastSquares/LeastSquares.cpp
+++ b/isis/src/base/objs/LeastSquares/LeastSquares.cpp
@@ -43,7 +43,7 @@ namespace Isis {
     p_solved = false;
     p_sparse = sparse;
     p_sigma0 = 0.;
-    
+
     p_sparseRows = sparseRows;
     p_sparseCols = sparseCols;
 
@@ -69,7 +69,7 @@ namespace Isis {
 
         p_parameterWeights.resize(sparseCols);
       }
-      
+
     }
     p_currentFillRow = -1;
   }
@@ -308,8 +308,8 @@ namespace Isis {
     if (coefs.dim1() < p_basis->Coefficients()) {
       QString msg = "Unable to solve least-squares using SVD method. No "
                     "solution available. Not enough knowns or knowns are "
-                    "co-linear ... [Unknowns = " 
-                    + toString(p_basis->Coefficients()) + "] [Knowns = " 
+                    "co-linear ... [Unknowns = "
+                    + toString(p_basis->Coefficients()) + "] [Knowns = "
                     + toString(coefs.dim1()) + "]";
       throw IException(IException::Unknown, msg, _FILEINFO_);
     }
@@ -444,7 +444,6 @@ namespace Isis {
   int LeastSquares::SolveSparse() {
 
     // form "normal equations" matrix by multiplying ATA
-    std::cout << p_sparseA.n_rows << ", " << p_sparseA.n_cols << std::endl;
     p_normals = p_sparseA.t()*p_sparseA;
 
     // Create the right-hand-side column vector 'b'
@@ -469,9 +468,9 @@ namespace Isis {
         p_ATb(i, 0) -= p_epsilonsSparse[i]*weight;
       }
     }
-    
+
     bool status = spsolve(p_xSparse, p_normals, p_ATb, "superlu");
-    
+
     if (status == false) {
       QString msg = "Could not solve sparse least squares problem.";
       throw IException(IException::Unknown, msg, _FILEINFO_);

--- a/isis/src/base/objs/LeastSquares/LeastSquares.truth
+++ b/isis/src/base/objs/LeastSquares/LeastSquares.truth
@@ -31,7 +31,6 @@ Number of Knowns = 7
   y =   1.43458		1.43458
 ---
 *** TEST 4:  SAME 3 POINTS, SPARSE ***
-3, 2
 Number of Knowns = 3
         SPARSE
   one = 3.08


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
A debug cout was left in LeastSquares

## Description
<!--- Describe your changes in detail -->
The cout was removed and test data was updated

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #620 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
IT produces extraneous command line output

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
built locally and tested on mac 10.13

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
