### PR TITLE
added mappt coordlist functionality

### DIFF
--- a/isis/src/base/apps/campt/campt.xml
+++ b/isis/src/base/apps/campt/campt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<application name="campt" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<application name="mappt" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:noNamespaceSchemaLocation=
 "http://isis.astrogeology.usgs.gov/Schemas/Application/application.xsd">
   <brief>
@@ -9,7 +9,7 @@ xsi:noNamespaceSchemaLocation=
 
   <description>
     <p>
-    Campt computes geometric and photometric information at a given pixel
+    mappt computes geometric and photometric information at a given pixel
     location or list of pixel locations in the input image <def link="Cube">cube</def>.
     The program computes spacecraft and instrument related information, and other types of
     coordinates as described later in this document. The user will have a choice of coordinates
@@ -35,7 +35,7 @@ xsi:noNamespaceSchemaLocation=
     flatfile of coordinates.
     </p>
     <p>
-    The following is a partial list of coordinates computed in the <i>campt</i> application:<br />
+    The following is a partial list of coordinates computed in the <i>mappt</i> application:<br />
     <br />
     <b>Geometric Information</b>: <def>Latitude</def>, <def>Longitude</def>, <def>Oblique Detector Resolution</def>,
        <def>Line Resolution</def>, <def>Oblique Line Resolution</def> <br />
@@ -56,10 +56,10 @@ xsi:noNamespaceSchemaLocation=
     a choice of a <def>PVL</def> file or a flat file. A PVL file is a text
     file in label format, while the flat file is a comma-delimited text file
     that is easily imported into most databases and digital spreadsheets
-    such as Microsoft Excel. Below is an example of <i>campt</i> output in <def>PVL</def>
+    such as Microsoft Excel. Below is an example of <i>mappt</i> output in <def>PVL</def>
     format. You can skim the left column of this PVL-formatted output file for
     a thorough listing of the types of coordinates, sun and instrument-related
-    information computed when using <i>campt</i>.
+    information computed when using <i>mappt</i>.
     </p>
 
     <pre>
@@ -200,7 +200,7 @@ End_Group
     </change>
     <change name="Ian Humphrey" date="2014-11-05">
       Added new parameters, USECOORDLIST, COORDLIST, and COORDTYPE for processing a list of
-      points as input. Reorganized campt. Fixes #1449.
+      points as input. Reorganized mappt. Fixes #1449.
     </change>
     <change name="Ian Humphrey" date="2015-03-03">
       Updated documentation. References #1449.
@@ -213,7 +213,7 @@ End_Group
     </change>
     <change name="Kaj Williams" date="2017-06-13">
       Resolved issue where the default value for the "allowoutside" parameter was supposed
-      to be set to "true", but the default _behavior_ of campt was instead consistent with a
+      to be set to "true", but the default _behavior_ of mappt was instead consistent with a
       setting of "false". In addition, corrected behavior where
       manually setting "allowoutside" to "false" was ignored. Ref # 2258.
     </change>
@@ -263,7 +263,7 @@ End_Group
           Selecting this parameter will enable the 'COORDLIST' and 'COORDTYPE' parameters in the
           GUI.
           <p>
-            Note that this parameter is optional when running <i>campt</i> on the
+            Note that this parameter is optional when running <i>mappt</i> on the
             command line.
           </p>
         </description>
@@ -289,7 +289,7 @@ End_Group
         <internalDefault>None</internalDefault>
         <description>
           An input comma-delimited flatfile of image coordinates or ground coordinates.
-          This allows the program to process multiple coordinates in a single run of <i>campt</i>,
+          This allows the program to process multiple coordinates in a single run of <i>mappt</i>,
           and output the results to the specified output file.
           <p>
             Expected order for image coordinates: sample, line<br/>
@@ -299,11 +299,11 @@ End_Group
             The "Error" keyword will only appear when using a coordinate list. The value of "Error"
             will then be NULL unless an error occurs during the processing of a coordinate in the
             coordinate list. Then, the value of this keyword will be the error message. This allows
