### PR TITLE
Fixed memory leak in Bullet shape model

### DIFF
--- a/isis/src/base/objs/BulletDskShape/BulletDskShape.cpp
+++ b/isis/src/base/objs/BulletDskShape/BulletDskShape.cpp
@@ -65,7 +65,18 @@ namespace Isis {
   /**
    * Desctructor
    */
-  BulletDskShape::~BulletDskShape() { }
+  BulletDskShape::~BulletDskShape() {
+    // Bullet does not clean up the mesh automatically, so we need to delete it manually
+    if (m_mesh) {
+      for (int i = 0; i < m_mesh->getIndexedMeshArray().size(); i++) {
+        btIndexedMesh &v_mesh = m_mesh->getIndexedMeshArray()[i];
+        delete[] v_mesh.m_triangleIndexBase;
+        v_mesh.m_triangleIndexBase = nullptr;
+        delete[] v_mesh.m_vertexBase;
+        v_mesh.m_vertexBase = nullptr;
+      }
+    }
+  }
 
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bullet Shape models now properly clean up

## Description
<!--- Describe your changes in detail -->
The Bullet library does not automatically delete the mesh objects, so code was added to delete the mesh when the shape is deleted.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3177 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is a large memory leak, potentially on the order of gigs

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests have been run and are passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
