### PR TITLE
Removed extra exceptions writing controlnets

### DIFF
--- a/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
+++ b/isis/src/control/objs/ControlNetVersioner/ControlNetVersioner.cpp
@@ -1803,10 +1803,7 @@ namespace Isis {
           pointType = ControlPointFileEntryV0002_PointType_Fixed;
           break;
         default:
-          QString msg = "Unable to create ProtoPoint [" + toString(protoPoint.id().c_str())
-                        + "] from file. Type enumeration ["
-                        + toString((int)(controlPoint->GetType())) + "] is invalid.";
-          throw IException(IException::Programmer, msg, _FILEINFO_);
+          pointType = ControlPointFileEntryV0002_PointType_Free;
           break;
       }
       protoPoint.set_type(pointType);
@@ -1852,11 +1849,7 @@ namespace Isis {
                            ControlPointFileEntryV0002_AprioriSource_BundleSolution);
           break;
         default:
-          QString msg = "Unable to create ProtoPoint [" + toString(protoPoint.id().c_str())
-                        + "] from file. Type enumeration ["
-                        + toString((int)(controlPoint->GetAprioriSurfacePointSource()))
-                        + "] is invalid.";
-          throw IException(IException::Programmer, msg, _FILEINFO_);
+          protoPoint.set_apriorisurfpointsource(ControlPointFileEntryV0002_AprioriSource_None);
           break;
       }
 
@@ -1883,11 +1876,7 @@ namespace Isis {
           protoPoint.set_aprioriradiussource(ControlPointFileEntryV0002_AprioriSource_DEM);
           break;
         default:
-          QString msg = "Unable to create ProtoPoint [" + toString(protoPoint.id().c_str())
-                        + "] from file. Type enumeration ["
-                        + toString((int)(controlPoint->GetAprioriRadiusSource()))
-                        + "] is invalid.";
-          throw IException(IException::Programmer, msg, _FILEINFO_);
+          protoPoint.set_aprioriradiussource(ControlPointFileEntryV0002_AprioriSource_None);
           break;
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Removed new exceptions introduced in controlnetversioner refactor.

## Description
<!--- Describe your changes in detail -->
When we moved the conversion from control point to protobuf message into the versioner, we also added several new exceptions checking for unusual values. Previously, unusual values were just reset to default. I changed all of them except for an empty pointID back to defaulting because they will not cause an issue. An empty pointID will causes serious issues because that is how the point is identified in the network graph and an empty string will cause problems there.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
hopefully fixes #2660 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Control nets were getting obliterated and work couldn't be saved.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I tried to reproduce the error and could not. Full test suite passed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
