### PR TITLE
Fix cubeit so it does not transfer tracking info. Fixes #5533

### DIFF
--- a/isis/src/base/apps/cubeit/cubeit.xml
+++ b/isis/src/base/apps/cubeit/cubeit.xml
@@ -80,7 +80,7 @@
        to pass when not using the default data area. Fixes #4783.
      </change>
      <change name="Stuart Sides" date="2018-11-19">
-       Removed the tracking lable group if it exists in the output cube. Fixes #5533.
+       Removed the tracking label group if it exists in the output cube. Fixes #5533.
      </change>
      </history>
 

--- a/isis/src/base/apps/cubeit/cubeit.xml
+++ b/isis/src/base/apps/cubeit/cubeit.xml
@@ -79,6 +79,9 @@
        Modified Makefile of badinputs app test to truncate paths before data directory. Allows tests
        to pass when not using the default data area. Fixes #4783.
      </change>
+     <change name="Stuart Sides" date="2018-11-19">
+       Removed the tracking lable group if it exists in the output cube. Fixes #5533.
+     </change>
      </history>
 
   <groups>

--- a/isis/src/base/apps/cubeit/main.cpp
+++ b/isis/src/base/apps/cubeit/main.cpp
@@ -183,6 +183,13 @@ void IsisMain() {
     ocube->deleteBlob("Table", "InputImages");
   }
 
+  // Delete the Tracking group if it exists (3.6.0 and up)
+  // The tracking group could be transfered from the first input cube, but it does not
+  // represent the images used in any other band after cubeit.
+  if(ocube->hasGroup("Tracking")) {
+    ocube->deleteGroup("Tracking");
+  }
+
   p2.EndProcess();
 
  // Now loop and mosaic in each cube


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix cubeit so it does not transfer tracking info. Fixes #5533
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://isis.astrogeology.usgs.gov/fixit/issues/5533
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows qview to run on images produced by the mosaic apps that have then been run through cubeit

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Images with and without the tracking information/group in the labels were run through cubeit. The labels were inspected to make sure the tracking info was not transferred to the output cube. qview was run on both output with success.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
