### PR TITLE
Fixes Qmos grid to properly consider PositiveWest and PositiveEast

### DIFF
--- a/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
@@ -43,8 +43,12 @@ namespace Isis {
         Latitude maxLat;
         Latitude startLat;
         Latitude endLat;
+      
 
       if (tproj->IsPositiveWest()) {
+        // GridGraphicsItem is written assuming positive east 
+        // for all angles. On positive West, lons come in swapped so we 
+        // need to account for this.
         Longitude temp = lonMin;
         lonMin = lonMax;
         lonMax = temp;
@@ -195,6 +199,9 @@ namespace Isis {
               double y = 0;
               
               bool valid;
+
+              // Set ground according to lon direction to get correct X,Y values 
+              // when drawing lines. 
               if (tproj->IsPositiveWest()) {
                 valid = tproj->SetGround(lat.degrees(), lon.positiveWest(Angle::Degrees));
               }
@@ -289,7 +296,9 @@ namespace Isis {
             while (!atMaxLat) {
               double x = 0;
               double y = 0;
-                
+              
+              // Set ground according to lon direction to get correct X,Y values 
+              // when drawing lines.  
               bool valid;
               if (tproj->IsPositiveWest()) {
                 valid = tproj->SetGround(lat.degrees(), lon.positiveWest(Angle::Degrees));

--- a/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
@@ -44,7 +44,7 @@ namespace Isis {
         Latitude startLat;
         Latitude endLat;
 
-      if (mappingGroup["LongitudeDirection"][0] == "PositiveWest") {
+      if (tproj->IsPositiveWest()) {
         Longitude temp = lonMin;
         lonMin = lonMax;
         lonMax = temp;
@@ -195,7 +195,7 @@ namespace Isis {
               double y = 0;
               
               bool valid;
-              if (mappingGroup["LongitudeDirection"][0] == "PositiveWest") {
+              if (tproj->IsPositiveWest()) {
                 valid = tproj->SetGround(lat.degrees(), lon.positiveWest(Angle::Degrees));
               }
               else {
@@ -291,7 +291,7 @@ namespace Isis {
               double y = 0;
                 
               bool valid;
-              if (mappingGroup["LongitudeDirection"][0] == "PositiveWest") {
+              if (tproj->IsPositiveWest()) {
                 valid = tproj->SetGround(lat.degrees(), lon.positiveWest(Angle::Degrees));
               }
               else {

--- a/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
@@ -48,9 +48,11 @@ namespace Isis {
         Longitude temp = lonMin;
         lonMin = lonMax;
         lonMax = temp;
+        //lonMin.setPositiveWest(-1*lonMin.positiveWest(Angle::Degrees), Angle::Degrees);
+        //lonMax.setPositiveWest(-1*lonMax.positiveWest(Angle::Degrees), Angle::Degrees);
       }
-
-        if (mappingGroup["LatitudeType"][0] == "Planetographic") {
+      
+      if (mappingGroup["LatitudeType"][0] == "Planetographic") {
 
           Distance equaRad(tproj->EquatorialRadius(), Distance::Meters);
           Distance polRad(tproj->PolarRadius(), Distance::Meters);
@@ -193,7 +195,15 @@ namespace Isis {
 
               double x = 0;
               double y = 0;
-              bool valid = tproj->SetUniversalGround(lat.degrees(), lon.degrees());
+
+              
+              bool valid;
+              if (mappingGroup["LongitudeDirection"][0] == "PositiveWest") {
+                valid = tproj->SetGround(lat.degrees(), lon.positiveWest(Angle::Degrees));
+              }
+              else {
+                valid = tproj->SetGround(lat.degrees(), lon.positiveEast(Angle::Degrees));
+              }
 
               if (valid) {
                 x = tproj->XCoord();
@@ -265,7 +275,6 @@ namespace Isis {
 
           // Create the longitude grid lines
           for (Longitude lon = minLon; lon != maxLon + lonInc; lon += lonInc) {
-
             if (lon > endLon && lon < maxLon) {
               lon = endLon;
             }
@@ -283,16 +292,20 @@ namespace Isis {
             while (!atMaxLat) {
               double x = 0;
               double y = 0;
-              bool valid = tproj->SetUniversalGround(lat.degrees(), lon.degrees());
+                
+              bool valid;
+              if (mappingGroup["LongitudeDirection"][0] == "PositiveWest") {
+                valid = tproj->SetGround(lat.degrees(), lon.positiveWest(Angle::Degrees));
+              }
+              else {
+                valid = tproj->SetGround(lat.degrees(), lon.positiveEast(Angle::Degrees));
+              }
 
               if (valid) {
                 x = tproj->XCoord();
                 y = -1 * tproj->YCoord();
 
                 if(havePrevious) {
-                  x = proj->XCoord();
-                  y = -1 * proj->YCoord();
-
                   if(previousX != x || previousY != y) {
                     QGraphicsLineItem* lonLine = 
                         new QGraphicsLineItem(QLineF(previousX, previousY, x, y), this);

--- a/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
@@ -48,8 +48,6 @@ namespace Isis {
         Longitude temp = lonMin;
         lonMin = lonMax;
         lonMax = temp;
-        //lonMin.setPositiveWest(-1*lonMin.positiveWest(Angle::Degrees), Angle::Degrees);
-        //lonMax.setPositiveWest(-1*lonMax.positiveWest(Angle::Degrees), Angle::Degrees);
       }
       
       if (mappingGroup["LatitudeType"][0] == "Planetographic") {
@@ -195,7 +193,6 @@ namespace Isis {
 
               double x = 0;
               double y = 0;
-
               
               bool valid;
               if (mappingGroup["LongitudeDirection"][0] == "PositiveWest") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

PositiveWest in qmos didn't display a line at 360 degrees, this was because the original grid code didn't incorporate positive west at all in its logic. 

This change moves the responsibility of converting between positive west/east to the grid drawing function instead of the projection code. This makes sure the grid is drawn correctly given arbitrary lat/lon ranges. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/USGS-Astrogeology/ISIS3/issues/3417

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually ran qmos with both PositiveWest and PositiveEast projections and changed parameters to ensure grid updates properly. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
