### PR TITLE
Added an option in lrolola2isis to sort the output file so order of points will be consistent for testing

### DIFF
--- a/isis/src/base/objs/LidarData/LidarData.cpp
+++ b/isis/src/base/objs/LidarData/LidarData.cpp
@@ -368,6 +368,8 @@ namespace Isis {
       outputFile = outputFile.setExtension("json");
     }
     else if (format == Test) {
+      // Format is same as Json, but points are sorted instead of random so that
+      // output can be compared to truth data
       outputFile = outputFile.setExtension("json");
       sort = true;
     }

--- a/isis/src/base/objs/LidarData/LidarData.cpp
+++ b/isis/src/base/objs/LidarData/LidarData.cpp
@@ -49,12 +49,20 @@ namespace Isis {
 
 
   /**
-   * Gets the list of Lidar data points.
+   * Gets the list of Lidar data points optionally sorted . 
    *
+   * @sort An option to sort the list.  The default is false (no sort).
    * @return @b QList<QSharedPointer<LidarControlPoint>> Returns list of Lidar control points.
+   * @internal
+   *   @history 2019-02-23 Debbie A Cook - Added optional argument to the points
+   *                           method to sort the list.  See LidarControlPoint for the sorting
+   *                           functor. The default behavior has not changed for backward
+   *                           compatability. References #5343.
    */
   QList< QSharedPointer<LidarControlPoint> > LidarData::points(bool sort) const {
     if (!sort) {
+      // This is the default behavior.  The list is coming from a QHash so the point order
+      // will vary.
       return m_points.values();
     }
     else {

--- a/isis/src/base/objs/LidarData/LidarData.cpp
+++ b/isis/src/base/objs/LidarData/LidarData.cpp
@@ -51,7 +51,7 @@ namespace Isis {
   /**
    * Gets the list of Lidar data points optionally sorted . 
    *
-   * @sort An option to sort the list.  The default is false (no sort).
+   * @param sort An option to sort the list.  The default is false (no sort).
    * @return @b QList<QSharedPointer<LidarControlPoint>> Returns list of Lidar control points.
    * @internal
    *   @history 2019-02-23 Debbie A Cook - Added optional argument to the points
@@ -361,12 +361,9 @@ namespace Isis {
    * @throws IException::User Throws User exception if it cannot open the file for writing.
    */
   void LidarData::write(FileName outputFile, LidarData::Format format) {
-    bool sort = false;
-    // Set up the output file
-
-    std::cout << "Formats are:  Json = " << Json << ", Binary = " << Binary << " and Test = " << Test << std::endl;
-    std::cout << "Current format = " << format << std::endl;
+    bool sort = false;  // Default behavior
     
+    // Set up the output file
     if (format == Json) {
       outputFile = outputFile.setExtension("json");
     }

--- a/isis/src/base/objs/LidarData/LidarData.cpp
+++ b/isis/src/base/objs/LidarData/LidarData.cpp
@@ -8,7 +8,7 @@
 #include <QJsonValue>
 #include <QList>
 #include <QRegExp>
-//#include <QSharedPointer>
+#include <QSharedPointer>
 #include <QString>
 #include <QStringList>
 #include <QTextStream>
@@ -20,7 +20,6 @@
 #include "IException.h"
 #include "iTime.h"
 #include "Latitude.h"
-//#include "LidarControlPoint.h"
 #include "Longitude.h"
 #include "Progress.h"
 #include "SerialNumberList.h"

--- a/isis/src/base/objs/LidarData/LidarData.h
+++ b/isis/src/base/objs/LidarData/LidarData.h
@@ -5,7 +5,6 @@
 #include <QList>
 #include <QMap>
 #include <QPointer>
-#include <QSharedPointer>
 #include <QString>
 #include <QVector>
 
@@ -19,7 +18,6 @@ class QJsonObject;
 namespace Isis {
   class Camera;
   class FileName;
-  //  class LidarControlPoint;
   class Progress;
   class SerialNumberList;
 

--- a/isis/src/base/objs/LidarData/LidarData.h
+++ b/isis/src/base/objs/LidarData/LidarData.h
@@ -41,7 +41,7 @@ namespace Isis {
    *                           write methods. Ref #5343.
    *   @history 2018-06-14 Ken Edmundson - Added typedef for QSharedPointer to LidarData object.
    *   @history 2019-02-23 Debbie A. Cook - Added sorting option to points() method with default 
-   *                           being to not sort.
+   *                           being to not sort. References #5343.
    *
    */
   class LidarData {

--- a/isis/src/base/objs/LidarData/LidarData.h
+++ b/isis/src/base/objs/LidarData/LidarData.h
@@ -5,18 +5,21 @@
 #include <QList>
 #include <QMap>
 #include <QPointer>
+#include <QSharedPointer>
 #include <QString>
 #include <QVector>
 
 #include "boost/numeric/ublas/symmetric.hpp"
 #include "boost/numeric/ublas/io.hpp"
 
+#include "LidarControlPoint.h"
+
 class QJsonObject;
 
 namespace Isis {
   class Camera;
   class FileName;
-  class LidarControlPoint;
+  //  class LidarControlPoint;
   class Progress;
   class SerialNumberList;
 
@@ -39,6 +42,8 @@ namespace Isis {
    *                           and adjusted variance/covariance matrix to the read and
    *                           write methods. Ref #5343.
    *   @history 2018-06-14 Ken Edmundson - Added typedef for QSharedPointer to LidarData object.
+   *   @history 2019-02-23 Debbie A. Cook - Added sorting option to points() method with default 
+   *                           being to not sort.
    *
    */
   class LidarData {
@@ -47,21 +52,23 @@ namespace Isis {
       /** Enumerates the file formats for serializing the LidarData class. */
       enum Format {
         Binary, /**< Serializes to a binary (QByteArray) .dat file. */
-        Json    /**< Serializes to a JSON .json file. */
+        Json,    /**< Serializes to a JSON .json file. */
+        Test    /**< Serializes to an ordered JSON .json file for comparing to truth data. */
       };
 
       LidarData();
 
       void insert(QSharedPointer<LidarControlPoint> point);
-      QList< QSharedPointer<LidarControlPoint> > points() const;
+
+      QList< QSharedPointer<LidarControlPoint> > points(bool sort = false) const;
 
       void SetImages(SerialNumberList &list, Progress *progress = 0);
 
-      // Serialization methods or LidarData
+      // Serialization methods for LidarData
       void read(FileName);
       void write(FileName, Format);
-
-    private:
+    
+    private:    
       /** Hash of the LidarControlPoints this class contains. */
       QHash<QString, QSharedPointer <LidarControlPoint> > m_points;
 

--- a/isis/src/control/objs/LidarControlPoint/LidarControlPoint.h
+++ b/isis/src/control/objs/LidarControlPoint/LidarControlPoint.h
@@ -51,7 +51,7 @@ namespace Isis {
    *   @history 2018-03-18 Debbie A. Cook Added Simultaneous measures 
    *   @history 2019-02-23 Debbie A. Cook Added Functor Predicate struct to sort
    *                                        based on Id.  This is needed for getting consistent 
-   *                                        output for comparting test data.
+   *                                        output for comparing test data. References #5343.
    */
   
   class LidarControlPoint : public ControlPoint {

--- a/isis/src/control/objs/LidarControlPoint/LidarControlPoint.h
+++ b/isis/src/control/objs/LidarControlPoint/LidarControlPoint.h
@@ -24,6 +24,12 @@
  *   http://www.usgs.gov/privacy.html.
  */
 
+#include <algorithm>
+#include <functional>
+
+#include <QPointer>
+#include <QSharedPointer>
+
 #include "ControlMeasure.h"
 #include "ControlPoint.h"
 #include "Cube.h"
@@ -43,6 +49,9 @@ namespace Isis {
    *   @history 2018-01-29 Makayla Shepherd Original version
    *   @history 2018-02-09 Ken Edmundson Added typedef forLidarControlPointQsp
    *   @history 2018-03-18 Debbie A. Cook Added Simultaneous measures 
+   *   @history 2019-02-23 Debbie A. Cook Added Functor Predicate struct to sort
+   *                                        based on Id.  This is needed for getting consistent 
+   *                                        output for comparting test data.
    */
   
   class LidarControlPoint : public ControlPoint {
@@ -58,6 +67,17 @@ namespace Isis {
     ControlPoint::Status setTime(iTime time);
     ControlPoint::Status addSimultaneous(QString newSerial);
 
+    //  Functor predicate for sorting LidarControlPoints
+    struct LidarControlPointLessThanFunctor :
+      public std::binary_function<QSharedPointer<LidarControlPoint>,
+                                                      QSharedPointer<LidarControlPoint>,
+                                                      bool> {
+      bool operator() ( QSharedPointer<LidarControlPoint> lcp1,
+                                    QSharedPointer<LidarControlPoint> lcp2)
+          {
+           return (lcp1->GetId() < lcp2->GetId());
+          }
+    };
     double range();
     double sigmaRange();
     iTime time();

--- a/isis/src/lro/apps/lrolola2isis/lrolola2isis.xml
+++ b/isis/src/lro/apps/lrolola2isis/lrolola2isis.xml
@@ -41,6 +41,10 @@
       Changed internal default for lidar coordinate a priori uncertainties to "none", allowing FREE
       lidar points.
       </change>
+    <change name="Debbie A Cook" date="2019-02-23">
+      Added new file OUTPUTTYPE=TEST, to be used strictly for testing.
+      This option does a SLOW sort on the output data.
+      </change>
   </history>
 
   <category>
@@ -92,6 +96,9 @@
             </option>
             <option value="JSON">
               <brief> JSON output file (.json)</brief>
+            </option>
+            <option value="TEST">
+              <brief> DO NOT USE (only for tests) ordered JSON output file (.json) </brief>
             </option>
           </list>
         </parameter>

--- a/isis/src/lro/apps/lrolola2isis/lrolola2isis.xml
+++ b/isis/src/lro/apps/lrolola2isis/lrolola2isis.xml
@@ -43,7 +43,7 @@
       </change>
     <change name="Debbie A Cook" date="2019-02-23">
       Added new file OUTPUTTYPE=TEST, to be used strictly for testing.
-      This option does a SLOW sort on the output data.
+      This option does a SLOW sort on the output data. References #5343.
       </change>
   </history>
 

--- a/isis/src/lro/apps/lrolola2isis/main.cpp
+++ b/isis/src/lro/apps/lrolola2isis/main.cpp
@@ -193,6 +193,9 @@ void IsisMain() {
   if (ui.GetString("OUTPUTTYPE") == "JSON") {
     lidarDataSet.write(ui.GetFileName("TO"), LidarData::Format::Json);
   }
+  else if (ui.GetString("OUTPUTTYPE") == "TEST") {
+    lidarDataSet.write(ui.GetFileName("TO"), LidarData::Format::Test);
+  }
   else {
     lidarDataSet.write(ui.GetFileName("TO"), LidarData::Format::Binary);
   }

--- a/isis/src/lro/apps/lrolola2isis/tsts/twoImage/Makefile
+++ b/isis/src/lro/apps/lrolola2isis/tsts/twoImage/Makefile
@@ -1,13 +1,10 @@
 APPNAME = lrolola2isis
 # This test exercises the ingestion of Lola data  the LRO mission.
-# This test is not complete.  The output still needs to be sorted by id and each point entry
-# (between {} needs to be moved as a unit.
+# The output is sorted by id to have consistent output for comparison
+# with the truth data.  Normal behavior fills the file from a hash so
+# the order varies.
 #
-# TODO
-# The pointid might need to be entered in single quotes to work ('Lidar????')
-# Will the cropped images be sufficient, or do we need the whole image?
-#
-# 2018-08-31 Debbie Cook - original skeleton of a test
+# 2018-08-31 Debbie A. Cook - original skeleton of a test
 
 include $(ISISROOT)/make/isismake.tsts
 

--- a/isis/src/lro/apps/lrolola2isis/tsts/twoImage/Makefile
+++ b/isis/src/lro/apps/lrolola2isis/tsts/twoImage/Makefile
@@ -1,0 +1,23 @@
+APPNAME = lrolola2isis
+# This test exercises the ingestion of Lola data  the LRO mission.
+# This test is not complete.  The output still needs to be sorted by id and each point entry
+# (between {} needs to be moved as a unit.
+#
+# TODO
+# The pointid might need to be entered in single quotes to work ('Lidar????')
+# Will the cropped images be sufficient, or do we need the whole image?
+#
+# 2018-08-31 Debbie Cook - original skeleton of a test
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+#	ls $(INPUT)/*.cub > $(OUTPUT)/twoImage.lis
+	cp $(INPUT)/*.lis $(OUTPUT)
+	$(APPNAME) from=$(INPUT)/LidarTest.csv cubes=$(OUTPUT)/twoImage.lis \
+	  to=$(OUTPUT)/LidarTest.json outputtype=test threshold=10  \
+	  point_range_sigma=10 point_latitude_sigma=10 point_longitude_sigma=10 \
+	  point_radius_sigma=10 pointid=Lidar????  \
+	  > /dev/null;
+	rm $(OUTPUT)/twoImage.lis
+	mv $(OUTPUT)/LidarTest.json $(OUTPUT)/LidarTest.txt


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
An apptest was added for lrolola2isis.  lrolola2isis.xml, LidarData, and LidarControlPoint were also modified to allow a sort option when an output file is created.  This option allows the output LidarControlPoints to be sorted by ID and provide a consistent order of the control points for comparing test output to the truth data.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit/issues/5343
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change was made to satisfy ISIS3 development requirements for testing applications.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->Visual inspection and repeated runs of the new application test.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->No noticeable change to other areas of the code.  The existing behavior was left as the default.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ x] My code follows the code style of this project. -->
- [ x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
