### PR TITLE
Update hyb2onc2isis to support newer image format

### DIFF
--- a/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncArchive.trn
+++ b/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncArchive.trn
@@ -16,6 +16,7 @@ End_Group
 Group = L0FileName
   Auto  
   InputKey       = P_L0NAME
+  InputKey       = L0FILE
   InputPosition  = FitsLabels
   OutputName     = L0FileName
   OutputPosition = (Object, IsisCube, Group, Archive)
@@ -94,6 +95,7 @@ End_Group
 # AMICA calls this one "ImageNumber"
 Group = ImageNumber
   Auto
+  Optional
   InputKey       = P_IMGID
   InputPosition  = FitsExtras
   OutputName     = ImageNumber

--- a/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncInstrument.trn
+++ b/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncInstrument.trn
@@ -16,6 +16,7 @@ End_Group
 Group = InstrumentId
   Auto
   InputKey       = P_NAME
+  InputKey       = NAIFNAME
   InputPosition  = FitsLabels
   OutputName     = InstrumentId
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -79,6 +80,7 @@ End_Group
 Group = ExposureDuration
   Auto
   InputKey       = EXPOSURE
+  InputKey       = XPOSURE
   InputPosition  = FitsLabels
   OutputName     = ExposureDuration
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -88,6 +90,7 @@ End_Group
 Group = SpacecraftClockStartCount
   Auto
   InputKey       = P_SCCSC
+  InputKey       = SCCL-BEG
   InputPosition  = FitsLabels
   OutputName     = SpacecraftClockStartCount
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -97,6 +100,7 @@ End_Group
 Group = SpacecraftClockEndCount
   Auto
   InputKey       = P_SCCEC
+  InputKey       = SCCL-END
   InputPosition  = FitsLabels
   OutputName     = SpacecraftClockStartCount
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -116,6 +120,7 @@ End_Group
 #s/c counter at data recorded time
 Group = OnboardDataRecordedTime
   Auto
+  Optional
   InputKey       = P_RECTI
   InputPosition  = FitsExtras
   OutputName     = OnboardDataRecordedTime
@@ -126,6 +131,7 @@ End_Group
 Group = Binning
   Auto
   InputKey       = P_BINN
+  InputKey       = NPIXBIN
   InputPosition  = FitsLabels
   OutputName     = Binning
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -136,6 +142,7 @@ End_Group
 Group = SelectedImageAreaX1
   Auto
   InputKey       = P_OPOSX1
+  InputKey       = ROI_LLX
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaX1
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -145,6 +152,7 @@ End_Group
 Group = SelectedImageAreaY1
   Auto
   InputKey       = P_OPOSY1
+  InputKey       = ROI_LLY
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaY1
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -154,6 +162,7 @@ End_Group
 Group = SelectedImageAreaX2
   Auto
   InputKey       = P_OPOSX2
+  InputKey       = ROI_URX
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaX2
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -163,6 +172,7 @@ End_Group
 Group = SelectedImageAreaY2
   Auto
   InputKey       = P_OPOSY2
+  InputKey       = ROI_URY
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaY2
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -171,6 +181,7 @@ End_Group
 
 Group = SelectedImageAreaX3
   Auto
+  Optional
   InputKey       = P_OPOSX3
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaX3
@@ -180,6 +191,7 @@ End_Group
 
 Group = SelectedImageAreaY3
   Auto
+  Optional
   InputKey       = P_OPOSY3
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaY3
@@ -189,6 +201,7 @@ End_Group
 
 Group = SelectedImageAreaX4
   Auto
+  Optional
   InputKey       = P_OPOSX4
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaX4
@@ -198,6 +211,7 @@ End_Group
 
 Group = SelectedImageAreaY4
   Auto
+  Optional
   InputKey       = P_OPOSY4
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaY4
@@ -217,6 +231,7 @@ End_Group
 Group = OffsetCorrection
   Auto
   InputKey       = OFFSETCR
+  InputKey       = AOFFSET
   InputPosition  = FitsLabels
   OutputName     = OffsetCorrection
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -235,6 +250,7 @@ End_Group
 Group = RadianceConversion
   Auto
   InputKey       = RADIANCE
