### PR TITLE
Used CK quality for PCK selection in spiceinit

### DIFF
--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -23,7 +23,7 @@
 
 using namespace std;
 
-namespace Isis { 
+namespace Isis {
 
   void getUserEnteredKernel(UserInterface &ui, const QString &param, Kernel &kernel);
   bool tryKernels(Cube *icube, Process &p, UserInterface &ui, Pvl *log,
@@ -42,16 +42,16 @@ namespace Isis {
    * @param ui The Application UI
    * @param(out) log The Pvl that attempted kernel sets will be logged to
    */
-  void spiceinit(UserInterface &ui, Pvl *log) { 
+  void spiceinit(UserInterface &ui, Pvl *log) {
     // Open the input cube
     Process p;
-    
+
     CubeAttributeInput cai;
     Cube *icube = p.SetInputCube(ui.GetFileName("FROM"), cai, ReadWrite);
     spiceinit(icube, ui, log);
     p.EndProcess();
   }
- 
+
 
   /**
    * Spiceinit a Cube
@@ -76,7 +76,7 @@ namespace Isis {
       QString msg = "At least one SPK quality must be selected";
       throw IException(IException::User, msg, _FILEINFO_);
     }
-    
+
     // Make sure it is not projected
     Projection *proj = NULL;
     try {
@@ -92,7 +92,7 @@ namespace Isis {
     }
 
     Pvl lab = *icube->label();
-    
+
     // if cube has existing polygon delete it
     if (icube->label()->hasObject("Polygon")) {
       icube->label()->deleteObject("Polygon");
@@ -144,7 +144,7 @@ namespace Isis {
       Kernel lk, pck, targetSpk, fk, ik, sclk, spk, iak, dem, exk;
       QList< priority_queue<Kernel> > ck;
       lk        = baseKernels.leapSecond(lab);
-      pck       = baseKernels.targetAttitudeShape(lab);
+      pck       = ckKernels.targetAttitudeShape(lab);
       targetSpk = baseKernels.targetPosition(lab);
       ik        = baseKernels.instrument(lab);
       sclk      = baseKernels.spacecraftClock(lab);
@@ -152,7 +152,7 @@ namespace Isis {
       fk        = ckKernels.frame(lab);
       ck        = ckKernels.spacecraftPointing(lab);
       spk       = spkKernels.spacecraftPosition(lab);
-      
+
       if (ui.GetBoolean("CKNADIR")) {
         // Only add nadir if no spacecraft pointing found, so we will set (priority) type to 0.
         QStringList nadirCk;
@@ -198,7 +198,7 @@ namespace Isis {
                          _FILEINFO_);
       }
       else if (ui.WasEntered("CK")) {
-        // if user entered ck 
+        // if user entered ck
         // empty ck queue list found in system
         while (ck.size()) {
           ck.pop_back();
@@ -209,10 +209,10 @@ namespace Isis {
         emptyKernelQueue.push(Kernel());
         ck.push_back(emptyKernelQueue);
       }
-      
+
       // while the first queue is not empty, loop through it until tryKernels() succeeds
       while (ck.at(0).size() != 0 && !kernelSuccess) {
-        // create an empty kernel 
+        // create an empty kernel
         Kernel realCkKernel;
         QStringList ckKernelList;
 
@@ -236,13 +236,13 @@ namespace Isis {
               Kernel topPriority = ck.at(i).top();
               ckKernelList.append(topPriority.kernels());
               // set the type to equal the type of the to priority of the first
-              //queue 
-              realCkKernel.setType(topPriority.type()); 
+              //queue
+              realCkKernel.setType(topPriority.type());
             }
           }
 
         }
-        // pop the top priority ck off only the first queue so that the next 
+        // pop the top priority ck off only the first queue so that the next
         // iteration will test the next highest priority of the first queue with
         // the top priority of each of the other queues.
         ck[0].pop();
@@ -267,14 +267,14 @@ namespace Isis {
   }
 
   /**
-   * If the user entered the parameter param, then kernel is replaced by the 
+   * If the user entered the parameter param, then kernel is replaced by the
    * user's values and quality is reset to 0. Otherwise, the kernels loaded by the
    * KernelDb class will be kept.
    *
    * @param param Name of the kernel input parameter
-   *  
-   * @param kernel Kernel object to be overwritten if the specified user parameter 
-   *               was entered. 
+   *
+   * @param kernel Kernel object to be overwritten if the specified user parameter
+   *               was entered.
    */
   void getUserEnteredKernel(UserInterface &ui, const QString &param, Kernel &kernel) {
     if (ui.WasEntered(param)) {
@@ -395,7 +395,7 @@ namespace Isis {
     // Get rid of old keywords from previously inited cubes
     if (currentKernels.hasKeyword("Source"))
       currentKernels.deleteKeyword("Source");
-    
+
     if (currentKernels.hasKeyword("SpacecraftPointing"))
       currentKernels.deleteKeyword("SpacecraftPointing");
 
@@ -450,7 +450,7 @@ namespace Isis {
       try {
         cam = icube->camera();
         currentKernels = icube->group("Kernels");
-        
+
         PvlKeyword source("Source");
 
         if (cam->isUsingAle()) {
@@ -461,11 +461,11 @@ namespace Isis {
         }
 
         currentKernels += source;
-        icube->putGroup(currentKernels);   
+        icube->putGroup(currentKernels);
         if (log){
           log->addGroup(currentKernels);
-        } 
-          
+        }
+
       }
       catch(IException &e) {
         Pvl errPvl = e.toPvl();
@@ -665,7 +665,7 @@ namespace Isis {
         continue;
       }
     }
-    
+
     if (log) {
       log->addGroup(logGrp);
     }

--- a/isis/src/base/apps/spiceinit/spiceinit.xml
+++ b/isis/src/base/apps/spiceinit/spiceinit.xml
@@ -90,9 +90,9 @@
        not have their paths expanded.  This is to allow variables like $msg/ to work correctly.
     </p>
     <p>
-      The spiceinit program will also add the RayTraceEngine, OnError, and Tolerance keywords to the Kernels 
-      group if specified in the IsisPreferences file. If included, these keywords specify the ray-tracing engine to use and how to use it for shapemodels. 
-      Please see the IsisPreferences file for more details. 
+      The spiceinit program will also add the RayTraceEngine, OnError, and Tolerance keywords to the Kernels
+      group if specified in the IsisPreferences file. If included, these keywords specify the ray-tracing engine to use and how to use it for shapemodels.
+      Please see the IsisPreferences file for more details.
 
     </p>
     <p><b>Troubleshooting:</b> If spiceinit is failing with the error
@@ -279,16 +279,21 @@
     </change>
     <change name="Kristin Berry" date="2017-06-06">
       Updated spiceinit to retain ShapeModel-related keywords set by the ShapeModelFactory and add them to the kernel
-      group. Like other keywords in the kernels group, if they are present at the beginning of a spiceinit run (if we are re-spiceiniting) 
-      they are removed. 
+      group. Like other keywords in the kernels group, if they are present at the beginning of a spiceinit run (if we are re-spiceiniting)
+      they are removed.
     </change>
     <change name="Kristin Berry" date="2017-08-06">
-      Updated spiceinit to remove code dealing with the CubeSupported Pvl Keyword, from the ShapeModel group in the IsisPreferences file, 
+      Updated spiceinit to remove code dealing with the CubeSupported Pvl Keyword, from the ShapeModel group in the IsisPreferences file,
       which has been removed.
     </change>
     <change name="Christopher Combs" date="2018-01-11">
       Made change to camera construction error throw for better reporting on uninstantiated cameras.
       Fixes #5163.
+    </change>
+    <change name="Jesse Mapel" date="2020-02-26">
+      Changed PCK selection to use the same qualities as CK so that target body parameters
+      derived from bundle adjustment can be used alongside CKs derived from bundle adjustment.
+      Fixes #3669.
     </change>
   </history>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This change uses the same kernel quality options for PCKs and CKs in spiceinit. This ensures that if target body parameters are solved for along-side sensor pointing, both updated kernels will be loaded.

This is a backwards compatible change because no PCK kernel DBs have type specification and hence ignore the allowed types check. Future kernel dbs that do have type specifications in them will operate differently with versions of ISIS before and after this change.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3669 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As part of the Enceladus global mosaic created by @blandoplanet & @lwellerastro they generated updated pointing kernels and an update PCK. In order to load the correct PCK, we needed a way to specify that the updated one was desired. This was approach was selected because it peserves existing behavior and doesn't require users to enter new parameters (such as having a PCK quality parameter).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests passed locally on osx10.13 and ubuntu18

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
