### PR TITLE
Fixing errors introduced in the tgo sprint

### DIFF
--- a/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
+++ b/isis/src/base/objs/ProcessExportPds4/ProcessExportPds4.cpp
@@ -304,17 +304,10 @@ namespace Isis {
           if (startTime.text() == "") {
             startTime.setAttribute("xsi:nil", "true");
           }
-          else {
-            QString timeValue = startTime.text();
-            PvlToXmlTranslationManager::resetElementValue(startTime, timeValue + "Z");
-          }
+
           QDomElement stopTime  = timeNode.firstChildElement("stop_date_time"); 
           if (stopTime.text() == "") {
             stopTime.setAttribute("xsi:nil", "true");
-          }
-          else {
-            QString timeValue = stopTime.text();
-            PvlToXmlTranslationManager::resetElementValue(stopTime, timeValue + "Z");
           }
 
           QStringList xmlPath;

--- a/isis/src/tgo/apps/tgocassis2isis/main.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/main.cpp
@@ -335,7 +335,7 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
   PvlKeyword *startTime = &outputLabel->findGroup("Instrument", Pvl::Traverse)["StartTime"];
   QString startTimeString = startTime[0];
   if (startTimeString.endsWith("Z", Qt::CaseInsensitive)) {
-    startTimeString.chop(2);
+    startTimeString.chop(1);
     startTime->setValue(startTimeString);
   }
 
@@ -343,7 +343,7 @@ void translateLabels(FileName &inputLabel, Cube *outputCube, QString instTransFi
     PvlKeyword *stopTime = &outputLabel->findGroup("Instrument", Pvl::Traverse)["StopTime"]; 
     QString stopTimeString = stopTime[0];
     if (stopTimeString.endsWith("Z", Qt::CaseInsensitive)){
-      stopTimeString.chop(2);
+      stopTimeString.chop(1);
       stopTime->setValue(stopTimeString);
     }
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With the changes made to ProcessExportPds4 for the tgo sprint, "Z" was being written twice to the end of the StartTime value. I modified the newly introduced reorder() method to not write the Z as it is written in successive calls from the constructor.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/USGS-Astrogeology/ISIS3/issues/3201


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Failing tgocassis2isis_app_test_exportedFile nightly test

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Re-running failed test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
