### PR TITLE
Fix for spkwriter test failing with bad personal IsisPreference file.…

### DIFF
--- a/isis/src/base/apps/spkwriter/tsts/apollo15_mixed/Makefile
+++ b/isis/src/base/apps/spkwriter/tsts/apollo15_mixed/Makefile
@@ -12,8 +12,9 @@ commands: $(BASES)
 #  Only use 12 digits in the output of tabledump due to precision issues
 $(BASES): $(OUTPUT)/apollo15_mixed.bsp
 	$(CP) $(INPUT)/$@.cub $(OUTPUT)
-	spiceinit $(ISISROOT)/TestPreferences from=$(OUTPUT)/$@.cub ckrecon=true cksmithed=true spk=$(OUTPUT)/apollo15_mixed.bsp > /dev/null;
-	tabledump $(ISISROOT)/TestPreferences from=$(OUTPUT)/$@.cub to=$(OUTPUT)/$@.txt \
+	spiceinit $(TSTARGS) from=$(OUTPUT)/$@.cub ckrecon=true cksmithed=true \
+	  spk=$(OUTPUT)/apollo15_mixed.bsp > /dev/null;
+	tabledump $(TSTARGS) from=$(OUTPUT)/$@.cub to=$(OUTPUT)/$@.txt \
 	  name=InstrumentPosition > /dev/null;
 	$(RM) $(OUTPUT)/$@.cub 
 

--- a/isis/src/base/apps/spkwriter/tsts/apollo15_mixed/Makefile
+++ b/isis/src/base/apps/spkwriter/tsts/apollo15_mixed/Makefile
@@ -12,8 +12,8 @@ commands: $(BASES)
 #  Only use 12 digits in the output of tabledump due to precision issues
 $(BASES): $(OUTPUT)/apollo15_mixed.bsp
 	$(CP) $(INPUT)/$@.cub $(OUTPUT)
-	spiceinit from=$(OUTPUT)/$@.cub ckrecon=true cksmithed=true spk=$(OUTPUT)/apollo15_mixed.bsp > /dev/null;
-	tabledump from=$(OUTPUT)/$@.cub to=$(OUTPUT)/$@.txt \
+	spiceinit $(ISISROOT)/TestPreferences from=$(OUTPUT)/$@.cub ckrecon=true cksmithed=true spk=$(OUTPUT)/apollo15_mixed.bsp > /dev/null;
+	tabledump $(ISISROOT)/TestPreferences from=$(OUTPUT)/$@.cub to=$(OUTPUT)/$@.txt \
 	  name=InstrumentPosition > /dev/null;
 	$(RM) $(OUTPUT)/$@.cub 
 

--- a/isis/src/base/apps/spkwriter/tsts/mariner10/Makefile
+++ b/isis/src/base/apps/spkwriter/tsts/mariner10/Makefile
@@ -5,16 +5,16 @@ include $(ISISROOT)/make/isismake.tsts
 #  Only use 12 digits in the output of tabledump due to precision issues
 commands:
 	$(APPNAME) FROM=$(INPUT)/0027399.cub \
-	TO=$(OUTPUT)/0027399.bsp > /dev/null;
+	           TO=$(OUTPUT)/0027399.bsp > /dev/null;
 	$(CP) $(INPUT)/0027399.cub $(OUTPUT)
-	spiceinit from=$(OUTPUT)/0027399.cub \
-	 spk=$(OUTPUT)/0027399.bsp > /dev/null;
-	tabledump from=$(OUTPUT)/0027399.cub \
+	spiceinit $(TSTARGS) from=$(OUTPUT)/0027399.cub \
+	   spk=$(OUTPUT)/0027399.bsp > /dev/null;
+	tabledump $(TSTARGS) from=$(OUTPUT)/0027399.cub \
 	  to=$(OUTPUT)/0027399.dat \
 	  name=InstrumentPosition > /dev/null;
-	cat $(OUTPUT)/0027399.dat \
-	  | sed 's/\([0-9][0-9]*\.[0-9]\{12\}\)\([0-9][0-9]*\)/\1/g' \
-	  > $(OUTPUT)/0027399.txt;
+	cat $(OUTPUT)/0027399.dat | \
+	  sed 's/\([0-9][0-9]*\.[0-9]\{12\}\)\([0-9][0-9]*\)/\1/g' > \
+	  $(OUTPUT)/0027399.txt;
 	$(RM) $(OUTPUT)/0027399.cub 
 	$(RM) $(OUTPUT)/0027399.bsp
 	$(RM) $(OUTPUT)/0027399.dat

--- a/isis/src/base/apps/spkwriter/tsts/messenger/Makefile
+++ b/isis/src/base/apps/spkwriter/tsts/messenger/Makefile
@@ -5,11 +5,11 @@ include $(ISISROOT)/make/isismake.tsts
 #  Only use 12 digits in the output of tabledump due to precision issues
 commands:
 	$(APPNAME) FROM=$(INPUT)/EW1025478282G.lev1.cub \
-	TO=$(OUTPUT)/EW1025478282G.bsp > /dev/null;
+	  TO=$(OUTPUT)/EW1025478282G.bsp > /dev/null;
 	$(CP) $(INPUT)/EW1025478282G.lev1.cub $(OUTPUT)
-	spiceinit from=$(OUTPUT)/EW1025478282G.lev1.cub \
-	 spk=$(OUTPUT)/EW1025478282G.bsp > /dev/null;
-	tabledump from=$(OUTPUT)/EW1025478282G.lev1.cub \
+	spiceinit $(TSTARGS) from=$(OUTPUT)/EW1025478282G.lev1.cub \
+	  spk=$(OUTPUT)/EW1025478282G.bsp > /dev/null;
+	tabledump $(TSTARGS) from=$(OUTPUT)/EW1025478282G.lev1.cub \
 	  to=$(OUTPUT)/EW1025478282G.txt \
 	  name=InstrumentPosition > /dev/null;
 #	cat $(OUTPUT)/EW1025478282G.dat \


### PR DESCRIPTION
… Fixes #3623

<!--- Provide a general summary of your changes in the Title above -->
Fixed the spkwriter test to not fail with an invalid personal IsisPreference file by specifying the TestPreference file on the command line for spiceinit and tabledump

## Description
<!--- Describe your changes in detail -->
same

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
