### PR TITLE
Fixed SummingMode keyword being set in tgocassis2isis 

### DIFF
--- a/isis/src/tgo/apps/tgocassis2isis/main.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/main.cpp
@@ -341,8 +341,9 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
 
   PvlGroup &archive = outputLabel->findGroup("Archive", Pvl::Traverse);
 
+  // Calculate SummingMode keyword and add to label
   QString sumMode;
-  if ((int)outputLabel->findGroup("Instrument", Pvl::Traverse)["Expanded"] == 1) {
+  if (inst.hasKeyword("Expanded") && (int)inst.findKeyword("Expanded") == 1) {
     sumMode = "0";
   }
   else {

--- a/isis/src/tgo/apps/tgocassis2isis/main.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/main.cpp
@@ -346,7 +346,7 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
     sumMode = "0";
   }
   else {
-    sumMode = (QString)archive["Window" + toString((int)archive["WindowCount"] + 1) + "Binning"];
+    sumMode = (QString)archive["Window" + (QString)archive["WindowCount"] + "Binning"];
   }
   PvlKeyword summingMode("SummingMode", sumMode);
   outputLabel->findGroup("Instrument", Pvl::Traverse).addKeyword(summingMode);

--- a/isis/src/tgo/apps/tgocassis2isis/main.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/main.cpp
@@ -33,10 +33,10 @@ void IsisMain() {
   try {
     ProcessImport importer;
     translateCoreInfo(xmlFileName, importer);
-    
+
     if(xmlFileName.removeExtension().addExtension("dat").fileExists()){
       importer.SetInputFile(xmlFileName.removeExtension().addExtension("dat").expanded());
-    } 
+    }
     else if (xmlFileName.removeExtension().addExtension("img").fileExists()) {
       importer.SetInputFile(xmlFileName.removeExtension().addExtension("img").expanded());
     }
@@ -45,7 +45,7 @@ void IsisMain() {
         ".dat or .img file for this XML exists and is located in the same directory.";
       throw IException(IException::User, msg, _FILEINFO_);
     }
-    
+
     Cube *outputCube = importer.SetOutputCube("TO");
 
     QString transRawFile = "/translations/tgoCassisInstrument.trn";
@@ -55,8 +55,8 @@ void IsisMain() {
     Pvl *outputLabel = outputCube->label();
     QString target = "";
     try {
-      translateLabels(xmlFileName, outputCube, transRawFile); 
-    } 
+      translateLabels(xmlFileName, outputCube, transRawFile);
+    }
     catch (IException &e) {
 
       if (translateMappingLabel(xmlFileName, outputCube)) {
@@ -65,13 +65,13 @@ void IsisMain() {
         }
         else {
           if(outputLabel->findObject("IsisCube").hasGroup("Instrument")) {
-            outputLabel->findObject("IsisCube").deleteGroup("Instrument"); 
+            outputLabel->findObject("IsisCube").deleteGroup("Instrument");
           }
         }
       }
       else {
         if(outputLabel->findObject("IsisCube").hasGroup("Mapping")) {
-          outputLabel->findObject("IsisCube").deleteGroup("Mapping"); 
+          outputLabel->findObject("IsisCube").deleteGroup("Mapping");
         }
         translateLabels(xmlFileName, outputCube, transExportFile);
       }
@@ -101,13 +101,13 @@ void IsisMain() {
 
 
 /**
- * Translate core info from labels and set ProcessImport object with 
+ * Translate core info from labels and set ProcessImport object with
  * these values.
  *
  * @param inputLabel Reference to the xml label file name from the input image.
  * @param importer Reference to the ProcessImport object to which core info will
  *                 be set.
- *  
+ *
  * @internal
  *   @history 2017-01-20 Jeannie Backer - Original Version
  */
@@ -117,15 +117,15 @@ void translateCoreInfo(FileName &inputLabel, ProcessImport &importer) {
   QString missionDir = (QString) dataDir["Tgo"];
 
   // Get the translation manager ready
-  FileName transFile; 
+  FileName transFile;
   try {
-    transFile = FileName(missionDir + "/translations/tgoCassis.trn"); 
+    transFile = FileName(missionDir + "/translations/tgoCassis.trn");
     XmlToPvlTranslationManager labelXlater(inputLabel, transFile.expanded());
     translateCoreInfo(labelXlater, importer);
-  } 
+  }
   catch (IException &e) {
     // if exported, use this!
-    transFile = FileName(missionDir + "/translations/tgoCassisRdr.trn"); 
+    transFile = FileName(missionDir + "/translations/tgoCassisRdr.trn");
     XmlToPvlTranslationManager labelXlater(inputLabel, transFile.expanded());
     translateCoreInfo(labelXlater, importer);
   }
@@ -133,13 +133,13 @@ void translateCoreInfo(FileName &inputLabel, ProcessImport &importer) {
 
 
 /**
- * Translate core info from labels and set ProcessImport object with 
+ * Translate core info from labels and set ProcessImport object with
  * these values.
  *
  * @param labelXlater Reference to the XmlToPvlTranslationManager objcet to use for the translation.
  * @param importer Reference to the ProcessImport object to which core info will
  *                 be set.
- *  
+ *
  * @internal
  *   @history 2017-01-20 Jeannie Backer - Original Version
  *   @history 2017-01-21 Krisitn Berry - Flipped ns & nl. They're flipped in the CaSSIS header.
@@ -158,7 +158,7 @@ void translateCoreInfo(XmlToPvlTranslationManager labelXlater, ProcessImport &im
   str = labelXlater.Translate("CoreType");
   importer.SetPixelType(PixelTypeEnumeration(str));
 
-  str = labelXlater.Translate("CoreByteOrder");    
+  str = labelXlater.Translate("CoreByteOrder");
   importer.SetByteOrder(ByteOrderEnumeration(str));
 
   importer.SetFileHeaderBytes(0);
@@ -172,15 +172,15 @@ void translateCoreInfo(XmlToPvlTranslationManager labelXlater, ProcessImport &im
 
 /**
  * Translate the cartographic info from the xml.
- * 
+ *
  * @param xmlFileName The xml label file name for the input image.
- * @param outputCube Pointer to output cube where ISIS3 labels will be added and 
+ * @param outputCube Pointer to output cube where ISIS3 labels will be added and
  *                   updated.
  */
 bool translateMappingLabel(FileName xmlFileName, Cube *outputCube) {
   //Translate the Mapping Group
   try {
-    PvlGroup &dataDir = Preference::Preferences().findGroup("DataDirectory"); 
+    PvlGroup &dataDir = Preference::Preferences().findGroup("DataDirectory");
     QString missionDir = (QString) dataDir["Tgo"];
     FileName mapTransFile(missionDir + "/translations/tgoCassisMapping.trn");
 
@@ -195,7 +195,7 @@ bool translateMappingLabel(FileName xmlFileName, Cube *outputCube) {
   catch (IException &e) {
     Pvl *outputLabel = outputCube->label();
     if(outputLabel->hasGroup("Mapping")) {
-      outputLabel->deleteGroup("Mapping"); 
+      outputLabel->deleteGroup("Mapping");
     }
     return false;
   }
@@ -205,14 +205,14 @@ bool translateMappingLabel(FileName xmlFileName, Cube *outputCube) {
 
 /**
  * Translate the Mosaic group info from the xml.
- * 
+ *
  * @param xmlFileName The xml label file name for the input image.
- * @param outputCube Pointer to output cube where ISIS3 labels will be added and 
+ * @param outputCube Pointer to output cube where ISIS3 labels will be added and
  *                   updated.
  */
 bool translateMosaicLabel(FileName xmlFileName, Cube *outputCube) {
   QDomDocument xmlDoc;
-    
+
   QFile xmlFile(xmlFileName.expanded());
   if ( !xmlFile.open(QIODevice::ReadOnly) ) {
     QString msg = "Could not open label file [" + xmlFileName.expanded() +
@@ -242,7 +242,7 @@ bool translateMosaicLabel(FileName xmlFileName, Cube *outputCube) {
         QStringList logicalIdStringList = logicalIdText.split(":");
         if (logicalIdStringList.contains("data_mosaic")) {
           try {
-            PvlGroup &dataDir = Preference::Preferences().findGroup("DataDirectory"); 
+            PvlGroup &dataDir = Preference::Preferences().findGroup("DataDirectory");
             QString missionDir = (QString) dataDir["Tgo"];
             FileName bandBinTransFile(missionDir + "/translations/tgoCassisMosaicBandBin.trn");
             // Get the translation manager ready for translating the band bin label
@@ -260,10 +260,10 @@ bool translateMosaicLabel(FileName xmlFileName, Cube *outputCube) {
           catch (IException &e) {
             Pvl *outputLabel = outputCube->label();
             if(outputLabel->hasGroup("Mosaic")) {
-              outputLabel->deleteGroup("Mosaic"); 
+              outputLabel->deleteGroup("Mosaic");
             }
             if(outputLabel->hasGroup("BandBin")) {
-              outputLabel->deleteGroup("BandBin"); 
+              outputLabel->deleteGroup("BandBin");
             }
             return false;
           }
@@ -276,13 +276,13 @@ bool translateMosaicLabel(FileName xmlFileName, Cube *outputCube) {
 
 
 /**
- * Translate instrument, bandbin, and archive info from xml label into ISIS3 
- * label and add kernels group. 
+ * Translate instrument, bandbin, and archive info from xml label into ISIS3
+ * label and add kernels group.
  *
  * @param inputLabel Reference to the xml label file name for the input image.
- * @param outputCube Pointer to output cube where ISIS3 labels will be added and 
+ * @param outputCube Pointer to output cube where ISIS3 labels will be added and
  *                   updated.
- *  
+ *
  * @internal
  *   @history 2017-01-20 Jeannie Backer - Original Version
  *   @history 2017-01-23 Kristin Berry - Added support for bandBin group and archive group
@@ -338,9 +338,19 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
     startTime->setValue(startTimeString);
   }
   iTime stime(startTimeString);
-  
+
   PvlGroup &archive = outputLabel->findGroup("Archive", Pvl::Traverse);
-                                                  
+
+  QString sumMode;
+  if ((int)outputLabel->findGroup("Instrument", Pvl::Traverse)["Expanded"] == 1) {
+    sumMode = "0";
+  }
+  else {
+    sumMode = (QString)archive["Window" + toString((int)archive["WindowCount"] + 1) + "Binning"];
+  }
+  PvlKeyword summingMode("SummingMode", sumMode);
+  outputLabel->findGroup("Instrument", Pvl::Traverse).addKeyword(summingMode);
+
   PvlKeyword yeardoy("YearDoy", toString(stime.Year()*1000 + stime.DayOfYear()));
   archive.addKeyword(yeardoy);
 
@@ -400,7 +410,7 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
       spacecraftCode = -143424;
     }
     else {
-      QString msg = "Unrecognized filter name [" 
+      QString msg = "Unrecognized filter name ["
         + filter
         + "].";
         throw IException(IException::User, msg, _FILEINFO_);
@@ -410,7 +420,7 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
     bandBin.addKeyword(PvlKeyword("NaifIkCode", toString(spacecraftCode)));
   }
   else {
-    QString msg = "Unrecognized Spacecraft name [" 
+    QString msg = "Unrecognized Spacecraft name ["
       + spcName
       + "] and instrument ID ["
       + instId


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added an Expanded keyword and set SummingMode keyword to be based on the proper window and set based on the new Expanded keyword.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/2634
https://github.com/USGS-Astrogeology/ISIS3/issues/2633

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
tgocassis2isis was looking in the wrong location for the SummingMode keyword. This was causing the wrong value to be stored.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all tgo tests. There will be test data to check in which I have ready to go.
I also modified raw cassis .xml files to hit all edge cases on ingest to confirm proper importing:
Window_Count = 1, Window1_Binning = 1, Exported = 0 --> SummingMode = 1
Window_Count = 2, Window2_Binning = 2, Exported = 0 --> SummingMode = 2
Window_Count = 1, Window1_Binning = 1, Exported = 1 --> SummingMode = 0
Window_Count = 1, Window1_Binning = 1                        --> SummingMode = 1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
