### PR TITLE
Pipeline Test Update

### DIFF
--- a/isis/src/base/objs/Pipeline/Pipeline.truth
+++ b/isis/src/base/objs/Pipeline/Pipeline.truth
@@ -454,7 +454,7 @@ PIPELINE -------> unitTest5 <------- PIPELINE
 input=$ISIS3DATA/odyssey/testData/I00831002RDR.cub
 PIPELINE -------> unitTest6 <------- PIPELINE
 noisefilter FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" SAMPLES="0" LINES="0"
-lowpass FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" -PREFERENCE="$ISISROOT/TestPreferences" SAMPLES="3" LINES="3"
+lowpass FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" SAMPLES="3" LINES="3" -PREFERENCE="$ISISROOT/TestPreferences"
 PIPELINE -------> unitTest6 <------- PIPELINE
 
 **ERROR** Running Isis program [noisefilter] failed with return status [2].

--- a/isis/src/base/objs/Pipeline/Pipeline.truth
+++ b/isis/src/base/objs/Pipeline/Pipeline.truth
@@ -454,23 +454,19 @@ PIPELINE -------> unitTest5 <------- PIPELINE
 input=$ISIS3DATA/odyssey/testData/I00831002RDR.cub
 PIPELINE -------> unitTest6 <------- PIPELINE
 noisefilter FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" SAMPLES="0" LINES="0"
-lowpass FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" SAMPLES="3" LINES="3"
+lowpass FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" -PREFERENCE="$ISISROOT/TestPreferences" SAMPLES="3" LINES="3"
 PIPELINE -------> unitTest6 <------- PIPELINE
 
 **ERROR** Running Isis program [noisefilter] failed with return status [2].
 **USER ERROR** Parameter [SAMPLES] must be greater than or equal to [1].
 Continuing ......
-unittest: Working
-0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed
 
 *** Application level continue option ***
 PIPELINE -------> unitTest7 <------- PIPELINE
 noisefilter FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" SAMPLES="0" LINES="0"
-lowpass FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" SAMPLES="3" LINES="3"
+lowpass FROM="$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub" TO="./out.cub" SAMPLES="3" LINES="3" -PREFERENCE="$ISISROOT/TestPreferences"
 PIPELINE -------> unitTest7 <------- PIPELINE
 
 **ERROR** Running Isis program [noisefilter] failed with return status [2].
 **USER ERROR** Parameter [SAMPLES] must be greater than or equal to [1].
 Continuing ......
-unittest: Working
-0% Processed10% Processed20% Processed30% Processed40% Processed50% Processed60% Processed70% Processed80% Processed90% Processed100% Processed

