### PR TITLE
Updated cisscal label output

### DIFF
--- a/isis/src/cassini/apps/cisscal/cisscal.xml
+++ b/isis/src/cassini/apps/cisscal/cisscal.xml
@@ -210,6 +210,9 @@
       Updated cisscal and documentation to better reflect the steps as of idl cisscal program
       version, 3.8, and added capabilities to use new dustrings files based on epoch.. Fixes #4708
     </change>
+    <change name="Adam Paqeutte" date="2019-08-07">
+      Added a version number to the cisscal label output. Currently at version 3.8.
+    </change>
   </history>
 
   <category>

--- a/isis/src/cassini/apps/cisscal/main.cpp
+++ b/isis/src/cassini/apps/cisscal/main.cpp
@@ -132,6 +132,7 @@ void IsisMain() {
 
   // Add the radiometry group
   gbl::calgrp.setName("Radiometry");
+  gbl::calgrp += PvlKeyword("CisscalVersion", "3.8");
 
   // The first ProcessByLine pass will either compute bitweight values or copy input values
 


### PR DESCRIPTION
Added a cisscal version number to the output of the cisscal application

## Description
Added a hard coded version number for the version of cisscal that has ported into ISIS

## Related Issue
Closes #2676 

## Motivation and Context
Allows user to see what version of cisscal ISIS is currently using.

## How Has This Been Tested?
This is being tested by the cisscal tests currently in ISIS as it will be a change to the label

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
