### PR TITLE
Modifying how ProcessRubberSheet::transformPatch() handles buffers

### DIFF
--- a/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
+++ b/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
@@ -1058,8 +1058,8 @@ namespace Isis {
     double F = ilineFunc.Coefficient(2);
 
     // Now we can do our typical backwards geom. Loop over the output cube
-    // coordinates and compute input cube coordinates, writing pixels to buffer
-    // 1-by-1
+    // coordinates and compute input cube coordinates for the corners of the current
+    // buffer. The buffer is the same size as the patch size.
     Brick oBrick(*OutputCubes[0], osampMax-osampMin+1, olineMax-olineMin+1, 1);
     oBrick.SetBasePosition(osampMin, olineMin, iportal.Band());
     int brickIndex = 0;

--- a/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.h
+++ b/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.h
@@ -200,13 +200,11 @@ namespace Isis {
 
       void transformPatch (double startingSample, double endingSample,
                            double startingLine, double endingLine,
-                           Brick &obrick, Portal &iportal,
-                           Transform &trans, Interpolator &interp);
+                           Portal &iportal, Transform &trans, Interpolator &interp);
 
       void splitPatch (double startingSample, double endingSample,
                        double startingLine, double endingLine,
-                       Brick &obrick, Portal &iportal,
-                       Transform &trans, Interpolator &interp);
+                       Portal &iportal, Transform &trans, Interpolator &interp);
 #if 0
       void transformPatch (double startingSample, double endingSample,
                            double startingLine, double endingLine);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A Buffer of size 1x1x1 was originally being used and written out to the ouput cube for every single pixel in the image. There is now a bigger Buffer being created (size depending on parameters to function) and it is only being written to the cube once fully filled.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This was a general improvement for LROC efficiency, but will have positive impact on ISIS as a whole. #3192

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The LROC mission team was experiencing long run times for cam2map for their data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the nightly testing suite as well as confirmed that other working cubes matched to an older version of the run of cam2map on ISIS (isis3.6.2).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
