### PR TITLE
Correct documentation.

### DIFF
--- a/isis/src/mro/apps/hijitreg/hijitreg.xml
+++ b/isis/src/mro/apps/hijitreg/hijitreg.xml
@@ -555,7 +555,7 @@
           </brief>
           <description>
              This file will contain the ControlNet created in the hijitreg application.  The data
-             will be in Pvl format.  This option is required if the subsequent transformations of
+             will be in binary control net format (use cnetbin2pvl later to convert to PVL, if needed).  This option is required if the subsequent transformations of
              the FROM files is desired.  hijitreg is specifically designed to apply a 1-D
              transform that shifts each line in the line and sample direction as indicated in
              the control net.


### PR DESCRIPTION
The file written to the path specified by CNETFILE will be in binary control network format, not plain-text PVL format.  

The incorrect description in this documentation has been incorrect for at least 7 years, based on the 'Blame' view of the relevant lines in hijitreg/main.cpp, ControlNet/ControlNet.h, and ControlNet/ControlNet.cpp.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
