### PR TITLE
Update unit test for Kaguya TC to match output of updated camera model

### DIFF
--- a/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCamera.truth
+++ b/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCamera.truth
@@ -28,8 +28,8 @@ DeltaSample =  0
 DeltaLine =  0
 
 For center pixel position ...
-Latitude off by:  -9.37449768301235054e-05
-Longitude off by:  -5.93533007986479788e-05
+Latitude OK
+Longitude OK
 
 
 Testing TC1 s L2B0 image...
@@ -61,5 +61,5 @@ DeltaSample =  0
 DeltaLine =  0
 
 For center pixel position ...
-Latitude off by:  0.000266978116243876684
-Longitude off by:  0.000317664115719651363
+Latitude OK
+Longitude OK

--- a/isis/src/kaguya/objs/KaguyaTcCamera/unitTest.cpp
+++ b/isis/src/kaguya/objs/KaguyaTcCamera/unitTest.cpp
@@ -51,8 +51,8 @@ int main(void) {
     // These should be lat/lon at center of image. To obtain these numbers for a new cube/camera,
     // set both the known lat and known lon to zero and copy the unit test output
     // "Latitude off by: " and "Longitude off by: " values directly into these variables.
-    double knownLat = 59.0972605733461691;
-    double knownLon = 311.467742700096323;
+    double knownLat = 58.3498029142273396;
+    double knownLon = 311.458498980458671;
 
     qDebug() << "Testing TC2 w L2B0 image...";
     Cube c("$kaguya/testData/TC2W2B0_01_02735N583E3115.cub", "r");
@@ -114,8 +114,8 @@ int main(void) {
     qDebug() << "";
     qDebug() << "";
     qDebug() << "Testing TC1 s L2B0 image...";
-    knownLat = -81.2150653963736175;
-    knownLon = 47.1989499604665284;
+    knownLat = -82.0214347373044603;
+    knownLon = 46.4180177580203335;
 
     Cube c2("$kaguya/testData/TC1S2B0_01_06691S820E0465.cub", "r");
     KaguyaTcCamera *cam2 = (KaguyaTcCamera *) CameraFactory::Create(c2);


### PR DESCRIPTION
## Description
Update unit test output for the Kaguya TC to match the output of the updated camera model. 

## Related Issue
#3217 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
