### PR TITLE
fixed compiler warning. Fixes #3531

### DIFF
--- a/isis/src/mro/apps/marci2isis/main.cpp
+++ b/isis/src/mro/apps/marci2isis/main.cpp
@@ -229,7 +229,7 @@ void IsisMain() {
         PvlKeyword varExposure("VariableExposureDuration");
         PvlKeyword frameNumber("FrameNumber");
 
-        for (int i=0; i < exptime.size(); i++) {
+        for (unsigned int i=0; i < exptime.size(); i++) {
           varExposure.addValue( QString::number(exptime[i]), "ms" );
           frameNumber.addValue( QString::number(frameseq[i]) );
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed comparison of singed and unsigned ints

## Description
<!--- Describe your changes in detail -->
Retyped loop variable to unsigned int

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Newer compiler was issuing a warning

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Reran all tests
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
