### PR TITLE
Updated Chan1 M3 test to use base lro dem 

### DIFF
--- a/isis/src/chandrayaan1/objs/Chandrayaan1M3Camera/Chandrayaan1M3Camera.truth
+++ b/isis/src/chandrayaan1/objs/Chandrayaan1M3Camera/Chandrayaan1M3Camera.truth
@@ -32,8 +32,8 @@ DeltaLine = 0.000000000
 For center pixel position ...
 Latitude OK
 Longitude OK
-RightAscension = 242.182569911
-Declination = -84.617919659
+RightAscension = 242.411157332
+Declination = -84.577243705
 
 Testing a Level-2 CH1 cube: 
 

--- a/isis/src/chandrayaan1/objs/Chandrayaan1M3Camera/unitTest.cpp
+++ b/isis/src/chandrayaan1/objs/Chandrayaan1M3Camera/unitTest.cpp
@@ -43,8 +43,8 @@ int main(void) {
     // set both the known lat and known lon to zero and copy the unit test output "Latitude off by: "
     // and "Longitude off by: " values directly into these variables. NOTE: These are only used
     // for the center of the image test, not the corners.
-    double knownLat = 61.4944183507184832;
-    double knownLon = 74.8961675572936798;
+    double knownLat = 61.50040250242506;
+    double knownLon = 74.89590535143694;
 
     Cube c("$chandrayaan1/testData/M3T20090630T083407_V03_RDN.cub", "r");
     Camera *cam = CameraFactory::Create(c);


### PR DESCRIPTION
## Description
The two test cubes used for the Chandrayaan1 M3 test used an internal-only, 35 GB DEM that is not distributed with ISIS. This caused this test to fail on jenkins, as there is no access to the `/work` area these DEMs were stored in. These cubes were updated to use the base-area lro dem which is already distributed with ISIS. This updated caused the output values for the unitTest calculations to be slightly different. This PR updates the unitTest with these new values. 

## Related Issue
#641 

## Motivation and Context
This issue came up in the context of trying to fix failing jenkins tests. 

## How Has This Been Tested?
Locally, the updated test passes. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
