### PR TITLE
Update export to PDS4 of PolarStereographic-projected ISIS cubes.

### DIFF
--- a/isis/appdata/translations/pds4ExportPolarStereographic.trn
+++ b/isis/appdata/translations/pds4ExportPolarStereographic.trn
@@ -248,13 +248,12 @@ End_Group
 
 Group = StraightVerticalLongitudeFromPole
   Auto
-  InputKey       = CenterLatitude
+  InputKey       = CenterLongitude
   InputGroup     = "IsisCube,Mapping"
   InputPosition  = (IsisCube, Mapping)
   OutputName     = cart:straight_vertical_longitude_from_pole
   OutputPosition = (Product_Observational, Observation_Area, Discipline_Area, cart:Cartography, cart:Spatial_Reference_Information, cart:Horizontal_Coordinate_System_Definition, cart:Planar, cart:Map_Projection, cart:Polar_Stereographic)
-  Translation    = (180, 90.0)
-  Translation    = (0, -90.0)
+  Translation    = (*, *)
 End_Group
 
 End


### PR DESCRIPTION
## Description
The incorrect translation was being used to calculate the output value for straight vertical longitude from pole for polar stereographic projections for exporting ISIS map-projected cubes to PDS4 (new translation was verified with Trent.) The actual problem in the original ticket is fixed due to removing the numerical values in the translation file. 

## Related Issue
Fixes #3869

## Motivation and Context
The CaSSIS pipeline was failing when integer values were used for the center latitude in the mapping group. It turns out that center latitude should not have been used in this way in the first place.

## How Has This Been Tested?
Works on both cubes provided by the CaSSIS team as an example of the problem (listed in ticket.)

Test data for tgocassisrdrgen not updated in the system yet, but will do so after merge.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
