### PR TITLE
Add a Distortion Model to Kaguya TC ISIS camera model

### DIFF
--- a/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCamera.cpp
+++ b/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCamera.cpp
@@ -18,6 +18,7 @@
  *   http://www.usgs.gov/privacy.html.
  */
 #include "KaguyaTcCamera.h"
+#include "KaguyaTcCameraDistortionMap.h"
 
 #include <QString>
 
@@ -76,7 +77,7 @@ namespace Isis {
                        "_BORESIGHT_LINE"));
 */
     // Setup distortion map
-    new CameraDistortionMap(this);
+    new KaguyaTcCameraDistortionMap(this, naifIkCode());
 
     // Setup the ground and sky map
     new CameraGroundMap(this);

--- a/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCamera.truth
+++ b/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCamera.truth
@@ -28,8 +28,8 @@ DeltaSample =  0
 DeltaLine =  0
 
 For center pixel position ...
-Latitude OK
-Longitude OK
+Latitude off by:  -9.37449768301235054e-05
+Longitude off by:  -5.93533007986479788e-05
 
 
 Testing TC1 s L2B0 image...
@@ -61,5 +61,5 @@ DeltaSample =  0
 DeltaLine =  0
 
 For center pixel position ...
-Latitude OK
-Longitude OK
+Latitude off by:  0.000266978116243876684
+Longitude off by:  0.000317664115719651363

