### PR TITLE
*DO NOT MERGE! work thus far for Kaguya Distortion model #3481

### DIFF
--- a/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCameraDistortionMap.cpp
+++ b/isis/src/kaguya/objs/KaguyaTcCamera/KaguyaTcCameraDistortionMap.cpp
@@ -28,14 +28,14 @@
 #include "KaguyaTcCameraDistortionMap.h"
 
 namespace Isis {
-  /** 
+  /**
    * Kaguya TC Camera distortion map constructor
    *
    * Create a camera distortion map for Kaguya's TC1 and TC2
-   * This class maps between distorted and undistorted 
-   * focal plane x/y's. The default mapping is the identity, that is, 
-   * the focal plane x/y and undistorted focal plane x/y will be 
-   * identical. 
+   * This class maps between distorted and undistorted
+   * focal plane x/y's. The default mapping is the identity, that is,
+   * the focal plane x/y and undistorted focal plane x/y will be
+   * identical.
    *
    * @param parent        the parent camera that will use this distortion map
    * @param zDirection    the direction of the focal plane Z-axis
@@ -46,12 +46,18 @@ namespace Isis {
       : CameraDistortionMap(parent) {
     QString odtxkey = "INS" + toString(naifIkCode) + "_DISTORTION_COEF_X";
     QString odtykey = "INS" + toString(naifIkCode) + "_DISTORTION_COEF_Y";
-    
+    QString boresightkey = "INS" + toString(naifIkCode) + "_BORESIGHT";
+
     for(int i = 0; i < 4; ++i) {
       p_odkx.push_back(p_camera->getDouble(odtxkey, i));
       p_odky.push_back(p_camera->getDouble(odtykey, i));
     }
-  }    
+
+    // add boresight x and y to coefficients vector
+    p_odkx.push_back(p_camera->getDouble(boresightkey, 0));
+    p_odky.push_back(p_camera->getDouble(boresightkey, 1));
+
+  }
 
 
 
@@ -62,7 +68,7 @@ namespace Isis {
   }
 
 
-  /** 
+  /**
    * Compute undistorted focal plane x/y
    *
    * Compute undistorted focal plane x/y given a distorted focal plane x/y.
@@ -71,12 +77,12 @@ namespace Isis {
    * implementation uses a polynomial distortion if the SetDistortion method
    * is invoked.  After calling this method, you can obtain the undistorted
    * x/y via the UndistortedFocalPlaneX and UndistortedFocalPlaneY methods
-   *  
+   *
    * This implements the following distortion correction from the IK for the terrain camera,
    * see: SEL_TC_V01.TI
-   *  
-   * r2 = x^2 + y^2 
-   *  
+   *
+   * r2 = x^2 + y^2
+   *
    * Distortion coefficients information:
    *  INS<INSTID>_DISTORTION_COEF_X  = ( a0, a1, a2, a3)
    *  INS<INSTID>_DISTORTION_COEF_Y  = ( b0, b1, b2, b3),
@@ -105,21 +111,20 @@ namespace Isis {
     double y = dy;
 
     double r2 = x*x + y*y;
-    double r = qSqrt(r2); 
-    double r3 = r2 * r; 
+    double r = qSqrt(r2);
+    double r3 = r2 * r;
 
-    // Apply distortion correction
-    double dr_x = p_odkx[0] + p_odkx[1] * r + p_odkx[2] * r2 + p_odkx[3] * r3;
-    double dr_y = p_odky[0] + p_odky[1] * r + p_odky[2] * r2 + p_odky[3] * r3;
+    double dr_x = p_odkx[0] + p_odkx[1] * r + p_odkx[2] * r2 + p_odkx[3] * r3 + p_odkx[4]; //add boresight offset
+    double dr_y = p_odky[0] + p_odky[1] * r + p_odky[2] * r2 + p_odky[3] * r3 + p_odky[4]; //add boresight offset
 
-    p_undistortedFocalPlaneX = x + dr_x; 
+    p_undistortedFocalPlaneX = x + dr_x;
     p_undistortedFocalPlaneY = y + dr_y;
 
     return true;
   }
 
 
-  /** 
+  /**
    * Compute distorted focal plane x/y
    *
    * Compute distorted focal plane x/y given an undistorted focal plane x/y.
@@ -165,7 +170,7 @@ namespace Isis {
       xx = xt * xt;
       yy = yt * yt;
       rr = xx + yy;
-      r = qSqrt(rr); 
+      r = qSqrt(rr);
       rrr = rr * r;
 
       // Radial distortion
@@ -203,4 +208,3 @@ namespace Isis {
     return bConverged;
   }
 }
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I am going to be out for the rest of the week and can't continue working on this issue. These changes cause the unit tests for KaguyaTcCamera to fail.

I've realized that there were some problems with my changes when I originally ran the isis comparison notebook, so this will need to be checked again.

In order to get the unit tests running,the unit tests need to point to new cubes which have been spiceinitted using the new code, these cubes can be found in `/home/pgiroux/KaguyaTestCubes`.

The camera.plugin version number still needs to be upticked, and the cubes in the test data area will likely need to be updated to the newer spiceinitted versions.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3481

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
