### PR TITLE
Fix: translate 2nd coord of ROI to (X4, Y4), not (X2, Y2), as expected by hyb2onccal

### DIFF
--- a/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncInstrument.trn
+++ b/isis/src/hayabusa2/apps/hyb2onc2isis/Hayabusa2OncInstrument.trn
@@ -161,6 +161,7 @@ End_Group
 
 Group = SelectedImageAreaX2
   Auto
+  Optional
   InputKey       = P_OPOSX2
   InputKey       = ROI_URX
   InputPosition  = FitsLabels
@@ -171,6 +172,7 @@ End_Group
 
 Group = SelectedImageAreaY2
   Auto
+  Optional
   InputKey       = P_OPOSY2
   InputKey       = ROI_URY
   InputPosition  = FitsLabels
@@ -201,8 +203,8 @@ End_Group
 
 Group = SelectedImageAreaX4
   Auto
-  Optional
   InputKey       = P_OPOSX4
+  InputKey       = ROI_URX
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaX4
   OutputPosition = (Object, IsisCube, Group, Instrument)
@@ -211,8 +213,8 @@ End_Group
 
 Group = SelectedImageAreaY4
   Auto
-  Optional
   InputKey       = P_OPOSY4
+  InputKey       = ROI_URY
   InputPosition  = FitsLabels
   OutputName     = SelectedImageAreaY4
   OutputPosition = (Object, IsisCube, Group, Instrument)


### PR DESCRIPTION
A small update to make hyb2onccal work after recent changes in the Hayabusa2 FITS header format.

## Description
I helped with a recent update to the .trn file in which we assumed that ROI_URX and ROI_URY should be translated to SelectedImageAreaX2 and SelectedImageAreaY2, but it's clear from https://github.com/USGS-Astrogeology/ISIS3/blob/53af27e53c06fb38d7cadcfc1b5754c1be3baf45/isis/src/hayabusa2/apps/hyb2onccal/main.cpp#L134 that X4 and Y4 are expected.

## Related Issue
https://github.com/USGS-Astrogeology/ISIS3/issues/3698
https://github.com/USGS-Astrogeology/ISIS3/pull/3813

## How Has This Been Tested?

Tried on 4.1.0 RC

```
(isis4) $ hyb2onccal from=hyb2_onc_20180801_163925_tvf_l2a.cub to=hyb2_onc_20180801_163925_tvf_l2a.cal.cub
bias: 289.9

dark current: 0.0293015
Group = RadiometricCalibration
  SoftwareName        = hyb2onccal
  SoftwareVersion     = 1.0
  ProcessDate         = 2020-04-05T17:11:22
  CalibrationFile     = $hayabusa2/calibration/onc/hyb2oncCalibration0001.trn
  FlatFieldFile       = $hayabusa2/calibration/flatfield/flat_v.cub
  CompressionFactor   = 16
  Bias_Bn             = (289.9, -1.5847, 0.01211)
  Bias                = 289.9 <DN>
  CalibrationUnits    = IOF
  RadianceStandard    = 1.0
  RadianceScaleFactor = 1.0
  SolarDistance       = 1.0 <AU>
  SolarFlux           = 1880.5
  IOFFactor           = 1.0
  Units               = DN
End_Group
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