--- a/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCameraDistortionMap.cpp
+++ b/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCameraDistortionMap.cpp
@@ -1,0 +1,214 @@
+/**
+ * @file
+ * $Revision: 1.4 $
+ * $Date: 2008/02/21 16:04:33 $
+ *
+ *   Unless noted otherwise, the portions of Isis written by the USGS are
+ *   public domain. See individual third-party library and package descriptions
+ *   for intellectual property information, user agreements, and related
+ *   information.
+ *
+ *   Although Isis has been used by the USGS, no warranty, expressed or
+ *   implied, is made by the USGS as to the accuracy and functioning of such
+ *   software and related material nor shall the fact of distribution
+ *   constitute any such warranty, and no responsibility is assumed by the
+ *   USGS in connection therewith.
+ *
+ *   For additional information, launch
+ *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html
+ *   in a browser or see the Privacy &amp; Disclaimers page on the Isis website,
+ *   http://isis.astrogeology.usgs.gov, and the USGS privacy and disclaimers on
+ *   http://www.usgs.gov/privacy.html.
+ */
+
+#include <QDebug>
+#include <QtGlobal>
+#include <QtMath>
+
+#include "KaguyaTcCameraDistortionMap.h"
+
+namespace Isis {
+  /** 
+   * Kaguya TC Camera distortion map constructor
+   *
+   * Create a camera distortion map for Kaguya's TC1 and TC2
+   * This class maps between distorted and undistorted 
+   * focal plane x/y's. The default mapping is the identity, that is, 
+   * the focal plane x/y and undistorted focal plane x/y will be 
+   * identical. 
+   *
+   * @param parent        the parent camera that will use this distortion map
+   * @param zDirection    the direction of the focal plane Z-axis
+   *                      (either 1 or -1)
+   *
+   */
+  KaguyaTcCameraDistortionMap::KaguyaTcCameraDistortionMap(Camera *parent, int naifIkCode)
+      : CameraDistortionMap(parent) {
+    QString odtxkey = "INS-" + toString(naifIkCode) + "_DISTORTION_COEF_X";
+    QString odtykey = "INS-" + toString(naifIkCode) + "_DISTORTION_COEF_X";
+
+    for(int i = 0; i < 4; ++i) {
+      p_odkx.push_back(p_camera->getDouble(odtxkey, i));
+      p_odky.push_back(p_camera->getDouble(odtykey, i));
+    }
+  }    
+
+
+
+  /**
+   * Destructor
+   */
+  KaguyaTcCameraDistortionMap::~KaguyaTcCameraDistortionMap() {
+  }
+
+
+  /** 
+   * Compute undistorted focal plane x/y
+   *
+   * Compute undistorted focal plane x/y given a distorted focal plane x/y.
+   * This virtual method can be used to apply various techniques for removing
+   * optical distortion in the focal plane of a camera.  The default
+   * implementation uses a polynomial distortion if the SetDistortion method
+   * is invoked.  After calling this method, you can obtain the undistorted
+   * x/y via the UndistortedFocalPlaneX and UndistortedFocalPlaneY methods
+   *
+   * @param dx distorted focal plane x in millimeters
+   * @param dy distorted focal plane y in millimeters
+   *
+   * @return if the conversion was successful
+   * @see SetDistortion
+   * @todo Generalize polynomial equation
+   */
+  bool KaguyaTcCameraDistortionMap::SetFocalPlane(double dx, double dy) {
+    p_focalPlaneX = dx;
+    p_focalPlaneY = dy;
+
+    double x = dx;
+    double y = dy;
+
+    // NEEDED? 
+    // 
+    // Get the distance from the focal plane center and if we are close
+    // then skip the distortion (this prevents division by zero)
+    double r = (x * x) + (y * y);
+    double r2 = r*r;
+    double r3 = r2*r;
+    if (r <= 1.0E-6) {
+      p_undistortedFocalPlaneX = dx;
+      p_undistortedFocalPlaneY = dy;
+      return true;
+    }
+
+    // Apply distortion correction
+    // see: SEL_TC_V01.TI
+    // r2 = x^2 + y^2
+    //   Line-of-sight vector of pixel no. n can be expressed as below.
+
+  //  Distortion coefficients information:
+  //   INS<INSTID>_DISTORTION_COEF_X  = ( a0, a1, a2, a3)
+  //   INS<INSTID>_DISTORTION_COEF_Y  = ( b0, b1, b2, b3),
+  //
+  // Distance r from the center:
+  //   r = - (n - INS<INSTID>_CENTER) * INS<INSTID>_PIXEL_SIZE.
+  //
+  // Line-of-sight vector v is calculated as
+  //   v[X] = INS<INSTID>BORESIGHT[X]
+  //          +a0 +a1*r +a2*r^2 +a3*r^3 ,
+  //   v[Y] = INS<INSTID>BORESIGHT[Y]
+  //          +r +a0 +a1*r +a2*r^2 +a3*r^3 ,
+  //   v[Z] = INS<INSTID>BORESIGHT[Z] .
+
+    double dr_x = p_odkx[0] + p_odkx[1] * r + p_odkx[2] * r2 + p_odkx[3] * r3;
+    double dr_y = p_odky[0] + p_odky[1] * r + p_odky[2] * r2 + p_odky[3] * r3;
+
+    p_undistortedFocalPlaneX = dr_x * x;
+    p_undistortedFocalPlaneY = dr_y * y;
+
+    return true;
+  }
+
+
+  /** 
+   * Compute distorted focal plane x/y
+   *
+   * Compute distorted focal plane x/y given an undistorted focal plane x/y.
+   * This virtual method is used to apply various techniques for adding
+   * optical distortion in the focal plane of a camera.  The default
+   * implementation of this virtual method uses a polynomial distortion if
+   * the SetDistortion method was invoked.
+   * After calling this method, you can obtain the distorted x/y via the
+   * FocalPlaneX and FocalPlaneY methods
+   *
+   * @param ux undistorted focal plane x in millimeters
+   * @param uy undistorted focal plane y in millimeters
+   *
+   * @return if the conversion was successful
+   * @see SetDistortion
+   * @todo Generalize polynomial equation
+   * @todo Figure out a better solution for divergence condition
+   */
+  bool KaguyaTcCameraDistortionMap::SetUndistortedFocalPlane(const double ux,
+      const double uy) {
+    p_undistortedFocalPlaneX = ux;
+    p_undistortedFocalPlaneY = uy;
+
+    double xt = ux;
+    double yt = uy;
+
+    double xx, yy, r, rr, rrr, dr_x, dr_y;
+    double xdistortion, ydistortion;
+    double xdistorted, ydistorted;
+    double xprevious, yprevious;
+
+    xprevious = 1000000.0;
+    yprevious = 1000000.0;
+
+    double tolerance = 0.000001;
+    bool bConverged = false;
+
+    // Iterating to introduce distortion...
+    // We stop when the difference between distorted coordinates
+    // in successive iterations is below the given tolerance
+    for (int i = 0; i < 50; i++) {
+      xx = xt * xt;
+      yy = yt * yt;
+      rr = xx + yy;
+      r = qSqrt(rr); 
+      rrr = rr * r;
+
+      // Radial distortion
+      // dr is the radial distortion contribution
+      dr_x = p_odkx[0] + p_odkx[1] * r + p_odkx[2] * rr + p_odkx[3] * rrr; // why did hayabusa have a -1
+      dr_y = p_odky[0] + p_odky[1] * r + p_odky[2] * rr + p_odky[3] * rrr; // why did hayabusa have a -1
+
+      // Distortion at the current point location
+      xdistortion = xt * dr_x;
+      ydistortion = yt * dr_y;
+
+      // updated image coordinates
+      xt = ux - xdistortion;
+      yt = uy - ydistortion;
+
+      // distorted point corrected for principal point
+      xdistorted = xt;
+      ydistorted = yt;
+
+      // check for convergence
+      if ((fabs(xt - xprevious) < tolerance) && (fabs(yt - yprevious) < tolerance)) {
+        bConverged = true;
+        break;
+      }
+
+      xprevious = xt;
+      yprevious = yt;
+    }
+
+    if (bConverged) {
+      p_focalPlaneX = xdistorted;
+      p_focalPlaneY = ydistorted;
+    }
+
+    return bConverged;
+  }
+}
+

