### PR TITLE
Fixed tc data set IDs

### DIFF
--- a/isis/src/kaguya/apps/kaguyatc2isis/kaguyatc2isis.cpp
+++ b/isis/src/kaguya/apps/kaguyatc2isis/kaguyatc2isis.cpp
@@ -41,12 +41,14 @@ namespace Isis {
         && id != "TC1_Level2B"
         && id != "TC2_Level2B"
         && id != "SLN-L-TC-3-S-LEVEL2B0-V1.0"
+        && id != "SLN-L-TC-3-W-LEVEL2B0-V1.0"
         && id != "SLN-L-TC-5-MORNING-MAP-V4.0") {
       QString msg = "Input file [" + labelFile + "] does not appear to be " +
                     "a supported Kaguya Terrain Camera format. " +
                     "DATA_SET_ID is [" + id + "]" +
                     "Valid formats include [TC_MAP, TCO_MAP, TC1_Level2B, " +
-                    "SLN-L-TC-3-S-LEVEL2B0-V1.0, SLN-L-TC-5-MORNING-MAP-V4.0]";
+                    "SLN-L-TC-3-S-LEVEL2B0-V1.0, SLN-L-TC-3-W-LEVEL2B0-V1.0, " +
+		    "SLN-L-TC-5-MORNING-MAP-V4.0]";
       throw IException(IException::Unknown, msg, _FILEINFO_);
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the W type data to the list of valid LVL2B0 Kaguya TC images in kaguyatc2isis.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3670 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The S data set was added, but the W data set was not. This allows the W data set to be ingested properly.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The test W image was able to be ingested and spiceinit'd. All tests also passed still.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
