### PR TITLE
Fixed cam2map ignoring band specifications on the input cube

### DIFF
--- a/isis/src/base/apps/cam2map/cam2map.cpp
+++ b/isis/src/base/apps/cam2map/cam2map.cpp
@@ -22,7 +22,7 @@ namespace Isis {
   void cam2map(UserInterface &ui, Pvl *log) {
     // Open the input cube
     Cube icube(ui.GetFileName("FROM"));
-    CubeAttributeInput inAtt(ui.GetFileName("FROM"));
+    CubeAttributeInput inAtt(ui.GetAsString("FROM"));
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }

--- a/isis/src/base/apps/cam2map/cam2map.cpp
+++ b/isis/src/base/apps/cam2map/cam2map.cpp
@@ -22,7 +22,7 @@ namespace Isis {
   void cam2map(UserInterface &ui, Pvl *log) {
     // Open the input cube
     Cube icube;
-    CubeAttributeInput inAtt(ui.GetAsString("FROM"));
+    CubeAttributeInput inAtt = ui.GetInputAttribute("FROM");
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }

--- a/isis/src/base/apps/cam2map/cam2map.cpp
+++ b/isis/src/base/apps/cam2map/cam2map.cpp
@@ -1,6 +1,7 @@
 #include "cam2map.h"
 
 #include "Camera.h"
+#include "CubeAttribute.h"
 #include "IException.h"
 #include "IString.h"
 #include "ProjectionFactory.h"
@@ -21,6 +22,10 @@ namespace Isis {
   void cam2map(UserInterface &ui, Pvl *log) {
     // Open the input cube
     Cube icube(ui.GetFileName("FROM"));
+    CubeAttributeInput inAtt(ui.GetFileName("FROM"));
+    if (inAtt.bands().size() != 0) {
+      icube.setVirtualBands(inAtt.bands());
+    }
 
     // Get the map projection file provided by the user
     Pvl userMap;

--- a/isis/src/base/apps/cam2map/cam2map.cpp
+++ b/isis/src/base/apps/cam2map/cam2map.cpp
@@ -21,11 +21,12 @@ namespace Isis {
 
   void cam2map(UserInterface &ui, Pvl *log) {
     // Open the input cube
-    Cube icube(ui.GetFileName("FROM"));
+    Cube icube;
     CubeAttributeInput inAtt(ui.GetAsString("FROM"));
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }
+    icube.open(ui.GetFileName("FROM"));
 
     // Get the map projection file provided by the user
     Pvl userMap;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
With the recent conversion of cam2map to a callable, the input Cube was changed to be manually opened instead of being opened by a Process object. This resulted in the input Cube not getting its input attributes (the only input Cube attribute is band selection FYI).

This is going to be a common problem we convert more of these applications. I considered adding a new openWithAttributes option to the Cube class, but I'm not sure if that is the correct dependency. For right now I simply copied the code from Process::SetInputCube.

Input on a good way to handle this so that we don't have 50 copies of this code is appreciated.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No issue, fixes a bug introduced in #3757

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is functionality that was temporarily lost, so we need to add it back. This was discovered because thmproc's app test uses cam2map's band selection via a Pipeline object.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests, except for currently nightly build failures, all passed on Ubuntu and existing cam2map and thmproc tests passed on OSX. I also manually tested that calling cam2map with from=some_lvl1.cub+2 properly projected only the second band.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
