### PR TITLE
Adds "Updates qmos to fix grid-drawing if LongitudeDirection is PositiveWest" to 3.8

### DIFF
--- a/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
@@ -29,6 +29,7 @@ namespace Isis {
       Longitude lonMin, Longitude lonMax) {
     setZValue(DBL_MAX);
 
+
     if (latInc > Angle(0.0, Angle::Degrees) && lonInc > Angle(0.0, Angle::Degrees)) {
       // Walk the grid, creating a QGraphicsLineItem for each line segment.
       Projection *proj = projectionSrc->getProjection();
@@ -42,6 +43,12 @@ namespace Isis {
         Latitude maxLat;
         Latitude startLat;
         Latitude endLat;
+
+      if (mappingGroup["LongitudeDirection"][0] == "PositiveWest") {
+        Longitude temp = lonMin;
+        lonMin = lonMax;
+        lonMax = temp;
+      }
 
         if (mappingGroup["LatitudeType"][0] == "Planetographic") {
 


### PR DESCRIPTION
See PR #3368 for more information. This PR is just to add the change to 3.8.

## Related Issue
#2696 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
