### PR TITLE
Added the ability to skip special pixels in phocube

### DIFF
--- a/isis/src/base/apps/phocube/main.cpp
+++ b/isis/src/base/apps/phocube/main.cpp
@@ -287,9 +287,10 @@ void IsisMain() {
         // If dn is true, make sure to not overwrite the original pixels with NULL for the dn band
         if (!specialPixels && IsSpecial(in[inIndex])) {
           for (int band = (dn) ? 1 : 0; band < nbands; band++) {
-            out[index] = Isis::NULL8;
+            out[index] = Isis::Null;
             index += 64 * 64;
           }
+
           continue;
         }
 
@@ -462,16 +463,14 @@ void IsisMain() {
           for (int band = (dn) ? 1 : 0; band < nbands; band++) {
             if(ra && band == raBandNum) {
               out[index] = cam->RightAscension();
-              index += 64 * 64;
             }
             else if (declination && band == raBandNum + 1) {
               out[index] = cam->Declination();
-              index += 64 * 64;
             }
             else {
-              out[index] = Isis::NULL8;
-              index += 64 * 64;
+              out[index] = Isis::Null;
             }
+            index += 64 * 64;
           }
         }
       }

--- a/isis/src/base/apps/phocube/main.cpp
+++ b/isis/src/base/apps/phocube/main.cpp
@@ -16,44 +16,6 @@
 using namespace std;
 using namespace Isis;
 
