### PR TITLE
Added gtest for ID and split TestUtilities into a cpp and h file to fix duplicate symbol error when building

### DIFF
--- a/isis/tests/IDTests.cpp
+++ b/isis/tests/IDTests.cpp
@@ -1,0 +1,83 @@
+#include "ID.h"
+#include "IException.h"
+#include "TestUtilities.h"
+#include "gtest/gtest.h"
+
+#include <QString>
+
+TEST(ID, ConstructorDefaultBaseNum) {
+  Isis::ID pid("ABC?");
+  EXPECT_PRED_FORMAT2(Isis::AssertQStringsEqual, pid.Next(), "ABC1");
+  EXPECT_PRED_FORMAT2(Isis::AssertQStringsEqual, pid.Next(), "ABC2");
+}
+
+
+TEST(ID, ConstructorSetBaseNum) {
+  Isis::ID pid("ABC?", 2);
+  EXPECT_PRED_FORMAT2(Isis::AssertQStringsEqual, pid.Next(), "ABC2");
+  EXPECT_PRED_FORMAT2(Isis::AssertQStringsEqual, pid.Next(), "ABC3");
+}
+
+
+TEST(ID, ConstructorNoReplacement) {
+  QString message = "No replacement set in string";
+  try {
+    Isis::ID pid("ABC");
+      FAIL() << "Expected an IException";
+  }
+  catch(Isis::IException &e) {
+    EXPECT_PRED_FORMAT2(Isis::AssertIExceptionMessage, e, message);
+  }
+  catch(...) {
+    FAIL() << "Expected error message: \"" << message.toStdString() << "\"";
+  }
+}
+
+
+TEST(ID, ConstructorMultipleReplacements) {
+  QString message = "contains more than one replacement set";
+  try {
+    Isis::ID pid("A?B?C");
+    FAIL() << "Expected an IException";
+  }
+  catch(Isis::IException &e) {
+    EXPECT_PRED_FORMAT2(Isis::AssertIExceptionMessage, e, message);
+  }
+  catch(...) {
+    FAIL() << "Expected error message: \"" << message.toStdString() << "\"";
+  }
+}
+
+
+TEST(ID, Next) {
+  Isis::ID pid("ABC??");
+  QString idString;
+
+  for (int i = 1; i < 20; i++) {
+    if (i < 10) {
+      idString = "ABC0" + QString::number(i);
+    }
+    else {
+      idString = "ABC" + QString::number(i);
+    }
+    EXPECT_PRED_FORMAT2(Isis::AssertQStringsEqual, pid.Next(), idString);
+  }
+}
+
+TEST(ID, NextMaximumReached) {
+  QString message = "Maximum number reached for string";
+  try {
+    Isis::ID pid("ABC?");
+    for (int i = 0; i < 11; i++) {
+      pid.Next();
+    } 
+    FAIL() << "Expected an IException";
+  }
+  catch(Isis::IException &e) {
+    EXPECT_PRED_FORMAT2(Isis::AssertIExceptionMessage, e, message);
+  }
+  catch(...) {
+    FAIL() << "Expected error message: \"" << message.toStdString() << "\"";
+  }
+}
+

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -1,0 +1,56 @@
+#include "TestUtilities.h"
+
+namespace Isis {
+
+  /**
+   * Custom IException assertion that checks that the exception message contains
+   * a substring.
+   */
+  ::testing::AssertionResult AssertIExceptionMessage(
+          const char* e_expr,
+          const char* contents_expr,
+          IException &e,
+          QString contents) {
+    if (e.toString().contains(contents)) return ::testing::AssertionSuccess();
+
+    return ::testing::AssertionFailure() << "IExeption "<< e_expr << "\'s error message (\"" 
+       << e.toString().toStdString() << "\") does not contain " << contents_expr << " (\"" 
+       << contents.toStdString() << "\").";
+  }
+  
+  
+  /**
+   * Custom IException assertion that checks that the exception is the expected 
+   * IException::ErrorType.
+   */
+  ::testing::AssertionResult AssertIExceptionError(
+          const char* e_expr,
+          const char* errorType_expr,
+          IException &e,
+          IException::ErrorType errorType) {
+    if (e.errorType() == errorType) return ::testing::AssertionSuccess();
+
+    return ::testing::AssertionFailure() << "IExeption "<< e_expr << "\'s error type (" 
+        << std::to_string(e.errorType()) << ") does not match expected error type (" 
+        << std::to_string(errorType) << ").";
+  }
+
+
+  /**
+   * Custom QString assertion that properly outputs them as string if they
+   * are different.
+   */
+  ::testing::AssertionResult AssertQStringsEqual(
+        const char* string1_expr,
+        const char* string2_expr,
+        QString string1,
+        QString string2) {
+    if (string1 != string2) {
+      return ::testing::AssertionFailure() << "QStrings " << string1_expr
+          << " (" << string1.toStdString() << ") and " << string2_expr
+          << " (" << string2.toStdString() << ") are not the same.";
+    }
+
+    return ::testing::AssertionSuccess();
+  }
+}

--- a/isis/tests/TestUtilities.h
+++ b/isis/tests/TestUtilities.h
@@ -11,57 +11,23 @@
 
 namespace Isis {
 
-  /**
-   * Custom IException assertion that checks that the exception message contains
-   * a substring.
-   */
   ::testing::AssertionResult AssertIExceptionMessage(
           const char* e_expr,
           const char* contents_expr,
           IException &e,
-          QString contents) {
-    if (e.toString().contains(contents)) return ::testing::AssertionSuccess();
+          QString contents);
 
-    return ::testing::AssertionFailure() << "IExeption "<< e_expr << "\'s error message (\"" 
-       << e.toString().toStdString() << "\") does not contain " << contents_expr << " (\"" 
-       << contents.toStdString() << "\").";
-  }
-  
-  
-  /**
-   * Custom IException assertion that checks that the exception is the expected 
-   * IException::ErrorType.
-   */
   ::testing::AssertionResult AssertIExceptionError(
           const char* e_expr,
           const char* errorType_expr,
           IException &e,
-          IException::ErrorType errorType) {
-    if (e.errorType() == errorType) return ::testing::AssertionSuccess();
+          IException::ErrorType errorType);
 
-    return ::testing::AssertionFailure() << "IExeption "<< e_expr << "\'s error type (" 
-        << std::to_string(e.errorType()) << ") does not match expected error type (" 
-        << std::to_string(errorType) << ").";
-  }
-
-
-  /**
-   * Custom QString assertion that properly outputs them as string if they
-   * are different.
-   */
   ::testing::AssertionResult AssertQStringsEqual(
         const char* string1_expr,
         const char* string2_expr,
         QString string1,
-        QString string2) {
-    if (string1 != string2) {
-      return ::testing::AssertionFailure() << "QStrings " << string1_expr
-          << " (" << string1.toStdString() << ") and " << string2_expr
-          << " (" << string2.toStdString() << ") are not the same.";
-    }
-
-    return ::testing::AssertionSuccess();
-  }
+        QString string2);
 }
 
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Converted ID makefile unit test to gtest. When using TestUtilities in multiple gtests, we were getting a duplicate symbol error from the linker. In order to fix this, we moved the TestUtilities.h function implementations into a .cpp file and created function prototypes in the header file. Now, multiple gtests can include TestUtilities.h.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/2820

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are in the process of converting makefile unit tests to gtest. When we create more tests, we are going to want to use TestUtilities in multiple tests and will not be able to because of this error. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built and ran all gtests using the isis3 conda environment.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
