### PR TITLE
Fix for QMOS not updating lat/lon ranges correctly. 

### DIFF
--- a/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/GridGraphicsItem.cpp
@@ -53,7 +53,6 @@ namespace Isis {
         lonMin = lonMax;
         lonMax = temp;
       }
-      
       if (mappingGroup["LatitudeType"][0] == "Planetographic") {
 
           Distance equaRad(tproj->EquatorialRadius(), Distance::Meters);
@@ -115,6 +114,7 @@ namespace Isis {
                           Angle::Degrees);
           maxLat = Latitude(latMax.degrees(), mappingGroup,
                           Angle::Degrees);
+          
 
           // Make sure our lat increment is non-zero
           if (!qFuzzyCompare(latInc.radians(), 0.0)) {
@@ -131,7 +131,7 @@ namespace Isis {
           if (qFuzzyCompare(endLat.degrees(), 90.0))
             endLat = Latitude(90.0, mappingGroup, Angle::Degrees);
         }
-
+        
         Longitude minLon(lonMin.degrees(), mappingGroup,
                         Angle::Degrees);
         Longitude maxLon(lonMax.degrees(), mappingGroup,
@@ -143,7 +143,7 @@ namespace Isis {
           startLon = Longitude(
             baseLon - Angle(floor((baseLon - minLon) / lonInc) * lonInc));
         }
-
+        
         Longitude endLon =
             (long)((maxLon - startLon) / lonInc) * lonInc + startLon;
 
@@ -199,7 +199,7 @@ namespace Isis {
               double y = 0;
               
               bool valid;
-
+              
               // Set ground according to lon direction to get correct X,Y values 
               // when drawing lines. 
               if (tproj->IsPositiveWest()) {
@@ -276,7 +276,7 @@ namespace Isis {
           firstIteration = true;
           atMaxLat = false;
           atMaxLon = false;
-
+          
           // Create the longitude grid lines
           for (Longitude lon = minLon; lon != maxLon + lonInc; lon += lonInc) {
             if (lon > endLon && lon < maxLon) {
@@ -300,8 +300,10 @@ namespace Isis {
               // Set ground according to lon direction to get correct X,Y values 
               // when drawing lines.  
               bool valid;
+              
               if (tproj->IsPositiveWest()) {
-                valid = tproj->SetGround(lat.degrees(), lon.positiveWest(Angle::Degrees));
+                  double glon = tproj->Has180Domain() ? -1*lon.positiveEast(Angle::Degrees): lon.positiveWest(Angle::Degrees);
+                  valid = tproj->SetGround(lat.degrees(), glon);
               }
               else {
                 valid = tproj->SetGround(lat.degrees(), lon.positiveEast(Angle::Degrees));

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicGridTool.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicGridTool.cpp
@@ -801,7 +801,12 @@ namespace Isis {
     configDialog->setAttribute(Qt::WA_DeleteOnClose);
     configDialog->show();
   }
-
+  
+  /*
+   * Updates lat/lon ranges when a new projection file is loaded. Also 
+   * forces the lat/lon extent source to Map resetting user options in the grid tool dialog. 
+   * 
+   */
   void MosaicGridTool::onProjectionChanged() {
     TProjection * tproj = (TProjection *)getWidget()->getProjection();
     

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicGridTool.h
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicGridTool.h
@@ -122,7 +122,8 @@ namespace Isis {
       void drawGrid(bool draw);
       void onCubesChanged();
       void onToolOpen(bool check);
-
+      void onProjectionChanged();
+    
     protected:
       QWidget *createToolBarWidget();
       QAction *getPrimaryAction();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
QMOS is broken on lon direction = positivewest on top of ranges being incorrect when new map files are loaded. This should fix the issue as described.  

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/USGS-Astrogeology/ISIS3/issues/3573

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We want the grid tool to work. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Manually tested with all the projection files @lwellerastro posted as part of the test. This includes switching between postivewest/east and 180 to 360 domains while messing with options in the grid tool to see if grid still draws correctly. Everything seems to work. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