-            for <i>campt</i> to continue processing the remaining coordinates in the coordinate
+            for <i>mappt</i> to continue processing the remaining coordinates in the coordinate
             list.
           </p>
           <p>
-            For the input of Latitude and Longitude, campt expects
+            For the input of Latitude and Longitude, mappt expects
             <def>Planetocentric Latitude</def> (within -90 to 90 boundary) and
             <def>Positive East Longitude</def> (with 0-360 boundary) to find the location in the
             input camera image.
@@ -354,7 +354,7 @@ End_Group
         <internalDefault>None</internalDefault>
         <description>
           A text file in label format (<def>PVL</def>) which will
-          contain the results of <i>campt</i>.  This file can
+          contain the results of <i>mappt</i>.  This file can
           be used in conjunction with the <i>getkey</i> application
           in order to pass the results to another program when developing
           scripts.
@@ -410,11 +410,11 @@ End_Group
           Allow sample/line values outside the image to be reported
         </brief>
         <description>
-          The Allowoutside parameter influences how <i>campt</i> will report
+          The Allowoutside parameter influences how <i>mappt</i> will report
           resulting latitude/longitude and sample/line coordinates that fall
           outside the input cube pixel boundaries.
           <p>
-          The default is set to True, which allows <i>campt</i> to return
+          The default is set to True, which allows <i>mappt</i> to return
           the values that are outside the cube pixel boundaries. For example,
           a given latitude/longitude might return a sample location of -1.0
           (a single whole pixel coordinate off the left side of the image).
@@ -422,7 +422,7 @@ End_Group
           </p>
           <p>
           When set to False, if a returned coordinate is off the image,
-          <i>campt</i> will fail.  This failure can be indicated and ignored
+          <i>mappt</i> will fail.  This failure can be indicated and ignored
           within a batch script when only coordinates that fall within the
           image cube pixel boundaries are desired.
           </p>

--- a/isis/src/base/apps/campt/campt.xml
+++ b/isis/src/base/apps/campt/campt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<application name="mappt" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<application name="campt" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 xsi:noNamespaceSchemaLocation=
 "http://isis.astrogeology.usgs.gov/Schemas/Application/application.xsd">
   <brief>
@@ -9,7 +9,7 @@ xsi:noNamespaceSchemaLocation=
 
   <description>
     <p>
-    mappt computes geometric and photometric information at a given pixel
+    campt computes geometric and photometric information at a given pixel
     location or list of pixel locations in the input image <def link="Cube">cube</def>.
     The program computes spacecraft and instrument related information, and other types of
     coordinates as described later in this document. The user will have a choice of coordinates
@@ -21,7 +21,7 @@ xsi:noNamespaceSchemaLocation=
     <ul>
       <li>The input image requires <def>SPICE</def> information (see <i>spiceinit</i>).</li>
       <li>The input image cube must be a <def>Level0</def>  or a <def>Level1</def> ISIS cube.</li>
-      <li>To use a <def>Level2</def> file as the input image (see <i>mappt</i>).</li>
+      <li>To use a <def>Level2</def> file as the input image (see <i>campt</i>).</li>
     </ul>
     </p>
     <p>
@@ -35,7 +35,7 @@ xsi:noNamespaceSchemaLocation=
     flatfile of coordinates.
     </p>
     <p>
-    The following is a partial list of coordinates computed in the <i>mappt</i> application:<br />
+    The following is a partial list of coordinates computed in the <i>campt</i> application:<br />
     <br />
     <b>Geometric Information</b>: <def>Latitude</def>, <def>Longitude</def>, <def>Oblique Detector Resolution</def>,
        <def>Line Resolution</def>, <def>Oblique Line Resolution</def> <br />
@@ -56,10 +56,10 @@ xsi:noNamespaceSchemaLocation=
     a choice of a <def>PVL</def> file or a flat file. A PVL file is a text
     file in label format, while the flat file is a comma-delimited text file
     that is easily imported into most databases and digital spreadsheets
