### PR TITLE
Moved Kernel type compositon to source file

### DIFF
--- a/isis/src/system/objs/Kernel/Kernel.cpp
+++ b/isis/src/system/objs/Kernel/Kernel.cpp
@@ -181,4 +181,17 @@ namespace Isis {
   bool Kernel::operator<(const Kernel &other) const {
     return (this->m_kernelType < other.m_kernelType);
   }
+
+
+  /**
+   * Logical operator for combining Type flags.
+   *
+   * @param a The first Type flag.
+   * @param b The second Type flag.
+   *
+   * @return Type flag that contains all Types in a and all Types in b.
+   */
+  Kernel::Type operator|(Kernel::Type a, Kernel::Type b) {
+      return static_cast<Kernel::Type>(static_cast<int>(a) | static_cast<int>(b));
+  }
 } //end namespace isis

--- a/isis/src/system/objs/Kernel/Kernel.h
+++ b/isis/src/system/objs/Kernel/Kernel.h
@@ -88,16 +88,7 @@ namespace Isis {
       Type m_kernelType;     //!< Enumeration value indicating the kernel type
   };
 
-  /**
-   * Logical operator for combining Type flags.
-   *
-   * @param a The first Type flag.
-   * @param b The second Type flag.
-   *
-   * @return Type flag that contains all Types in a and all Types in b.
-   */
-  Kernel::Type operator|(Kernel::Type a, Kernel::Type b) {
-      return static_cast<Kernel::Type>(static_cast<int>(a) | static_cast<int>(b));
-  }
+
+  Kernel::Type operator|(Kernel::Type a, Kernel::Type b);
 };
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Moved the definition of the Kernel::Type composition function into Kernels.cpp

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixed an error introduced by #3626 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Removing the inline caused re-definition errors during linking of the .o files:
```
/usr/bin/ld.gold: error: objects/CMakeFiles/isis3.dir/system/objs/KernelDb/KernelDb.cpp.o: multiple definition of 'Isis::operator|(Isis::Kernel::Type, Isis::Kernel::Type)'
/usr/bin/ld.gold: objects/CMakeFiles/isis3.dir/system/objs/Kernel/Kernel.cpp.o: previous definition here
/usr/bin/ld.gold: error: objects/CMakeFiles/isis3.dir/system/apps/kerneldbgen/SpiceDbGen.cpp.o: multiple definition of 'Isis::operator|(Isis::Kernel::Type, Isis::Kernel::Type)'
/usr/bin/ld.gold: objects/CMakeFiles/isis3.dir/system/objs/Kernel/Kernel.cpp.o: previous definition here
collect2: error: ld returned 1 exit status
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built locally and the tests that use it passed on Mac and Linux.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
