### PR TITLE
Fixed bug where findrx was not adding a history blob to the input cube

### DIFF
--- a/isis/src/base/apps/findrx/findrx.xml
+++ b/isis/src/base/apps/findrx/findrx.xml
@@ -44,6 +44,9 @@
     <change name="Jeannie Walldren" date="2010-08-02">
         Updated to use new SearchChip SubchipValidPercent value from the template.
     </change>
+    <change name="Kaitlyn Lee" date="2019-03-25">
+        Added method writeHistory() to add an entry to the history blob of the input cube.
+    </change>
   </history>
 
   <groups>

--- a/isis/src/base/apps/findrx/findrx.xml
+++ b/isis/src/base/apps/findrx/findrx.xml
@@ -46,6 +46,7 @@
     </change>
     <change name="Kaitlyn Lee" date="2019-03-25">
         Added method writeHistory() to add an entry to the history blob of the input cube.
+        Updated code up to coding standards.
     </change>
   </history>
 

--- a/isis/src/base/apps/findrx/main.cpp
+++ b/isis/src/base/apps/findrx/main.cpp
@@ -1,3 +1,5 @@
+#include "Application.h"
+#include "History.h"
 #include "Isis.h"
 #include "PvlGroup.h"
 #include "UserInterface.h"
@@ -12,6 +14,8 @@
 using namespace std;
 using namespace Isis;
 
+void writeHistory(Cube &cube);
+
 void IsisMain() {
   // Import cube data & PVL information
   Cube cube;
@@ -19,7 +23,7 @@ void IsisMain() {
   cube.open(ui.GetFileName("FROM"), "rw");
   Pvl *regdef;
   // If regdef was supplied by the user, use it. else, use the template.
-  if(ui.WasEntered("REGDEF")) {
+  if (ui.WasEntered("REGDEF")) {
     regdef = new Pvl(ui.GetFileName("REGDEF"));
   }
   else {
@@ -29,19 +33,19 @@ void IsisMain() {
 
   // If the Keyword sizes don't match up, throw errors.
   int nres = reseaus["Line"].size();
-  if(nres != reseaus["Sample"].size()) {
+  if (nres != reseaus["Sample"].size()) {
     QString msg = "Sample size incorrect [Sample size " +
                  toString(reseaus["Sample"].size()) + " != " + " Line size " +
                  toString(reseaus["Line"].size()) + "]";
     throw IException(IException::Unknown, msg, _FILEINFO_);
   }
-  if(nres != reseaus["Type"].size()) {
+  if (nres != reseaus["Type"].size()) {
     QString msg = "Type size incorrect [Type size " +
                  toString(reseaus["Type"].size()) + " != " + " Line size " +
                  toString(reseaus["Line"].size()) + "]";
     throw IException(IException::Unknown, msg, _FILEINFO_);
   }
-  if(nres != reseaus["Valid"].size()) {
+  if (nres != reseaus["Valid"].size()) {
     QString msg = "Valid size incorrect [Valid size " +
                  toString(reseaus["Valid"].size()) + " != " + " Line size " +
                  toString(reseaus["Line"].size()) + "]";
@@ -62,7 +66,7 @@ void IsisMain() {
 
   //If the mark reseaus option is set...then create a brick.
   Brick *white = NULL;
-  if(ui.GetBoolean("MARK") == true) {
+  if (ui.GetBoolean("MARK") == true) {
     white = new Brick(1, 1, 1, Isis::UnsignedByte);
     (*white)[0] = Isis::Hrs;
   }
@@ -71,19 +75,19 @@ void IsisMain() {
   double subsearchValidPercent = ar->SubsearchValidPercent();
 
   // And the loop...
-  for(int res = 0; res < nres; ++res) {
+  for (int res = 0; res < nres; ++res) {
     // Output chips
     ar->SearchChip()->TackCube(toDouble(reseaus["Sample"][res]), toDouble(reseaus["Line"][res]));
     ar->SearchChip()->Load(cube);
     ar->PatternChip()->Load(pattern, 0, 1.0, res + 1);
     int type = toInt(reseaus["Type"][res]);
     // If the reseaus is in the center (type 5) use full percent value
-    if(type == 5) {
+    if (type == 5) {
       ar->SetPatternValidPercent(patternValidPercent);
       ar->SetSubsearchValidPercent(subsearchValidPercent);
     }
     // else if the reseaus is on an edge (type 2,4,6, or 8) use half percent value
-    else if(type % 2 == 0) {
+    else if (type % 2 == 0) {
       ar->SetPatternValidPercent(patternValidPercent / 2.0);
       ar->SetSubsearchValidPercent(subsearchValidPercent / 2.0);
     }
@@ -95,7 +99,7 @@ void IsisMain() {
 
     ar->Register();
 
-    if(ar->Success()) {
+    if (ar->Success()) {
       reseaus["Sample"][res] = toString(ar->CubeSample());
       reseaus["Line"][res] = toString(ar->CubeLine());
       reseaus["Valid"][res] = "1";
@@ -105,7 +109,7 @@ void IsisMain() {
     }
 
     // And if the reseaus are to be marked...mark em
-    if(white != NULL) {
+    if (white != NULL) {
       double line = toDouble(reseaus["Line"][res]);
       double sample = toDouble(reseaus["Sample"][res]);
       white->SetBasePosition(int(sample), int(line), 1);
@@ -119,5 +123,32 @@ void IsisMain() {
   reseaus["Status"] = "Refined";
 
   pattern.close();
+  writeHistory(cube);
   cube.close();
+}
+
+
+/**
+ * Writes out the History blob to a cube
+ *
+ * @param cube Cube to add History blob to
+ */
+void writeHistory(Cube &cube) {
+  bool addedHist = false;
+  Isis::Pvl *inlabel = cube.label();
+  for (int i = 0; i < inlabel->objects(); i++) {
+    if (inlabel->object(i).isNamed("History") && Isis::iApp != NULL) {
+      Isis::History h( (QString)inlabel->object(i)["Name"] );
+      cube.read(h);
+      h.AddEntry();
+      cube.write(h);
+      addedHist = true;
+    }
+  }
+
+  if (!addedHist && Isis::iApp != NULL) {
+    Isis::History h("IsisCube");
+    h.AddEntry();
+    cube.write(h);
+  }
 }

--- a/isis/src/base/apps/findrx/main.cpp
+++ b/isis/src/base/apps/findrx/main.cpp
@@ -1,15 +1,16 @@
-#include "Application.h"
-#include "History.h"
 #include "Isis.h"
-#include "PvlGroup.h"
-#include "UserInterface.h"
-#include "Cube.h"
-#include "Chip.h"
-#include "Progress.h"
-#include "IException.h"
+
+#include "Application.h"
 #include "AutoReg.h"
 #include "AutoRegFactory.h"
 #include "Brick.h"
+#include "Chip.h"
+#include "Cube.h"
+#include "History.h"
+#include "IException.h"
+#include "Progress.h"
+#include "PvlGroup.h"
+#include "UserInterface.h"
 
 using namespace std;
 using namespace Isis;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Because findrx does not use Process, it needed its own writeHistory method to write out the history blob to the cube. Added a call to the method before closing the cube.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/3150

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This was a bug fix; findrx should be adding a history entry to the cube. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran findrx on cube provided by Lynn Weller. Then, ran cathist on that same cube. The history entry was added. Ran unit and app tests, and all passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
