### PR TITLE
Adding truth data folder to photomet app test testDemWarning

### DIFF
--- a/isis/src/base/apps/photomet/tsts/testDemWarning/truth/test_mix_DEM.pvl
+++ b/isis/src/base/apps/photomet/tsts/testDemWarning/truth/test_mix_DEM.pvl
@@ -1,0 +1,20 @@
+Group = NormalizationModelParametersUsed
+  NORMNAME = MIXED
+  INCREF   = 0.0
+  INCMAT   = 80.0
+  THRESH   = 30.0
+  ALBEDO   = 1.0
+End_Group
+
+Group = AtmosphericModelParametersUsed
+End_Group
+
+Group = PhotometricModelParametersUsed
+  PHTNAME = MINNAERT
+  K       = 0.5
+End_Group
+
+Group = Warning
+  Warning = "The MIXED Normalized model is not recommended for use with the
+             DEM Angle Source option"
+End_Group

--- a/isis/src/base/apps/photomet/tsts/testDemWarning/truth/test_topo_DEM.pvl
+++ b/isis/src/base/apps/photomet/tsts/testDemWarning/truth/test_topo_DEM.pvl
@@ -1,0 +1,19 @@
+Group = NormalizationModelParametersUsed
+  NORMNAME = TOPO
+  INCREF   = 0.0
+  THRESH   = 30.0
+  ALBEDO   = 1.0
+End_Group
+
+Group = AtmosphericModelParametersUsed
+End_Group
+
+Group = PhotometricModelParametersUsed
+  PHTNAME = MINNAERT
+  K       = 0.5
+End_Group
+
+Group = Warning
+  Warning = "The TOPO Normalized model is not recommended for use with the DEM
+             Angle Source option"
+End_Group


### PR DESCRIPTION
Adding the truth folder necessary for the photomet app test of testDemWarning

## Description
I forgot to include this data in my original photomet warning update PR (#3486 ). 

## Related Issue
Related to issue #3519 

## Motivation and Context
This data is necessary for the photomet app tests. When I ran the tests locally, everything worked fine, but now the same tests are failing on Jenkins. 

## How Has This Been Tested?
This is the test...
Worked on my computer when I was running the app tests locally 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
