### PR TITLE
Removed grep from Makefile and added Program to diff file for cnethist

### DIFF
--- a/isis/src/control/apps/cnethist/tsts/case01/Makefile
+++ b/isis/src/control/apps/cnethist/tsts/case01/Makefile
@@ -12,7 +12,7 @@ commands:
 	to=hist.txt \
 	bin_width = 0.1 >& $(OUTPUT)/temp.txt;
 	cat $(OUTPUT)/temp.txt | grep -v "Processed" | grep -v "Reading Control Points" \
-		| grep -v "Adding Control Points to Network"  | grep -v "Program" > $(OUTPUT)/error.pvl;
+		| grep -v "Adding Control Points to Network" > $(OUTPUT)/error.pvl;
 	cat hist.txt  \
 	  | sed 's/\/[^,]*\/\([^,\/]*\.net\)/\1/g' \
 	  | sed 's/\([0-9][0-9]*\.[0-9][0-9][0-9][0-9][0-9]\)\([0-9][0-9]*\)/\1/g' \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The path to the isis jenkins build on prog26 takes up two lines in an output pvl. The makefile was using grep to remove this line from the pvl, but since the path is too long, some of the path was left in the output. This caused the case01 cnethist test to fail on the jenkins build. We instead added Program (the name of the keyword in the output pvl that stored the path) to the diff file.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/641

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows test to pass.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Reran test to make sure it still passes in a local build.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
