### PR TITLE
Replaced code, removed earlier, that abandons work on a tile Fixes: #3466

### DIFF
--- a/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
+++ b/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
@@ -901,10 +901,6 @@ namespace Isis {
       osamps.push_back(tsamp);
       olines.push_back(tline);
     }
-    else {
-      splitPatch(ssamp, esamp, sline, eline, iportal, trans, interp);
-      return;
-    }
 
     // Upper right control point
     if (trans.Xform(tsamp,tline,esamp,sline)) {
@@ -912,10 +908,6 @@ namespace Isis {
       ilines.push_back(sline);
       osamps.push_back(tsamp);
       olines.push_back(tline);
-    }
-    else {
-      splitPatch(ssamp, esamp, sline, eline, iportal, trans, interp);
-      return;
     }
 
     // Lower left control point
@@ -925,10 +917,6 @@ namespace Isis {
       osamps.push_back(tsamp);
       olines.push_back(tline);
     }
-    else {
-      splitPatch(ssamp, esamp, sline, eline, iportal, trans, interp);
-      return;
-    }
 
     // Lower right control point
     if (trans.Xform(tsamp,tline,esamp,eline)) {
@@ -937,7 +925,15 @@ namespace Isis {
       osamps.push_back(tsamp);
       olines.push_back(tline);
     }
-    else {
+
+    // If none of the 4 input tile corners transformed inside the output cube, give up on this tile
+    // NOTE: Probably should split if the tile is large
+    if (isamps.size() == 0) {
+      return;
+    }
+
+    // If at least one of the 4 input tile corners did NOT transform, spit it
+    if (isamps.size() < 4) {
       splitPatch(ssamp, esamp, sline, eline, iportal, trans, interp);
       return;
     }

--- a/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
+++ b/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
@@ -932,7 +932,7 @@ namespace Isis {
       return;
     }
 
-    // If at least one of the 4 input tile corners did NOT transform, spit it
+    // If at least one of the 4 input tile corners did NOT transform, split it
     if (isamps.size() < 4) {
       splitPatch(ssamp, esamp, sline, eline, iportal, trans, interp);
       return;


### PR DESCRIPTION
…is outside the output image

<!--- Provide a general summary of your changes in the Title above -->

## Description
Previous work on ProcessRubberSheet removed an explicit test to abandon work on a tile if none of the four corners projected into the output cube. This test was put back to keep the algorithm from quadtreeing tiles that are outside the output cube.  It is possible for all four corners of a tile to be outside the output cube, but still have data that needs to be projected (e.g., a corner of the output cube intersects an edge of the tile, but not any corners, or the tile contains the entire output cube).

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/3466

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The issue reported a case where the program appeared to run forever. It was in fact running very slow (100's of time slower than before the test was removed). The slowness was magnified by the lat/lon range used. Only a small portion of the input image was in the output range.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Timing test were performed before and after the change. All times returned to their expected values (i.e., they were better than before the original change that removed the tests).
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Putting the four corner test back in increased the performance of cam2map forward patch when a large portion of the input cube does not project into the output cube. The increase is estimated to be at least one order of magnitude. This change also slows down the same forward patch algorithm for case where most of the input cube projects into the output cube, but only slightly (estimated to be a few seconds).

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
