### PR TITLE
Catching OpenCV error in findfeatures

### DIFF
--- a/isis/src/control/apps/findfeatures/GenericTransform.cpp
+++ b/isis/src/control/apps/findfeatures/GenericTransform.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
- * $Revision$ 
- * $Date$ 
+ * $Revision$
+ * $Date$
  *
  *   Unless noted otherwise, the portions of Isis written by the USGS are public
  *   domain. See individual third-party library and package descriptions for
@@ -27,41 +27,41 @@
 
 namespace Isis {
 /** Generic constructor is simply an identity transform */
-GenericTransform::GenericTransform() : ImageTransform("GenericTransform"), 
+GenericTransform::GenericTransform() : ImageTransform("GenericTransform"),
                                        m_matrix(), m_inverse(), m_size(0,0) {
   setMatrix(cv::Mat::eye(3, 3, CV_64FC1));
 }
 
 /** Named generic identity matrix */
-GenericTransform::GenericTransform(const QString &name) : ImageTransform(name), 
-                                                          m_matrix(), 
-                                                          m_inverse(), 
-                                                          m_size(0,0) { 
+GenericTransform::GenericTransform(const QString &name) : ImageTransform(name),
+                                                          m_matrix(),
+                                                          m_inverse(),
+                                                          m_size(0,0) {
   setMatrix(cv::Mat::eye(3, 3, CV_64FC1));
 }
 
 /** Construct named transform with a 3x3 transformation matrix */
-GenericTransform::GenericTransform(const QString &name, const cv::Mat &matrix) : 
-                                   ImageTransform(name), m_matrix(), m_inverse(), 
-                 m_size(0,0) { 
+GenericTransform::GenericTransform(const QString &name, const cv::Mat &matrix) :
+                                   ImageTransform(name), m_matrix(), m_inverse(),
+                 m_size(0,0) {
   setMatrix( matrix );
 }
 
 /** Construct named transfrom with 3x3 matrix with a size specification */
 GenericTransform::GenericTransform(const QString &name, const cv::Mat &matrix,
-                                   const cv::Size &imSize) : 
-                                   ImageTransform(name), m_matrix(), 
-                                   m_inverse(), 
-                                   m_size(imSize) { 
+                                   const cv::Size &imSize) :
+                                   ImageTransform(name), m_matrix(),
+                                   m_inverse(),
+                                   m_size(imSize) {
   setMatrix( matrix );
 }
 
 /** Construct named transfrom with 3x3 matrix with a subarea specification */
 GenericTransform::GenericTransform(const QString &name, const cv::Mat &matrix,
-                                   const GenericTransform::RectArea &subarea) : 
-                                   ImageTransform(name), m_matrix(), 
-                                   m_inverse(), m_size(subarea.size()) { 
-  cv::Mat tmatrix = ImageTransform::translation(-subarea.x, -subarea.y); 
+                                   const GenericTransform::RectArea &subarea) :
+                                   ImageTransform(name), m_matrix(),
+                                   m_inverse(), m_size(subarea.size()) {
+  cv::Mat tmatrix = ImageTransform::translation(-subarea.x, -subarea.y);
   setMatrix( tmatrix * matrix );
   setSize( subarea.size() );
 }
@@ -78,23 +78,23 @@ cv::Mat GenericTransform::getMatrix() const {
 cv::Mat GenericTransform::getInverse() const {
   return ( m_inverse);
 }
- 
+
 /** Return the resulting size of the transformed image */
 cv::Size GenericTransform::getSize(const cv::Mat &image) const {
   if ( 0 == m_size.width ) {  return ( image.size() );  }
-  return (m_size); 
+  return (m_size);
 }
 
 /** Transform the image matrix using the matrix and size constraints */
 cv::Mat GenericTransform::render(const cv::Mat &image) const {
   cv::Mat result;
-  warpPerspective(image, result, getMatrix(), getSize(image), 
-                  CV_INTER_LINEAR); 
+  warpPerspective(image, result, getMatrix(), getSize(image),
+                  CV_INTER_LINEAR);
 #if 0
   // Gots to be run in the GUI in order for this to work!!
   cv::namedWindow("Original", CV_WINDOW_AUTOSIZE);
   cv::imshow("Original", image);
-   
+
   cv::namedWindow("Transformed", CV_WINDOW_AUTOSIZE);
   cv::imshow("Transformed", result);
 
@@ -106,11 +106,11 @@ cv::Mat GenericTransform::render(const cv::Mat &image) const {
 
 /**
  * @brief Compute the forward transform of a point
- *  
- * This method applies the matrix to a point using a perspective transform. 
- *  
+ *
+ * This method applies the matrix to a point using a perspective transform.
+ *
  * @param point   Point to transform
- * 
+ *
  * @return cv::Point2f Rsulting transformed point using the matrix
  */
 cv::Point2f GenericTransform::forward(const cv::Point2f &point) const {
@@ -122,9 +122,9 @@ cv::Point2f GenericTransform::forward(const cv::Point2f &point) const {
 
 /**
  * @brief Compute the inverse transform of a point
- * 
+ *
  * @param point Point to invert
- * 
+ *
  * @return cv::Point2f Resulting inverse tranform
  */
 cv::Point2f GenericTransform::inverse(const cv::Point2f &point) const {
@@ -148,6 +148,11 @@ void GenericTransform::setInverse(const cv::Mat &matrix) {
 
 /** Calculate the inverse transform from the forward matrix */
 cv::Mat GenericTransform::calculateInverse(const cv::Mat &matrix) {
+  if (matrix.empty()) {  // inverting an empty matrix causes a segfault
+    QString msg = "Can't invert empty matrix.";
+    throw IException(IException::Programmer, msg, _FILEINFO_);
+  }
+
   return ( matrix.inv() );
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When `GenericTransform::calculateInverse`  get's an empty matrix it causes a CV exception, this simply recontextualizes it as a slightly more specific ISIS exception. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #557 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
