### PR TITLE
Added error message to prevent user from running caminfo on a level 2 cube.

### DIFF
--- a/isis/src/base/apps/caminfo/main.cpp
+++ b/isis/src/base/apps/caminfo/main.cpp
@@ -63,6 +63,12 @@ void IsisMain() {
   Process p;
   Cube *incube = p.SetInputCube("FROM");
 
+  if (incube->hasGroup("Mapping")) {
+    QString msg = "Caminfo expects a level 1 input cube. For more information, see:\n"
+    "https://isis.astrogeology.usgs.gov/documents/Glossary/Glossary.html#Level1";
+    throw IException(IException::Unknown, msg, _FILEINFO_);
+  }
+
   // General data gathering
   general = new QList< QPair<QString, QString> >;
   general->append(MakePair("Program",     caminfo_program));
@@ -248,7 +254,7 @@ void IsisMain() {
         bandGeom->setMaxEmission(maxema);
       }
     }
-    
+
     bandGeom->collect(*cam, *incube, doGeometry, doPolygon, getFootBlob, precision);
 
     // Check if the user requires valid image center geometry
@@ -427,7 +433,7 @@ void GenerateCSVOutput(Cube *incube,
   if (not appending) {
     keys.remove(QRegExp(delim + "$")); // Get rid of the extra delim char (",")
     outFile << keys << endl;
-  } 
+  }
   values.remove(QRegExp(delim + "$")); // Get rid of the extra delim char (",")
   outFile << values << endl;
   outFile.close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously, caminfo would run and produce output if a level 2 cube input. This change enforces that caminfo only expects level 1 cubes.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3364 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran caminfo with a level 2 cube and a level 1 cube to ensure that results were as expected.
Existing tests for caminfo still pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
