### PR TITLE
Added Working BundleMeasure gtest File

### DIFF
--- a/isis/tests/BundleMeasureTests.cpp
+++ b/isis/tests/BundleMeasureTests.cpp
@@ -1,3 +1,5 @@
+#include <memory>
+
 #include "BundleControlPoint.h"
 #include "BundleMeasure.h"
 #include "BundleSettings.h"
@@ -8,159 +10,137 @@
 
 #include "gmock/gmock.h"
 
+using namespace std;
+
 // To be used for basic setup of a BundleMeasure test object. (Fixture Function)
-class BundleMeasure_CreateObj : public ::testing::Test
-{
+class BundleMeasure_CreateObj : public ::testing::Test {
 
   protected:
-    // Create a ControlPoint object using the default constructor
-    // to feed its pointer into the BundleControlPoint constructor.
-    ControlPoint controlPoint;
 
-    // Create a ControlMeasure object using the default constructor
-    // to feed its pointer into the BundleMeasure constructor.
-    ControlMeasure controlMeasure;
-
-    // Since BundleMeasure and BundleControlPoint do not have
-    // default constructors, and C++ does not allow for object declarations
-    // pointers to each respective object are used.
-    BundleMeasure *testBundleMeasurePtr;
-    BundleControlPoint *testBundleControlPointPtr;
+    // Declare unique pointers to expose them when using the fixture.
+    unique_ptr<ControlPoint> controlPoint;
+    unique_ptr<ControlMeasure> controlMeasure;
+    unique_ptr<BundleMeasure> testBundleMeasurePtr;
+    unique_ptr<BundleControlPoint> testBundleControlPointPtr;
 
 
-    void SetUp() override
-    {
-      // BundleControlPoint testBundleControlPoint;
+    void SetUp() override {
+
+      // Create a ControlPoint object using the default constructor
+      // to feed its pointer into the BundleControlPoint constructor.
+      controlPoint = unique_ptr<ControlPoint>( new ControlPoint() );
+
+      // Create a ControlMeasure object using the default constructor
+      // to feed its pointer into the BundleMeasure constructor.
+      controlMeasure = unique_ptr<ControlMeasure>( new ControlMeasure() );
+
       // Create a BundleSettingsQsp to feed it to
       // the BundleMeasure constructor.
       BundleSettingsQsp bundleSettingsQsp( new BundleSettings );
 
-      // Create a BundleControlPoint object to feed its pointer into
-      // the BundleMeasure constructor.
-      BundleControlPoint bundleControlPoint( bundleSettingsQsp, &controlPoint );
-
-      // Finally, the SetUp function creates the BundleMeasure object
-      // from all of the objects made previously.
-      // std::cout << &controlMeasure << '\n';
-      BundleMeasure bundleMeasure( &controlMeasure, &bundleControlPoint );
-
-      // The pointers are then linked to the newly-created BundleMeasure and
+      // The pointers are then linked to newly-created BundleMeasure and
       // BundleControlPoint objects.
-      testBundleMeasurePtr = &bundleMeasure;
-      testBundleControlPointPtr = &bundleControlPoint;
+      testBundleControlPointPtr = unique_ptr<BundleControlPoint>( new BundleControlPoint( bundleSettingsQsp,
+                                                                                     controlPoint.get() ) );
+
+      testBundleMeasurePtr = unique_ptr<BundleMeasure>( new BundleMeasure( controlMeasure.get(),
+                                                                           testBundleControlPointPtr.get() ) );
 
     }
-
 };
 
-TEST_F( BundleMeasure_CreateObj, test1 ) {
-  testBundleMeasurePtr->setRejected(true);
-  EXPECT_TRUE(controlPoint.IsRejected());
+TEST_F( BundleMeasure_CreateObj, Constructor ) {
+  EXPECT_FALSE( testBundleMeasurePtr->isRejected() );
+
+  EXPECT_EQ( NULL, testBundleMeasurePtr->camera() );
+
+  // May need to check for Not Null rather than checking the BCP pointer.
+  EXPECT_EQ( testBundleControlPointPtr.get(), testBundleMeasurePtr->parentControlPoint() );
+
+  // Without the use of their respective setters, these QSharedPointers will be pointed to NULL
+  EXPECT_TRUE( testBundleMeasurePtr->parentBundleImage().isNull() );
+  EXPECT_TRUE( testBundleMeasurePtr->parentBundleObservation().isNull() );
+  EXPECT_THROW( testBundleMeasurePtr->observationSolveSettings(), IException );
+
+  // Uses ISIS' Null value.
+  EXPECT_EQ( Null, testBundleMeasurePtr->sample() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->sampleResidual() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->line() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->lineResidual() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->residualMagnitude() );
+  EXPECT_TRUE( testBundleMeasurePtr->cubeSerialNumber().isNull() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneComputedX() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneComputedY() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneMeasuredX() );
+  EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneMeasuredY() );
+  EXPECT_THROW( testBundleMeasurePtr->observationIndex(), IException );
 }
 
-// TEST_F( BundleMeasure_CreateObj, Constructor )
-// {
-//   EXPECT_FALSE( testBundleMeasurePtr->isRejected() );
-//
-//   EXPECT_EQ( NULL, testBundleMeasurePtr->camera() );
-//
-//   // May need to check for Not Null rather than checking the BCP pointer.
-//   EXPECT_EQ( testBundleControlPointPtr, testBundleMeasurePtr->parentControlPoint() );
-//
-//   // Without the use of their respective setters, these QSharedPointers will be pointed to NULL
-//   EXPECT_TRUE( testBundleMeasurePtr->parentBundleImage().isNull() );
-//   EXPECT_TRUE( testBundleMeasurePtr->parentBundleObservation().isNull() );
-//   EXPECT_THROW( testBundleMeasurePtr->observationSolveSettings(), IException );
-//
-//   // Uses ISIS' Null value.
-//   EXPECT_EQ( Null, testBundleMeasurePtr->sample() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->sampleResidual() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->line() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->lineResidual() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->residualMagnitude() );
-//   EXPECT_TRUE( testBundleMeasurePtr->cubeSerialNumber().isNull() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneComputedX() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneComputedY() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneMeasuredX() );
-//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneMeasuredY() );
-//   EXPECT_THROW( testBundleMeasurePtr->observationIndex(), IException );
-// }
-//
-//
-// TEST_F( BundleMeasure_CreateObj, CopyConstructor )
-// {
-//   BundleMeasure testBundleMeasure = *testBundleMeasurePtr;
-//
-//   // Using the isRejected Boolean to confirm that the testBundleMeasure
-//   // was copied correctly.
-//   // Note: The default value of isRejected is false.
-//   testBundleMeasure.setRejected( true );
-//
-//   // The copy constructor is then used on the testBundleMeasure object.
-//   BundleMeasure copiedBundleMeasure = BundleMeasure( testBundleMeasure );
-//
-//   // Confirm that this is a copy of the testBundleMeasure by checking the
-//   // isRejected value.
-//   EXPECT_TRUE( copiedBundleMeasure.isRejected() );
-//
-//   // Confirm that the copied BundleMeasure is not simply pointing to
-//   // the testBundleMeasure using the isRejected value again.
-//
-//   copiedBundleMeasure.setRejected( false );
-//
-//   EXPECT_FALSE( copiedBundleMeasure.isRejected() );
-//   EXPECT_TRUE( testBundleMeasure.isRejected() );
-// }
-//
-// TEST_F( BundleMeasure_CreateObj, CopyConstructor2 )
-// {
-//   // Using the isRejected Boolean to confirm that the testBundleMeasure
-//   // was copied correctly.
-//   // Note: The default value of isRejected is false.
-//   std::cout << "Setting Reject" << '\n';
-//   testBundleMeasurePtr->setRejected( true );
-//   std::cout << "Reject Set" << '\n';
-//
-//   // The copy constructor is then used on the testBundleMeasure object.
-//   BundleMeasure copiedBundleMeasure( *testBundleMeasurePtr );
-//
-//   // Confirm that this is a copy of the testBundleMeasure by checking the
-//   // isRejected value.
-//   EXPECT_TRUE( copiedBundleMeasure.isRejected() );
-//
-//   // Confirm that the copied BundleMeasure is not simply pointing to
-//   // the testBundleMeasure using the isRejected value again.
-//
-//   copiedBundleMeasure.setRejected( false );
-//
-//   EXPECT_FALSE( copiedBundleMeasure.isRejected() );
-//   EXPECT_TRUE( testBundleMeasurePtr->isRejected() );
-// }
-//
-// TEST_F( BundleMeasure_CreateObj, AssignmentOperator )
-// {
-//   // Using the isRejected Boolean to confirm that the testBundleMeasure
-//   // was assigned correctly.
-//   // Note: The default value of isRejected is false.
-//   //testBundleMeasurePtr->setRejected( true );
-//   BundleMeasure assignedBundleMeasure = *testBundleMeasurePtr;
-//
-//   // Using the isRejected Boolean to confirm that the testBundleMeasure
-//   // was assigned correctly.
-//   // Note: The default value of isRejected is false.
-//   //assignedBundleMeasure.setRejected( true );
-//
-//
-//
-//
-// }
-//
-// TEST_F( BundleMeasure_CreateObj, IsRejected )
-// {
-//   EXPECT_EQ( false, testBundleMeasurePtr->isRejected() );
-//   testBundleMeasurePtr->setRejected( true );
-//   EXPECT_EQ( true, testBundleMeasurePtr->isRejected() );
-//   testBundleMeasurePtr->setRejected( false );
-//   EXPECT_EQ( false, testBundleMeasurePtr->isRejected() );
-//
-// }
+TEST_F( BundleMeasure_CreateObj, CopyConstructor ) {
+
+  // First, check if the lineResidual is being initialized to ISIS3 Null.
+  EXPECT_EQ( testBundleMeasurePtr->lineResidual(), Null );
+
+  // The interior ControlMeasure object's Line Residual will be used to confirm
+  // that the BundleMeasure was copied properly.
+  controlMeasure->SetResidual( 1.0, 1.0 );
+
+  // Confirm that the Line Residual was set to 1.0
+  EXPECT_EQ( testBundleMeasurePtr->lineResidual(), 1.0 );
+
+  // The copy constructor is then used on the object associated with
+  // testBundleMeasurePtr.
+  BundleMeasure copiedBundleMeasure( *testBundleMeasurePtr );
+
+  // Confirm that this is a copy of the testBundleMeasure by checking the
+  // isRejected value.
+  EXPECT_EQ( copiedBundleMeasure.lineResidual(), 1.0 );
+
+  // Set the IsRejected boolean to true for further testing.
+  // (The default value is false)
+  copiedBundleMeasure.setRejected( true );
+
+  // Both are expected to be true, since BundleMeasure's copy constructor
+  // is a shallow copy, meaning that it copies the pointers to the internal
+  // objects
+  EXPECT_TRUE( copiedBundleMeasure.isRejected() );
+  EXPECT_TRUE( testBundleMeasurePtr->isRejected() );
+}
+
+TEST_F( BundleMeasure_CreateObj, AssignmentOperator ) {
+
+  // First, check if the lineResidual is being initialized to ISIS3 Null.
+  EXPECT_EQ( testBundleMeasurePtr->lineResidual(), Null );
+
+  // The interior ControlMeasure object's Line Residual will be used to confirm
+  // that the BundleMeasure was assigned properly.
+  controlMeasure->SetResidual( 1.0, 1.0 );
+
+  // Confirm that the Line Residual was set to 1.0
+  EXPECT_EQ( testBundleMeasurePtr->lineResidual(), 1.0 );
+
+  // The assignment operator is then used on the testBundleMeasure object.
+  BundleMeasure assignedBundleMeasure = *testBundleMeasurePtr;
+
+  // Confirm that the assignment of testBundleMeasure worked by checking the
+  // isRejected boolean.
+  EXPECT_EQ( assignedBundleMeasure.lineResidual(), 1.0 );
+
+  // Set the IsRejected boolean to true for further testing.
+  // (The default value is false)
+  assignedBundleMeasure.setRejected( true );
+
+  // Finally, check if the isRejected boolean was changed for both references.
+  EXPECT_TRUE( assignedBundleMeasure.isRejected() );
+  EXPECT_TRUE( testBundleMeasurePtr->isRejected() );
+
+}
+
+TEST_F( BundleMeasure_CreateObj, IsRejected ) {
+  EXPECT_EQ( false, testBundleMeasurePtr->isRejected() );
+  testBundleMeasurePtr->setRejected( true );
+  EXPECT_EQ( true, testBundleMeasurePtr->isRejected() );
+  testBundleMeasurePtr->setRejected( false );
+  EXPECT_EQ( false, testBundleMeasurePtr->isRejected() );
+
+}

--- a/isis/tests/BundleMeasureTests.cpp
+++ b/isis/tests/BundleMeasureTests.cpp
@@ -1,0 +1,166 @@
+#include "BundleControlPoint.h"
+#include "BundleMeasure.h"
+#include "BundleSettings.h"
+#include "ControlMeasure.h"
+#include "ControlPoint.h"
+#include "IException.h"
+#include "SpecialPixel.h"
+
+#include "gmock/gmock.h"
+
+// To be used for basic setup of a BundleMeasure test object. (Fixture Function)
+class BundleMeasure_CreateObj : public ::testing::Test
+{
+
+  protected:
+    // Create a ControlPoint object using the default constructor
+    // to feed its pointer into the BundleControlPoint constructor.
+    ControlPoint controlPoint;
+
+    // Create a ControlMeasure object using the default constructor
+    // to feed its pointer into the BundleMeasure constructor.
+    ControlMeasure controlMeasure;
+
+    // Since BundleMeasure and BundleControlPoint do not have
+    // default constructors, and C++ does not allow for object declarations
+    // pointers to each respective object are used.
+    BundleMeasure *testBundleMeasurePtr;
+    BundleControlPoint *testBundleControlPointPtr;
+
+
+    void SetUp() override
+    {
+      // BundleControlPoint testBundleControlPoint;
+      // Create a BundleSettingsQsp to feed it to
+      // the BundleMeasure constructor.
+      BundleSettingsQsp bundleSettingsQsp( new BundleSettings );
+
+      // Create a BundleControlPoint object to feed its pointer into
+      // the BundleMeasure constructor.
+      BundleControlPoint bundleControlPoint( bundleSettingsQsp, &controlPoint );
+
+      // Finally, the SetUp function creates the BundleMeasure object
+      // from all of the objects made previously.
+      // std::cout << &controlMeasure << '\n';
+      BundleMeasure bundleMeasure( &controlMeasure, &bundleControlPoint );
+
+      // The pointers are then linked to the newly-created BundleMeasure and
+      // BundleControlPoint objects.
+      testBundleMeasurePtr = &bundleMeasure;
+      testBundleControlPointPtr = &bundleControlPoint;
+
+    }
+
+};
+
+TEST_F( BundleMeasure_CreateObj, test1 ) {
+  testBundleMeasurePtr->setRejected(true);
+  EXPECT_TRUE(controlPoint.IsRejected());
+}
+
+// TEST_F( BundleMeasure_CreateObj, Constructor )
+// {
+//   EXPECT_FALSE( testBundleMeasurePtr->isRejected() );
+//
+//   EXPECT_EQ( NULL, testBundleMeasurePtr->camera() );
+//
+//   // May need to check for Not Null rather than checking the BCP pointer.
+//   EXPECT_EQ( testBundleControlPointPtr, testBundleMeasurePtr->parentControlPoint() );
+//
+//   // Without the use of their respective setters, these QSharedPointers will be pointed to NULL
+//   EXPECT_TRUE( testBundleMeasurePtr->parentBundleImage().isNull() );
+//   EXPECT_TRUE( testBundleMeasurePtr->parentBundleObservation().isNull() );
+//   EXPECT_THROW( testBundleMeasurePtr->observationSolveSettings(), IException );
+//
+//   // Uses ISIS' Null value.
+//   EXPECT_EQ( Null, testBundleMeasurePtr->sample() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->sampleResidual() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->line() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->lineResidual() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->residualMagnitude() );
+//   EXPECT_TRUE( testBundleMeasurePtr->cubeSerialNumber().isNull() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneComputedX() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneComputedY() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneMeasuredX() );
+//   EXPECT_EQ( Null, testBundleMeasurePtr->focalPlaneMeasuredY() );
+//   EXPECT_THROW( testBundleMeasurePtr->observationIndex(), IException );
+// }
+//
+//
+// TEST_F( BundleMeasure_CreateObj, CopyConstructor )
+// {
+//   BundleMeasure testBundleMeasure = *testBundleMeasurePtr;
+//
+//   // Using the isRejected Boolean to confirm that the testBundleMeasure
+//   // was copied correctly.
+//   // Note: The default value of isRejected is false.
+//   testBundleMeasure.setRejected( true );
+//
+//   // The copy constructor is then used on the testBundleMeasure object.
+//   BundleMeasure copiedBundleMeasure = BundleMeasure( testBundleMeasure );
+//
+//   // Confirm that this is a copy of the testBundleMeasure by checking the
+//   // isRejected value.
+//   EXPECT_TRUE( copiedBundleMeasure.isRejected() );
+//
+//   // Confirm that the copied BundleMeasure is not simply pointing to
+//   // the testBundleMeasure using the isRejected value again.
+//
+//   copiedBundleMeasure.setRejected( false );
+//
+//   EXPECT_FALSE( copiedBundleMeasure.isRejected() );
+//   EXPECT_TRUE( testBundleMeasure.isRejected() );
+// }
+//
+// TEST_F( BundleMeasure_CreateObj, CopyConstructor2 )
+// {
+//   // Using the isRejected Boolean to confirm that the testBundleMeasure
+//   // was copied correctly.
+//   // Note: The default value of isRejected is false.
+//   std::cout << "Setting Reject" << '\n';
+//   testBundleMeasurePtr->setRejected( true );
+//   std::cout << "Reject Set" << '\n';
+//
+//   // The copy constructor is then used on the testBundleMeasure object.
+//   BundleMeasure copiedBundleMeasure( *testBundleMeasurePtr );
+//
+//   // Confirm that this is a copy of the testBundleMeasure by checking the
+//   // isRejected value.
+//   EXPECT_TRUE( copiedBundleMeasure.isRejected() );
+//
+//   // Confirm that the copied BundleMeasure is not simply pointing to
+//   // the testBundleMeasure using the isRejected value again.
+//
+//   copiedBundleMeasure.setRejected( false );
+//
+//   EXPECT_FALSE( copiedBundleMeasure.isRejected() );
+//   EXPECT_TRUE( testBundleMeasurePtr->isRejected() );
+// }
+//
+// TEST_F( BundleMeasure_CreateObj, AssignmentOperator )
+// {
+//   // Using the isRejected Boolean to confirm that the testBundleMeasure
+//   // was assigned correctly.
+//   // Note: The default value of isRejected is false.
+//   //testBundleMeasurePtr->setRejected( true );
+//   BundleMeasure assignedBundleMeasure = *testBundleMeasurePtr;
+//
+//   // Using the isRejected Boolean to confirm that the testBundleMeasure
+//   // was assigned correctly.
+//   // Note: The default value of isRejected is false.
+//   //assignedBundleMeasure.setRejected( true );
+//
+//
+//
+//
+// }
+//
+// TEST_F( BundleMeasure_CreateObj, IsRejected )
+// {
+//   EXPECT_EQ( false, testBundleMeasurePtr->isRejected() );
+//   testBundleMeasurePtr->setRejected( true );
+//   EXPECT_EQ( true, testBundleMeasurePtr->isRejected() );
+//   testBundleMeasurePtr->setRejected( false );
+//   EXPECT_EQ( false, testBundleMeasurePtr->isRejected() );
+//
+// }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We are currently porting the old ISIS3 tests to the gtest framework, and BundleMeasure was the first Class I was assigned to port over. Since testing most of the functions in BundleMeasure would essentially be testing the Classes it is composed of, only four tests were implemented.  
These are:

- A constructor test
- A copy constructor test
- An assignment operator test
- An isRejected function test.

Note: A test fixture is used to create the BundleMeasure Object for testing, since the only available constructor has many dependencies.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Can't currently find the issue that regards porting the old unit tests to gtest.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We are porting ISIS3's testing suite to gtest, and BundleUtilities was a good place for me to start.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The test file compiles properly and produces the expected (passing) outputs when the testing suite is run.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
