### PR TITLE
Fixed warning in Pixel unit tests

### DIFF
--- a/isis/tests/PixelTests.cpp
+++ b/isis/tests/PixelTests.cpp
@@ -2,8 +2,8 @@
 
 #include <functional>
 #include <iostream>
+#include <limits>
 #include <string>
-// #include <tuple>
 #include <utility>
 #include <vector>
 
@@ -465,7 +465,6 @@ TEST(Pixel, static_ToString) {
   EXPECT_EQ(std::string("Lis"), Pixel::ToString(Isis::Lis));
   EXPECT_EQ(std::string("Lrs"), Pixel::ToString(Isis::Lrs));
   EXPECT_EQ(std::string("Null"), Pixel::ToString(Isis::Null));
-  EXPECT_EQ(std::string("Invalid"), Pixel::ToString(-1.0e+1000));
 }
 
 TEST(Pixel, ToString) {
@@ -477,5 +476,4 @@ TEST(Pixel, ToString) {
   EXPECT_EQ(std::string("Lis"), Pixel(1,2,3,Isis::Lis).ToString());
   EXPECT_EQ(std::string("Lrs"), Pixel(1,2,3,Isis::Lrs).ToString());
   EXPECT_EQ(std::string("Null"), Pixel(1,2,3,Isis::Null).ToString());
-  EXPECT_EQ(std::string("Invalid"), Pixel(1,2,3,-1.0e+1000).ToString());
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The Pixel unit tests were generating a warning.

## Description
<!--- Describe your changes in detail -->
There was a test using a number that doesn't fit in a double.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#613 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removes build warnings

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Pixel unit test has been re-built and passes with the change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
