### PR TITLE
Cisscal Output Change

### DIFF
--- a/isis/src/cassini/apps/cisscal/cisscal.xml
+++ b/isis/src/cassini/apps/cisscal/cisscal.xml
@@ -15,7 +15,7 @@
       division.  The user may choose between intensity units and I/F for the DN
       to flux conversion.
 
-      If you are trying to run run cisscal on a cube ingested/created with an ISIS
+      If you are trying to run cisscal on a cube ingested/created with an ISIS
       version less than 3.9 and are getting these errors:
       **ERROR** PVL Keyword [ShutterStateId] does not exist in [Group = Instrument].
       **ERROR** Labels do not appear contain a valid Cassini ISS instrument.

--- a/isis/src/cassini/apps/cisscal/cisscal.xml
+++ b/isis/src/cassini/apps/cisscal/cisscal.xml
@@ -13,14 +13,14 @@
       correction, bias subtraction, dark subtraction, non-linearity correction,
       flat field correction, DN to flux conversion, and correction factor
       division.  The user may choose between intensity units and I/F for the DN
-      to flux conversion.  
+      to flux conversion.
 
       If you are trying to run run cisscal on a cube ingested/created with an ISIS
       version less than 3.9 and are getting these errors:
       **ERROR** PVL Keyword [ShutterStateId] does not exist in [Group = Instrument].
       **ERROR** Labels do not appear contain a valid Cassini ISS instrument.
       You will need to reingest the original image using ciss2isis or another
-      ingesting program. 
+      ingesting program.
 
       This application is derived from the IDL CISSCAL
       application developed by the Cassini Imaging Central Laboratory for
@@ -122,7 +122,7 @@
         Step 7: Divide by Correction Factor
       </strong>
       This step is implemented in order to force theory and observation to match.
-      It consists of 2 processes.  First, the image is divided by its correction factor. 
+      It consists of 2 processes.  First, the image is divided by its correction factor.
       This step requires no user defined parameters. It uses a correction factor file found
       in the Cassini calibration correction directory.
       Second, a sensitivity vs time correction is completed.
@@ -228,6 +228,10 @@
       checks for ShutterStateId, added check for bias mean strip,
       updated values in divideByAreaPixel, and added sensitivity vs
       time correction. Fixes #3351.
+    </change>
+    <change name="Adam Paquette" date="2019-11-06">
+      Moved output cube instantiation from the beginning of the script to after
+      the dark subtraction and bit weight corrections have been performed.
     </change>
   </history>
 

--- a/isis/src/cassini/apps/cisscal/cisscal.xml
+++ b/isis/src/cassini/apps/cisscal/cisscal.xml
@@ -230,8 +230,8 @@
       time correction. Fixes #3351.
     </change>
     <change name="Adam Paquette" date="2019-11-06">
-      Moved output cube instantiation from the beginning of the script to after
-      the dark subtraction and bit weight corrections have been performed.
+      Removed the cube when either an associated bitweight file is not present,
+      or the dark current calculation fails.
       Fixes #3446.
     </change>
   </history>

--- a/isis/src/cassini/apps/cisscal/cisscal.xml
+++ b/isis/src/cassini/apps/cisscal/cisscal.xml
@@ -232,6 +232,7 @@
     <change name="Adam Paquette" date="2019-11-06">
       Moved output cube instantiation from the beginning of the script to after
       the dark subtraction and bit weight corrections have been performed.
+      Fixes #3446.
     </change>
   </history>
 

--- a/isis/src/cassini/apps/cisscal/main.cpp
+++ b/isis/src/cassini/apps/cisscal/main.cpp
@@ -121,9 +121,6 @@ void IsisMain() {
   // instead the bitweightCorrected vector is used as the initial values before
   // the rest of the calibration steps are performed.
   gbl::incube = secondpass.SetInputCube("FROM"); // Calibrate() parameter in[0]
-  // we need to set output cube at the beginning of the program to check right
-  // away for CubeCustomization IsisPreference and throw an error, if necessary.
-  Cube *outcube = secondpass.SetOutputCube("TO"); // Calibrate() parameter out[0]
 
   // resize 2dimensional vectors
   gbl::bitweightCorrected.resize(gbl::incube->sampleCount());
@@ -208,6 +205,10 @@ void IsisMain() {
                      _FILEINFO_);
   }
 
+  // we need to set output cube at the beginning of the program to check right
+  // away for CubeCustomization IsisPreference and throw an error, if necessary.
+  Cube *outcube = secondpass.SetOutputCube("TO"); // Calibrate() parameter out[0]
+
   //Linearity Correction
   gbl::Linearize();
 
