### PR TITLE
Adds NthOrderPolynomial class to ISIS needed for jitterfit for EIS

### DIFF
--- a/isis/src/base/objs/NthOrderPolynomial/Makefile
+++ b/isis/src/base/objs/NthOrderPolynomial/Makefile
@@ -1,0 +1,7 @@
+ifeq ($(ISISROOT), $(BLANK))
+.SILENT:
+error:
+	echo "Please set ISISROOT";
+else
+	include $(ISISROOT)/make/isismake.objs
+endif

--- a/isis/src/base/objs/NthOrderPolynomial/Makefile
+++ b/isis/src/base/objs/NthOrderPolynomial/Makefile
@@ -1,7 +1,0 @@
-ifeq ($(ISISROOT), $(BLANK))
-.SILENT:
-error:
-	echo "Please set ISISROOT";
-else
-	include $(ISISROOT)/make/isismake.objs
-endif

--- a/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.cpp
+++ b/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.cpp
@@ -1,0 +1,71 @@
+/**
+ * @file
+ * $Revision: 1.1.1.1 $
+ * $Date: 2006/10/31 23:18:08 $
+ *
+ *   Unless noted otherwise, the portions of Isis written by the USGS are public
+ *   domain. See individual third-party library and package descriptions for
+ *   intellectual property information,user agreements, and related information.
+ *
+ *   Although Isis has been used by the USGS, no warranty, expressed or implied,
+ *   is made by the USGS as to the accuracy and functioning of such software
+ *   and related material nor shall the fact of distribution constitute any such
+ *   warranty, and no responsibility is assumed by the USGS in connection
+ *   therewith.
+ *
+ *   For additional information, launch
+ *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see
+ *   the Privacy &amp; Disclaimers page on the Isis website,
+ *   http://isis.astrogeology.usgs.gov, and the USGS privacy and disclaimers on
+ *   http://www.usgs.gov/privacy.html.
+ */
+
+#include <math.h>
+#include <QString>
+
+#include "FileName.h"
+#include "Constants.h"
+#include "IException.h"
+#include "NthOrderPolynomial.h"
+
+using namespace std;
+namespace Isis {
+
+  /**
+   * Create an NthOrderPolynomial
+   * 
+   * @param degree The order/degree of the polynomial
+   * 
+   */
+  NthOrderPolynomial::NthOrderPolynomial(int degree) : 
+    Isis::BasisFunction("NthOrderPolynomial", 2, degree) {
+    p_degree = degree;
+  }
+  
+
+  /**
+   * This is the the overriding virtual function that provides the expansion into
+   * the nth order polynomial equation. 
+   *  
+   * See BasisFunction for more information.
+   *
+   * @param vars A vector of double values to use for the expansion.
+   */
+  void NthOrderPolynomial::Expand(const std::vector<double> &vars) {
+
+    if((int) vars.size() != Variables()) {
+      QString mess = "Number of variables given (" + QString::number(vars.size())
+          + ") does not match expected (" + Variables() + ")!";
+      throw IException(IException::Programmer, mess, _FILEINFO_);
+    }
+    
+    double t1 = vars[0];
+    double t2 = vars[1];
+    p_terms.clear();
+    for (int i = p_degree; i >= 1; i--) {
+      p_terms.push_back(pow(t1, i) - pow(t2, i));
+    }
+    return;
+  }
+} // end namespace isis
+

