### PR TITLE
Updated truthdata for ProcessExportPds4 class to match updates made f…

### DIFF
--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.truth
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.truth
@@ -2,14 +2,14 @@ Testing ProcessExportPds4
 
 Testing default object
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational/>
 
 Testing default CaSSIS export
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -28,13 +28,20 @@ Testing default CaSSIS export
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -53,6 +60,13 @@ Testing default CaSSIS export
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
@@ -61,9 +75,9 @@ Testing xml input
 
 Testing export pixel types
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -82,15 +96,22 @@ Testing export pixel types
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -104,17 +125,24 @@ Testing export pixel types
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -128,19 +156,26 @@ Testing export pixel types
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -154,21 +189,28 @@ Testing export pixel types
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -182,23 +224,30 @@ Testing export pixel types
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -212,15 +261,22 @@ Testing export pixel types
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
 
 Testing missing start and end times
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -239,6 +295,13 @@ Testing missing start and end times
     <elements>254</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>
@@ -246,9 +309,9 @@ Testing missing start and end times
 Testing exporting a map projected product
 
 <?xml version="1.0" encoding="utf-8"?>
-<?xml-model href="http://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
-<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1900.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational>0</offset>
    <axes>2</axes>
    <axis_index_order>Last Index Fastest</axis_index_order>
@@ -267,6 +330,13 @@ Testing exporting a map projected product
     <elements>2371</elements>
     <sequence_number>2</sequence_number>
    </Axis_Array>
+   <Special_Constants>
+    <missing_constant>-1.79769313486231491e+308</missing_constant>
+    <high_instrument_saturation>-1.79769313486231551e+308</high_instrument_saturation>
+    <high_representation_saturation>-1.79769313486231571e+308</high_representation_saturation>
+    <low_instrument_saturation>-1.79769313486231531e+308</low_instrument_saturation>
+    <low_representation_saturation>-1.79769313486231511e+308</low_representation_saturation>
+   </Special_Constants>
   </Array_2D_Image>
  </File_Area_Observational>
 </Product_Observational>


### PR DESCRIPTION
…or CaSSIS sprint


## Description
I forgot to update the truthdata for ProcessExportPds4's unit test associated with #3137 
This fixes it.

## Related Issue
#3137

## Motivation and Context
I forgot to update the test data.

## How Has This Been Tested?
This is a fix for a test. The test now passes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
