### PR TITLE
Hayabusa2 cat test

### DIFF
--- a/isis/src/hayabusa2/tsts/Makefile
+++ b/isis/src/hayabusa2/tsts/Makefile
@@ -1,0 +1,4 @@
+BLANKS = "%-6s"
+LENGTH = "%-42s"
+
+include $(ISISROOT)/make/isismake.tststree

--- a/isis/src/hayabusa2/tsts/OncCamera/Makefile
+++ b/isis/src/hayabusa2/tsts/OncCamera/Makefile
@@ -16,24 +16,24 @@ commands:
 		to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=400 LINE=750 ALLOWOUTSIDE=no \
 		> /dev/null
 
-	# Bottom of planet
+ 	# Left side of planet
 	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
 	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=318 LINE=760 ALLOWOUTSIDE=no \
 	  > /dev/null
 
-	# Right side of planet
+	# Bottom of planet
 	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
 	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=400 LINE=841 ALLOWOUTSIDE=no \
 	  > /dev/null
 
-	# Top of planet
+	# Right side of planet
 	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
 	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=483 LINE=754 ALLOWOUTSIDE=no \
 	  > /dev/null
 
-	# Left side of planet
+	# Top of planet
 	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
-	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=400 LINE=670 ALLOWOUTSIDE=no \
+	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=400 LINE=680 ALLOWOUTSIDE=no \
 	  > /dev/null
 		
 	$(RM) $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub > /dev/null

--- a/isis/src/hayabusa2/tsts/OncCamera/Makefile
+++ b/isis/src/hayabusa2/tsts/OncCamera/Makefile
@@ -1,0 +1,40 @@
+INGEST = hyb2onc2isis
+INIT = spiceinit
+CAMPT = campt
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	$(INGEST) $(TSTARGS) from= $(INPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit \
+	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub > /dev/null
+
+	$(INIT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
+	  > /dev/null
+
+	# Center of planet
+	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
+		to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=400 LINE=750 ALLOWOUTSIDE=no \
+		> /dev/null
+
+	# Bottom of planet
+	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
+	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=318 LINE=760 ALLOWOUTSIDE=no \
+	  > /dev/null
+
+	# Right side of planet
+	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
+	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=400 LINE=841 ALLOWOUTSIDE=no \
+	  > /dev/null
+
+	# Top of planet
+	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
+	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=483 LINE=754 ALLOWOUTSIDE=no \
+	  > /dev/null
+
+	# Left side of planet
+	$(CAMPT) $(TSTARGS) from= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub \
+	  to= $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.IMG--finalOutput.pvl SAMPLE=400 LINE=670 ALLOWOUTSIDE=no \
+	  > /dev/null
+		
+	$(RM) $(OUTPUT)/hyb2_onc_20151203_072958_w2f_l2a.fit.cub > /dev/null
+	$(RM) $(OUTPUT)/../print.prt > /dev/null


### PR DESCRIPTION
PR to add category tests for hayabusa2 in ISIS

## Description
Added makefiles to run integration tests for hayabusa2, to test that a hayabusa2 image can be ingested, spiceinit'd, and check with campt.

## Related Issue
Closes #3302

## Motivation and Context
Since we are working on how kernel data is downloaded, it would be beneficial to have some testing to see if the issue is newly updated/downloaded kernels.

## How Has This Been Tested?
All other apps are being tested individually so this is to make sure all of the pieces work together.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
