### PR TITLE
Fixed race condition in FileName tests

### DIFF
--- a/isis/tests/FileNameTests.cpp
+++ b/isis/tests/FileNameTests.cpp
@@ -157,33 +157,33 @@ TEST(FileName, HighestVersion) {
 
 TEST(FileName, NewVersion) {
   std::ofstream fileStream;
-  fileStream.open("test000001.cub");
+  fileStream.open("NewVersion000001.cub");
   fileStream << "test";
   fileStream.close();
-  fileStream.open("test000002.cub");
+  fileStream.open("NewVersion000002.cub");
   fileStream << "test";
   fileStream.close();
 
-  FileName file("test??????.cub");
-  EXPECT_EQ("./test000003.cub", file.newVersion().expanded());
-  remove("test000001.cub");
-  remove("test000002.cub");
-  remove("test000003.cub");
+  FileName file("NewVersion??????.cub");
+  EXPECT_EQ("./NewVersion000003.cub", file.newVersion().expanded());
+  remove("NewVersion000001.cub");
+  remove("NewVersion000002.cub");
+  remove("NewVersion000003.cub");
 }
 
 TEST(FileName, FileExists) {
   std::ofstream fileStream;
-  fileStream.open("test000001.cub");
+  fileStream.open("FileExists000001.cub");
   fileStream << "test";
   fileStream.close();
 
-  FileName realFile("test000001.cub");
+  FileName realFile("FileExists000001.cub");
   EXPECT_TRUE(realFile.fileExists());
 
   FileName fakeFile("test.cub");
   EXPECT_FALSE(fakeFile.fileExists());
 
-  remove("test000001.cub");
+  remove("FileExists000001.cub");
 }
 
 TEST(FileName, CreateTempFile) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed the names of the files used in the FileName tests to ensure there are not conflicts.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3401 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Two tests used the same files which resulted in a race condition and intermittent test failure.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
FileName tests were run 1000 times with random ordering and did not fail.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
