### PR TITLE
Fixed error when trying to export a compressed image using pds2hideal. Fixes #5525.

### DIFF
--- a/isis/src/base/objs/ImportPdsTable/ImportPdsTable.cpp
+++ b/isis/src/base/objs/ImportPdsTable/ImportPdsTable.cpp
@@ -465,9 +465,18 @@ namespace Isis {
     }
     //  Get some pertinent information from the label
     PvlObject &tabObj = label.findObject(tableName);
+    // The table description contains the actual "RECORD_BYTES"
     if (tabObj.hasKeyword("RECORD_BYTES")) {
       m_recordBytes = (int) tabObj.findKeyword("RECORD_BYTES");
     }
+    // The table description has "ROW_BYTES" and "ROW_SUFFIX_BYTES". These summed is the 
+    // record length. Can be for detached and attached labels
+    else if (tabObj.hasKeyword("ROW_BYTES") && tabObj.hasKeyword("ROW_SUFFIX_BYTES")) {
+      m_recordBytes = (int) tabObj.findKeyword("ROW_BYTES") +
+                      (int) tabObj.findKeyword("ROW_SUFFIX_BYTES");
+    }
+    // The table record length is defined by the file record
+    // length (i.e., table is in with the image)
     else {
       m_recordBytes = (int) label.findKeyword("RECORD_BYTES");
     }

--- a/isis/src/base/objs/ImportPdsTable/ImportPdsTable.h
+++ b/isis/src/base/objs/ImportPdsTable/ImportPdsTable.h
@@ -103,6 +103,8 @@ namespace Isis {
    *   @history 2016-02-24 Ian Humphrey - Updated documentation and unit test. Added edrindex.lbl
    *                           and edrindex.tab files to data directory (for tests). Fixes #2397.
    *   @history 2016-03-10 Jeannie Backer - Removed non-UTF8 character. References #2397.
+   *   @history 2018-02-12 Stuart Sides - Added detached table capabilities for label files
+   *                                      without a "RECORD_BYTES" keyword. References #5525.
    *  
    *  
    * @todo The binary table import methods were written after the ascii table 

--- a/isis/src/mro/apps/pds2hideal/tsts/compressedImage/Makefile
+++ b/isis/src/mro/apps/pds2hideal/tsts/compressedImage/Makefile
@@ -1,0 +1,17 @@
+# This tests the following conditions:
+#
+# -- We can export a compressed image.
+# -- The tables in the compressed image do not have the keyword RECORD_BYTES.
+# -- When exported, the compressed and uncompressed input data produce the same output.
+APPNAME = pds2hideal
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	$(APPNAME) FROM=$(INPUT)/PSP_009492_1280_RED.NOPROJ.lbl \
+	  to=$(OUTPUT)/uncompressed.cub > /dev/null;
+	$(APPNAME) FROM=$(INPUT)/PSP_009492_1280_RED_COMPRESSED.NOPROJ.IMG \
+	  to=$(OUTPUT)/compressed.cub > /dev/null;
+	cubediff from=$(OUTPUT)/uncompressed.cub from2=$(OUTPUT)/compressed.cub \
+	  to=$(OUTPUT)/comparisonTruth.txt > /dev/null;
+

--- a/isis/src/mro/apps/pds2hideal/tsts/compressedImage/Makefile
+++ b/isis/src/mro/apps/pds2hideal/tsts/compressedImage/Makefile
@@ -9,9 +9,9 @@ include $(ISISROOT)/make/isismake.tsts
 
 commands:
 	$(APPNAME) FROM=$(INPUT)/PSP_009492_1280_RED.NOPROJ.lbl \
-	  to=$(OUTPUT)/uncompressed.cub > /dev/null;
+	  to=$(OUTPUT)/uncompressed_lbl.cub > /dev/null;
 	$(APPNAME) FROM=$(INPUT)/PSP_009492_1280_RED_COMPRESSED.NOPROJ.IMG \
-	  to=$(OUTPUT)/compressed.cub > /dev/null;
-	cubediff from=$(OUTPUT)/uncompressed.cub from2=$(OUTPUT)/compressed.cub \
+	  to=$(OUTPUT)/compressed_img.cub > /dev/null;
+	cubediff from=$(OUTPUT)/uncompressed_lbl.cub from2=$(OUTPUT)/compressed_img.cub \
 	  to=$(OUTPUT)/comparisonTruth.txt > /dev/null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The compressed image's table objects do not contain the keyword RECORD_BYTES, causing the program to fail. When the keyword is not found in the table object, the ROW_BYTES and ROW_SUFFIX_BYTES are now added to create the record length. pds2hideal can now export compressed images with this format.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://isis.astrogeology.usgs.gov/fixit/issues/5525

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
pds2hideal was crashing when trying to export a compressed image because ImportPdsTable could not find the RECORD_BYTES keyword in the table objects.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Wrote new make file app test that compares the exported cubes of a compressed image and a detached label and uncompressed image. The cubes should be exactly the same. Ran all app and unit tests to make sure the changes did not break anything. All tests are passing.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