-    such as Microsoft Excel. Below is an example of <i>mappt</i> output in <def>PVL</def>
+    such as Microsoft Excel. Below is an example of <i>campt</i> output in <def>PVL</def>
     format. You can skim the left column of this PVL-formatted output file for
     a thorough listing of the types of coordinates, sun and instrument-related
-    information computed when using <i>mappt</i>.
+    information computed when using <i>campt</i>.
     </p>
 
     <pre>
@@ -200,7 +200,7 @@ End_Group
     </change>
     <change name="Ian Humphrey" date="2014-11-05">
       Added new parameters, USECOORDLIST, COORDLIST, and COORDTYPE for processing a list of
-      points as input. Reorganized mappt. Fixes #1449.
+      points as input. Reorganized campt. Fixes #1449.
     </change>
     <change name="Ian Humphrey" date="2015-03-03">
       Updated documentation. References #1449.
@@ -213,7 +213,7 @@ End_Group
     </change>
     <change name="Kaj Williams" date="2017-06-13">
       Resolved issue where the default value for the "allowoutside" parameter was supposed
-      to be set to "true", but the default _behavior_ of mappt was instead consistent with a
+      to be set to "true", but the default _behavior_ of campt was instead consistent with a
       setting of "false". In addition, corrected behavior where
       manually setting "allowoutside" to "false" was ignored. Ref # 2258.
     </change>
@@ -231,7 +231,7 @@ End_Group
   <seeAlso>
     <applications>
       <item>spiceinit</item>
-      <item>mappt</item>
+      <item>campt</item>
       <item>getkey</item>
     </applications>
   </seeAlso>
@@ -263,7 +263,7 @@ End_Group
           Selecting this parameter will enable the 'COORDLIST' and 'COORDTYPE' parameters in the
           GUI.
           <p>
-            Note that this parameter is optional when running <i>mappt</i> on the
+            Note that this parameter is optional when running <i>campt</i> on the
             command line.
           </p>
         </description>
@@ -289,7 +289,7 @@ End_Group
         <internalDefault>None</internalDefault>
         <description>
           An input comma-delimited flatfile of image coordinates or ground coordinates.
-          This allows the program to process multiple coordinates in a single run of <i>mappt</i>,
+          This allows the program to process multiple coordinates in a single run of <i>campt</i>,
           and output the results to the specified output file.
           <p>
             Expected order for image coordinates: sample, line<br/>
@@ -299,11 +299,11 @@ End_Group
             The "Error" keyword will only appear when using a coordinate list. The value of "Error"
             will then be NULL unless an error occurs during the processing of a coordinate in the
             coordinate list. Then, the value of this keyword will be the error message. This allows
-            for <i>mappt</i> to continue processing the remaining coordinates in the coordinate
+            for <i>campt</i> to continue processing the remaining coordinates in the coordinate
             list.
           </p>
           <p>
-            For the input of Latitude and Longitude, mappt expects
+            For the input of Latitude and Longitude, campt expects
             <def>Planetocentric Latitude</def> (within -90 to 90 boundary) and
             <def>Positive East Longitude</def> (with 0-360 boundary) to find the location in the
             input camera image.
@@ -354,7 +354,7 @@ End_Group
         <internalDefault>None</internalDefault>
         <description>
           A text file in label format (<def>PVL</def>) which will
-          contain the results of <i>mappt</i>.  This file can
+          contain the results of <i>campt</i>.  This file can
           be used in conjunction with the <i>getkey</i> application
           in order to pass the results to another program when developing
           scripts.
@@ -410,11 +410,11 @@ End_Group
           Allow sample/line values outside the image to be reported
         </brief>
         <description>
-          The Allowoutside parameter influences how <i>mappt</i> will report
+          The Allowoutside parameter influences how <i>campt</i> will report
           resulting latitude/longitude and sample/line coordinates that fall
           outside the input cube pixel boundaries.
           <p>
