### PR TITLE
Adds support for JAXA archive Level 2B2 images to Kaguya MI in ISIS.

### DIFF
--- a/isis/src/kaguya/apps/kaguyami2isis/KaguyaMiInstrument.trn
+++ b/isis/src/kaguya/apps/kaguyami2isis/KaguyaMiInstrument.trn
@@ -33,11 +33,13 @@ End_Group
 Group = SpacecraftName
   Auto
   InputKey       = SPACECRAFT_NAME
+  InputKey       = INSTRUMENT_HOST_NAME
   InputGroup     = ROOT
   InputPosition  = ROOT
   OutputName     = SpacecraftName
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (KAGUYA, SELENE-M)
+  Translation    = (KAGUYA, "SELENE MAIN ORBITER")
 End_Group
 
 Group = InstrumentName
@@ -513,6 +515,7 @@ End_Group
 Group = FirstDetectorElementPosition
   Auto
   InputKey       = FIRST_DETECTOR_ELEMENT_POSITION
+  InputKey       = FIRST_DETECTOR_ELEM_POSITION
   InputGroup     = ROOT
   InputPosition  = ROOT
   OutputName     = FirstDetectorElementPosition

--- a/isis/src/kaguya/apps/kaguyami2isis/kaguyami2isis.xml
+++ b/isis/src/kaguya/apps/kaguyami2isis/kaguyami2isis.xml
@@ -6,7 +6,7 @@
 
   <description>
     <p>
-      This program will import a PDS formatted Kaguya MI VIS and NIR level 1 (EDR)
+      This program will import a PDS formatted Kaguya MI VIS and NIR level 1 (EDR) or level 2B2
       image into an Isis cube.
     </p>
     <p>
@@ -78,6 +78,9 @@
       Added a new error message informing the user that the file they are using is not compatible with
       kaguyami2isis. Fixes #2358.
     </change>
+    <change name="Kaitlyn Lee" date="2020-03-31">
+      Updated documentation to include level 2B2 support.
+    </change>
   </history>
 
   <category>
@@ -94,11 +97,10 @@
         </brief>
         <description>
           Use this parameter to select the Kaguya MI VIS or
-	  NIR EDR filename. This file must contain the PDS
-          labels.
+	        NIR level 1 or level 2B2 filename. This file must contain the PDS labels.
         </description>
         <filter>
-          *.img *.IMG
+          *.img *.IMG *.lbl *.LBL
         </filter>
       </parameter>
 

--- a/isis/src/kaguya/apps/kaguyami2isis/tsts/level2b2/Makefile
+++ b/isis/src/kaguya/apps/kaguyami2isis/tsts/level2b2/Makefile
@@ -1,0 +1,18 @@
+APPNAME = kaguyami2isis
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	# Visible
+	$(APPNAME) from=$(INPUT)/MNA_2B2_01_01228N602E1354.lbl \
+	  to=$(OUTPUT)/MNA_2B2_01_01228N602E1354.cub > /dev/null;
+	catlab from=$(OUTPUT)/MNA_2B2_01_01228N602E1354.cub \
+	  to=$(OUTPUT)/MNA_2B2_01_01228N602E1354.pvl > /dev/null;
+
+        # IR
+	$(APPNAME) from=$(INPUT)/MVA_2B2_01_01228N608E1354.lbl \
+          to=$(OUTPUT)/MVA_2B2_01_01228N608E1354.cub > /dev/null;
+	catlab from=$(OUTPUT)/MVA_2B2_01_01228N608E1354.cub \
+	  to=$(OUTPUT)/MVA_2B2_01_01228N608E1354.pvl > /dev/null;
+
+

