### PR TITLE
Update photomet's LunarLambertEmperical model to handle PVL input in photemplate format. Fixes #3608

### DIFF
--- a/isis/src/base/objs/LunarLambertEmpirical/LunarLambertEmpirical.cpp
+++ b/isis/src/base/objs/LunarLambertEmpirical/LunarLambertEmpirical.cpp
@@ -61,6 +61,7 @@ namespace Isis {
     p_photoPhaseCurveList.clear();
   }
 
+
   /**
     * Set the empirical Lunar Lambert function phase angle list.  This is the list
     * of phase angles that Lunar Lambert L values and phase curve list values will
@@ -86,6 +87,40 @@ namespace Isis {
     }
   }
 
+
+  /**
+    * Set the empirical Lunar Lambert function phase angle list.  This is the list
+    * of phase angles that Lunar Lambert L values and phase curve list values will
+    * be provided for. A spline curve will be used to interpolate L values and
+    * phase curve values that exist between the given phase angles. The values
+    * in the phase angle list are limited to values that are >=0 and <=180.
+    *
+    * @param phaselist  PvlKeyword containing phase angles to interpolate
+    */
+  void LunarLambertEmpirical::SetPhotoPhaseList(PvlKeyword phaseList) {
+
+    // If the format is Keyword="1,2,3,4,5" rather than Keyword = (1,2,3,4,5) 
+    if (phaseList.size() == 1) {
+      SetPhotoPhaseList(QString(phaseList));
+      return;
+    }
+
+    double phaseAngle;
+    p_photoPhaseList.clear();
+
+    for (int i=0; i< phaseList.size(); i++) {
+      phaseAngle = phaseList[i].toDouble();
+
+      if (phaseAngle < 0.0 || phaseAngle > 180.0) {
+        QString msg = "Invalid value of empirical Lunar Lambert phase angle list value [" +
+                          toString(phaseAngle) + "]";
+        throw IException(IException::User, msg, _FILEINFO_);
+      }
+      p_photoPhaseList.push_back(phaseAngle);
+    }
+  }
+
+
   /**
     * Set the empirical Lunar Lambert function L exponent list.  This is used to
     * govern the limb-darkening in the Lunar Lambert photometric function.  Values
@@ -107,6 +142,32 @@ namespace Isis {
     }
   }
 
+
+  /**
+    * Set the empirical Lunar Lambert function L exponent list.  This is used to
+    * govern the limb-darkening in the Lunar Lambert photometric function.  Values
+    * of the Lunar Lambert exponent generally fall in the range from 0.0
+    * (Lambert function) to 1.0 (Lommel-Seeliger or "lunar" function). There are
+    * no limits on the value of this parameter, but values far outside the 0 to 1
+    * range will not be very useful.
+    *
+    * @param llist  PvkKeyword containing List of Lunar Lambert function exponents to interpolate
+    */
+  void LunarLambertEmpirical::SetPhotoLList(PvlKeyword lstrList) {
+
+    // If the format is Keyword="1,2,3,4,5" rather than Keyword = (1,2,3,4,5) 
+    if (lstrList.size() == 1) {
+      SetPhotoLList(QString(lstrList));
+      return;
+    }
+
+    p_photoLList.clear();
+    for (int i=0; i<lstrList.size(); i++) {
+      p_photoLList.push_back(lstrList[i].toDouble());
+    }
+  }
+
+
   /**
     * Set the empirical Lunar Lambert function phase curve list.  This list provides
     * the brightness values that correspond to the limb-darkening values in the
@@ -124,6 +185,30 @@ namespace Isis {
       p_photoPhaseCurveList.push_back(phasecurve);
     }
   }
+
+
+  /**
+    * Set the empirical Lunar Lambert function phase curve list.  This list provides
+    * the brightness values that correspond to the limb-darkening values in the
+    * empirical Lunar Lambert photometric function.
+    *
+    * @param phasecurvelist  PvlKeyword containing list of brightness values corresponding 
+    * to Lunar Lambert function exponents
+    */
+  void LunarLambertEmpirical::SetPhotoPhaseCurveList(PvlKeyword photocurvestrList) {
+
+    // If the format is Keyword="1,2,3,4,5" rather than Keyword = (1,2,3,4,5) 
+    if (photocurvestrList.size() == 1) {
+      SetPhotoPhaseCurveList(QString(photocurvestrList));
+      return;
+    }
+
+    p_photoPhaseCurveList.clear();
+    for (int i=0; i<photocurvestrList.size(); i++) {
+      p_photoPhaseCurveList.push_back(photocurvestrList[i].toDouble());
+    }
+  }
+
 
   double LunarLambertEmpirical::PhotoModelAlgorithm(double phase, double incidence,
                                        double emission) {

--- a/isis/src/base/objs/LunarLambertEmpirical/LunarLambertEmpirical.h
+++ b/isis/src/base/objs/LunarLambertEmpirical/LunarLambertEmpirical.h
@@ -55,6 +55,10 @@ namespace Isis {
    *
    * @internal
    *  @history 2011-08-17 Janet Barrett - Ported from ISIS2 to ISIS3.
+   *  @history 2019-12-19 Kristin Berry - Updated to add support for PvlKeywords to
+   *                         SetPhotoPhaseList, SetPhotoLList, and SetPhotoPhaseCurveList
+   *                         Fixes #3608, this allows photomet to work with this model
+   *                         using FROMPVL, rather than specifying the lists directly. 
    */
   class LunarLambertEmpirical : public PhotoModel {
     public:
@@ -62,8 +66,11 @@ namespace Isis {
       virtual ~LunarLambertEmpirical();
 
       void SetPhotoPhaseList(QString phasestrlist);
+      void SetPhotoPhaseList(PvlKeyword phaselist); 
       void SetPhotoLList(QString kstrlist);
+      void SetPhotoLList(PvlKeyword lstrList);
       void SetPhotoPhaseCurveList(QString phasecurvestrlist);
+      void SetPhotoPhaseCurveList(PvlKeyword phasecurvestrlist);
 
       //! Return photometric phase angle list
 //      inline std::vector<double> PhotoPhaseList() const {

--- a/isis/src/base/objs/LunarLambertEmpirical/LunarLambertEmpirical.truth
+++ b/isis/src/base/objs/LunarLambertEmpirical/LunarLambertEmpirical.truth
@@ -26,3 +26,27 @@ Albedo = 0.0087672
 Test phase=180.0, incidence=90.0, emission=90.0 ...
 Albedo = -0
 
+Object = PhotometricModel
+  Group = Algorithm
+    Name           = LunarLambertEmpirical
+    PhaseList      = (0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120,
+                      130, 140)
+    LList          = (0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1,
+                      1.2, 1.3, 1.4)
+    PhaseCurveList = (0, 0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7, 3, 3.3,
+                      3.6, 3.9, 4.2)
+  End_Group
+End_Object
+End
+
+Test phase=0.0, incidence=0.0, emission=0.0 ...
+Albedo = 0
+Test phase=38.0, incidence=11.0, emission=20.0 ...
+Albedo = 1.13647
+Test phase=65.0, incidence=45.0, emission=30.0 ...
+Albedo = 1.62206
+Test phase=127.0, incidence=52.0, emission=33.0 ...
+Albedo = 3.4634
+Test phase=180.0, incidence=90.0, emission=90.0 ...
+Albedo = 9.72
+

--- a/isis/src/base/objs/LunarLambertEmpirical/unitTest.cpp
+++ b/isis/src/base/objs/LunarLambertEmpirical/unitTest.cpp
@@ -62,5 +62,64 @@ int main() {
     e.print();
   }
 
+  // Test Keyword = (1,2,3,4,5) format for input
+  // 
+  // The actual numbers used for this test are not relevant -- this test's primary purpose is to 
+  // ensure that this format of input is usable for the calculations done by the class without the 
+  // program error-ing out. 
+  PvlGroup algOtherFormat("Algorithm");
+  algOtherFormat += PvlKeyword("Name", "LunarLambertEmpirical");
+
+  PvlKeyword phaseList("PhaseList");
+  PvlKeyword lList("LList"); 
+  PvlKeyword phaseCurveList("PhaseCurveList");
+
+  for (int i=0; i < 15; i++) {
+    phaseList += QString::number(i*10);
+    lList += QString::number(i*0.1); 
+    phaseCurveList += QString::number(i*0.3);
+  }
+
+  algOtherFormat += phaseList; 
+  algOtherFormat += lList; 
+  algOtherFormat += phaseCurveList; 
+
+  PvlObject photometricModel("PhotometricModel");
+  photometricModel.addGroup(algOtherFormat);
+
+  Pvl pvlOtherFormat;
+  pvlOtherFormat.addObject(photometricModel);
+  std::cout << pvlOtherFormat << std::endl << std::endl;
+
+  try {
+    PhotoModel *pm = PhotoModelFactory::Create(pvlOtherFormat);
+
+    std::vector<double>phaselist = pm->PhotoPhaseList();
+
+    std::cout << "Test phase=0.0, incidence=0.0, emission=0.0 ..." <<
+              std::endl;
+    std::cout << "Albedo = " << pm->CalcSurfAlbedo(0.0, 0.0, 0.0) <<
+              std::endl;
+    std::cout << "Test phase=38.0, incidence=11.0, emission=20.0 ..." <<
+              std::endl;
+    std::cout << "Albedo = " << pm->CalcSurfAlbedo(38.0, 11.0, 20.0) <<
+              std::endl;
+    std::cout << "Test phase=65.0, incidence=45.0, emission=30.0 ..." <<
+              std::endl;
+    std::cout << "Albedo = " << pm->CalcSurfAlbedo(65.0, 45.0, 30.0) <<
+              std::endl;
+    std::cout << "Test phase=127.0, incidence=52.0, emission=33.0 ..." <<
+              std::endl;
+    std::cout << "Albedo = " << pm->CalcSurfAlbedo(127.0, 52.0, 33.0) <<
+              std::endl;
+    std::cout << "Test phase=180.0, incidence=90.0, emission=90.0 ..." <<
+              std::endl;
+    std::cout << "Albedo = " << pm->CalcSurfAlbedo(180.0, 90.0, 90.0) <<
+              std::endl << std::endl;
+  }
+  catch(IException &e) {
+    e.print();
+  }
+
   return 0;
 }


### PR DESCRIPTION
# Description
This updates the `photomet` LunarLambertEmperical model to handle frompvl input of of the form `PvlKeyword = (1,2,3,3,4)` in addition to  `PvlKeyword = "1,2,3,3,4"`

In addition to the related issue, since the ISIS application `photemplate` produces PVL files in this format, supporting this format of input is important. 

## Related Issue
#3608 

## Motivation and Context
`photomet` would fail when used with the `frompvl` parameter and `model='LunarLambertEmperical` if the pvl specified was of the format generated by `photemplate` and has keywords of the form: 
`PvlKeyword = (1,2,3,3,4)`.

## How Has This Been Tested?
Existing unit test passes and the failure from #3608 can no longer be replicated using the test data.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
