### PR TITLE
Added C-Shell variable setup

### DIFF
--- a/isis/scripts/isis3VarInit.py
+++ b/isis/scripts/isis3VarInit.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-"""This program builds shell scripts that define ISIS3 environment variables during conda environment activation and deactivation, and creates some directories."""
+"""
+This program builds shell scripts that define ISIS3 environment variables during
+conda environment activation and deactivation, and creates some directories.
+"""
 
 import argparse
 import os
@@ -13,12 +16,12 @@ import sys
 #  software to the public domain.
 #
 #
-#   Description:  This program builds the shell scripts that define the 
-#       ISISROOT/ISIS3DATA/ISIS3TESTDATA environment variables for the user 
+#   Description:  This program builds the shell scripts that define the
+#       ISISROOT/ISIS3DATA/ISIS3TESTDATA environment variables for the user
 #       when the ISIS3 conda environment is activated, and clean up when it is
 #       deactivated.
 #
-#       The data directory and test directory are optional command line arguments.  
+#       The data directory and test directory are optional command line arguments.
 #       If the user chooses not to set them, they will both be created in the
 #       $ISISROOT directory.
 #
@@ -37,14 +40,17 @@ import sys
 #       Description: Streamlined the program, improved documentation, and made the directory and
 #                    file creation more `pythonic' rather than using system calls.
 #
+#       Author:  Jesse Mapel
+#       Date:    2019-03-25
+#       Description: Added
+#
 #
 ##########################################################################################################
 
 # There are still a lot of Python 2 installations out there, and if people don't have
 # their conda environment set up properly, the error message they'll get will be hard
 # to decipher.  This might help:
-assert( sys.version_info >= (3,2) ) # Must be using Python 3.2 or later, is conda set up?
-
+assert( sys.version_info >= (3,2) ) # Must be using Python 3.2 or later
 
 # This just wraps and reports on the directory creation:
 def mkdir( p ):
@@ -58,7 +64,7 @@ def mkdir( p ):
 # Set up and then parse the command line:
 parser = argparse.ArgumentParser( description=__doc__ )
 