--- a/isis/src/kaguya/objs/KaguyaMiCamera/KaguyaMiCamera.cpp
+++ b/isis/src/kaguya/objs/KaguyaMiCamera/KaguyaMiCamera.cpp
@@ -112,7 +112,6 @@ namespace Isis {
 
 
     KaguyaMiCameraDistortionMap *distMap = new KaguyaMiCameraDistortionMap(this);
-    //LroNarrowAngleDistortionMap *distMap = new LroNarrowAngleDistortionMap(this);
     distMap->SetDistortion(naifIkCode());
 
     // Setup the ground and sky map

--- a/isis/src/kaguya/objs/KaguyaMiCamera/KaguyaMiCamera.h
+++ b/isis/src/kaguya/objs/KaguyaMiCamera/KaguyaMiCamera.h
@@ -24,7 +24,7 @@
 
 namespace Isis {
   /**
-   * @brief LRO Narrow Angle Camera Model
+   * @brief Kaguya MI Camera Model
    *
    * This is the camera model for the Kaguya Multiband pushbroom imagers (VIR and NIR)
    *

--- a/isis/src/kaguya/objs/KaguyaMiCamera/KaguyaMiCamera.truth
+++ b/isis/src/kaguya/objs/KaguyaMiCamera/KaguyaMiCamera.truth
@@ -69,6 +69,76 @@ Latitude OK
 Longitude OK
 
 --------------------------------------------
+FileName: MVA_2B2_01_01228N608E1354.cub
+CK Frame: -131330
+
+Kernel IDs: 
+CK Frame ID = -131000
+CK Reference ID = 1
+SPK Target ID = -131
+SPK Reference ID = 1
+
+Spacecraft Name Long: Kaguya
+Spacecraft Name Short: Kaguya
+Instrument Name Long: Multi Band Imager Visible
+Instrument Name Short: MI-VIS
+
+For upper left corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For upper right corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For lower left corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For lower right corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For center pixel position ...
+Latitude OK
+Longitude OK
+
+--------------------------------------------
+FileName: MNA_2B2_01_01228N602E1354.cub
+CK Frame: -131340
+
+Kernel IDs: 
+CK Frame ID = -131000
+CK Reference ID = 1
+SPK Target ID = -131
+SPK Reference ID = 1
+
+Spacecraft Name Long: Kaguya
+Spacecraft Name Short: Kaguya
+Instrument Name Long: Multi Band Imager Infrared
+Instrument Name Short: MI-NIR
+
+For upper left corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For upper right corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For lower left corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For lower right corner ...
+DeltaSample = 0.000000000
+DeltaLine = 0.000000000
+
+For center pixel position ...
+Latitude OK
+Longitude OK
+
+--------------------------------------------
 
 Testing exceptions:
 

--- a/isis/src/kaguya/objs/KaguyaMiCamera/unitTest.cpp
+++ b/isis/src/kaguya/objs/KaguyaMiCamera/unitTest.cpp
@@ -44,10 +44,12 @@ int main(int argc, char *argv[]) {
     // These should be lat/lon at center of image. To obtain these numbers for a new cube/camera,
     // set both the known lat and known lon to zero and copy the unit test output "Latitude off by: "
     // and "Longitude off by: " values directly into these variables.
-    double knownLat[2] = { -12.0400820752276996, 47.7445483329470406 };
-    double knownLon[2] = { 355.7272261079595523, 42.9611485167199660 };
+    double knownLat[4] = { -12.0400820752276996, 47.7445483329470406, 60.8041933170744215, 0.0};
+    double knownLon[4] = { 355.7272261079595523, 42.9611485167199660, 135.3886983694549713, 0.0};
 
-    char files[2][1024] = { "$kaguya/testData/MI_VIS.cub", "$kaguya/testData/MI_NIR.cub" };
+    char files[4][1024] = { "$kaguya/testData/MI_VIS.cub", "$kaguya/testData/MI_NIR.cub", 
+                            "$kaguya/testData/MVA_2B2_01_01228N608E1354.cub", 
+                            "$kaguya/testData/MNA_2B2_01_01228N602E1354.cub"};
  
     for (unsigned int i = 0; i < sizeof(knownLat) / sizeof(double); i++) {
       Cube c(files[i], "r");

--- a/isis/src/kaguya/objs/KaguyaMiCamera/unitTest.cpp
+++ b/isis/src/kaguya/objs/KaguyaMiCamera/unitTest.cpp
@@ -44,8 +44,10 @@ int main(int argc, char *argv[]) {
     // These should be lat/lon at center of image. To obtain these numbers for a new cube/camera,
     // set both the known lat and known lon to zero and copy the unit test output "Latitude off by: "
     // and "Longitude off by: " values directly into these variables.
-    double knownLat[4] = { -12.0400820752276996, 47.7445483329470406, 60.8041933170744215, 0.0};
-    double knownLon[4] = { 355.7272261079595523, 42.9611485167199660, 135.3886983694549713, 0.0};
+    double knownLat[4] = { -12.0400820752276996, 47.7445483329470406, 
+                            60.8041933170744215, 60.1567063916710580};
+    double knownLon[4] = { 355.7272261079595523, 42.9611485167199660, 
+                           135.3886983694549713, 135.3809757236753057};
 
     char files[4][1024] = { "$kaguya/testData/MI_VIS.cub", "$kaguya/testData/MI_NIR.cub", 
                             "$kaguya/testData/MVA_2B2_01_01228N608E1354.cub", 


### PR DESCRIPTION
##  Description
Adds support for JAXA archive Level 2B2 images to Kaguya MI in ISIS and associated tests. 
Includes updated unit test for camera model with new data format and updated ingestion test.

## Related Issue
Is there an issue for this work? 

## Motivation and Context
Supports work on Kaguya MI level 2b2 images in ISIS. 

## How Has This Been Tested?
Local tests pass and newly added tests for new functionality pass.

To test the camera model: 
I took 4-5 of these images and compared them against an internal Lola/Kaguya merged DEM that was `map2cam`'d with the test cubes as the match images. These were blinked in qview and I used the 'measure' tool to get some rough estimates of offset and they were 5+ pixels, but due to them being uncontrolled and without smithed spice, this seemed like a reasonable offset to Jesse and Stuart (and me.) If you're internal and would like to take a look at these cubes, they are at `/work/projects/kberry/kaguya2020`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
