### PR TITLE
Updates to tgocassisrdrgen and ProcessExportPds4 to add content to exported CaSSIS Label.

### DIFF
--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
@@ -754,6 +754,33 @@ namespace Isis {
                                                     toString(base));
         elementArrayElement.appendChild(offsetElement);
       }
+
+      // Add the Special_Constants class to define ISIS special pixel values: 
+
+      // Assume 32-bit/Real for CaSSIS
+      QDomElement specialConstantElement = m_domDoc->createElement("Special_Constants");
+      arrayImageElement.insertAfter(specialConstantElement,
+                                    arrayImageElement.lastChildElement("Axis_Array"));
+
+      QDomElement nullElement = m_domDoc->createElement("missing_constant");
+      PvlToXmlTranslationManager::setElementValue(nullElement, QString::number(NULL8, 'g', 18)); //toString(NULL8));
+      specialConstantElement.appendChild(nullElement);
+
+      QDomElement highInstrumentSatElement = m_domDoc->createElement("high_instrument_saturation");
+      PvlToXmlTranslationManager::setElementValue(highInstrumentSatElement, QString::number(HIGH_INSTR_SAT8, 'g', 18));
+      specialConstantElement.appendChild(highInstrumentSatElement);
+
+      QDomElement highRepresentationSatElement = m_domDoc->createElement("high_representation_saturation");
+      PvlToXmlTranslationManager::setElementValue(highRepresentationSatElement, QString::number(HIGH_REPR_SAT8, 'g', 18));
+      specialConstantElement.appendChild(highRepresentationSatElement);
+
+      QDomElement lowInstrumentSatElement = m_domDoc->createElement("low_instrument_saturation");
+      PvlToXmlTranslationManager::setElementValue(lowInstrumentSatElement, QString::number(LOW_INSTR_SAT8, 'g', 18));
+      specialConstantElement.appendChild(lowInstrumentSatElement);
+
+      QDomElement lowRepresentationSatElement = m_domDoc->createElement("low_representation_saturation");
+      PvlToXmlTranslationManager::setElementValue(lowRepresentationSatElement, QString::number(LOW_REPR_SAT8, 'g', 18));
+      specialConstantElement.appendChild(lowRepresentationSatElement);
     }
   }
 