--- a/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.h
+++ b/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.h
@@ -33,12 +33,6 @@ namespace Isis {
    *
    * This is a derived class from the BasisFunction class which creates an nth order polynomial.
    *  
-   * The parabolic function has the following form:
-   *
-   * @f[
-   *   x = A + B*y + C*y**2
-   * @f]
-   *
    * @ingroup Math
    *
    * @author  2018-01-01 Unknown

--- a/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.h
+++ b/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.h
@@ -1,0 +1,66 @@
+
+#ifndef NthOrderPolynomial_h
+#define NthOrderPolynomial_h
+/**
+ * @file
+ * $Revision: 1.1.1.1 $
+ * $Date: 2006/10/31 23:18:08 $
+ *
+ *   Unless noted otherwise, the portions of Isis written by the USGS are public
+ *   domain. See individual third-party library and package descriptions for
+ *   intellectual property information,user agreements, and related information.
+ *
+ *   Although Isis has been used by the USGS, no warranty, expressed or implied,
+ *   is made by the USGS as to the accuracy and functioning of such software
+ *   and related material nor shall the fact of distribution constitute any such
+ *   warranty, and no responsibility is assumed by the USGS in connection
+ *   therewith.
+ *
+ *   For additional information, launch
+ *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see
+ *   the Privacy &amp; Disclaimers page on the Isis website,
+ *   http://isis.astrogeology.usgs.gov, and the USGS privacy and disclaimers on
+ *   http://www.usgs.gov/privacy.html.
+ */
+
+#include <vector>
+#include "BasisFunction.h"
+
+namespace Isis {
+
+  /**
+   * @brief NthOrderPolynomial basis function
+   *
+   * This is a derived class from the BasisFunction class which creates an nth order polynomial.
+   *  
+   * The parabolic function has the following form:
+   *
+   * @f[
+   *   x = A + B*y + C*y**2
+   * @f]
+   *
+   * @ingroup Math
+   *
+   * @author  2018-01-01 Unknown
+   *
+   * @internal
+   *  @history 2018-01-01 Unknown - Initial Version
+   *  @history 2020-01-08 Kristin Berry - Update documentation prior to checkin to dev.
+   */
+
+  class NthOrderPolynomial : public Isis::BasisFunction {
+    public:
+      NthOrderPolynomial(int degree);
+
+      //! Destroys the NthOrderPolynomial object
+      ~NthOrderPolynomial() {}
+
+      void Expand(const std::vector<double> &vars);
+    
+  private:
+    int p_degree;
+  };
+
+}
+#endif
+

--- a/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.truth
+++ b/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.truth
@@ -14,7 +14,7 @@ Vars   = 2
 9
 -3
 3
----- 2nd order ----
+--------
 Name   = NthOrderPolynomial
 Ncoefs = 6
 Vars   = 2

--- a/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.truth
+++ b/isis/src/base/objs/NthOrderPolynomial/NthOrderPolynomial.truth
@@ -1,0 +1,27 @@
+Name   = NthOrderPolynomial
+Ncoefs = 3
+Vars   = 2
+0.5
+0.5
+0.5
+---
+-12.5
+-19
+-5
+-1
+---
+4.5
+9
+-3
+3
+---- 2nd order ----
+Name   = NthOrderPolynomial
+Ncoefs = 6
+Vars   = 2
+-13.5
+-63
+33
+-15
+9
+-3
+3

--- a/isis/src/base/objs/NthOrderPolynomial/unitTest.cpp
+++ b/isis/src/base/objs/NthOrderPolynomial/unitTest.cpp
@@ -1,0 +1,56 @@
+#include "NthOrderPolynomial.h"
+#include <iostream>
+#include "Preference.h"
+
+using namespace Isis;
+using namespace std;
+
+int main() {
+  Preference::Preferences(true);
+
+  NthOrderPolynomial b(3);
+  vector<double> coefs;
+  coefs.push_back(0.5);
+  coefs.push_back(0.5);
+  coefs.push_back(0.5);
+  b.SetCoefficients(coefs);
+
+  cout << "Name   = " << b.Name() << endl;
+  cout << "Ncoefs = " << b.Coefficients() << endl;
+  cout << "Vars   = " << b.Variables() << endl;
+  for(int i = 0; i < b.Coefficients(); i++) {
+    cout << b.Coefficient(i) << endl;
+  }
+
+  cout << "---" << endl;
+  vector<double> vars;
+  vars.push_back(2.0);
+  vars.push_back(3.0);
+  cout << b.Evaluate(vars) << endl;
+  for(int i = 0; i < b.Coefficients(); i++) {
+    cout << b.Term(i) << endl;
+  }
+
+  cout << "---" << endl;
+  vars[0] = 1.0;
+  vars[1] = -2.0;
+  cout << b.Evaluate(vars) << endl;
+  for(int i = 0; i < b.Coefficients(); i++) {
+    cout << b.Term(i) << endl;
+  }
+
+  NthOrderPolynomial c(6);
+  cout << "---- 2nd order ----" << endl;
+  cout << "Name   = " << c.Name() << endl;
+  cout << "Ncoefs = " << c.Coefficients() << endl;
+  cout << "Vars   = " << c.Variables() << endl;
+  coefs.push_back(1.0);
+  coefs.push_back(1.0);
+  coefs.push_back(1.0);
+
+  c.SetCoefficients(coefs);
+  cout << c.Evaluate(vars) << endl;
+  for(int i = 0; i < c.Coefficients(); i++) {
+    cout << c.Term(i) << endl;
+  }
+}

--- a/isis/src/base/objs/NthOrderPolynomial/unitTest.cpp
+++ b/isis/src/base/objs/NthOrderPolynomial/unitTest.cpp
@@ -40,7 +40,7 @@ int main() {
   }
 
   NthOrderPolynomial c(6);
-  cout << "---- 2nd order ----" << endl;
+  cout << "--------" << endl;
   cout << "Name   = " << c.Name() << endl;
   cout << "Ncoefs = " << c.Coefficients() << endl;
   cout << "Vars   = " << c.Variables() << endl;


### PR DESCRIPTION
## Description
Adds the `NthOrderPolynomial` class to ISIS. This class is used to support Europa clipper / EIS code in the `jitterfit` application and more. 

## Related Issue
Not needed; PR is into `clipper` not `dev`.

## Motivation and Context
The `NthOrderPolynomial` class was added to support `jitterfit` needed to correct EIS images. 

## How Has This Been Tested?
An extremely simple unit test was added. (Copied and lightly modified from one of the other `Polynomial` classes.) 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
