### PR TITLE
Changes for de430

### DIFF
--- a/isis/src/mer/apps/mical/main.cpp
+++ b/isis/src/mer/apps/mical/main.cpp
@@ -89,6 +89,8 @@ void IsisMain() {
   // Astronomical Units (AU)
   QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
   furnsh_c(bspKernel.toLatin1().data());
+  QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
+  furnsh_c(satKernel.toLatin1().data());
   QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
   furnsh_c(pckKernel.toLatin1().data());
   double sunpos[6], lt;
@@ -97,6 +99,7 @@ void IsisMain() {
   double kmperAU = 1.4959787066E8;
   gbl::sunAU = dist / kmperAU;
   unload_c(bspKernel.toLatin1().data());
+  unload_c(satKernel.toLatin1().data());
   unload_c(pckKernel.toLatin1().data());
 
 
@@ -317,5 +320,3 @@ void helperButtonLogCalKernel() {
   Application::GuiLog(OQString);
   Application::GuiLog(p);
 }
-
-

--- a/isis/src/mer/apps/mical/mical.xml
+++ b/isis/src/mer/apps/mical/mical.xml
@@ -87,6 +87,10 @@
       Changed pvl.DIFF of input for all app tests to ignore file names. Allows test to pass when not
       using default data area. Fixes #4738.
     </change>
+    <change name="Jesse Mapel" date="2019-05-15">
+      Now loads latest Mars satellites kernel because the planets kernel (de430)
+      only provides Mars Barycenter.
+    </change>
   </history>
 
   <category>

--- a/isis/src/mgs/apps/moccal/main.cpp
+++ b/isis/src/mgs/apps/moccal/main.cpp
@@ -133,6 +133,8 @@ void IsisMain() {
   // Astronomical Units (AU)
   QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
   furnsh_c(bspKernel.toLatin1().data());
+  QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
+  furnsh_c(satKernel.toLatin1().data());
   QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
   furnsh_c(pckKernel.toLatin1().data());
   double sunpos[6], lt;
@@ -141,6 +143,7 @@ void IsisMain() {
   double kmPerAU = 1.4959787066E8;
   double sunAU = dist / kmPerAU;
   unload_c(bspKernel.toLatin1().data());
+  unload_c(satKernel.toLatin1().data());
   unload_c(pckKernel.toLatin1().data());
 
   // See if the user wants counts/ms or i/f but if w0 is 0 then

--- a/isis/src/mgs/apps/moccal/moccal.xml
+++ b/isis/src/mgs/apps/moccal/moccal.xml
@@ -15,7 +15,7 @@
     very little or no radiometric calibration information.  It is supported
     to a very limited extent but is not in use at this time.
     </p>
-    
+
     <p>
     The MGS MOC NA detector has a total of 2048 pixels.  The WA Red and WA
     Blue detectors have a total of 3456 pixels.  Images from MOC may or may
@@ -56,31 +56,31 @@
     Note that all corrections are applied relative to the actual hardware
     pixel.
     </p>
-    
+
     moccal has a number of parameters required to process MGS MOC image
     data.  Most of these parameters are read from an ISIS parameter defaults
-    file located in the the mgs directory specified in the IsisPreference file.  
+    file located in the the mgs directory specified in the IsisPreference file.
     This file has the form:
-     <pre>    
+     <pre>
       $mgs/calibration/moccal.kernel.xxx
-    
+
       where "xxx" is a positive number.
-     </pre>  
+     </pre>
     moccal will search for the parameter file with the highest number and
     load all its defaults needed to process MOC images.  Note that the
     caller may explicity provide an alternative ISIS parameter defaults
     file name in the "CALKERNEL" input parameter if they have their own
     set of defaults that applies to MOC data.  See an existing calibration
     file for details on how to configure this file.
-    
+
     <p>
     The MOC response equation (without pixel-to-pixel variation terms) is as
     follows:
     </p>
-    
+
     <pre>
            dn = a * (r * ex + dc * ex + g) + (z - off)
-    
+
       where r is the average signal being generated at the focal
       plane (in DN/msec at minimum gain), z is the fixed zero
       offset, off is the commanded variable offset, dc is the dark
@@ -89,14 +89,14 @@
       system gain (where minimum gain is 1 and all other gains
       are &gt;1) and ex is the exposure time in milliseconds.
     </pre>
-    
+
     moccal computes "r" from "dn" at every pixel in the input MOC image.
     Hence, the actual equation moccal implements is as follows:
-    
+
     <pre>
            r = ((dn - z + off) / a - g) / ex - dc
     </pre>
-    
+
    <p>
     Additional pixel-to-pixel variations are corrected by a detector
     coefficient file also specified in the parameter defaults file.  This
@@ -116,10 +116,10 @@
     equation to correct for individual pixel variation.  Note that some
     detectors, namely WA Blue, may not have a pixel variation correction
     derived.  For these cases, moccal will apply the
-    calibration equation without pixel-to-pixel variation applied. 
+    calibration equation without pixel-to-pixel variation applied.
    </p>
-    
-    <p>  
+
+    <p>
     Prior to MGS MOC mapping phases, MOC NA downtrack summing modes
     greater than 1 was implemented differently in onboard camera software.
     A software patch was made at some point prior to normal mission
@@ -141,9 +141,9 @@
 
     <pre>
     References:
-    
+
     "MOC2 Calibration Report, October 1997 [SCCS 10/17/97 version 1.3]"
-    
+
     "Software Interface Specification, Narrow Angle and Wide Angle
        Standard Data Products (September 1999 (revised for MGS)
        (formatted April 7, 2000))"
@@ -161,11 +161,11 @@
       Fixed buffer overflow
     </change>
     <change name="Steven Lambright" date="2008-05-13">
-      Removed references to CubeInfo 
+      Removed references to CubeInfo
     </change>
     <change name="Jeannie Walldren" date="2008-11-05">
-      Changed MocLabels references from IsNarrowAngle(), IsWideAngleBlue(), 
-      IsWideAngleRed() to NarrowAngle(), WideAngleBlue(), WideAngleRed(), 
+      Changed MocLabels references from IsNarrowAngle(), IsWideAngleBlue(),
+      IsWideAngleRed() to NarrowAngle(), WideAngleBlue(), WideAngleRed(),
       respectively.
     </change>
     <change name="Steven Koechle" date="2009-05-14">
@@ -173,6 +173,10 @@
     </change>
     <change name="Jeannie Walldren" date="2011-05-03">
       Removed Mgs namespace scope.
+    </change>
+    <change name="Jesse Mapel" date="2019-05-15">
+      Now loads latest Mars satellites kernel because the planets kernel (de430)
+      only provides Mars Barycenter.
     </change>
   </history>
 
@@ -225,11 +229,11 @@
         <internalDefault>Internal Default</internalDefault>
         <description>
           If you do not enter a file, mocal will search for a file with the form:
-         <pre>    
+         <pre>
           $mgs/calibration/moccal.kernel.xxx
-        
+
           where "xxx" is a positive number.
-         </pre>  
+         </pre>
           The kernel with the highest version (xxx) will be used.
           See an existing calibration
           file for details on how to configure this file.
@@ -252,7 +256,7 @@
            WA.  Should they not have this value, a W0 of 0.0 will be detected and
            I/F cannot be generated.  moccal will detect occurances of W0=0.0 and
            report this to the user whilst functioning as if IOF="NO" irregardless
-           of what may have been provided by the user for IOF.  Conversion to I/F 
+           of what may have been provided by the user for IOF.  Conversion to I/F
            takes place after calibration and pixel-to-pixel variation correction.
         </description>
       </parameter>

--- a/isis/src/mro/apps/ctxcal/ctxcal.xml
+++ b/isis/src/mro/apps/ctxcal/ctxcal.xml
@@ -80,10 +80,10 @@
     </table>
 
     <p>
-    If SpatialSumming is 1, the dark current pixels for the A and B channel are 
-    averaged separately, then the A channel dark average is subtracted from the 
-    A channel image pixels and the B channel dark average is subtracted from the 
-    B channel image pixels.  If SpatialSumming is 2 the dark current pixels are 
+    If SpatialSumming is 1, the dark current pixels for the A and B channel are
+    averaged separately, then the A channel dark average is subtracted from the
+    A channel image pixels and the B channel dark average is subtracted from the
+    B channel image pixels.  If SpatialSumming is 2 the dark current pixels are
     averaged together then this average is subtracted from all image pixels.
     </p>
 
@@ -97,9 +97,9 @@
     </pre>
 
     where r is the average signal being generated at the focal plane (in
-    DN/msec), darkCurrent is the dark current term (in DN/msec), flatPixel is 
-    the pixel dependent gain, and exposure is the exposure time in milliseconds. 
-    </p> 
+    DN/msec), darkCurrent is the dark current term (in DN/msec), flatPixel is
+    the pixel dependent gain, and exposure is the exposure time in milliseconds.
+    </p>
 
     <p>
     If the IOF parameter is chosen, the output pixels are converted to
@@ -108,7 +108,7 @@
     a CTX response of 3660.5 DN/msec.
 
     <pre>
-        
+
     For any pixel i, on line L
 
       r(i,L) = ( inputPixel(i,L) - darkCurrent(L) ) / flatPixel(i,L) ) / iof
@@ -117,7 +117,7 @@
     w1 = w0 * (2.07E8)^2 / dist^2
     w0 = 3660.5 dn/msec
     dist = distance between Sun and Mars in kilometers
-    exposure = line exposure duration in milliseconds 
+    exposure = line exposure duration in milliseconds
     </pre>
     </p>
 
@@ -140,13 +140,17 @@
         Added an application test
     </change>
     <change name="Steven Lambright" date="2008-05-13">
-      Removed references to CubeInfo 
+      Removed references to CubeInfo
     </change>
     <change name="Steven Koechle" date="2008-12-04">
       Removed hard coded flatfile, now searchs for highest version
     </change>
     <change name="Ian Humphrey" date="2014-06-23">
       Modified hard coded flatfile in app tests to relative paths using $ISIS3DATA. Fixes #2054.
+    </change>
+    <change name="Jesse Mapel" date="2019-05-15">
+      Now loads latest Mars satellites kernel because the planets kernel (de430)
+      only provides Mars Barycenter.
     </change>
   </history>
 

--- a/isis/src/mro/apps/ctxcal/main.cpp
+++ b/isis/src/mro/apps/ctxcal/main.cpp
@@ -135,12 +135,15 @@ void IsisMain() {
     // Astronomical Units (AU)
     QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
     furnsh_c(bspKernel.toLatin1().data());
+    QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
+    furnsh_c(satKernel.toLatin1().data());
     QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
     furnsh_c(pckKernel.toLatin1().data());
     double sunpos[6], lt;
     spkezr_c("sun", etStart, "iau_mars", "LT+S", "mars", sunpos, &lt);
     double dist1 = vnorm_c(sunpos);
     unload_c(bspKernel.toLatin1().data());
+    unload_c(satKernel.toLatin1().data());
     unload_c(pckKernel.toLatin1().data());
 
     double dist = 2.07E8;
@@ -233,5 +236,3 @@ void Calibrate(Buffer &in, Buffer &out) {
   }
 
 }
-
-

--- a/isis/src/mro/objs/HiCal/HiCalConf.cpp
+++ b/isis/src/mro/objs/HiCal/HiCalConf.cpp
@@ -331,7 +331,7 @@ bool HiCalConf::_naifLoaded = false;
     (void) spkpos_c(targetName.toLatin1().data(), obsStartTime, "J2000", "LT+S", "sun",
                     sunv, &lt);
     double sunkm = vnorm_c(sunv);
-    NaifStatus::CheckErrors(); 
+    NaifStatus::CheckErrors();
     //  Return in AU units
     return (sunkm/1.49597870691E8);
   }
@@ -419,14 +419,19 @@ void HiCalConf::loadNaifTiming( ) {
     Isis::FileName pck("$base/kernels/spk/de???.bsp");
     pck = pck.highestVersion();
 
+    Isis::FileName sat("$base/kernels/spk/mar???.bsp");
+    sat = sat.highestVersion();
+
 //  Load the kernels
     QString lsk = leapseconds.expanded();
     QString sClock = sclk.expanded();
     QString pConstants = pck.expanded();
+    QString satConstants = sat.expanded();
     furnsh_c(lsk.toLatin1().data());
     furnsh_c(sClock.toLatin1().data());
     furnsh_c(pConstants.toLatin1().data());
-    NaifStatus::CheckErrors(); 
+    furnsh_c(satConstants.toLatin1().data());
+    NaifStatus::CheckErrors();
 
 //  Ensure it is loaded only once
     _naifLoaded = true;
@@ -605,4 +610,3 @@ QString HiCalConf::parser(const QString &s, const ValueList &vlist,
 }
 
 }  // namespace Isis
-

--- a/isis/src/mro/objs/HiCal/HiCalConf.h
+++ b/isis/src/mro/objs/HiCal/HiCalConf.h
@@ -90,6 +90,8 @@ namespace Isis {
    *          to compute the new CcdChannelIndex keyword.
    * @history 2015-07-31 Kristin Berry - Added NaifStatus::CheckErrors() to see if any NAIF errors
    *          were signaled. References #2248.
+   * @history 2019-05-16 Jesse Mapel - Added Mars satellite kernel because the
+   *          base planet orbit kernel only has Mars Bayrcenter now.
    */
   class HiCalConf : public DbAccess {
     public:

--- a/isis/src/system/objs/KernelDb/KernelDb.truth
+++ b/isis/src/system/objs/KernelDb/KernelDb.truth
@@ -271,7 +271,7 @@ $mro/kernels/spk/kernels.????.db
 $mro/kernels/iak/kernels.????.db
 
 TargetPosition Kernels: 
-$base/kernels/spk/de405.bsp
+$base/kernels/spk/de430.bsp
 
 SpacecraftPointing Kernels: 
 $mro/kernels/ck/mro_sc_psp_080108_080114.bc
@@ -381,7 +381,7 @@ $mro/kernels/spk/kernels.????.db
 $mro/kernels/iak/kernels.????.db
 
 TargetPosition Kernels: 
-$base/kernels/spk/de405.bsp
+$base/kernels/spk/de430.bsp
 
 SpacecraftPointing Kernels: 
 $mro/kernels/ck/mro_sc_psp_080108_080114.bc


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changes to tests and applications required based on updating from de405 to de430

## Description
<!--- Describe your changes in detail -->
The largest change is that the position of Mars (499) is no longer in de430, only the position of Mars Barycenter (4) is available. Many of the calibration apps load the planets SPK and expect it to contain the position of Mars (499). I changed these to now load the Mars satellite kernel which the position of Mars (499) has been moved to based on [comments from NAIF](https://naif.jpl.nasa.gov/pub/naif/generic_kernels/spk/planets/aareadme_de430-de431.txt).

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #3255 because it required updating to de430

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We updated to de430. This caused several things to break or have test differences.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Changes have been tested on Ubuntu18 and Mac OS 10.13. All tests are passing (with updated truth data in some cases).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
