### PR TITLE
Speed up q-isis applications by decreasing the number of times CubeViewport::paintPixmap() gets a new stretch

### DIFF
--- a/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
+++ b/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
@@ -1269,10 +1269,14 @@ namespace Isis {
 
           QRgb *rgb = (QRgb *) p_image->scanLine(y);
 
+          Stretch redStretch = p_red.getStretch();
+          Stretch greenStretch = p_green.getStretch();
+          Stretch blueStretch = p_blue.getStretch();
+
           for(int x = dataArea.left(); x <= dataArea.right(); x++) {
-            int redPix = (int)(p_red.getStretch().Map(redLine[ x - p_redBuffer->bufferXYRect().left()]) + 0.5);
-            int greenPix = (int)(p_green.getStretch().Map(greenLine[ x - p_greenBuffer->bufferXYRect().left()]) + 0.5);
-            int bluePix = (int)(p_blue.getStretch().Map(blueLine[ x - p_blueBuffer->bufferXYRect().left()]) + 0.5);
+            int redPix = (int)(redStretch.Map(redLine[ x - p_redBuffer->bufferXYRect().left()]) + 0.5);
+            int greenPix = (int)(greenStretch.Map(greenLine[ x - p_greenBuffer->bufferXYRect().left()]) + 0.5);
+            int bluePix = (int)(blueStretch.Map(blueLine[ x - p_blueBuffer->bufferXYRect().left()]) + 0.5);
 
             rgb[x] = qRgb(redPix, greenPix, bluePix);
           }

--- a/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
+++ b/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
@@ -1191,6 +1191,10 @@ namespace Isis {
 
         QRgb *rgb = (QRgb *) p_image->scanLine(y);
 
+        Stretch redStretch = p_red.getStretch();
+        Stretch greenStretch = p_green.getStretch();
+        Stretch blueStretch = p_blue.getStretch();
+
         for(int x = dataArea.left(); x <= dataArea.right(); x++) {
           int bufferLeft = p_grayBuffer->bufferXYRect().left();
           int bufferX = x - bufferLeft;
@@ -1211,9 +1215,9 @@ namespace Isis {
 
           // This is still RGB; the pairs are identical but the boundary
           //   conditions are different. Display saturations cause this.
-          int redPix = (int)(p_red.getStretch().Map(bufferVal) + 0.5);
-          int greenPix = (int)(p_green.getStretch().Map(bufferVal) + 0.5);
-          int bluePix = (int)(p_blue.getStretch().Map(bufferVal) + 0.5);
+          int redPix = (int)(redStretch.Map(bufferVal) + 0.5);
+          int greenPix = (int)(greenStretch.Map(bufferVal) + 0.5);
+          int bluePix = (int)(blueStretch.Map(bufferVal) + 0.5);
           rgb[x] =  qRgb(redPix, greenPix, bluePix);
         }
       }

--- a/isis/src/qisis/objs/CubeViewport/CubeViewport.h
+++ b/isis/src/qisis/objs/CubeViewport/CubeViewport.h
@@ -128,6 +128,9 @@ namespace Isis {
    *  @history 2018-07-31 Kaitlyn Lee - Added setTrackingCube() and trackingCube() so that a
    *                          tracking cube is stored when needed and we do not have to open it in
    *                          AdvancedTrackTool every time the cursor is moved.
+   *  @history 2020-06-09 Kristin Berry - Updated paintPixmap() to move getStretch out of inner
+   *                          for loops. This provides a significant speed increase for qisis
+   *                          applications with cube viewports.
    */
   class CubeViewport : public QAbstractScrollArea {
       Q_OBJECT


### PR DESCRIPTION
## Description
I updated the `CubeViewport::paintPixmap()` method to move several `getStretch()` calls out of a for loop. The stretch values do not actually change during the loop, so there is no reason to call `getStretch()` over and over again. 

Prior to this change, `getStretch()` was being called over 900,000 times for a single test image! 

Each time `getStretch()` is called, the copy constructor for `Stretch` would be called. After PR #3717 which added the ability to save stretches to the cube, the copy constructor for Blob would then also be called 900,000 times for a single image. The source of the slowdown appears to have been "the slight increase in time required to also call the Blob copy constructor" times 900,000.

## Related Issue
Fixes #3854 (by fixing a long-pre-existing problem.)

## Motivation and Context
See related issue.

## How Has This Been Tested?
Locally, the slowdown is gone, and this is in fact faster than ever. 

A build containing these changes was tested by @lwellerastro.

I also checked to make sure that for a cubelist of input cubes that the stretch never changed inside the inner for-loop.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
