### PR TITLE
Improved voycal error messages

### DIFF
--- a/isis/src/voyager/apps/voycal/voycal.xml
+++ b/isis/src/voyager/apps/voycal/voycal.xml
@@ -8,26 +8,26 @@
 
   <description>
     <p>
-      VOYCAL performs radiometric corrections to planetary images acquired by the  
-      Viking orbiter and Voyager spacecraft vidicon cameras. VOYCAL performs a  
-      radiometric correction in two steps. First, VOYCAL corrects for the varying  
-      response of the vidicon across the field-of-view of the camera.  
-      Multiplicative  and additive correction coefficients, as a function of line 
-      and sample position,  are applied to an image array to produce the results 
-      of an 'ideal' camera.   Optionally, for Voyager cameras, a non-linearity 
-      correction can be additionally  applied to the image data.  Secondly, VOYCAL 
-      converts the image data to radiance factor values.  The radiance factor is 
-      defined as the ratio of the observed radiance and the radiance of a white 
+      VOYCAL performs radiometric corrections to planetary images acquired by the
+      Viking orbiter and Voyager spacecraft vidicon cameras. VOYCAL performs a
+      radiometric correction in two steps. First, VOYCAL corrects for the varying
+      response of the vidicon across the field-of-view of the camera.
+      Multiplicative  and additive correction coefficients, as a function of line
+      and sample position,  are applied to an image array to produce the results
+      of an 'ideal' camera.   Optionally, for Voyager cameras, a non-linearity
+      correction can be additionally  applied to the image data.  Secondly, VOYCAL
+      converts the image data to radiance factor values.  The radiance factor is
+      defined as the ratio of the observed radiance and the radiance of a white
       screen, normal to the incident rays of the sun.
     </p>
-    <br>EQUATIONS</br> 
-    <br>-----------------</br> 
+    <br>EQUATIONS</br>
+    <br>-----------------</br>
     <p>
-      The sensitivity of a vidicon camera varies across the field of view of an 
-      image frame.  VOYCAL performs an additive, mutiplicative, and non-linearity 
-      radiometric correction to an image to 
-      correct for the varying sensitivity of the camera.  For information on the 
-      radiometric properties of a vidicon camera, see the references; 
+      The sensitivity of a vidicon camera varies across the field of view of an
+      image frame.  VOYCAL performs an additive, mutiplicative, and non-linearity
+      radiometric correction to an image to
+      correct for the varying sensitivity of the camera.  For information on the
+      radiometric properties of a vidicon camera, see the references;
     </p>
 
     <p>"Inflight Performance of the Viking Visual Imaging Subsystem"
@@ -82,8 +82,8 @@
   </pre>
   <p>The linearity correction to the DN values is performed before the gain
 and offset correction is applied. If the linearity option is chosen, and
-the voylin.pvl file has a table entry for the mission camera of the data being 
-processed, or the user has provided TAE input for the coefficients B,K,LINORM, 
+the voylin.pvl file has a table entry for the mission camera of the data being
+processed, or the user has provided TAE input for the coefficients B,K,LINORM,
 then a linearity correction will be made. The
 result of the linearity correction is fed into the equation shown
 above.  Thus, the result of the linearity correction is called DL(i,j).
@@ -103,6 +103,9 @@ The following linearity equation is used:</p>
     </change>
     <change name="Debbie A. Cook" date="2012-07-06">
        Updated Spice members to be more compliant with Isis coding standards. References #972.
+    </change>
+    <change name="Jesse Mapel" date="2019-08-06">
+       Updated error message when coefficients cannot be found. References #2685.
     </change>
   </history>
 
@@ -140,7 +143,7 @@ The following linearity equation is used:</p>
           Output cube
          </brief>
          <description>
-           The output cube which will contain the radiometrically corrected 
+           The output cube which will contain the radiometrically corrected
            data.
          </description>
          <filter>
@@ -157,10 +160,10 @@ The following linearity equation is used:</p>
           Option for Linear correction
         </brief>
         <description>
-          Option to apply Linear correction to cube. Must have matching data in 
-          voylin.pvl. Equation can be viewed in general description.   
+          Option to apply Linear correction to cube. Must have matching data in
+          voylin.pvl. Equation can be viewed in general description.
         </description>
-      </parameter> 
+      </parameter>
     </group>
   </groups>
 </application>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Changed voycal to report all of the missing coefficients instead of just the first one.

## Description
<!--- Describe your changes in detail -->
Previously voycal checked each coefficient separately. This resulted in cases where all of the coefficients were missing only reporting that the first coefficient was missing. I tweaked the logic to check for all of them at once and then report all of the missing coefficients.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This doesn't address the problem in #2685 but it gives a better error message when an image that doesn't have calibration is found.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Voycal doesn't support calibration for some images. In these cases the error message only reported OmegaNaught as missing. Hopefully this makes what's going on more clear to users. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests are still passing and the new error message is reporting correctly for the images in #2685.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
