### PR TITLE
correcting swapped line sample prints in enlarge application output file

### DIFF
--- a/isis/src/base/objs/Enlarge/Enlarge.cpp
+++ b/isis/src/base/objs/Enlarge/Enlarge.cpp
@@ -141,8 +141,8 @@ namespace Isis {
     resultsGrp += PvlKeyword("EndingSample",    toString((int)mdEndSample));
     resultsGrp += PvlKeyword("LineIncrement",   toString(1. / mdLineScale));
     resultsGrp += PvlKeyword("SampleIncrement", toString(1. / mdSampleScale));
-    resultsGrp += PvlKeyword("OutputLines",     toString(miOutputSamples));
-    resultsGrp += PvlKeyword("OutputSamples",   toString(miOutputLines));
+    resultsGrp += PvlKeyword("OutputLines",     toString(miOutputLines));
+    resultsGrp += PvlKeyword("OutputSamples",   toString(miOutputSamples));
 
     SubArea subArea;
     subArea.SetSubArea(mInCube->lineCount(), mInCube->sampleCount(), (int)mdStartLine, (int)mdStartSample,

--- a/isis/src/base/objs/Enlarge/Enlarge.truth
+++ b/isis/src/base/objs/Enlarge/Enlarge.truth
@@ -1,4 +1,16 @@
 Testing Enlarge Class ... 
+Group = Results
+  InputLines      = 126
+  InputSamples    = 126
+  StartingLine    = 1
+  StartingSample  = 1
+  EndingLine      = 126
+  EndingSample    = 126
+  LineIncrement   = 0.5
+  SampleIncrement = 0.5
+  OutputLines     = 252
+  OutputSamples   = 252
+End_Group
 Object = IsisCube
   Object = Core
     StartByte   = 65537

--- a/isis/src/base/objs/Enlarge/unitTest.cpp
+++ b/isis/src/base/objs/Enlarge/unitTest.cpp
@@ -31,7 +31,8 @@ void IsisMain() {
 
   cerr << "Testing Enlarge Class ... " << endl;
   p.StartProcess(*trans, *interp);
-  trans->UpdateOutputLabel(outCube);
+  PvlGroup results = trans->UpdateOutputLabel(outCube);
+  cerr << results << endl;
   Pvl *outLabel = outCube->label();
   outLabel->deleteObject("History");
   cerr << *outLabel;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Corrected the enlarge application output file prints.

## Description
<!--- Describe your changes in detail -->
Swapped the line and sample variables in the enlarge output file prints to accurately represent values.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Issue #3659 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Issue #3659 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing tests for enlarge were run and passed. Since this is just an output file change and does not change the functionality of the application.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