--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
@@ -47,6 +47,9 @@ namespace Isis {
   ProcessExportPds4::ProcessExportPds4() {
 
     m_lid = "";
+    m_versionId = "";
+    m_title = "";
+
     m_imageType = StandardImage;
 
     qSetGlobalQHashSeed(1031); // hash seed to force consistent output
@@ -319,6 +322,19 @@ namespace Isis {
   }
 
 
+// FIXME docs needed
+   void ProcessExportPds4::setVersionId(QString versionId) {
+    m_versionId = versionId;
+  }
+
+   void ProcessExportPds4::setTitle(QString title) {
+    m_title = title;
+  }
+
+
+
+
+
   /**
    * Allows mission specific programs to use specified 
    * versions of dictionaries. 
@@ -365,6 +381,16 @@ namespace Isis {
 
     QDomElement lidElement = identificationElement.firstChildElement("logical_identifier");
     PvlToXmlTranslationManager::resetElementValue(lidElement, m_lid);
+
+    if (m_versionId != "") {
+      QDomElement versionElement = identificationElement.firstChildElement("version_id"); 
+      PvlToXmlTranslationManager::resetElementValue(versionElement, m_versionId);
+    }
+
+    if (m_title != "") {
+      QDomElement titleElement = identificationElement.firstChildElement("title"); 
+      PvlToXmlTranslationManager::resetElementValue(titleElement, m_title);
+    }
 
     // Get export history and add <Modification_History> element.
     // These regular expressions match the pipe followed by the date from

--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
@@ -1033,11 +1033,10 @@ namespace Isis {
       double maxLon = inputMapping.findKeyword("MaximumLongitude");
       double minLon = inputMapping.findKeyword("MinimumLongitude");
       xmlPath.clear();
-      xmlPath << "Product_Observational" 
+      xmlPath << "Product_Observational"
               << "Observation_Area" 
-              << "Discipline_Area" 
+              << "Discipline_Area"
               << "cart:Cartography" 
-              << "cart:Map_Projection" 
               << "cart:Spatial_Domain"
               << "cart:Bounding_Coordinates";
       QDomElement boundingCoordElement = getElement(xmlPath, baseElement);
@@ -1046,18 +1045,16 @@ namespace Isis {
 
       // translation files currently handles Positive West case where east = min, west = max
       // so if positive east, swap min/max
-      if(QString::compare(lonDir, "Positive East", Qt::CaseInsensitive) == 0) {
+      if(QString::compare(lonDir, "PositiveEast", Qt::CaseInsensitive) == 0) {
         // west min, east max
         PvlToXmlTranslationManager::resetElementValue(eastElement, toString(maxLon), "deg");
         PvlToXmlTranslationManager::resetElementValue(westElement, toString(minLon), "deg");
       }
     }
-
-
   }
 
 
- /**
+/**
   * Convenience method to get an element given a path and its parent. 
   * 
   * @param xmlPath The XML path to the element to retrieve, 

--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
@@ -322,17 +322,37 @@ namespace Isis {
   }
 
 
-// FIXME docs needed
+  /**
+   * Allows mission specific programs to set version_id
+   * required for PDS4 labels. This value is added to the xml file 
+   * by the identificationArea() method. 
+   *  
+   * The input string should be colon separated string with 6 
+   * identifiers: 
+   *  
+   * @author 2019-03-01 Kristin Berry
+   * 
+   * @param versiondId The version_id value required for PDS4 
+   *            compliant labels.
+   */
    void ProcessExportPds4::setVersionId(QString versionId) {
     m_versionId = versionId;
   }
 
+
+  /**
+   * Allows mission specific programs to set the title
+   * required for PDS4 labels. This value is added to the xml file 
+   * by the identificationArea() method. 
+   *  
+   * @author 2019-03-01 Kristin Berry
+   * 
+   * @param title The title value required for PDS4 
+   *            compliant labels.
+   */
    void ProcessExportPds4::setTitle(QString title) {
     m_title = title;
   }
-
-
-
 
 
   /**

--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
@@ -64,10 +64,10 @@ namespace Isis {
     m_domDoc->appendChild(xmlHeader);
 
     // base pds4 schema location
-    m_schemaLocation = "http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.xsd"; 
+    m_schemaLocation = "http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd"; 
 
     QString xmlModel;
-    xmlModel += "href=\"http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch\" ";
+    xmlModel += "href=\"http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch\" ";
     xmlModel += "schematypens=\"http://purl.oclc.org/dsdl/schematron\"";
     QDomProcessingInstruction header =
         m_domDoc->createProcessingInstruction("xml-model", xmlModel);
@@ -432,18 +432,17 @@ namespace Isis {
    * the PDS4 labels. 
    */
   void ProcessExportPds4::displaySettings() {
+    // Add header info
+    addSchema("PDS4_DISP_1B00.sch", 
+              "PDS4_DISP_1B00.xsd",
+              "xmlns:disp", 
+              "http://pds.nasa.gov/pds4/disp/v1"); 
 
     Pvl *inputLabel = InputCubes[0]->label(); 
     FileName translationFileName;
     translationFileName = "$base/translations/pds4ExportDisplaySettings.trn";
     PvlToXmlTranslationManager xlator(*inputLabel, translationFileName.expanded());
     xlator.Auto(*m_domDoc);
-
-    // Add header info
-    addSchema("PDS4_DISP_1700.sch", 
-              "PDS4_DISP_1700.xsd",
-              "xmlns:disp", 
-              "http://pds.nasa.gov/pds4/disp/v1"); 
   }
 
   
@@ -455,8 +454,8 @@ namespace Isis {
     Pvl *inputLabel = InputCubes[0]->label(); 
     if ( !inputLabel->findObject("IsisCube").hasGroup("BandBin") ) return;
     // Add header info
-    addSchema("PDS4_IMG_1900.sch", 
-              "PDS4_IMG_1900.xsd",
+    addSchema("PDS4_IMG_1A10_1510.sch", 
+              "PDS4_IMG_1A10_1510.xsd",
               "xmlns:img", 
               "http://pds.nasa.gov/pds4/img/v1"); 
     
@@ -977,8 +976,8 @@ namespace Isis {
         !(inputLabel->findObject("IsisCube").hasGroup("Mapping"))) return;
     PvlGroup &inputMapping = inputLabel->findGroup("Mapping", Pvl::Traverse);
 
-    addSchema("PDS4_CART_1700.sch", 
-              "PDS4_CART_1700.xsd",
+    addSchema("PDS4_CART_1900.sch", 
+              "PDS4_CART_1900.xsd",
               "xmlns:cart", 
               "http://pds.nasa.gov/pds4/cart/v1"); 
 

--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.h
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.h
@@ -75,6 +75,9 @@ namespace Isis {
    *                           attributes to elements. Matches pds validate tool specifations.
    *   @history 2018-06-12 Kristin Berry - Added schema associated with the img class when it is
    *                           used.
+   *   @history 2019-03-01 Kristin Berry - Added ability to set version_id and title, added
+   *                           Special_Constants to define ISIS special pixel values, fixed east/west
+   *                           bounding coordinates swap bug. Fixes git issue #2635.
    */
 
   class ProcessExportPds4: public Isis::ProcessExport {

--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.h
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.h
@@ -108,6 +108,8 @@ namespace Isis {
       QDomElement getElement(QStringList xmlPath, QDomElement parent=QDomElement());
       void addHistory(QString description, QString date = "tbd", QString version = "1.0");
       void setLogicalId(QString lid);
+      void setVersionId(QString versionId);
+      void setTitle(QString title);
       void setSchemaLocation(QString schema);
       void setImageType(ImageType imageType);
 
@@ -131,6 +133,8 @@ namespace Isis {
       QDomDocument *m_domDoc;               //!< XML label.
       QString m_schemaLocation;             //!< QString with all schema locations required.
       QString m_lid;                        //!< QString with specified logical identifier.
+      QString m_versionId;                  //!< QString with specified version id.
+      QString m_title;                      //!< QString with specified title. 
       ImageType m_imageType;                //!< Type of image data to be written.
 
   };

--- a/isis/src/tgo/apps/tgocassisrdrgen/main.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/main.cpp
@@ -69,15 +69,15 @@ void IsisMain() {
   }
   else {
     // Get the observationId from the Archive Group, or the Mosaic group, if the input is a mosaic
-    QString observationId; 
+    QString observationId;
 
-    if(label->findObject("IsisCube").hasGroup("Archive")){
-      PvlGroup archiveGroup = label->findObject("IsisCube").findGroup("Archive");
-      observationId = archiveGroup.findKeyword("ObservationId")[0];
-    }
-    else if (label->findObject("IsisCube").hasGroup("Mosaic")) {
+    if (label->findObject("IsisCube").hasGroup("Mosaic")) {
       PvlGroup mosaicGroup = label->findObject("IsisCube").findGroup("Mosaic");
       observationId = mosaicGroup.findKeyword("ObservationId")[0];
+    }
+    else if(label->findObject("IsisCube").hasGroup("Archive")){
+      PvlGroup archiveGroup = label->findObject("IsisCube").findGroup("Archive");
+      observationId = archiveGroup.findKeyword("ObservationId")[0];
     }
     productId.setValue(observationId);
   }

--- a/isis/src/tgo/apps/tgocassisrdrgen/main.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/main.cpp
@@ -86,6 +86,16 @@ void IsisMain() {
   logicalId += productId[0];
   process.setLogicalId(logicalId);
 
+  // Set Title
+  if ( ui.WasEntered("TITLE") ) {
+    process.setTitle( ui.GetString("TITLE") );
+  }
+
+  // Set Version ID
+  if ( ui.WasEntered("VERSIONID") ) {
+    process.setVersionId( ui.GetString("VERSIONID") );
+  }
+
   // std PDS4 label
   process.StandardPds4Label();
 

--- a/isis/src/tgo/apps/tgocassisrdrgen/main.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/main.cpp
@@ -99,7 +99,7 @@ void IsisMain() {
   // std PDS4 label
   process.StandardPds4Label();
 
-  process.addSchema("PDS4_PSA_1000.sch", 
+/*  process.addSchema("PDS4_PSA_1000.sch", 
                     "PDS4_PSA_1000.xsd",
                     "xmlns:psa", 
                     "http://psa.esa.int/psa/v1");
@@ -107,12 +107,12 @@ void IsisMain() {
   process.addSchema("PDS4_PSA_EM16_CAS_1000.sch", 
                     "PDS4_PSA_EM16_CAS_1000.xsd",
                     "xmlns",
-                    "http://psa.esa.int/psa/em16/cas/v1");
+                    "http://psa.esa.int/psa/em16/cas/v1");*/
 
   // Add geometry schema for mosaics
   if (label->findObject("IsisCube").hasGroup("Mosaic")) {
-    process.addSchema("PDS4_GEOM_1900_1510.sch", 
-                      "PDS4_GEOM_1900_1510.xsd",
+    process.addSchema("PDS4_GEOM_1B00_1610.sch", 
+                      "PDS4_GEOM_1B00_1610.xsd",
                       "xmlns:geom",
                       "https://pds.jpl.nasa.gov/datastandards/schema/released/geom/v1");
   }

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
@@ -41,6 +41,10 @@
     <change name="Kristin Berry" date="2018-06-12">
       Updated to use the tgoCassisExportMosaic.trn translation file when the input cube is a mosaic.
     </change>
+    <change name="Kristin Berry" date="2019-03-01">
+      Added TITLE and VERSIONID optional parameters to specify these values in the exported PDS4 label. 
+      Fixed bug that disabled reading of mosaics with Archive groups. 
+    </change>
   </history>
 
   <category>

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.xml
@@ -89,6 +89,26 @@
           Update the default Product ID value. This value will be the last section of the PDS4 logical_identifier value.
         </description>
       </parameter>
+      <parameter name="TITLE">
+        <type>string</type>
+        <internalDefault>None</internalDefault>
+        <brief>
+          Product ID value
+        </brief>
+        <description>
+          Update the default Title value. 
+        </description>
+      </parameter>
+      <parameter name="VERSIONID">
+        <type>string</type>
+        <internalDefault>None</internalDefault>
+        <brief>
+          Product ID value
+        </brief>
+        <description>
+          Update the default Version ID value. 
+        </description>
+      </parameter>
     </group>
 
   </groups>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Made the following changes associated with updating the exported PDS4 label for CaSSIS images: 

* Added 32-bit ISIS Special Pixel Constants to ProcessExportPds4 to be exported to PDS4 labels
* Add ability to set title and version id in exported PDS4 product in `tgocassisrdrgen` (and also the `ProcessExportPds4` API
*  Fix bug that occurs when exporting mosaics with Archive groups and fixed min/max lat/lon to east/west bounding box positive east flip bug
* Added CaSSIS-specific `Mission_Area` with information about the use (or nonuse) of smithed cks.  
* Added `Alias_List`
* Fixed `latitude_of_projection_origin` to be 0. (This should always be 0 in this case.) 

Many of the modifications that result in different output are not in the code changes associated with this PR, but in updated translation files. 

## Related Issue
#2635. This PR adds the requested content to the exported PDS4 label from `tgocassisrdrgen`. 

## Motivation and Context
These modifications and additions were requested by the CaSSIS team both for PDS4 compliance and to add needed information to the exported label. 

## How Has This Been Tested?
This has been tested by-hand on a newly-provided mosiacked cube with an Archive group containing information about the smithed ck kernels and a non-projected cube. 

Automated tests that involve export are failing because truthdata needs to be updated to include the added tags. 

Other CaSSIS automated tests pass. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
