### PR TITLE
Port #3397 to 3.8

### DIFF
--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -28,6 +28,7 @@
 #include <QDate>
 #include <QDebug>
 #include <QDir>
+#include <QLocale>
 #include <QPair>
 #include <QString>
 #include <QTemporaryFile>
@@ -622,8 +623,7 @@ namespace Isis {
                     foundFile.mid(truncateRange.second + 1);
 
       }
-
-      QDate fileDate = QDate::fromString(foundFile, fileQDatePattern);
+      QDate fileDate = QLocale(QLocale::English, QLocale::UnitedStates).toDate(foundFile, fileQDatePattern);
 
       if (fileDate.isValid()) {
         // No missions before Sputnik 1, so we must be in the new millenium

--- a/isis/src/base/objs/FileName/FileName.h
+++ b/isis/src/base/objs/FileName/FileName.h
@@ -110,7 +110,8 @@ namespace Isis {
    *   @history 2017-04-21 Cole Neubauer - Updated documentation for the class Fixes #4121
    *   @history 2018-04-06 Kaitlyn Lee - Moved method documentation to cpp file and
    *                           updated it for consistency. Fixes #5230.
-
+   *   @history 2019-08-07 Jesse Mapel - Replaced QDate::fromFile call with QLocale::toDate
+   *                           calls to ensure US English is always used. Fixes #3340
    */
   class FileName {
     public:

--- a/isis/tests/FileListTests.cpp
+++ b/isis/tests/FileListTests.cpp
@@ -11,12 +11,12 @@ TEST(FileList, NonExistantFileConstructor)
   }
   catch(Isis::IException &e)
   {
-    EXPECT_TRUE(e.toString().toLatin1().contains("Unable to open [FakeFile]."))
+    EXPECT_TRUE(e.toString().toLatin1().contains("Unable to open [FakeFile]"))
       << e.toString().toStdString();
   }
   catch(...)
   {
-    FAIL() << "Expected an IException\"Unable to open [FakeFile].\"";
+    FAIL() << "Expected an IException\"Unable to open [FakeFile]\"";
   }
 }
 


### PR DESCRIPTION
* Changed FileName to use US English for date conversions

* Removed defaulte locale

* Fixed FileList test

## Description
Cherry-pick of #3379 onto 3.8 branch for 3.8.1 release.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues or RedMine Issues at https://fixit.wr.usgs.gov/fixit) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3340 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Bug fix is stages for 3.9 release, needs to be ported fro 3.8.1 release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests are passing on 3.8 build except for cisscal changes from #2676 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
