### PR TITLE
fixed building errors

### DIFF
--- a/isis/src/CMakeLists.txt
+++ b/isis/src/CMakeLists.txt
@@ -15,3 +15,4 @@ foreach( mod ${modules} )
   string(REPLACE "${CMAKE_CURRENT_LIST_DIR}/" "" strippedmod ${mod})
   add_isis_module(${strippedmod} ${strippedmod})
 endforeach()
+

--- a/isis/tests/CMakeLists.txt
+++ b/isis/tests/CMakeLists.txt
@@ -8,11 +8,41 @@ file(GLOB test_source "${CMAKE_SOURCE_DIR}/tests/*.cpp")
 file(GLOB isis_libs "${CMAKE_BINARY_DIR}/lib/*.so")
 file(GLOB isis_mac_libs "${CMAKE_BINARY_DIR}/lib/*.dylib")
 
+set(MISSION_LIBS
+  apollo
+  cassini
+  chandrayaan1
+  clementine
+  clipper
+  dawn
+  galileo
+  hayabusa
+  hayabusa2
+  juno
+  kaguya
+  lo
+  lro
+  mariner
+  mer
+  messenger
+  mex
+  mgs
+  mro
+  near
+  newhorizons
+  odyssey
+  osirisrex
+  rosetta
+  tgo
+  viking
+  voyager)
+
+
 # Link runISISTests with what we want to test and the GTest and pthread library
 add_executable(runISISTests
                IsisTestMain.cpp
                ${test_source})
 
-target_link_libraries(runISISTests isis3 ${isis_libs} ${isis_mac_libs} ${ALLLIBS} ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} Threads::Threads)
+target_link_libraries(runISISTests isis3 ${MISSION_LIBS} ${ALLLIBS} ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} Threads::Threads)
 
 gtest_discover_tests(runISISTests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/isis/tests/FunctionalTestsLeisa2isis.cpp
+++ b/isis/tests/FunctionalTestsLeisa2isis.cpp
@@ -63,6 +63,7 @@ TEST(leisa2isisTest, leisa2isisTestDefault) {
 
   // BandBin Group
   // Check size, first, 2 middle, and last values? Enough?
+  PvlGroup &bandbin = isisLabel->findGroup("BandBin", Pvl::Traverse);
   ASSERT_EQ(bandbin["Center"].size(), 256);
   ASSERT_EQ(bandbin["Width"].size(), 256);
   ASSERT_EQ(bandbin["OriginalBand"].size(), 256);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This should get ISIS building again. Compile error in newhorizons tests and test CMake file globbing always failed since libraries don't exist at configure time.  

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

None, Jenkins is failing to build.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We want things to build 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Builds and Functional tests passing locally 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
