### PR TITLE
Sets up tab completion for tcsh on conda activate

### DIFF
--- a/isis/scripts/isis3VarInit.py
+++ b/isis/scripts/isis3VarInit.py
@@ -113,6 +113,8 @@ with open( activate_vars_csh, mode='w' ) as a:
 setenv ISISROOT {}
 setenv ISIS3DATA {}
 setenv ISIS3TESTDATA {}
+
+source $CONDA_PREFIX/scripts/tabCompletion.csh
 """.format(os.environ['CONDA_PREFIX'], args.data_dir, args.test_dir)
     a.write(script)
 print( 'Wrote '+activate_vars_csh )

--- a/isis/scripts/tabCompletion.csh
+++ b/isis/scripts/tabCompletion.csh
@@ -1,0 +1,25 @@
+#!/bin/csh
+
+
+# Setup tab completion
+if ( -f $ISISROOT/bin/isiscomplete ) then
+  set newBinaries = `/bin/ls $ISISROOT/bin/xml | grep -v qt.conf | sed s%\.xml%%`
+  set i = 0
+  set loop = 0
+  set chunk = ""
+  foreach app ($newBinaries)
+    @ i = $i + 1
+    @ loop = $loop + 1
+    set chunk = "$chunk $app"
+    if ( "$i" == 100 || "$loop" == $#newBinaries) then
+      eval `$ISISROOT/bin/isiscomplete $chunk`
+      set i = 1
+      set chunk = ""
+    endif
+  end
+  unset i
+  unset loop
+  unset chunk
+  unset app
+  unset newBinaries
+endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The isis3VarInit.py script now adds sourcing of a new tabComplettion.csh script to the conda/activate.d/env_vars.csh script. This enables the tab completion behavior we had in tcsh before the introduction of conda envs. Tab completion now activated when activating the environment.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/3163

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This re-enables the lost tab-completion capabilities in local builds of ISIS

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a tester environment, adding changes to the isis3VarInit.py script as well as the tabCompletion.csh script. After running the former and reactivating the env, tab completion was working in tcsh.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