-// Global variables
-Camera *cam;
-TProjection *proj;
-int nbands;
-bool noCamera;
-bool specialPixels;
-
-bool dn;
-bool phase;
-bool emission;
-bool incidence;
-bool localEmission;
-bool localIncidence;
-bool latitude;
-bool longitude;
-bool pixelResolution;
-bool lineResolution;
-bool sampleResolution;
-bool detectorResolution;
-bool obliqueDetectorResolution;
-bool northAzimuth;
-bool sunAzimuth;
-bool spacecraftAzimuth;
-bool offnadirAngle;
-bool subSpacecraftGroundAzimuth;
-bool subSolarGroundAzimuth;
-bool morphologyRank;
-bool albedoRank;
-bool ra;
-bool declination;
-bool bodyFixedX;
-bool bodyFixedY;
-bool bodyFixedZ;
-
-int raBandNum;
-
-void phocube(Buffer &in, Buffer &out);
-
 
 // Function to create a keyword with same values of a specified count
 template <typename T> PvlKeyword makeKey(const QString &name,
@@ -73,8 +35,6 @@ MosData *getMosaicIndicies(Camera &camera, MosData &md);
 void UpdateBandKey(const QString &keyname, PvlGroup &bb, const int &nvals,
                    const QString &default_value = "Null");
 
-
-
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
 
@@ -82,6 +42,8 @@ void IsisMain() {
   // projection information
   Process p1;
   Cube *icube = p1.SetInputCube("FROM", OneBand);
+
+  bool noCamera;
   if (ui.GetString("SOURCE") == "CAMERA") {
     noCamera = false;
   }
@@ -89,6 +51,8 @@ void IsisMain() {
     noCamera = true;
   }
 
+  Camera *cam;
+  TProjection *proj;
   if(noCamera) {
     try {
       proj = (TProjection *) icube->projection();
@@ -113,30 +77,30 @@ void IsisMain() {
   ProcessByBrick p;
 
   // Find out which bands are to be created
-  nbands = 0;
-  phase = false;
-  emission = false;
-  incidence = false;
-  localEmission = false;
-  localIncidence = false;
-  lineResolution = false;
-  sampleResolution = false;
-  detectorResolution = false;
-  obliqueDetectorResolution = false;
-  sunAzimuth = false;
-  spacecraftAzimuth = false;
-  offnadirAngle = false;
-  subSpacecraftGroundAzimuth = false;
-  subSolarGroundAzimuth = false;
-  morphologyRank = false;
-  albedoRank = false;
-  northAzimuth = false;
-  ra = false;
-  declination = false;
-  bodyFixedX = false;
-  bodyFixedY = false;
-  bodyFixedZ = false;
-  raBandNum = 0;  // 0 based, if RA is 5th band, raBandNum will be 4
+  int nbands = 0;
+  bool phase = false;
+  bool emission = false;
+  bool incidence = false;
+  bool localEmission = false;
+  bool localIncidence = false;
+  bool lineResolution = false;
+  bool sampleResolution = false;
+  bool detectorResolution = false;
+  bool obliqueDetectorResolution = false;
+  bool sunAzimuth = false;
+  bool spacecraftAzimuth = false;
+  bool offnadirAngle = false;
+  bool subSpacecraftGroundAzimuth = false;
+  bool subSolarGroundAzimuth = false;
+  bool morphologyRank = false;
+  bool albedoRank = false;
+  bool northAzimuth = false;
+  bool ra = false;
+  bool declination = false;
+  bool bodyFixedX = false;
+  bool bodyFixedY = false;
+  bool bodyFixedZ = false;
+  int raBandNum = 0;  // 0 based, if RA is 5th band, raBandNum will be 4
 
   if (!noCamera) {
     if ((phase = ui.GetBoolean("PHASE"))) nbands++;
@@ -162,9 +126,17 @@ void IsisMain() {
     if ((bodyFixedY = ui.GetBoolean("BODYFIXED"))) nbands++;
     if ((bodyFixedZ = ui.GetBoolean("BODYFIXED"))) nbands++;
   }
+
+  bool dn;
   if ((dn = ui.GetBoolean("DN"))) nbands++;
+
+  bool latitude;
   if ((latitude = ui.GetBoolean("LATITUDE"))) nbands++;
+
+  bool longitude;
   if ((longitude = ui.GetBoolean("LONGITUDE"))) nbands++;
+
+  bool pixelResolution;
   if ((pixelResolution = ui.GetBoolean("PIXELRESOLUTION"))) nbands++;
 
   if (nbands < 1) {
@@ -288,7 +260,223 @@ void IsisMain() {
     name += "Body Fixed Z";
   }
 
-  specialPixels = ui.GetBoolean("SPECIALPIXELS");
+  bool specialPixels = ui.GetBoolean("SPECIALPIXELS");
+
+  /**
+   * Computes all the geometric properties for the output buffer. Certain
+   * knowledge of the buffers size is assumed below, so ensure the buffer
+   * is still of the expected size.
+   * 
+   * @param in  The input cube buffer.
+   * @param out The output cube buffer.
+   */
+  auto phocube = [&](Buffer &in, Buffer &out)->void {
+    for (int i = 0; i < 64; i++) {
+      for (int j = 0; j < 64; j++) {
+
+        MosData mosd, *p_mosd(0);  // For special mosaic angles
+
+        int index = i * 64 + j;
+        int inIndex = index;
+
+        if (dn) {
+          out[index] = in[index];
+          index += 64 * 64;
+        }
+
+        // If dn is true, make sure to not overwrite the original pixels with NULL for the dn band
+        if (!specialPixels && IsSpecial(in[inIndex])) {
+          for (int band = (dn) ? 1 : 0; band < nbands; band++) {
+            out[index] = Isis::NULL8;
+            index += 64 * 64;
+          }
+          continue;
+        }
+
+        // Checks to see if the point is off the body
+        double samp = out.Sample(index);
+        double line = out.Line(index);
+        bool isGood = false;
+        if (noCamera) {
+          isGood = proj->SetWorld(samp, line);
+        }
+        else {
+          isGood = cam->SetImage(samp, line);
+        }
+
+        if (isGood) {
+
+          if (phase) {
+            out[index] = cam->PhaseAngle();
+            index += 64 * 64;
+          }
+          if (emission) {
+            out[index] = cam->EmissionAngle();
+            index += 64 * 64;
+          }
+          if (incidence) {
+            out[index] = cam->IncidenceAngle();
+            index += 64 * 64;
+          }
+          if (localEmission || localIncidence) {
+            Angle phase;
+            Angle incidence;
+            Angle emission;
+            bool success;
+            cam->LocalPhotometricAngles(phase, incidence, emission, success);
+
+            if (localEmission) {
+              out[index] = emission.degrees();
+              index += 64 * 64;
+            }
+
+            if (localIncidence) {
+              out[index] = incidence.degrees();
+              index += 64 * 64;
+            }
+          }
+          if (latitude) {
+            if (noCamera) {
+              out[index] = proj->UniversalLatitude();
+            }
+            else {
+              out[index] = cam->UniversalLatitude();
+            }
+            index += 64 * 64;
+          }
+          if (longitude) {
+            if (noCamera) {
+              out[index] = proj->UniversalLongitude();
+            }
+            else {
+              out[index] = cam->UniversalLongitude();
+            }
+            index += 64 * 64;
+          }
+          if (pixelResolution) {
+            if (noCamera) {
+              out[index] = proj->Resolution();
+            }
+            else {
+              out[index] = cam->PixelResolution();
+            }
+            index += 64 * 64;
+          }
+          if (lineResolution) {
+            out[index] = cam->LineResolution();
+            index += 64 * 64;
+          }
+          if (sampleResolution) {
+            out[index] = cam->SampleResolution();
+            index += 64 * 64;
+          }
+          if (detectorResolution) {
+            out[index] = cam->DetectorResolution();
+            index += 64 * 64;
+          }
+          if (obliqueDetectorResolution) {
+            out[index] = cam->ObliqueDetectorResolution();
+            index += 64 * 64;
+          }
+          if (northAzimuth) {
+            out[index] = cam->NorthAzimuth();
+            index += 64 * 64;
+          }
+          if (sunAzimuth) {
+            out[index] = cam->SunAzimuth();
+            index += 64 * 64;
+          }
+          if (spacecraftAzimuth) {
+            out[index] = cam->SpacecraftAzimuth();
+            index += 64 * 64;
+          }
+          if (offnadirAngle) {
+            out[index] = cam->OffNadirAngle();
+            index += 64 * 64;
+          }
+          if (subSpacecraftGroundAzimuth) {
+            double ssplat, ssplon;
+            ssplat = ssplon = 0.0;
+            cam->subSpacecraftPoint(ssplat, ssplon);
+            out[index] = cam->GroundAzimuth(cam->UniversalLatitude(),
+                cam->UniversalLongitude(), ssplat, ssplon);
+            index += 64 * 64;
+          }
+          if (subSolarGroundAzimuth) {
+            double sslat, sslon;
+            sslat = sslon = 0.0;
+            cam->subSolarPoint(sslat,sslon);
+            out[index] = cam->GroundAzimuth(cam->UniversalLatitude(),
+                cam->UniversalLongitude(), sslat, sslon);
+            index += 64 * 64;
+          }
+
+          // Special Mosaic indexes
+          if (morphologyRank) {
+            if (!p_mosd) {
+              p_mosd = getMosaicIndicies(*cam, mosd);
+            }
+            out[index] = mosd.m_morph;
+            index += 64 * 64;
+          }
+
+          if (albedoRank) {
+            if (!p_mosd) {
+              p_mosd = getMosaicIndicies(*cam, mosd);
+            }
+            out[index] = mosd.m_albedo;
+            index += 64 * 64;
+          }
+
+          if (ra) {
+            out[index] = cam->RightAscension();
+            index += 64 * 64;
+          }
+
+          if (declination) {
+            out[index] = cam->Declination();
+            index += 64 * 64;
+          }
+
+          if (!noCamera) {
+            double pB[3];
+            cam->Coordinate(pB);
+            if (bodyFixedX) {
+              out[index] = pB[0];
+              index += 64 * 64;
+            }
+
+            if (bodyFixedY) {
+              out[index] = pB[1];
+              index += 64 * 64;
+            }
+            if (bodyFixedZ) {
+              out[index] = pB[2];
+              index += 64 * 64;
+            }
+          }
+        }
+
+        // Trim outer space except RA and dec bands
+        else {
+          for (int band = (dn) ? 1 : 0; band < nbands; band++) {
+            if(ra && band == raBandNum) {
+              out[index] = cam->RightAscension();
+              index += 64 * 64;
+            }
+            else if (declination && band == raBandNum + 1) {
+              out[index] = cam->Declination();
+              index += 64 * 64;
+            }
+            else {
+              out[index] = Isis::NULL8;
+              index += 64 * 64;
+            }
+          }
+        }
+      }
+    }
+  };
 
   (void) p.SetInputCube("FROM", OneBand);
   Cube *ocube = p.SetOutputCube("TO", icube->sampleCount(),
@@ -320,217 +508,6 @@ void IsisMain() {
   UpdateBandKey("Width", bb, nvals, "1.0");
 
   p.EndProcess();
-}
-
-//  Computes all the geometric properties for the output buffer.  Certain
-//  knowledge of the buffers size is assumed below, so ensure the buffer
-//  is still of the expected size.
-void phocube(Buffer &in, Buffer &out) {
-  for (int i = 0; i < 64; i++) {
-    for (int j = 0; j < 64; j++) {
-
-      MosData mosd, *p_mosd(0);  // For special mosaic angles
-
-      int index = i * 64 + j;
-      int inIndex = index;
-
-      if (dn) {
-        out[index] = in[index];
-        index += 64 * 64;
-      }
-
-      // If dn is true, make sure to not overwrite the original pixels with NULL for the dn band
-      if (!specialPixels && IsSpecial(in[inIndex])) {
-        for (int band = (dn) ? 1 : 0; band < nbands; band++) {
-          out[index] = Isis::NULL8;
-          index += 64 * 64;
-        }
-        continue;
-      }
-
-      // Checks to see if the point is off the body
-      double samp = out.Sample(index);
-      double line = out.Line(index);
-      bool isGood = false;
-      if (noCamera) {
-        isGood = proj->SetWorld(samp, line);
-      }
-      else {
-        isGood = cam->SetImage(samp, line);
-      }
-
-      if (isGood) {
-
-        if (phase) {
-          out[index] = cam->PhaseAngle();
-          index += 64 * 64;
-        }
-        if (emission) {
-          out[index] = cam->EmissionAngle();
-          index += 64 * 64;
-        }
-        if (incidence) {
-          out[index] = cam->IncidenceAngle();
-          index += 64 * 64;
-        }
-        if (localEmission || localIncidence) {
-          Angle phase;
-          Angle incidence;
-          Angle emission;
-          bool success;
-          cam->LocalPhotometricAngles(phase, incidence, emission, success);
-
-          if (localEmission) {
-            out[index] = emission.degrees();
-            index += 64 * 64;
-          }
-
-          if (localIncidence) {
-            out[index] = incidence.degrees();
-            index += 64 * 64;
-          }
-        }
-        if (latitude) {
-          if (noCamera) {
-            out[index] = proj->UniversalLatitude();
-          }
-          else {
-            out[index] = cam->UniversalLatitude();
-          }
-          index += 64 * 64;
-        }
-        if (longitude) {
-          if (noCamera) {
-            out[index] = proj->UniversalLongitude();
-          }
-          else {
-            out[index] = cam->UniversalLongitude();
-          }
-          index += 64 * 64;
-        }
-        if (pixelResolution) {
-          if (noCamera) {
-            out[index] = proj->Resolution();
-          }
-          else {
-            out[index] = cam->PixelResolution();
-          }
-          index += 64 * 64;
-        }
-        if (lineResolution) {
-          out[index] = cam->LineResolution();
-          index += 64 * 64;
-        }
-        if (sampleResolution) {
-          out[index] = cam->SampleResolution();
-          index += 64 * 64;
-        }
-        if (detectorResolution) {
-          out[index] = cam->DetectorResolution();
-          index += 64 * 64;
-        }
-        if (obliqueDetectorResolution) {
-          out[index] = cam->ObliqueDetectorResolution();
-          index += 64 * 64;
-        }
-        if (northAzimuth) {
-          out[index] = cam->NorthAzimuth();
-          index += 64 * 64;
-        }
-        if (sunAzimuth) {
-          out[index] = cam->SunAzimuth();
-          index += 64 * 64;
-        }
-        if (spacecraftAzimuth) {
-          out[index] = cam->SpacecraftAzimuth();
-          index += 64 * 64;
-        }
-        if (offnadirAngle) {
-          out[index] = cam->OffNadirAngle();
-          index += 64 * 64;
-        }
-        if (subSpacecraftGroundAzimuth) {
-          double ssplat, ssplon;
-          ssplat = ssplon = 0.0;
-          cam->subSpacecraftPoint(ssplat, ssplon);
-          out[index] = cam->GroundAzimuth(cam->UniversalLatitude(),
-              cam->UniversalLongitude(), ssplat, ssplon);
-          index += 64 * 64;
-        }
-        if (subSolarGroundAzimuth) {
-          double sslat, sslon;
-          sslat = sslon = 0.0;
-          cam->subSolarPoint(sslat,sslon);
-          out[index] = cam->GroundAzimuth(cam->UniversalLatitude(),
-              cam->UniversalLongitude(), sslat, sslon);
-          index += 64 * 64;
-        }
-
-        // Special Mosaic indexes
-        if (morphologyRank) {
-          if (!p_mosd) {
-            p_mosd = getMosaicIndicies(*cam, mosd);
-          }
-          out[index] = mosd.m_morph;
-          index += 64 * 64;
-        }
-
-        if (albedoRank) {
-          if (!p_mosd) {
-            p_mosd = getMosaicIndicies(*cam, mosd);
-          }
-          out[index] = mosd.m_albedo;
-          index += 64 * 64;
-        }
-
-        if (ra) {
-          out[index] = cam->RightAscension();
-          index += 64 * 64;
-        }
-
-        if (declination) {
-          out[index] = cam->Declination();
-          index += 64 * 64;
-        }
-
-        if (!noCamera) {
-          double pB[3];
-          cam->Coordinate(pB);
-          if (bodyFixedX) {
-            out[index] = pB[0];
-            index += 64 * 64;
-          }
-
-          if (bodyFixedY) {
-            out[index] = pB[1];
-            index += 64 * 64;
-          }
-          if (bodyFixedZ) {
-            out[index] = pB[2];
-            index += 64 * 64;
-          }
-        }
-      }
-
-      // Trim outer space except RA and dec bands
-      else {
-        for (int band = (dn) ? 1 : 0; band < nbands; band++) {
-          if(ra && band == raBandNum) {
-            out[index] = cam->RightAscension();
-            index += 64 * 64;
-          }
-          else if (declination && band == raBandNum + 1) {
-            out[index] = cam->Declination();
-            index += 64 * 64;
-          }
-          else {
-            out[index] = Isis::NULL8;
-            index += 64 * 64;
-          }
-        }
-      }
-    }
-  }
 }
 
 

--- a/isis/src/base/apps/phocube/phocube.xml
+++ b/isis/src/base/apps/phocube/phocube.xml
@@ -305,6 +305,10 @@ xsi:noNamespaceSchemaLocation=
     <change name="Kaitlyn Lee" date="2019-02-15">
       Allowed RA and DEC to be exported regardless if the pixel is off body. Fixes #4446.
     </change>
+    <change name="Kaitlyn Lee" date="2020-06-04">
+      Added SPECIALPIXELS parameter to allow users to skip calculations on special pixels, excluding
+      RA and DEC. This changed merged the two process functions.
+    </change>
   </history>
 
   <category>
@@ -403,6 +407,15 @@ xsi:noNamespaceSchemaLocation=
     </group>
 
     <group name="Photometry">
+      <parameter name="SPECIALPIXELS">
+        <type>boolean</type>
+        <default><item>TRUE</item></default>
+        <brief>Include special pixels in the ouptut image</brief>
+        <description>
+          If this parameter is true, calculations will be done on special pixels.
+          If this parameter is false, special pixels will be skipped and set to NULL in the output image for all bands selected.
+        </description>
+      </parameter>
       <parameter name="DN">
         <type>boolean</type>
         <default><item>FALSE</item></default>

--- a/isis/src/base/apps/phocube/phocube.xml
+++ b/isis/src/base/apps/phocube/phocube.xml
@@ -309,7 +309,8 @@ xsi:noNamespaceSchemaLocation=
       Added SPECIALPIXELS parameter to allow users to skip calculations on special pixels, excluding
       RA and DEC. This changed merged the two process functions, which were created to speed up 
       the application when copying over DN values. After a few time tests, it doesn't look like the 
-      merge causes the application to run longer.
+      merge causes the application to run longer. Changed the process function to be a lambda function
+      to get rid of global variables.
     </change>
   </history>
 

--- a/isis/src/base/apps/phocube/phocube.xml
+++ b/isis/src/base/apps/phocube/phocube.xml
@@ -307,7 +307,9 @@ xsi:noNamespaceSchemaLocation=
     </change>
     <change name="Kaitlyn Lee" date="2020-06-04">
       Added SPECIALPIXELS parameter to allow users to skip calculations on special pixels, excluding
-      RA and DEC. This changed merged the two process functions.
+      RA and DEC. This changed merged the two process functions, which were created to speed up 
+      the application when copying over DN values. After a few time tests, it doesn't look like the 
+      merge causes the application to run longer.
     </change>
   </history>
 

--- a/isis/src/base/apps/phocube/tsts/ignore_special_pixels/Makefile
+++ b/isis/src/base/apps/phocube/tsts/ignore_special_pixels/Makefile
@@ -1,0 +1,13 @@
+# Tests that special pixels in the input are set to null for all bands.
+APPNAME = phocube
+
+include $(ISISROOT)/make/isismake.tsts
+
+commands:
+	$(APPNAME) from=$(INPUT)/ab102401.cropped.lvl2.cub \
+	  to=$(OUTPUT)/output.cub \
+	  specialpixels=false \
+	  dn=true \
+	  radec=true > /dev/null; 
+	catlab from=$(OUTPUT)/output.cub \
+	  to=$(OUTPUT)/output.pvl > /dev/null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a parameter that defaults to true for backwards compatibility. This parameter allows users to skip any calculations on special pixels and sets the value to NULL in all bands except the DN band if selected. Needed to merge two process methods to propagate the input cube buffer to the main process method. There was concern that this would slow down phocube, but after some time tests, this does not seem that case.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/3646

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Has the possibility to speed up phocube if a user wishes to skip special pixels by not calling the setImage() method in Camera.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Created a new test called ignore_special_pixels and existing phocube tests pass.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
