### PR TITLE
Added preferences variable to shapemodel path.

### DIFF
--- a/isis/src/base/apps/spiceinit/tsts/shapemodel/Makefile
+++ b/isis/src/base/apps/spiceinit/tsts/shapemodel/Makefile
@@ -9,13 +9,13 @@ commands:
 # Test with IsisPreferences set for Embree
 	cp $(INPUT)/st_2458542208_v.cub $(OUTPUT)/ > /dev/null;
 	$(APPNAME) from=$(OUTPUT)/st_2458542208_v.cub shape=user \
-	model=$(ISIS3DATA)/hayabusa/kernels/dsk/hay_a_amica_5_itokawashape_v1_0_512q.bds \
+	model='$$hayabusa/kernels/dsk/hay_a_amica_5_itokawashape_v1_0_64q.bds' \
 	-pref=$(INPUT)/IsisPreferences_embree > /dev/null;
 	catlab from=$(OUTPUT)/st_2458542208_v.cub to=$(OUTPUT)/label_embree.pvl > /dev/null;
 
 # Test with IsisPreferences set for Bullet
 	$(APPNAME) from=$(OUTPUT)/st_2458542208_v.cub shape=user \
-	model=$(ISIS3DATA)/hayabusa/kernels/dsk/hay_a_amica_5_itokawashape_v1_0_512q.bds \
+	model='$$hayabusa/kernels/dsk/hay_a_amica_5_itokawashape_v1_0_64q.bds' \
 	-pref=$(INPUT)/IsisPreferences_bullet > /dev/null; 
 	catlab from=$(OUTPUT)/st_2458542208_v.cub to=$(OUTPUT)/label_bullet.pvl > /dev/null;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Edited makefile with updated shapemodel path.

## Description
Replaced local path with relative path based on configuration file.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Resolves #3520

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Jenkins fails because the makefile uses local data.  This changes the makefile to use a relative path.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
make test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