@@ -272,7 +273,7 @@ void IsisMain() {
  *            check for ShutterStateId, and if it is Disabled,
  *            do not subtract an offset from the exposure time.
  *            Added Sensitivity vs Time Correction after
- *            correction factors. 
+ *            correction factors.
  *            Matches cisscal version 3.9.1.
  */
 void gbl::Calibrate(vector<Buffer *> &in, vector<Buffer *> &out) {
@@ -1315,7 +1316,7 @@ void gbl::FindShutterOffset() {
  * @internal
  *   @history 2008-11-05 Jeannie Walldren - Original version
  *   @history 2019-08-14 Kaitlyn Lee - Added check for
- *            ShutterStateId. Updated solid angle and optics 
+ *            ShutterStateId. Updated solid angle and optics
  *            area values. Matches cisscal version 3.9.1.
  */
 void gbl::DivideByAreaPixel() {
@@ -1333,8 +1334,8 @@ void gbl::DivideByAreaPixel() {
   //  OpticsArea is (Diameter of Primary Mirror)^2 * Pi/4
   //      Optics areas below come from radii in "Final Report, Design
   //      and Analysis of Filters for the Cassini Narrow and Wide
-  //      Optics" by David Hasenauer, May 19, 1994.  
-     
+  //      Optics" by David Hasenauer, May 19, 1994.
+
   //  We will adjust here for the effects of SUM modes
   //  (which effectively give pixels of 4 or 16 times normal size)
 

--- a/isis/src/cassini/apps/cisscal/main.cpp
+++ b/isis/src/cassini/apps/cisscal/main.cpp
@@ -121,6 +121,9 @@ void IsisMain() {
   // instead the bitweightCorrected vector is used as the initial values before
   // the rest of the calibration steps are performed.
   gbl::incube = secondpass.SetInputCube("FROM"); // Calibrate() parameter in[0]
+  // we need to set output cube at the beginning of the program to check right
+  // away for CubeCustomization IsisPreference and throw an error, if necessary.
+  Cube *outcube = secondpass.SetOutputCube("TO"); // Calibrate() parameter out[0]
 
   // resize 2dimensional vectors
   gbl::bitweightCorrected.resize(gbl::incube->sampleCount());
@@ -166,6 +169,8 @@ void IsisMain() {
   else { // Bitweight correction
     FileName bitweightFile = gbl::FindBitweightFile();
     if(!bitweightFile.fileExists()) { // bitweight file not found, stop calibration
+      // Remove the output cube since it will be empty at this point
+      outcube->close(true);
       throw IException(IException::Io,
                        "Unable to calibrate image. BitweightFile ***"
                        + bitweightFile.expanded() + "*** not found.", _FILEINFO_);
@@ -200,14 +205,12 @@ void IsisMain() {
   }
   catch(IException &e) { // cannot perform dark current, stop calibration
     e.print();
+    // Remove the output cube since it will be empty at this point
+    outcube->close(true);
     throw IException(e, IException::Unknown,
                      "Unable to calibrate image. Dark current calculations failed.",
                      _FILEINFO_);
   }
-
-  // we need to set output cube at the beginning of the program to check right
-  // away for CubeCustomization IsisPreference and throw an error, if necessary.
-  Cube *outcube = secondpass.SetOutputCube("TO"); // Calibrate() parameter out[0]
 
   //Linearity Correction
   gbl::Linearize();

--- a/isis/src/cassini/apps/cisscal/tsts/badCisscalImage/Makefile
+++ b/isis/src/cassini/apps/cisscal/tsts/badCisscalImage/Makefile
@@ -1,0 +1,9 @@
+APPNAME = cisscal
+
+include $(ISISROOT)/make/isismake.tsts
+
+
+commands:
+	-$(APPNAME) from=$(INPUT)/N1605851822_1.cub \
+	to=$(OUTPUT)/N1605851822_1.truth.cub >& $(OUTPUT)/error.txt;
+	$(RM) print.prt > /dev/null;


### PR DESCRIPTION
Updated cisscal output cub creation to after bitweight correction and dark subtraction

## Description
Moved the output cube correction to after potential errors could be thrown from cisscal, preventing an empty cube from being created.

## Related Issue
Closes #3446

## Motivation and Context
This change prevents pipelines from trying to use bad output data from cisscal.

## How Has This Been Tested?
A new test has been added to check if one of these images does indeed fail, and fails in the way we expect it to fail.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
