### PR TITLE
Closed cube file and deleted cube after propagating tables #3841

### DIFF
--- a/isis/src/base/apps/map2cam/map2cam.cpp
+++ b/isis/src/base/apps/map2cam/map2cam.cpp
@@ -13,7 +13,9 @@ namespace Isis{
   Cube *mcube;
   Camera *outcam;
 
+
   void map2cam_f(UserInterface &ui) {
+
     // Open the input camera cube that we will be matching and create
     // the camera object
     FileName match = FileName(ui.GetFileName("MATCH"));
@@ -75,6 +77,8 @@ namespace Isis{
     // Cleanup
     delete transform;
     delete interp;
+
+    p.EndProcess();
   }
 
   // Transform object constructor

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -627,6 +627,8 @@ namespace Isis {
         }
       }
     }
+    fromCube->close();
+    delete fromCube;
   }
 
   /**

--- a/isis/src/base/objs/Process/Process.h
+++ b/isis/src/base/objs/Process/Process.h
@@ -154,6 +154,7 @@ namespace Isis {
    *                          empty QList is provided to this parameter which will propagate all
    *                          tables. Updated unitTest to test this change. References #4433.
    *  @history 2018-07-27 Kaitlyn Lee - Added unsigned/signed integer pixel type handling.
+   *  @history 2020-06-06 Stuart Sides - Closed cube file used to propagte tables.
    */
   class Process {
     protected:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Closed heap allocated cube file before returning

## Description
<!--- Describe your changes in detail -->
The cube file was opened but not closed in Process::PropagateTables. It is not closed and deleted.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes 3841

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local tests are good

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