--- a/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCameraDistortionMap.h
+++ b/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCameraDistortionMap.h
@@ -1,0 +1,59 @@
+/**
+ * @file
+ * $Revision: 1.3 $
+ * $Date: 2008/02/21 16:04:33 $
+ *
+ *   Unless noted otherwise, the portions of Isis written by the USGS are
+ *   public domain. See individual third-party library and package descriptions
+ *   for intellectual property information, user agreements, and related
+ *   information.
+ *
+ *   Although Isis has been used by the USGS, no warranty, expressed or
+ *   implied, is made by the USGS as to the accuracy and functioning of such
+ *   software and related material nor shall the fact of distribution
+ *   constitute any such warranty, and no responsibility is assumed by the
+ *   USGS in connection therewith.
+ *
+ *   For additional information, launch
+ *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html
+ *   in a browser or see the Privacy &amp; Disclaimers page on the Isis website,
+ *   http://isis.astrogeology.usgs.gov, and the USGS privacy and disclaimers on
+ *   http://www.usgs.gov/privacy.html.
+ */
+#ifndef KaguyaTcCameraDistortionMap_h
+#define KaguyaTcCameraDistortionMap_h
+
+#include "CameraDistortionMap.h"
+
+namespace Isis {
+  /** Distort/undistort focal plane coordinates for Kaguya's TC cameras.
+   *
+   * Creates a map for adding/removing optical distortions
+   * from the focal plane of a camera.
+   *
+   * @ingroup Camera
+   *
+   * @see Camera
+   *
+   * @author 2019-04-04 Kristin Berry
+   *
+   * @internal
+   *   @history 2019-04-04 Kristin Berry - Original version.
+   *
+   */
+  class KaguyaTcCameraDistortionMap : public CameraDistortionMap {
+    public:
+      KaguyaTcCameraDistortionMap(Camera *parent, int naifIkCode);
+
+      virtual ~KaguyaTcCameraDistortionMap();
+
+      virtual bool SetFocalPlane(double dx, double dy);
+
+      virtual bool SetUndistortedFocalPlane(double ux, double uy);
+
+    protected:
+      std::vector<double> p_odkx; //!< distortion x coefficients
+      std::vector<double> p_odky; //!< distortion y coefficients
+  };
+};
+#endif


### PR DESCRIPTION
Adds a distortion model to the Kaguya TC camera in ISIS. 

## Description
Implements the distortion model from the Kaguya IC instrument kernel (`$ISIS3DATA/kaguya/kernels/ik/SEL_TC_V01.TI`,) with two modifications:

* I assumed that the v[Y] equation actually should use the b0-b3 coefficients, rather than a0-a3, since they're defined in  INS<INSTID>_DISTORTION_COEF_Y  = ( b0, b1, b2, b3), above.

* I removed the additional `+r` from the v[Y] equation as it resulted in an unreasonably large correction.

These were both removed under the assumption that the equations were copied over with slight errors from another source. 

## Related Issue
There is no ticket that I'm aware of, but this PR is into the `kaguyatc` branch, not dev.

## Motivation and Context
Adds the distortion correction to the ISIS camera model for better-corrected results. 

## How Has This Been Tested?
The existing unit test for the `Kaguya TC` camera model in ISIS does have very slightly different lat/lons calculated, but I believe this is expected. 

New lat/lon differences from old Kaguya TC camera model. (Old lat/lons were 0.) :

 ```
1239: < Latitude off by:  -9.37449768301235054e-05
1239: < Longitude off by:  -5.93533007986479788e-05
1239: ---
1239: < Latitude off by:  0.000266978116243876684
1239: < Longitude off by:  0.00031766411571965136

```

camtest output: 

```
  Group = CamTestResults
    FailedConversionsToLatLong    = 0
    FailedConversionsToSampleLine = 0
    SuccessfulConversions         = 14936448
    Average                       = 2.50008371339043e-05
    StandardDeviation             = 3.49036317431005e-05
    Minimum                       = 2.08688905433224e-11
    Maximum                       = 8.84242417557446e-04

```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