-parser.add_argument('-d','--data-dir', 
+parser.add_argument('-d','--data-dir',
                     default=os.environ['CONDA_PREFIX']+'/data',
                     help='ISIS3 Data Directory, default: %(default)s' )
 parser.add_argument('-t','--test-dir',
@@ -79,19 +85,35 @@ mkdir( activate_dir )
 mkdir( deactivate_dir )
 
 # Write the files that manage the ISIS3 environments:
-activate_vars   =   activate_dir+'/env_vars.sh'
-deactivate_vars = deactivate_dir+'/env_vars.sh'
+activate_vars_sh   =   activate_dir+'/env_vars.sh'
+deactivate_vars_sh = deactivate_dir+'/env_vars.sh'
+activate_vars_csh   =   activate_dir+'/env_vars.csh'
+deactivate_vars_csh = deactivate_dir+'/env_vars.csh'
 
-with open( activate_vars, mode='w' ) as a:
+with open( activate_vars_sh, mode='w' ) as a:
     a.write('#!/bin/sh\n')
     a.write('export ISISROOT='+      os.environ['CONDA_PREFIX']+'\n')
     a.write('export ISIS3DATA='+     args.data_dir +'\n')
     a.write('export ISIS3TESTDATA='+ args.test_dir +'\n')
-print( 'Wrote '+activate_vars )
+print( 'Wrote '+activate_vars_sh )
 
-with open( deactivate_vars, mode='w' ) as d:
+with open( deactivate_vars_sh, mode='w' ) as d:
     d.write('#!/bin/sh\n')
     d.write('unset ISISROOT\n')
     d.write('unset ISIS3DATA\n')
     d.write('unset ISIS3TESTDATA\n')
-print( 'Wrote '+deactivate_vars )
+print( 'Wrote '+deactivate_vars_sh )
+
+with open( activate_vars_csh, mode='w' ) as a:
+    a.write('#!/bin/csh\n')
+    a.write('setenv ISISROOT '+      os.environ['CONDA_PREFIX']+'\n')
+    a.write('setenv ISIS3DATA '+     args.data_dir +'\n')
+    a.write('setenv ISIS3TESTDATA '+ args.test_dir +'\n')
+print( 'Wrote '+activate_vars_csh )
+
+with open( deactivate_vars_csh, mode='w' ) as d:
+    d.write('#!/bin/csh\n')
+    d.write('unsetenv ISISROOT\n')
+    d.write('unsetenv ISIS3DATA\n')
+    d.write('unsetenv ISIS3TESTDATA\n')
+print( 'Wrote '+deactivate_vars_csh )

--- a/isis/scripts/isis3VarInit.py
+++ b/isis/scripts/isis3VarInit.py
@@ -42,7 +42,7 @@ import sys
 #
 #       Author:  Jesse Mapel
 #       Date:    2019-03-25
-#       Description: Added
+#       Description: Added C-Shell support.
 #
 #
 ##########################################################################################################

--- a/isis/scripts/isis3VarInit.py
+++ b/isis/scripts/isis3VarInit.py
@@ -91,29 +91,37 @@ activate_vars_csh   =   activate_dir+'/env_vars.csh'
 deactivate_vars_csh = deactivate_dir+'/env_vars.csh'
 
 with open( activate_vars_sh, mode='w' ) as a:
-    a.write('#!/bin/sh\n')
-    a.write('export ISISROOT='+      os.environ['CONDA_PREFIX']+'\n')
-    a.write('export ISIS3DATA='+     args.data_dir +'\n')
-    a.write('export ISIS3TESTDATA='+ args.test_dir +'\n')
+    script = """#!/bin/sh
+export ISISROOT={}
+export ISIS3DATA={}
+export ISIS3TESTDATA={}
+""".format(os.environ['CONDA_PREFIX'], args.data_dir, args.test_dir)
+    a.write(script)
 print( 'Wrote '+activate_vars_sh )
 
 with open( deactivate_vars_sh, mode='w' ) as d:
-    d.write('#!/bin/sh\n')
-    d.write('unset ISISROOT\n')
-    d.write('unset ISIS3DATA\n')
-    d.write('unset ISIS3TESTDATA\n')
+    script = """#!/bin/sh
+unset ISISROOT
+unset ISIS3DATA
+unset ISIS3TESTDATA
+"""
+    d.write(script)
 print( 'Wrote '+deactivate_vars_sh )
 
 with open( activate_vars_csh, mode='w' ) as a:
-    a.write('#!/bin/csh\n')
-    a.write('setenv ISISROOT '+      os.environ['CONDA_PREFIX']+'\n')
-    a.write('setenv ISIS3DATA '+     args.data_dir +'\n')
-    a.write('setenv ISIS3TESTDATA '+ args.test_dir +'\n')
+    script = """#!/bin/csh
+setenv ISISROOT {}
+setenv ISIS3DATA {}
+setenv ISIS3TESTDATA {}
+""".format(os.environ['CONDA_PREFIX'], args.data_dir, args.test_dir)
+    a.write(script)
 print( 'Wrote '+activate_vars_csh )
 
 with open( deactivate_vars_csh, mode='w' ) as d:
-    d.write('#!/bin/csh\n')
-    d.write('unsetenv ISISROOT\n')
-    d.write('unsetenv ISIS3DATA\n')
-    d.write('unsetenv ISIS3TESTDATA\n')
+    script = """#!/bin/sh
+unsetenv ISISROOT
+unsetenv ISIS3DATA
+unsetenv ISIS3TESTDATA
+"""
+    d.write(script)
 print( 'Wrote '+deactivate_vars_csh )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This adds setup for the ISIS environment variables when activating the installation conda environment in c-shell

## Description
<!--- Describe your changes in detail -->
The isis3VarInit.py script now writes a c-shell script similar to the bash script to setup and tear-down the environment variables on activate and deactivate respectively.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3164 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Installing ISIS on c-shell requires manually setting up the environment variables. This makes it so users only have to run this script once on installation and then they will be automatically setup.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that the script works for bash and tcsh.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