-          The default is set to True, which allows <i>mappt</i> to return
+          The default is set to True, which allows <i>campt</i> to return
           the values that are outside the cube pixel boundaries. For example,
           a given latitude/longitude might return a sample location of -1.0
           (a single whole pixel coordinate off the left side of the image).
@@ -422,7 +422,7 @@ End_Group
           </p>
           <p>
           When set to False, if a returned coordinate is off the image,
-          <i>mappt</i> will fail.  This failure can be indicated and ignored
+          <i>campt</i> will fail.  This failure can be indicated and ignored
           within a batch script when only coordinates that fall within the
           image cube pixel boundaries are desired.
           </p>

--- a/isis/src/base/apps/campt/campt.xml
+++ b/isis/src/base/apps/campt/campt.xml
@@ -9,7 +9,7 @@ xsi:noNamespaceSchemaLocation=
 
   <description>
     <p>
-    campt computes geometric and photometric information at a given pixel
+    Campt computes geometric and photometric information at a given pixel
     location or list of pixel locations in the input image <def link="Cube">cube</def>.
     The program computes spacecraft and instrument related information, and other types of
     coordinates as described later in this document. The user will have a choice of coordinates
@@ -21,7 +21,7 @@ xsi:noNamespaceSchemaLocation=
     <ul>
       <li>The input image requires <def>SPICE</def> information (see <i>spiceinit</i>).</li>
       <li>The input image cube must be a <def>Level0</def>  or a <def>Level1</def> ISIS cube.</li>
-      <li>To use a <def>Level2</def> file as the input image (see <i>campt</i>).</li>
+      <li>To use a <def>Level2</def> file as the input image (see <i>mappt</i>).</li>
     </ul>
     </p>
     <p>
@@ -231,7 +231,7 @@ End_Group
   <seeAlso>
     <applications>
       <item>spiceinit</item>
-      <item>campt</item>
+      <item>mappt</item>
       <item>getkey</item>
     </applications>
   </seeAlso>

