### PR TITLE
Changed jitterfit test to use a csv

### DIFF
--- a/isis/src/clipper/apps/jitterfit/tsts/default/Makefile
+++ b/isis/src/clipper/apps/jitterfit/tsts/default/Makefile
@@ -13,3 +13,5 @@ commands:
 		scale=1.0 > /dev/null; 
 	catlab from=$(OUTPUT)/simulated_clipper_eis_nac_rolling_shutter.cub \
 		to=$(OUTPUT)/simulated_clipper_eis_nac_rolling_shutter_labels.pvl > /dev/null;
+	$(SED) 's/[# ]//g' $(OUTPUT)/coefficients.txt > $(OUTPUT)/coefficients.csv;
+	$(RM) $(OUTPUT)/coefficients.txt > /dev/null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The new jitterfit application outputs a CSV file that contains the coefficients, the format of that file does not work well with the Makefile tests. So, I changed the jitterfit test to clean up the header and added tolerances (test data is ready to be checked in at /work/users/jmapel/ISIS3/isis/src/clipper/apps/jitterfit/tsts/default).

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No issue, this was found during release prep

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
OSX produces very slightly different results (About 12 sig figs) and needs to have a tolerance file for the tests to pass.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Test works on OSX 10.13 and Ubuntu 18 builds.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
