### PR TITLE
clemhirescal: Adds support for all MCP gain settings for filters A and D

### DIFF
--- a/isis/src/clementine/apps/clemhirescal/clemhirescal.xml
+++ b/isis/src/clementine/apps/clemhirescal/clemhirescal.xml
@@ -12,6 +12,19 @@
       are four flat images, one for each of the four possible filters.
       Information for this program came from JGR Vol 108, A radiometric
       calibration for the Clementine Hires camera: Robinson, Malaret, White.
+      The original paper can be found at https://doi.org/10.1029/2000JE001241
+
+      The equation for the A filter yields k values that are identical to those
+      in Table 5 from Robinson et al. (2003), therefore the pixel values in the
+      output image are the same as they would be if the k values from Table 5
+      were hard coded into the script.
+      
+      The equation for the D filter yields k values that differ from the
+      hard-coded values by less than 1 standard deviation as reported in Table 6
+      of Robinson et al. (2003).  The radiance values that result from the
+      computed k values differ by no more than .0583% of the radiance values
+      computed from the k values published in Table 6.
+
   </description>
   <history>
     <change name="Mackenzie Boyd" date="2009-08-03">
@@ -19,6 +32,7 @@
     </change>
     <change name="Austin Sanders" date="2019-11-06">
       Replaced lookup tables with calibration equations.
+      See description for more detailed information.
     </change>
   </history>
 

--- a/isis/src/clementine/apps/clemhirescal/clemhirescal.xml
+++ b/isis/src/clementine/apps/clemhirescal/clemhirescal.xml
@@ -9,13 +9,16 @@
       camera. It does so through the use of some constants based on offset and
       flat images based on filter type. There are six possible offsets, with the
       resultant change being anywhere between eight and fifty to the DN. There
-      are four flat images, one for each of the four possible filters. 
-      Information for this program came from JGR Vol 108, A radiometric 
+      are four flat images, one for each of the four possible filters.
+      Information for this program came from JGR Vol 108, A radiometric
       calibration for the Clementine Hires camera: Robinson, Malaret, White.
   </description>
   <history>
     <change name="Mackenzie Boyd" date="2009-08-03">
       Original version
+    </change>
+    <change name="Austin Sanders" date="2019-11-06">
+      Replaced lookup tables with calibration equations.
     </change>
   </history>
 
@@ -110,7 +113,7 @@
         </brief>
         <description>
             The K value is the absolute coefficient per wavelength and MCP gain
-            state. This is an average of several possible K values, the default 
+            state. This is an average of several possible K values, the default
             should not be used when possible as it is an average.
         </description>
       </parameter>

--- a/isis/src/clementine/apps/clemhirescal/main.cpp
+++ b/isis/src/clementine/apps/clemhirescal/main.cpp
@@ -48,22 +48,25 @@ void IsisMain() {
   double dataOffset[] = { -49.172, -41.0799, -32.8988, -24.718, -16.98, -8.0};
   offset = dataOffset[index];
 
-  // Computer the K value to convert to I/F.  The K value per MCP and wavelength
-  // were obtained from JGR publication Vol 108, A radiometric calibration for the
-  // Clementine HIRES camera: Robinson, Malart, White, page 17
+  // Compute the K value to convert to I/F. The functions for K value per MCP
+  //  gain state and filter are based on Robinson, M. S., Malaret, E.,
+  //  and White, T. ( 2003), A radiometric calibration for the Clementine HIRES
+  //  camera, J. Geophys. Res., 108, 5028, doi:10.1029/2000JE001241, E4.
+  //  The functions were determined by fitting a line to the data in Table 5 (A filter)
+  //  or Table 6 (D filter) of Robinson et al., as described on page 11.
   UserInterface &ui = Application::GetUserInterface();
   if(ui.GetString("KFROM").compare("COMPUTED") == 0) {
     wave = wave.toUpper();
     int MCP = label->findGroup("Instrument", Pvl::Traverse)["MCPGainModeID"];
-    // Two possible MCP gains for filter A
+    // Linear fit of values in Table 5
     if(wave == "A") {
         abscoef = ((-5.33333333333333 * pow(10, -5) * MCP) + 0.00937);
     }
-    // Three possiblities for filter D
+    // Linear fit of values in Table 6
     else if(wave == "D") {
         abscoef = ((-9.75301204819275 * pow(10, -5) * MCP) + 0.0163866265);
     }
-    // Other filters not supported for preset K value
+    // Other filters not supported for calculated K value
     else {
       QString message = "Image is of filter [" + wave + "], not supported type A or D, enter your own K value";
       throw IException(IException::User, message, _FILEINFO_);

--- a/isis/src/clementine/apps/clemhirescal/main.cpp
+++ b/isis/src/clementine/apps/clemhirescal/main.cpp
@@ -57,32 +57,11 @@ void IsisMain() {
     int MCP = label->findGroup("Instrument", Pvl::Traverse)["MCPGainModeID"];
     // Two possible MCP gains for filter A
     if(wave == "A") {
-      if(MCP == 156) {
-        abscoef = 0.00105;
-      }
-      else if(MCP == 159) {
-        abscoef = 0.00089;
-      }
-      else {
-        QString message = "Image is not one of supported MCP Gain Mode IDs, enter your own K value";
-        throw IException(IException::Unknown, message, _FILEINFO_);
-      }
+        abscoef = ((-5.33333333333333 * pow(10, -5) * MCP) + 0.00937);
     }
     // Three possiblities for filter D
     else if(wave == "D") {
-      if(MCP == 151) {
-        abscoef = 0.001655;
-      }
-      else if(MCP == 154) {
-        abscoef = 0.001375;
-      }
-      else if(MCP == 158) {
-        abscoef = 0.00097;
-      }
-      else {
-        QString message = "Image is not one of supported MCP Gain Mode IDs, enter your own K value";
-        throw IException(IException::User, message, _FILEINFO_);
-      }
+        abscoef = ((-9.75301204819275 * pow(10, -5) * MCP) + 0.0163866265);
     }
     // Other filters not supported for preset K value
     else {


### PR DESCRIPTION
## Description
Replaces the lookup tables in clemhirescal with calibration equations.  

## Related Issue
Resolves #3190 

## Motivation and Context
The current implementation scales pixel values by a calibration constant (k) that is selected from an incomplete lookup table.  Due to the incompleteness of the lookup tables, we are currently unable to support the full range of Clementine HIRES images unless the user manually derives and specifies a calibration factor.

## How Has This Been Tested?
One image from each filter type (A and D) was tested using the following command:
fx f1=1234_original_cal.cub f2=1234_cal.cub to=tolerance_boolean.cub equation="\(1+(0.01*f1))>=f2>=(1-(0.01*f1))"

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