--- a/isis/src/base/apps/mappt/mappt.cpp
+++ b/isis/src/base/apps/mappt/mappt.cpp
@@ -92,10 +92,8 @@ void mappt(Cube *icube, UserInterface &ui, Pvl *log, CubeAttributeInput* inAtt) 
       
       for(int i = 0; i < log->groups(); i++) {
         PvlGroup group = log->group(i);
-        std::cout << group << std::endl;
         for(int j = 0; j < group.keywords(); j++) {
           os << (QString)group[j];
-          std::cout << (QString)group[j] << std::endl; 
           if(j < group.keywords() - 1) {
             os << ",";
           }

--- a/isis/src/base/apps/mappt/mappt.cpp
+++ b/isis/src/base/apps/mappt/mappt.cpp
@@ -9,12 +9,18 @@
 #include "TProjection.h"
 #include "ProjectionFactory.h"
 #include "SpecialPixel.h"
+#include "CSVReader.h"
 
 #include "mappt.h"
 
 using namespace std;
 
+
 namespace Isis {
+
+QList< QPair<double, double> > getMapPoints(const UserInterface &ui, bool usePointList);
+PvlGroup getProjPointInfo(Cube *icube, QPair<double, double> point, UserInterface &ui, Pvl *log);
+  
 void mappt(UserInterface &ui, Pvl *log) {
   Cube *cube = new Cube();
   CubeAttributeInput inAtt = ui.GetInputAttribute("FROM");
@@ -29,18 +35,28 @@ void mappt(UserInterface &ui, Pvl *log) {
 
 void mappt(Cube *icube, UserInterface &ui, Pvl *log, CubeAttributeInput* inAtt) {
   // Open the input cube and initialize the projection
-  TProjection *proj = (TProjection *) icube->projection();
+  
+  QList<QPair<double, double>> points = getMapPoints(ui, ui.WasEntered("COORDLIST"));
+   
+  if(log) {
+    for(int i = 0; i < points.size(); i++) {
+      log->addGroup(getProjPointInfo(icube, points[i], ui, log));
+    } 
+  }
+}
 
 
+PvlGroup getProjPointInfo(Cube *icube, QPair<double, double> point, UserInterface &ui, Pvl *log) { 
   // Get the coordinate
   bool outsideAllowed = ui.GetBoolean("ALLOWOUTSIDE");
   int cubeLineLimit = icube->lineCount() + .5;
   int cubeSampleLimit = icube->sampleCount() + .5;
 
+  TProjection *proj = (TProjection *) icube->projection();
   // Get the sample/line position if we have an image point
   if(ui.GetString("TYPE") == "IMAGE") {
-    double samp = ui.GetDouble("SAMPLE");
-    double line = ui.GetDouble("LINE");
+    double samp = point.first;
+    double line = point.second;
 
     if (!outsideAllowed) {
       if (samp < .5 || line < .5 || samp > cubeSampleLimit || line > cubeLineLimit) {
@@ -53,8 +69,8 @@ void mappt(Cube *icube, UserInterface &ui, Pvl *log, CubeAttributeInput* inAtt) 
 
   // Get the lat/lon position if we have a ground point
   else if(ui.GetString("TYPE") == "GROUND") {
-    double lat = ui.GetDouble("LATITUDE");
-    double lon = ui.GetDouble("LONGITUDE");
+    double lat = point.first;
+    double lon = point.second;
 
     // Make sure we have a valid latitude value
     if(fabs(lat) > 90.0) {
@@ -135,8 +151,8 @@ void mappt(Cube *icube, UserInterface &ui, Pvl *log, CubeAttributeInput* inAtt) 
 
   // Get the x/y position if we have a projection point
   else {
-    double x = ui.GetDouble("X");
-    double y = ui.GetDouble("Y");
+    double x = point.first;
+    double y = point.second;
     proj->SetCoordinate(x, y);
   }
 
@@ -266,91 +282,56 @@ void mappt(Cube *icube, UserInterface &ui, Pvl *log, CubeAttributeInput* inAtt) 
         results += pE180;
         results += pW360;
       }
-    }
-    
-    if (log) {
-      log->addGroup(results);
-    }
+    } 
+  }
 
-    // Write an output label file if necessary
-    if(ui.WasEntered("TO")) {
-      // Get user params from ui
-      QString outFile = FileName(ui.GetFileName("TO")).expanded();
-      bool exists = FileName(outFile).fileExists();
-      bool append = ui.GetBoolean("APPEND");
+  return results; 
+}
 
-      // Write the pvl group out to the file
-      if(ui.GetString("FORMAT") == "PVL") {
-        Pvl temp;
-        temp.addGroup(results);
-        if(append) {
-          temp.append(outFile);
-        }
-        else {
-          temp.write(outFile);
-        }
+
+QList< QPair<double, double> > getMapPoints(const UserInterface &ui, bool usePointList) {
+    double point1 = 0.0;
+    double point2 = 0.0;
+    QList< QPair<double, double> > points;
+    QString pointType = ui.GetString("TYPE");
+
+    // Check if the provided coordinate list is valid, i.e. a Samp/Line or Lat/Long coordinate per row
+    if (usePointList) {
+
+      CSVReader reader;
+      reader.read(FileName(ui.GetFileName("COORDLIST")).expanded());
+
+      if (!reader.isTableValid(reader.getTable()) || reader.columns() != 2) {
+        QString msg = "Coordinate file formatted incorrectly.\n"
+                      "Each row must have two columns: a sample,line or a latitude,longitude pair.";
+        throw IException(IException::User, msg, _FILEINFO_);
       }
-
-      // Create a flatfile of the same data
-      // The flatfile is comma delimited and can be imported into Excel
+      for (int row = 0; row < reader.rows(); row++) {
+        point1 = toDouble(reader.getRow(row)[0]);
+        point2 = toDouble(reader.getRow(row)[1]);
+        points.append(QPair<double, double>(point1, point2));
+      }
+    }
+    // Grab the coordinate from the ui position parameters if no coordinate list is provided
+    else {
+      if (pointType == "IMAGE") {
+        if (ui.WasEntered("SAMPLE"))
+          point1 = ui.GetDouble("SAMPLE");
+        if (ui.WasEntered("LINE"))
+          point2 = ui.GetDouble("LINE");
+      }
+      else if (pointType == "GROUND") {
+        point1 = ui.GetDouble("LATITUDE");
+        point2 = ui.GetDouble("LONGITUDE");
+      }
       else {
-        ofstream os;
-        bool writeHeader = false;
-        if(append) {
-          os.open(outFile.toLatin1().data(), ios::app);
-          if(!exists) {
-            writeHeader = true;
-          }
-        }
-        else {
-          os.open(outFile.toLatin1().data(), ios::out);
-          writeHeader = true;
-        }
-
-        // Rearrange the order of the lat/lons for the csv
-        results.deleteKeyword( pE360.name() );
-        results.deleteKeyword( pE180.name() );
-        results.deleteKeyword( pW360.name() );
-        results.deleteKeyword( pW180.name() );
-        results.deleteKeyword( centLat.name() );
-        results.deleteKeyword( graphLat.name() );
-        //Correct order.
-        results += centLat;
-        results += graphLat;
-        results += pE360;
-        results += pE180;
-        results += pW360;
-        results += pW180;
-
-        if(writeHeader) {
-          for(int i = 0; i < results.keywords(); i++) {
-            os << results[i].name();
-
-            if(i < results.keywords() - 1) {
-              os << ",";
-            }
-          }
-          os << endl;
-        }
-
-        for(int i = 0; i < results.keywords(); i++) {
-          os << (QString)results[i];
-
-          if(i < results.keywords() - 1) {
-            os << ",";
-          }
-        }
-        os << endl;
+        // Projection type selected
+        point1 = ui.GetDouble("X");
+        point2 = ui.GetDouble("Y");
       }
+      points.append(QPair<double, double>(point1, point2));
     }
-    else if(ui.GetString("FORMAT") == "FLAT") {
-      QString msg = "Flat file must have a name.";
-      throw IException(IException::User, msg, _FILEINFO_);
-    }
-  }
-  else {
-    QString msg = "Could not project requested position";
-    throw IException(IException::Unknown, msg, _FILEINFO_);
-  }
+
+    return points;
 }
 }

--- a/isis/src/base/apps/mappt/mappt.h
+++ b/isis/src/base/apps/mappt/mappt.h
@@ -1,5 +1,5 @@
-#ifndef campt_h
-#define campt_h
+#ifndef mappt_h
+#define mappt_h
 
 #include "Pvl.h"
 #include "UserInterface.h"

--- a/isis/src/base/apps/mappt/mappt.xml
+++ b/isis/src/base/apps/mappt/mappt.xml
@@ -302,7 +302,7 @@
           Enable coordinate list parameters in the GUI
         </brief>
         <description>
-          Selecting this parameter will enable the 'COORDLIST' and 'COORDTYPE' parameters in the
+          Selecting this parameter will enable the 'COORDLIST' parameter in the
           GUI.
           <p>
             Note that this parameter is optional when running <i>mappt</i> on the
@@ -332,12 +332,13 @@
         </brief>
         <internalDefault>None</internalDefault>
         <description>
-          An input comma-delimited flatfile of image coordinates or ground coordinates.
+          An input comma-delimited flatfile of image, ground or projection coordinates.
           This allows the program to process multiple coordinates in a single run of <i>mappt</i>,
           and output the results to the specified output file.
           <p>
             Expected order for image coordinates: sample, line<br/>
             Expected order for ground coordinates: latitude, longitude
+            Expected order for projection coordinates: X, Y
           </p>
           <p>
             The "Error" keyword will only appear when using a coordinate list. The value of "Error"

--- a/isis/src/base/apps/mappt/mappt.xml
+++ b/isis/src/base/apps/mappt/mappt.xml
@@ -56,7 +56,7 @@
       Added application test
     </change>
     <change name="Elizabeth Miller" date="2006-06-29">
-      Changed name to mappt and made ui look like skypt and campt
+      Changed name to mappt and made ui look like skypt and mappt
     </change>
     <change name="Sean Crosby" date="2007-04-12">
       Changed flatfile output so it duplicates PVL data.  User now
@@ -305,7 +305,7 @@
           Selecting this parameter will enable the 'COORDLIST' and 'COORDTYPE' parameters in the
           GUI.
           <p>
-            Note that this parameter is optional when running <i>campt</i> on the
+            Note that this parameter is optional when running <i>mappt</i> on the
             command line.
           </p>
         </description>
@@ -333,7 +333,7 @@
         <internalDefault>None</internalDefault>
         <description>
           An input comma-delimited flatfile of image coordinates or ground coordinates.
-          This allows the program to process multiple coordinates in a single run of <i>campt</i>,
+          This allows the program to process multiple coordinates in a single run of <i>mappt</i>,
           and output the results to the specified output file.
           <p>
             Expected order for image coordinates: sample, line<br/>
@@ -343,11 +343,11 @@
             The "Error" keyword will only appear when using a coordinate list. The value of "Error"
             will then be NULL unless an error occurs during the processing of a coordinate in the
             coordinate list. Then, the value of this keyword will be the error message. This allows
-            for <i>campt</i> to continue processing the remaining coordinates in the coordinate
+            for <i>mappt</i> to continue processing the remaining coordinates in the coordinate
             list.
           </p>
           <p>
-            For the input of Latitude and Longitude, campt expects
+            For the input of Latitude and Longitude, mappt expects
             <def>Planetocentric Latitude</def> (within -90 to 90 boundary) and
             <def>Positive East Longitude</def> (with 0-360 boundary) to find the location in the
             input camera image.

--- a/isis/src/base/apps/mappt/mappt.xml
+++ b/isis/src/base/apps/mappt/mappt.xml
@@ -56,7 +56,7 @@
       Added application test
     </change>
     <change name="Elizabeth Miller" date="2006-06-29">
-      Changed name to mappt and made ui look like skypt and mappt
+      Changed name to mappt and made ui look like skypt and campt
     </change>
     <change name="Sean Crosby" date="2007-04-12">
       Changed flatfile output so it duplicates PVL data.  User now

--- a/isis/src/base/apps/mappt/mappt.xml
+++ b/isis/src/base/apps/mappt/mappt.xml
@@ -178,10 +178,6 @@
               This option interprets the coordinate as sample/line and will
               compute latitude/longitude and x/y
             </description>
-            <inclusions>
-              <item>SAMPLE</item>
-              <item>LINE</item>
-            </inclusions>
             <exclusions>
               <item>LATITUDE</item>
               <item>LONGITUDE</item>
@@ -200,11 +196,6 @@
               This option interprets the coordinate as latitude/longitude and will
               compute sample/line and x/y
             </description>
-            <inclusions>
-              <item>LATITUDE</item>
-              <item>LONGITUDE</item>
-              <item>COORDSYS</item>
-            </inclusions>
             <exclusions>
               <item>SAMPLE</item>
               <item>LINE</item>
@@ -218,10 +209,6 @@
               This option interprets the coordinate as x/y and will
               compute sample/line and latitude/longitude
             </description>
-            <inclusions>
-              <item>X</item>
-              <item>Y</item>
-            </inclusions>
             <exclusions>
               <item>SAMPLE</item>
               <item>LINE</item>
@@ -306,6 +293,74 @@
           This is the y coordinate value used to compute the other coordinate values.  It
            will be a projection Y value in meters.
         </description>
+      </parameter>
+
+      <parameter name = "USECOORDLIST">
+        <type>boolean</type>
+        <default><item>FALSE</item></default>
+        <brief>
+          Enable coordinate list parameters in the GUI
+        </brief>
+        <description>
+          Selecting this parameter will enable the 'COORDLIST' and 'COORDTYPE' parameters in the
+          GUI.
+          <p>
+            Note that this parameter is optional when running <i>campt</i> on the
+            command line.
+          </p>
+        </description>
+        <inclusions>
+          <item>COORDLIST</item>
+          <item>TYPE</item>
+        </inclusions>
+        <exclusions>
+          <item>TYPE</item>
+          <item>SAMPLE</item>
+          <item>X</item>
+          <item>Y</item>
+          <item>LINE</item>
+          <item>LATITUDE</item>
+          <item>LONGITUDE</item>
+        </exclusions>
+      </parameter>
+
+      <parameter name="COORDLIST">
+        <type>filename</type>
+        <fileMode>input</fileMode>
+        <brief>
+          Input comma-delimited file of image or ground coordinates
+        </brief>
+        <internalDefault>None</internalDefault>
+        <description>
+          An input comma-delimited flatfile of image coordinates or ground coordinates.
+          This allows the program to process multiple coordinates in a single run of <i>campt</i>,
+          and output the results to the specified output file.
+          <p>
+            Expected order for image coordinates: sample, line<br/>
+            Expected order for ground coordinates: latitude, longitude
+          </p>
+          <p>
+            The "Error" keyword will only appear when using a coordinate list. The value of "Error"
+            will then be NULL unless an error occurs during the processing of a coordinate in the
+            coordinate list. Then, the value of this keyword will be the error message. This allows
+            for <i>campt</i> to continue processing the remaining coordinates in the coordinate
+            list.
+          </p>
+          <p>
+            For the input of Latitude and Longitude, campt expects
+            <def>Planetocentric Latitude</def> (within -90 to 90 boundary) and
+            <def>Positive East Longitude</def> (with 0-360 boundary) to find the location in the
+            input camera image.
+          </p>
+        </description>
+        <exclusions>
+          <item>SAMPLE</item>
+          <item>LINE</item>
+          <item>X</item>
+          <item>Y</item>
+          <item>LATITUDE</item>
+          <item>LONGITUDE</item>
+        </exclusions>
       </parameter>
 
       <parameter name="ALLOWOUTSIDE">

--- a/isis/tests/FunctionalTestsMappt.cpp
+++ b/isis/tests/FunctionalTestsMappt.cpp
@@ -348,7 +348,6 @@ TEST_F(DefaultCube, FunctionalTestMapptBadColumnError) {
                            "type=image"};
 
   UserInterface options(APP_XML, args);
-  std::cout << "here" << std::endl;
   Pvl appLog;
   try {
     mappt(projTestCube, options, &appLog);

--- a/isis/tests/FunctionalTestsMappt.cpp
+++ b/isis/tests/FunctionalTestsMappt.cpp
@@ -346,8 +346,9 @@ TEST_F(DefaultCube, FunctionalTestMapptBadColumnError) {
                            "UseCoordList=True", 
                            "append=false",
                            "type=image"};
-  UserInterface options(APP_XML, args);
 
+  UserInterface options(APP_XML, args);
+  std::cout << "here" << std::endl;
   Pvl appLog;
   try {
     mappt(projTestCube, options, &appLog);
@@ -362,5 +363,4 @@ TEST_F(DefaultCube, FunctionalTestMapptBadColumnError) {
               "Each row must have two columns: a sample,line or a latitude,longitude pair.\"";
   }
 
-  PvlGroup mapPoint = appLog.group(0);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Mappt now has a coordlist option like campt. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/USGS-Astrogeology/ISIS3/issues/3872

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This makes mappt more in line with campt and allows users to avoid multiple mappt runs on the same projected image. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tests added and are passing 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
