### PR TITLE
Update IsisPreferences to include backwards compatibility with instances of $ISIS3DATA

### DIFF
--- a/isis/IsisPreferences
+++ b/isis/IsisPreferences
@@ -175,6 +175,9 @@ EndGroup
 ########################################################
 
 Group = DataDirectory
+# Backwards compatability for versions prior to 4.1.0
+  ISIS3DATA    = $ISISDATA
+
   Apollo15     = $ISISDATA/apollo15
   Apollo16     = $ISISDATA/apollo16
   Apollo17     = $ISISDATA/apollo17


### PR DESCRIPTION
## Description
Update IsisPreferences to include backwards compatibility with instances of $ISIS3DATA in cubes or preference files. 

This would be useful in cases such as: A cube was spiceinited with a dem, and the path was set as "$ISIS3DATA/base/dems/dem.cub". And was tested on this case.

## Related Issue
#3727, but deliberately left out of the big PR for that issue due to wanting to put this change in separately.

## Motivation and Context
See description.

## How Has This Been Tested?
I spiceinited a cube with a dem with `$ISIS3DATA` included in the path. Without these updates, campt on that cube fails. With these updates, it succeeds.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
