### PR TITLE
Add nadir to props **DO NOT MERGE**

### DIFF
--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -179,21 +179,17 @@ namespace Isis {
     //  ephemerides. (2008-02-27 (KJB))
     if (m_usingNaif) {
       try {
-        // At this time ALE does not compute pointing for the nadir option in spiceinit
-        // If NADIR is turned on fail here so ISIS can create nadir pointing
-        if (kernels["InstrumentPointing"][0].toUpper() == "NADIR") {
-          QString msg = "Falling back to ISIS generation of nadir pointing";
-          throw IException(IException::Programmer, msg, _FILEINFO_);
-        }
-        
         if (isd == NULL){
           // try using ALE
           std::ostringstream kernel_pvl;
           kernel_pvl << kernels;
 
           json props;
-          props["kernels"] = kernel_pvl.str();
+          if (kernels["InstrumentPointing"][0].toUpper() == "NADIR") {
+            props["nadir"] = true;
+          }
 
+          props["kernels"] = kernel_pvl.str();
           isd = ale::load(lab.fileName().toStdString(), props.dump(), "isis");
         }
         


### PR DESCRIPTION
Allow isis to pass nadir as a property to ale for initialization.

This is marked "do not merge" due to an unresolved / identified error in communication between ISIS and ALE.  Despite placing nadir=true in the properties, the process fails and calculation defaults to ISIS.
## Description
Passes nadir as a property for nadir calculation within ale.
## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
Ale was recently updated to allow for nadir calculation, this passes a parameter that will toggle that functionality when necessary.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