--- a/isis/src/base/objs/Pipeline/unitTest.cpp
+++ b/isis/src/base/objs/Pipeline/unitTest.cpp
@@ -16,7 +16,7 @@ void PipeContinue();
 
 void IsisMain() {
   Preference::Preferences(true);
-  
+
   UserInterface &ui = Application::GetUserInterface();
   ui.PutFileName("FROM",  "$ISIS3DATA/odyssey/testData/I00831002RDR.even.cub");
   ui.PutFileName("FROM2", "$ISIS3DATA/odyssey/testData/I00831002RDR.odd.cub");
@@ -50,14 +50,14 @@ void IsisMain() {
   ui.PutFileName("FROM", "unitTest.lis");
   std::cerr << "Testing listing methods" << std::endl;
   PipeListed();
-  
+
   ui.Clear("FROM");
   ui.Clear("TO");
   ui.PutAsString("FROM", "$ISIS3DATA/odyssey/testData/I00831002RDR.cub");
   ui.PutFileName("TO", "./out.cub");
   std::cerr << "*** Branching Pipe with a branch disabled ***" << std::endl;
   PipeBranchDisabled();
-  
+
   ui.Clear("TO");
   ui.PutFileName("TO",   "./out.cub");
   std::cerr << "\n*** Continue option ***" << endl;
@@ -292,7 +292,7 @@ void PipeListed() {
 
 /**
  * Unittest pipeline with branch disabled
- * 
+ *
  * @author sprasad (12/20/2010)
  */
 void PipeBranchDisabled(void)
@@ -304,7 +304,7 @@ void PipeBranchDisabled(void)
   p.AddOriginalBranch("lpf");
   p.AddOriginalBranch("hpf");
   p.KeepTemporaryFiles(false);
-  
+
   p.AddToPipeline("lowpass");
   p.Application("lowpass").SetInputParameter("FROM", false);
   p.Application("lowpass").SetOutputParameter("TO", "lowpass");
@@ -312,9 +312,9 @@ void PipeBranchDisabled(void)
   p.Application("lowpass").AddConstParameter("lpf", "LINES", "3");
   p.Application("lowpass").EnableBranch("lpf", true);
   p.Application("lowpass").EnableBranch("hpf", false);
-  
+
   //std::cerr << p;
-    
+
   p.AddToPipeline("highpass");
   p.Application("highpass").SetInputParameter("FROM", false);
   p.Application("highpass").SetOutputParameter("TO", "highpass");
@@ -322,15 +322,15 @@ void PipeBranchDisabled(void)
   p.Application("highpass").AddConstParameter("hpf", "LINES", "3");
   p.Application("highpass").EnableBranch("lpf", false);
   p.Application("highpass").EnableBranch("hpf", true);
-  
+
   //std::cerr << p;
-  
+
   p.AddToPipeline("fx");
   p.Application("fx").SetInputParameter("FROMLIST", PipelineApplication::LastAppOutputList, false);
   p.Application("fx").SetOutputParameter("TO", "add");
   p.Application("fx").AddConstParameter("MODE", "LIST");
   p.Application("fx").AddConstParameter("EQUATION", "f1+f2");
-  
+
   std::cerr << p;
 }
 
@@ -338,33 +338,34 @@ void PipeContinue(void)
 {
   // Pipeline level "continue"
   Pipeline pc1("unitTest6");
-  
+
   pc1.SetInputFile(FileName("$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub"));
   pc1.SetOutputFile("TO");
   pc1.SetContinue(true);
   pc1.KeepTemporaryFiles(false);
-  
+
   pc1.AddToPipeline("noisefilter");
   // Intentionally broken parameters
-  pc1.Application("noisefilter").SetInputParameter("FROM",     false);
-  pc1.Application("noisefilter").SetOutputParameter("TO",      "");
-  pc1.Application("noisefilter").AddConstParameter("SAMPLES",  "0");
-  pc1.Application("noisefilter").AddConstParameter("LINES",    "0");
-  
+  pc1.Application("noisefilter").SetInputParameter("FROM", false);
+  pc1.Application("noisefilter").SetOutputParameter("TO", "");
+  pc1.Application("noisefilter").AddConstParameter("SAMPLES", "0");
+  pc1.Application("noisefilter").AddConstParameter("LINES", "0");
+
   pc1.AddToPipeline("lowpass");
+  pc1.Application("lowpass").AddConstParameter("-PREFERENCE", "$ISISROOT/TestPreferences");
   pc1.Application("lowpass").SetInputParameter ("FROM", false);
   pc1.Application("lowpass").SetOutputParameter("TO", "lowpass");
   pc1.Application("lowpass").AddConstParameter ("SAMPLES", "3");
   pc1.Application("lowpass").AddConstParameter ("LINES", "3");
-  
+
   cerr << pc1 << endl;
-  
+
   pc1.Run();
-  
+
 
   cerr << "\n*** Application level continue option ***\n";
   Pipeline pc2("unitTest7");
-  
+
   pc2.SetInputFile(FileName("$ISIS3DATA/mro/testData/PSP_001446_1790_BG12_0.cub"));
   pc2.SetOutputFile("TO");
   pc2.KeepTemporaryFiles(false);
@@ -376,15 +377,16 @@ void PipeContinue(void)
   pc2.Application("nf1").SetOutputParameter("TO",      "");
   pc2.Application("nf1").AddConstParameter("SAMPLES",  "0");
   pc2.Application("nf1").AddConstParameter("LINES",    "0");
-  
+
   pc2.AddToPipeline("lowpass", "lpf1");
   pc2.Application("lpf1").SetInputParameter ("FROM", false);
   pc2.Application("lpf1").SetOutputParameter("TO", "lpf1");
   pc2.Application("lpf1").AddConstParameter ("SAMPLES", "3");
   pc2.Application("lpf1").AddConstParameter ("LINES", "3");
-  
+  pc2.Application("lpf1").AddConstParameter("-PREFERENCE", "$ISISROOT/TestPreferences");
+
   cerr << pc2 << endl;
-  
+
   pc2.Run();
   remove("./out.cub");
 }

--- a/isis/src/base/objs/Pipeline/unitTest.cpp
+++ b/isis/src/base/objs/Pipeline/unitTest.cpp
@@ -352,16 +352,15 @@ void PipeContinue(void)
   pc1.Application("noisefilter").AddConstParameter("LINES", "0");
 
   pc1.AddToPipeline("lowpass");
-  pc1.Application("lowpass").AddConstParameter("-PREFERENCE", "$ISISROOT/TestPreferences");
   pc1.Application("lowpass").SetInputParameter ("FROM", false);
   pc1.Application("lowpass").SetOutputParameter("TO", "lowpass");
   pc1.Application("lowpass").AddConstParameter ("SAMPLES", "3");
   pc1.Application("lowpass").AddConstParameter ("LINES", "3");
+  pc1.Application("lowpass").AddConstParameter("-PREFERENCE", "$ISISROOT/TestPreferences");
 
   cerr << pc1 << endl;
 
   pc1.Run();
-
 
   cerr << "\n*** Application level continue option ***\n";
   Pipeline pc2("unitTest7");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated the pipeline unit test to use the TestPreferences where necessary.

## Description
Added two -PREFERENCE flags to unit test 6 and 7 for the Pipeline object. This prevents user preferences files from overriding the test output, making the test output consistent with what we expect to see.

## Related Issue
#641 

## Motivation and Context
This fix helps to bring ISIS in line with the Jenkins CI environments we are trying to setup for continuous integration.

## How Has This Been Tested?
Tested by changing the user IsisPreference file and seeing the same test output

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
