### PR TITLE
Removed requirement of having to start a path with a slash Fixes #3534

### DIFF
--- a/isis/src/base/apps/pvldiff/main.cpp
+++ b/isis/src/base/apps/pvldiff/main.cpp
@@ -134,8 +134,8 @@ void compareKeywords(PvlKeyword &pvl1, PvlKeyword &pvl2) {
     if ( ignoreFilePaths.hasKeyword(pvl1.name()) &&
          (((ignoreFilePaths[pvl1.name()].size() > 1 && ignoreFilePaths[pvl1.name()][i] == "true") ||
          (ignoreFilePaths[pvl1.name()].size() == 1 && ignoreFilePaths[pvl1.name()][0] == "true"))) ) {
-      val1 =  val1.replace(QRegularExpression("(\\/[\\w\\-\\. ]*)+\\/"), "");
-      val2 =  val2.replace(QRegularExpression("(\\/[\\w\\-\\. ]*)+\\/"), "");
+      val1 =  val1.replace(QRegularExpression("(\[\\w\\-\\$\\. ]*)+\\/"), "");
+      val2 =  val2.replace(QRegularExpression("(\[\\w\\-\\$\\. ]*)+\\/"), "");
     }
 
 


### PR DESCRIPTION
… the dollar sign to the regex to allow the ignorepath feature to ignore file paths that start with an environment or isis variable

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
