### PR TITLE
Added flag to skip SSL verification in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ pipeline
                                       # Use the conda cache running on the Jenkins host
                                       conda config --set channel_alias http://dmz-jenkins.wr.usgs.gov
                                       conda config --set always_yes True
+                                      conda config --set ssl_verify false 
                                       conda create -n isis python=3
                                     '''
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,7 @@ pipeline
                                 stage ("${label}") {
 
                                     env.STAGE_STATUS = "Checking out ISIS"
+                                    git config --global http.sslVerify false
                                     checkout scm
                                     isisEnv.add("ISISROOT=${pwd()}/build")
                                     cmakeFlags.add("-DCMAKE_INSTALL_PREFIX=${pwd()}/install")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline
                                 stage ("${label}") {
 
                                     env.STAGE_STATUS = "Checking out ISIS"
-                                    sh `git config --global http.sslVerify false`
+                                    sh 'git config --global http.sslVerify false'
                                     checkout scm
                                     isisEnv.add("ISISROOT=${pwd()}/build")
                                     cmakeFlags.add("-DCMAKE_INSTALL_PREFIX=${pwd()}/install")

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline
                                 stage ("${label}") {
 
                                     env.STAGE_STATUS = "Checking out ISIS"
-                                    git config --global http.sslVerify false
+                                    sh `git config --global http.sslVerify false`
                                     checkout scm
                                     isisEnv.add("ISISROOT=${pwd()}/build")
                                     cmakeFlags.add("-DCMAKE_INSTALL_PREFIX=${pwd()}/install")

--- a/build.groovy
+++ b/build.groovy
@@ -56,6 +56,7 @@ def setGitHubBuildStatus(status) {
 node("${env.OS.toLowerCase()}") {
     stage ("Checkout") {
         env.STAGE_STATUS = "Checking out ISIS"
+        git config --global http.sslVerify false
         checkout scm
         isisEnv.add("ISISROOT=${pwd()}/build")
         cmakeFlags.add("-DCMAKE_INSTALL_PREFIX=${pwd()}/install")

--- a/build.groovy
+++ b/build.groovy
@@ -56,7 +56,7 @@ def setGitHubBuildStatus(status) {
 node("${env.OS.toLowerCase()}") {
     stage ("Checkout") {
         env.STAGE_STATUS = "Checking out ISIS"
-        sh `git config --global http.sslVerify false`
+        sh 'git config --global http.sslVerify false'
         checkout scm
         isisEnv.add("ISISROOT=${pwd()}/build")
         cmakeFlags.add("-DCMAKE_INSTALL_PREFIX=${pwd()}/install")

--- a/build.groovy
+++ b/build.groovy
@@ -56,7 +56,7 @@ def setGitHubBuildStatus(status) {
 node("${env.OS.toLowerCase()}") {
     stage ("Checkout") {
         env.STAGE_STATUS = "Checking out ISIS"
-        git config --global http.sslVerify false
+        sh `git config --global http.sslVerify false`
         checkout scm
         isisEnv.add("ISISROOT=${pwd()}/build")
         cmakeFlags.add("-DCMAKE_INSTALL_PREFIX=${pwd()}/install")

--- a/build.groovy
+++ b/build.groovy
@@ -68,6 +68,7 @@ node("${env.OS.toLowerCase()}") {
             # Use the conda cache running on the Jenkins host
             conda config --set channel_alias http://dmz-jenkins.wr.usgs.gov
             conda config --set always_yes True
+            conda config --set ssl_verify false 
             conda create -n isis python=3
         '''
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a command to disable SSL verify before checking out the repo in the Jenkins CI build.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No issue, we're troubleshooting this through ASC IT. The reason we are disabling this stuff is that DOI likes to change our SSL certificates very frequently. This causes anything that needs to hit an external server to fail. Removing SSL verification will allow us to keep working as DOI changes things on us.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Jenkins builds are now running but failing at checkout.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This PR will test the build.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