+  InputKey       = RADCONV
   InputPosition  = FitsLabels
   OutputName     = RadianceConversion
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -262,6 +278,7 @@ End_Group
 Group = L2BFlatFileName
   Auto
   InputKey       = L2BFLTFN
+  InputKey       = FLATFN
   InputPosition  = FitsLabels
   OutputName     = L2BFlatFileName
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -270,6 +287,7 @@ End_Group
 
 Group = L2BSystemEfficiencyFileName
   Auto
+  Optional
   InputKey       = L2BEFCFN
   InputPosition  = FitsLabels
   OutputName     = L2BSystemEfficiencyFileName
@@ -280,6 +298,7 @@ End_Group
 Group = L2CShapeModelFileName
   Auto
   InputKey       = L2CSHPFN
+  InputKey       = SHAPEFN
   InputPosition  = FitsLabels
   OutputName     = L2CShapeModelFileName
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -289,6 +308,7 @@ End_Group
 Group = L2DPhaseFunctionFileName
   Auto
   InputKey       = L2DPHSFN
+  InputKey       = PHASEFN
   InputPosition  = FitsLabels
   OutputName     = L2DPhaseFunctionFileName
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -298,6 +318,7 @@ End_Group
 Group = L2DShapeModelFileName
   Auto
   InputKey       = L2DSHPFN
+  InputKey       = SHAPEFN
   InputPosition  = FitsLabels
   OutputName     = L2DShapeModelFileName
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -307,6 +328,7 @@ End_Group
 # the following image ID is assigned by the onboard image processor:
 Group = ImageID
   Auto
+  Optional
   InputKey       = P_IMGID
   InputPosition  = FitsExtras
   OutputName     = ImageID
@@ -465,6 +487,7 @@ End_Group
 Group = Compression
   Auto
   InputKey       = P_CMPSTY
+  InputKey       = IMGCMPRV
   InputPosition  = FitsLabels
   OutputName     = Compression
   OutputPosition = (Object, IsisCube, Group, Instrument)

--- a/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncKernels.trn
+++ b/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncKernels.trn
@@ -7,6 +7,7 @@ Group = NaifCode
   Auto
   Optional
   InputKey       = P_ID
+  InputKey       = NAIFID
   InputPosition  = FitsLabels
   OutputName     = NaifFrameCode
   OutputPosition = (Object, IsisCube, Group, Kernels)

--- a/isis/src/hayabusa2/apps/hyb2onc2isis/tsts/newFits/Makefile
+++ b/isis/src/hayabusa2/apps/hyb2onc2isis/tsts/newFits/Makefile
@@ -1,0 +1,18 @@
+# Test for new format of Hayabusa2 fits images released 2019-2020
+#
+# @history 2020-03-29 Kristin Berry - Added along with support for new format
+#
+APPNAME = hyb2onc2isis
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	$(APPNAME) from=$(INPUT)/hyb2_onc_20180710_060508_tvf_l2a.fit  \
+	           to=$(OUTPUT)/hyb2_onc_20180710_060508_tvf_l2a.cub   \
+	           >& /dev/null;
+	catlab     from=$(OUTPUT)/hyb2_onc_20180710_060508_tvf_l2a.cub \
+	           to=$(OUTPUT)/labels.pvl                             \
+	           >& /dev/null;
+	catoriglab from=$(OUTPUT)/hyb2_onc_20180710_060508_tvf_l2a.cub \
+	           to=$(OUTPUT)/origLab.pvl                            \
+	           >& /dev/null;


### PR DESCRIPTION
##  Description
Updates `hyb2onc2isis` to support more a recent format of Hayabusa2 fits images with different label keywords needed by ISIS. Most of this PR is just adding the changes to translation files identified by @foobarbecue (Thanks!) in #3698 to ISIS.

To get the resulting cubes spiceinit-ing, it was also necessary to make several updates to the hayabusa2 kernel area.

## Related Issue
#3698

## Motivation and Context
Updates `hyb2onc2isis` to work with more recently released Hayabusa2 fits files.The label format has changed enough that the translation files needed to be updated.

## How Has This Been Tested?
Old hayabusa2 tests pass and added a test for the new format.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
