### PR TITLE
Changed cube sample and line loop to double

### DIFF
--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -2135,9 +2135,9 @@ namespace Isis {
 
 
 /**
- * Returns the latitude and longitude range for the Cube. More accurate than the minimum and 
- * maximum latitude and longitude from the mapping group. 
- * 
+ * Returns the latitude and longitude range for the Cube. More accurate than the minimum and
+ * maximum latitude and longitude from the mapping group.
+ *
  * @param[out] minLatitude minimum latitude present in the cube
  * @param[out] maxLatitude maximum latitude present in the cube
  * @param[out] minLongitude minimum longitude present in the cube
@@ -2181,16 +2181,16 @@ namespace Isis {
     maxLatitude = -99999;
     maxLongitude = -99999;
 
-    for (int sample = 0.5; sample < sampleCount() + 0.5; sample++) {
+    for (double sample = 0.5; sample < sampleCount() + 0.5; sample++) {
     // Checks to see if the point is in outer space
-      for (int line = 0.5; line < lineCount() + 0.5; line++) {
+      for (double line = 0.5; line < lineCount() + 0.5; line++) {
         if (useProj) {
           isGood = proj->SetWorld(sample, line);
         }
         else {
           isGood = cam->SetImage(sample, line);
         }
-      
+
         double lat, lon;
         if (isGood) {
           if (useProj) {
@@ -2198,10 +2198,10 @@ namespace Isis {
             lon = proj->UniversalLongitude();
           }
           else {
-            lat = cam->UniversalLatitude(); 
-            lon = cam->UniversalLongitude(); 
+            lat = cam->UniversalLatitude();
+            lon = cam->UniversalLongitude();
           }
-        
+
           // update mix/max lat/lons
           if (lat < minLatitude) {
             minLatitude = lat;
@@ -2209,23 +2209,23 @@ namespace Isis {
           else if (lat > maxLatitude) {
             maxLatitude = lat;
           }
-          
+
           if (lon < minLongitude) {
             minLongitude = lon;
           }
           else if (lon > maxLongitude) {
-            maxLongitude = lon; 
+            maxLongitude = lon;
           }
         }
       }
     }
-    if ( (minLatitude == 99999) || (minLongitude == 99999) || (maxLatitude == -99999) || 
+    if ( (minLatitude == 99999) || (minLongitude == 99999) || (maxLatitude == -99999) ||
     (maxLongitude == -99999) ) {
       QString msg = "Unable to calculate a minimum or maximum latitutde or longitude.";
         throw IException(IException::Unknown, msg, _FILEINFO_);
     }
   }
-  
+
   /**
    * Write the Pvl labels to the cube's label file. Excess data in the attached
    *   labels is set to 0.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the index in a loop from int to double so that it properly stores fractional lines and samples.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3419 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Using an int caused these values to be truncated resulting in the wrong sub-pixel locations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests passed except for BundleUtilities which is failing due to bundleout changes from #3404 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
