### PR TITLE
Removed tracking table warning

### DIFF
--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
@@ -61,7 +61,7 @@ namespace Isis {
     connect(p_action, SIGNAL(triggered()), p_tableWin, SLOT(raise()));
     connect(p_action, SIGNAL(triggered()), p_tableWin, SLOT(syncColumns()));
     p_tableWin->installEventFilter(this);
-    
+
     // Adds each item of checkBoxItems to the table.
     // If a tool tip is specified, we cannot skip parameters, so -1 and
     // Qt::Horizontal are specified.
@@ -498,7 +498,7 @@ namespace Isis {
       // Always write out columns et and utc, regardless of whether set image succeeds
       iTime time(cvp->camera()->time());
       p_tableWin->table()->item(row, getIndex("Ephemeris Time"))->
-                           setText(QString::number(time.Et(), 'f', 15));      
+                           setText(QString::number(time.Et(), 'f', 15));
       QString time_utc = time.UTC();
       p_tableWin->table()->item(row, getIndex("UTC"))->setText(time_utc);
 
@@ -623,7 +623,7 @@ namespace Isis {
         int iTrackBand = -1;
 
         // This is a mosaic in the new format or the external tracking cube itself
-        if(cCube->hasGroup("Tracking") || 
+        if(cCube->hasGroup("Tracking") ||
                 (cCube->hasTable(trackingTableName) && cCube->bandCount() == 1)) {
           Cube *trackingCube;
           if(cCube->hasGroup("Tracking")) {
@@ -632,7 +632,7 @@ namespace Isis {
           else {
             trackingCube = cCube;
           }
-          
+
           // Read the cube DN value from TRACKING cube at location (piLine, piSample)
           Portal trackingPortal(trackingCube->sampleCount(), 1, trackingCube->pixelType());
           trackingPortal.SetPosition(piSample, piLine, 1);
@@ -694,15 +694,18 @@ namespace Isis {
               psSrcSerialNum = QString(cFileTable[piOrigin][1]);
             }
           }
-        } 
-        
-        if (piOrigin == -1) { // If not from an image, display N/A
-          psSrcFileName = "N/A";
-          psSrcSerialNum = "N/A";
         }
+
       }
       catch (IException &e) {
-          QMessageBox::warning((QWidget *)parent(), "Warning", e.toString());
+          // This gets called too frequently to raise a warning; so, suppress the error
+          // and return invalid.
+          piOrigin = -1;
+      }
+
+      if (piOrigin == -1) { // If not from an image, display N/A
+        psSrcFileName = "N/A";
+        psSrcSerialNum = "N/A";
       }
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The warning in the Advanced Track Tool was being raised every time the mouse was moved  when a mosaic had an old tracking table that was either corrupted, or had the band removed. This made it impossible to move the mouse over such and image, even when the image data was still valid. By suppressing the exception and returning N/A these mosaics now work like regular mosaics.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #3685 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Some mosaics were unusable in qview

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on both MAC OS 10.13 and Ubuntu 18 and the issue is resolved. Also, checked a mosaic with a valid tracking table. This code is part of the GUI so it does not have automated testing associated with it.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
