### PR TITLE
Fixes ddd2isis to support updated uvflat files

### DIFF
--- a/isis/src/base/apps/ddd2isis/ddd2isis.xml
+++ b/isis/src/base/apps/ddd2isis/ddd2isis.xml
@@ -41,6 +41,10 @@
       bands. Removed the internal default of the output parameter set to None so
       that an output file is now requried. Fixes #703.
     </change>
+    <change name="Adam Paquette" date="2020-02-28">
+      Updated the dataTypes QMap with a new mapping (32, 4) to handle ingesting
+      the updated uvflat files from malin. Fixes #3715.
+    </change>
   </history>
 
   <category>

--- a/isis/src/base/apps/ddd2isis/main.cpp
+++ b/isis/src/base/apps/ddd2isis/main.cpp
@@ -100,6 +100,7 @@ void IsisMain() {
   dataTypes.insert(1450903360, 8);
   dataTypes.insert(8, 1);
   dataTypes.insert(16, 2);
+  dataTypes.insert(32, 4);
   dataTypes.insert(48, 2);
 
   // Read bytes 16-19 to get the bit type
@@ -128,6 +129,12 @@ void IsisMain() {
     // Old header format's offset is always 1024.
      dataTypeBytes = dataTypes.value(totalBandBits);
      nOffset = 1024;
+  }
+
+  if (dataTypeBytes == 0) {
+    string msg = "The value totalBandBits [" + to_string(totalBandBits) + "] does not map " +
+                  "to any byte size in the dataTypes table.";
+    throw IException(IException::Programmer, msg, _FILEINFO_);
   }
 
   fin.close();

--- a/isis/src/base/apps/ddd2isis/tsts/badBandBit/Makefile
+++ b/isis/src/base/apps/ddd2isis/tsts/badBandBit/Makefile
@@ -1,0 +1,24 @@
+APPNAME = ddd2isis
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	# TEST: Throws an error when trying to open the file
+	if [ `$(APPNAME) \
+                FROM=$(INPUT)/bad_flat.ddd \
+                TO=$(OUTPUT)/bad_flat.cub \
+                2> $(OUTPUT)/temp.txt > /dev/null` ]; \
+                then true; \
+                fi;
+	
+	# TEST: Throws an error when trying to read from a cub instead of ddd
+	if [ `$(APPNAME) \
+                FROM=$(INPUT)/bad_flat.cub \
+                TO=$(OUTPUT)/bad_flat.cub \
+                2>> $(OUTPUT)/temp.txt > /dev/null` ]; \
+                then true; \
+                fi;
+
+        # Removes input file path up until input
+	$(SED) 's+\[.*/input+[input+' $(OUTPUT)/temp.txt > $(OUTPUT)/errorTruth.txt;
+	$(RM) $(OUTPUT)/temp.txt


### PR DESCRIPTION
Allows the ddd2isis app to read the new uvflat files from malin

## Description
Updates the mapping of bits to bytes in ddd2isis so if an image with a 32 bit datatype comes through it can be processed.

## Related Issue
Closes #3715

## Motivation and Context
This changes allows the marci uvflat files to be updated to the most recent version.

## How Has This Been Tested?
With a new test but in the old ISIS test fashion of make files and data area additions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
