### PR TITLE
Updated TrackingTable test to evaluate potentially erroring method before outputing results.

### DIFF
--- a/isis/src/base/objs/TrackingTable/TrackingTable.truth
+++ b/isis/src/base/objs/TrackingTable/TrackingTable.truth
@@ -12,12 +12,12 @@ Third record : fileName3.dat, 456789
 TrackingTable object created
 
 Testing the pixelToFileName method ...
-FileName with pixel value 2: FileName with pixel value 2: does not exist and an exception is thrown.
+FileName with pixel value 2: does not exist and an exception is thrown.
 **PROGRAMMER ERROR** Cannot convert pixel [2] to a filename, pixel is below valid minimum [3].
 FileName with pixel value 3: fileName1.cub
 FileName with pixel value 4: fileName2.cub
 FileName with pixel value 5: fileName3.dat
-FileName with pixel value 6: FileName with pixel value 6: does not exist and an exception is thrown.
+FileName with pixel value 6: does not exist and an exception is thrown.
 **PROGRAMMER ERROR** Cannot convert pixel [6] to a filename, pixel is above valid maximum [6].
 
 Testing the fileNameToPixel method ...

--- a/isis/src/base/objs/TrackingTable/unitTest.cpp
+++ b/isis/src/base/objs/TrackingTable/unitTest.cpp
@@ -72,11 +72,12 @@ int main(int argc, char *argv[]) {
 
     for (int i = 2; i < 7; i++) {
       try {
+        FileName fname = trackingTable2.pixelToFileName(i);
         cout << "FileName with pixel value " << i << ": "
-             << trackingTable2.pixelToFileName(i).name() << endl;
+             << fname.name() << endl;
       }
       catch (IException &e) {
-        cout << "FileName with pixel value " << i 
+        cout << "FileName with pixel value " << i
              << ": does not exist and an exception is thrown." << endl;
         e.print();
       }

--- a/isis/src/system/objs/KernelDb/KernelDb.cpp
+++ b/isis/src/system/objs/KernelDb/KernelDb.cpp
@@ -799,7 +799,6 @@ namespace Isis {
     }
     catch (IException &e) {
       noConfigFile = true;
-      std::cerr << e.what() << std::endl;
     }
     if (noConfigFile) {
       FileName kernelDb(directory + "/kernels.????.db");

--- a/isis/src/system/objs/KernelDb/KernelDb.cpp
+++ b/isis/src/system/objs/KernelDb/KernelDb.cpp
@@ -799,6 +799,7 @@ namespace Isis {
     }
     catch (IException &e) {
       noConfigFile = true;
+      std::cerr << e.what() << std::endl;
     }
     if (noConfigFile) {
       FileName kernelDb(directory + "/kernels.????.db");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously we were seeing different test outputs where the string before the call was not being shifted to cout. Now it evaluates the potentially erroring method before shifting to cout.

Specifically, this is what was happening:

```
290: ------------------ DIFFERENCES ------------------ 
290: 15c15
290: < FileName with pixel value 2: does not exist and an exception is thrown.
290: ---
290: > FileName with pixel value 2: FileName with pixel value 2: does not exist and an exception is thrown.
290: 20c20
290: < FileName with pixel value 6: does not exist and an exception is thrown.
290: ---
290: > FileName with pixel value 6: FileName with pixel value 6: does not exist and an exception is thrown.
290: 
290: ------------------------------------------------- 
```

`<` is the test output and `>` is the truthdata.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No issue, nightly Jenkins CI is failing on Ubuntu

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Getting nightly Jenkins CI passing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Mac and Ubuntu and the TrackingTable test passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
