### PR TITLE
Added fix to Spice Server to accept clients with version nums >=3.5.*.*

### DIFF
--- a/isis/src/base/apps/spiceserver/main.cpp
+++ b/isis/src/base/apps/spiceserver/main.cpp
@@ -149,13 +149,18 @@ void IsisMain() {
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
-    if ( ui.GetBoolean("CHECKVERSION") && otherVersion != Application::Version() ) {
-      QString msg = "The SPICE server only supports the latest Isis version [" +
-                    Application::Version() + "], version [" + otherVersion +
-                    "] is not compatible";
-      throw IException(IException::User, msg, _FILEINFO_);
-    }
 
+    if (ui.GetBoolean("CHECKVERSION") ) {
+      QStringList remoteVersion = otherVersion.split(QRegExp("\\s+"))[0].split(QRegExp("\\."));
+      if ( remoteVersion[1].toInt() < 5) {
+
+       QString msg ="The SPICE server only supports Isis versions greater than or equal to 3.5.*.*.";
+               msg += "Your version:   [" + otherVersion + "] is not compatible";
+        throw IException(IException::User, msg, _FILEINFO_);
+
+      }
+
+    }
     // This next section looks a lot like spiceinit, its semi-duplicated because
     //   I did not want users to be able to spiceinit a label without cube
     //   data.

--- a/isis/src/base/apps/spiceserver/spiceserver.xml
+++ b/isis/src/base/apps/spiceserver/spiceserver.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<application name="spiceserver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Application/application.xsd">
+<application name="spiceserver" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Application/application.xsd">
   <brief>
     Spiceinit Server
   </brief>
@@ -49,6 +50,10 @@
     </change>
     <change name="Makayla Shepherd" date="2015-09-08">
       Modified to open the temporary cube correctly. Fixes #2213.
+    </change>
+    <change name="Tyler Wilson" date="2019-02-11">
+      Modified the version check.  Now all versions of ISIS3 >= 3.5.*.* will be acceptable
+      to the application.
     </change>
   </history>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Spiceinit is failing if the ISIS3 client version is not equal to 3.5.2  This fix eases that restriction, and spiceinit will only fail if the ISIS3 client version is less than or equal to 3.5.*.*  When we have more time, the spiceit server contained within a docker container will be a stable alternative to the current spice server.

## Description
<!--- Describe your changes in detail -->

- Parsed the client's ISIS3 version string with a regular expression to extract the second digit.  (ie. a typical call to Application::Version() returns a string that looks like this:  "IsisVersion       = "3.5.3.c4ebd24 alpha | 2018-08-01") My fix pulls out the 5.  If the second digit is greater than or equal to 5, spice server allows the connection.  If it is not, then the connection will fail with an error message.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Spice server is not accepting any connections from the latest release of ISIS3.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
It hasn't.  This is a quick and dirty fix to get the spice server back up.  A longer term solution would
be to place the spiceit server application within a docker container and test that extensively.  
<!--- Include details of your testing environment, and the tests you ran to -->
N/A
<!--- see how your change affects other areas of the code, etc. -->
Spice server is completely separate from the rest of ISIS3 so no changes to the rest of ISIS3 are possible.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
