### PR TITLE
Updated pvldiff to support PvlContainers with unequal keyword lengths

### DIFF
--- a/isis/src/base/apps/pvldiff/main.cpp
+++ b/isis/src/base/apps/pvldiff/main.cpp
@@ -73,7 +73,7 @@ void IsisMain() {
   differenceReason = "";
 }
 
-void compareKeywords(PvlKeyword &pvl1, PvlKeyword &pvl2) {
+void compareKeywords(PvlKeyword &pvl1, PvlKeyword &pvl2) { 
   if ( pvl1.name().compare(pvl2.name()) != 0 ) {
     filesMatch = false;
     differenceReason = "Keyword '" + pvl1.name() + "' does not match keyword '" + pvl2.name() + "'";
@@ -183,7 +183,9 @@ void compareKeywords(PvlKeyword &pvl1, PvlKeyword &pvl2) {
 }
 
 void compareObjects(PvlObject &pvl1, PvlObject &pvl2) {
-
+  
+  removeIngoredKeys(pvl1, pvl2);
+  
   if ( pvl1.name().compare(pvl2.name()) != 0 ) {
     filesMatch = false;
     differenceReason = "Object " + pvl1.name() + " does not match " +

--- a/isis/src/base/apps/pvldiff/main.cpp
+++ b/isis/src/base/apps/pvldiff/main.cpp
@@ -18,10 +18,11 @@ PvlGroup tolerances;
 PvlGroup ignoreKeys;
 PvlGroup ignoreFilePaths;
 
-void compareKeywords(const PvlKeyword &pvl1, const PvlKeyword &pvl2);
-void compareObjects(const PvlObject &pvl1, const PvlObject &pvl2);
-void compareGroups(const PvlGroup &pvl1, const PvlGroup &pvl2);
-
+void compareKeywords(PvlKeyword &pvl1, PvlKeyword &pvl2);
+void compareObjects(PvlObject &pvl1, PvlObject &pvl2);
+void compareGroups(PvlGroup &pvl1, PvlGroup &pvl2);
+void removeIngoredKeys(PvlContainer &pvl1, PvlContainer &pvl2);
+  
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
 
@@ -31,8 +32,8 @@ void IsisMain() {
   differenceReason = "";
   filesMatch = true;
 
-  const Pvl file1(ui.GetFileName("FROM"));
-  const Pvl file2(ui.GetFileName("FROM2"));
+  Pvl file1(ui.GetFileName("FROM"));
+  Pvl file2(ui.GetFileName("FROM2"));
 
   if ( ui.WasEntered("DIFF") ) {
     Pvl diffFile(ui.GetFileName("DIFF"));
@@ -72,7 +73,7 @@ void IsisMain() {
   differenceReason = "";
 }
 
-void compareKeywords(const PvlKeyword &pvl1, const PvlKeyword &pvl2) {
+void compareKeywords(PvlKeyword &pvl1, PvlKeyword &pvl2) {
   if ( pvl1.name().compare(pvl2.name()) != 0 ) {
     filesMatch = false;
     differenceReason = "Keyword '" + pvl1.name() + "' does not match keyword '" + pvl2.name() + "'";
@@ -181,7 +182,8 @@ void compareKeywords(const PvlKeyword &pvl1, const PvlKeyword &pvl2) {
   }
 }
 
-void compareObjects(const PvlObject &pvl1, const PvlObject &pvl2) {
+void compareObjects(PvlObject &pvl1, PvlObject &pvl2) {
+
   if ( pvl1.name().compare(pvl2.name()) != 0 ) {
     filesMatch = false;
     differenceReason = "Object " + pvl1.name() + " does not match " +
@@ -224,7 +226,22 @@ void compareObjects(const PvlObject &pvl1, const PvlObject &pvl2) {
   }
 }
 
-void compareGroups(const PvlGroup &pvl1, const PvlGroup &pvl2) {
+void removeIngoredKeys(PvlContainer &pvl1, PvlContainer &pvl2) {
+  for (auto it=ignoreKeys.begin(); it!=ignoreKeys.end();it++ ) {
+      if (pvl1.hasKeyword(it->name()) && ignoreKeys[it->name()][0] != "false") {
+        pvl1 -= *it;    
+      }
+
+      if (pvl2.hasKeyword(it->name()) && ignoreKeys[it->name()][0] != "false") {
+        pvl2 -= *it;    
+      }
+    }
+}
+
+
+void compareGroups(PvlGroup &pvl1, PvlGroup &pvl2) {
+  removeIngoredKeys(pvl1, pvl2);
+
   if ( pvl1.keywords() != pvl2.keywords() ) {
     filesMatch = false;
     return;


### PR DESCRIPTION
 

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
PvlDiff diff files didn't support containers with unequal keywords. This should fix this, necessary for ignoring `Source = <whatever>` keyword in ISIS tests.

Isis tests were updated and this is needed to make those tests pass. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
