### PR TITLE
Updated logic so that min/max are not calculated if values are provided

### DIFF
--- a/isis/src/base/apps/hist/hist.xml
+++ b/isis/src/base/apps/hist/hist.xml
@@ -66,7 +66,7 @@
       Histogram object no longer has SetRange, updated to use SetValidRange
     </change>
     <change name="Steven Lambright" date="2008-05-12">
-      Removed references to CubeInfo 
+      Removed references to CubeInfo
     </change>
     <change name="Noah Hilt" date="2008-08-01">
       Changed the plot window to the new HistogramToolWindow
@@ -79,7 +79,11 @@
     <change name="Curtis Rose" date="2016-06-10">
      Changed the application to fail immediately if the TO argument is not
      entered from the commandline. Fixes #3914.
-    </change>	
+    </change>
+    <change name="Austin Sanders" date="2020-06-08">
+      Updated logic such that min/max values are no longer calculated from .cub
+      if values are provided by the user.  Fixes #3881.
+    </change>
   </history>
 
   <oldName>

--- a/isis/src/base/apps/hist/main.cpp
+++ b/isis/src/base/apps/hist/main.cpp
@@ -27,16 +27,38 @@ void IsisMain() {
     QString msg = "The [TO] parameter must be entered";
     throw IException(IException::User, msg, _FILEINFO_);
   }
-  
-  // Setup the histogram
-  Histogram hist(*icube, 1, p.Progress() );
-  if(ui.WasEntered("MINIMUM") ) {
-    hist.SetValidRange(ui.GetDouble("MINIMUM"),ui.GetDouble("MAXIMUM") );     
-  }
 
-  if(ui.WasEntered("NBINS")) {
-    hist.SetBins(ui.GetInteger("NBINS"));
+  Histogram *hist;
+  if (ui.WasEntered("MINIMUM") && ui.WasEntered("MAXIMUM")){
+    int nbins = 0;
+
+    if (ui.WasEntered("NBINS")){
+      nbins = ui.GetInteger("NBINS");
+    }
+    else {
+      // Calculate bins based on data type.
+      // Bin calculations are based on logic in Histogram::InitializeFromCube
+      if (icube->pixelType() == UnsignedByte) {
+        nbins = 256;
+      }
+      else if (icube->pixelType() == SignedWord ||
+               icube->pixelType() == UnsignedWord ||
+               icube->pixelType() == UnsignedInteger ||
+               icube->pixelType() == SignedInteger ||
+               icube->pixelType() == Real) {
+        nbins = 65536;
+      }
+      else {
+        IString msg = "Unsupported pixel type";
+        throw IException(IException::Programmer, msg, _FILEINFO_);
+      }
+    }
+    hist = new Histogram(ui.GetDouble("MINIMUM"), ui.GetDouble("MAXIMUM"), nbins);
   }
+  else {
+    hist = new Histogram(*icube, 1, p.Progress());
+  }
+  // Setup the histogram
 
   // Loop and accumulate histogram
   p.Progress()->SetText("Gathering Histogram");
@@ -47,7 +69,7 @@ void IsisMain() {
   for(int i = 1; i <= icube->lineCount(); i++) {
     line.SetLine(i);
     icube->read(line);
-    hist.AddData(line.DoubleBuffer(), line.size());
+    hist->AddData(line.DoubleBuffer(), line.size());
     p.Progress()->CheckStatus();
   }
 
@@ -59,22 +81,22 @@ void IsisMain() {
 
     fout << "Cube:           " << ui.GetFileName("FROM") << endl;
     fout << "Band:           " << icube->bandCount() << endl;
-    fout << "Average:        " << hist.Average() << endl;
-    fout << "Std Deviation:  " << hist.StandardDeviation() << endl;
-    fout << "Variance:       " << hist.Variance() << endl;
-    fout << "Median:         " << hist.Median() << endl;
-    fout << "Mode:           " << hist.Mode() << endl;
-    fout << "Skew:           " << hist.Skew() << endl;
-    fout << "Minimum:        " << hist.Minimum() << endl;
-    fout << "Maximum:        " << hist.Maximum() << endl;
+    fout << "Average:        " << hist->Average() << endl;
+    fout << "Std Deviation:  " << hist->StandardDeviation() << endl;
+    fout << "Variance:       " << hist->Variance() << endl;
+    fout << "Median:         " << hist->Median() << endl;
+    fout << "Mode:           " << hist->Mode() << endl;
+    fout << "Skew:           " << hist->Skew() << endl;
+    fout << "Minimum:        " << hist->Minimum() << endl;
+    fout << "Maximum:        " << hist->Maximum() << endl;
     fout << endl;
-    fout << "Total Pixels:    " << hist.TotalPixels() << endl;
-    fout << "Valid Pixels:    " << hist.ValidPixels() << endl;
-    fout << "Null Pixels:     " << hist.NullPixels() << endl;
-    fout << "Lis Pixels:      " << hist.LisPixels() << endl;
-    fout << "Lrs Pixels:      " << hist.LrsPixels() << endl;
-    fout << "His Pixels:      " << hist.HisPixels() << endl;
-    fout << "Hrs Pixels:      " << hist.HrsPixels() << endl;
+    fout << "Total Pixels:    " << hist->TotalPixels() << endl;
+    fout << "Valid Pixels:    " << hist->ValidPixels() << endl;
+    fout << "Null Pixels:     " << hist->NullPixels() << endl;
+    fout << "Lis Pixels:      " << hist->LisPixels() << endl;
+    fout << "Lrs Pixels:      " << hist->LrsPixels() << endl;
+    fout << "His Pixels:      " << hist->HisPixels() << endl;
+    fout << "Hrs Pixels:      " << hist->HrsPixels() << endl;
 
     //  Write histogram in tabular format
     fout << endl;
@@ -84,14 +106,14 @@ void IsisMain() {
     Isis::BigInt total = 0;
     double cumpct = 0.0;
 
-    for(int i = 0; i < hist.Bins(); i++) {
-      if(hist.BinCount(i) > 0) {
-        total += hist.BinCount(i);
-        double pct = (double)hist.BinCount(i) / hist.ValidPixels() * 100.;
+    for(int i = 0; i < hist->Bins(); i++) {
+      if(hist->BinCount(i) > 0) {
+        total += hist->BinCount(i);
+        double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.;
         cumpct += pct;
 
-        fout << hist.BinMiddle(i) << ",";
-        fout << hist.BinCount(i) << ",";
+        fout << hist->BinMiddle(i) << ",";
+        fout << hist->BinCount(i) << ",";
         fout << total << ",";
         fout << pct << ",";
         fout << cumpct << endl;
@@ -137,13 +159,13 @@ void IsisMain() {
     QVector<QPointF> binCountData;
     QVector<QPointF> cumPctData;
     double cumpct = 0.0;
-    for(int i = 0; i < hist.Bins(); i++) {
-      if(hist.BinCount(i) > 0) {
-        binCountData.append(QPointF(hist.BinMiddle(i), hist.BinCount(i) ) );
+    for(int i = 0; i < hist->Bins(); i++) {
+      if(hist->BinCount(i) > 0) {
+        binCountData.append(QPointF(hist->BinMiddle(i), hist->BinCount(i) ) );
 
-        double pct = (double)hist.BinCount(i) / hist.ValidPixels() * 100.;
+        double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.;
         cumpct += pct;
-        cumPctData.append(QPointF(hist.BinMiddle(i), cumpct) );
+        cumPctData.append(QPointF(hist->BinMiddle(i), cumpct) );
       }
     }
 
@@ -172,7 +194,7 @@ void IsisMain() {
     for(int y = 0; y < binCountData.size(); y++) {
 
       intervals[y].interval = QwtInterval(binCountData[y].x(),
-                                          binCountData[y].x() + hist.BinSize());
+                                          binCountData[y].x() + hist->BinSize());
 
       intervals[y].value = binCountData[y].y();
 //       if(values[y] > maxYValue) maxYValue = values[y];
@@ -194,14 +216,14 @@ void IsisMain() {
 //     plot->setScale(QwtPlot::yLeft, 0, maxYValue);
 //     plot->setScale(QwtPlot::xBottom, hist.Minimum(), hist.Maximum());
 
-    QLabel *label = new QLabel("  Average = " + QString::number(hist.Average()) + '\n' +
-           "\n  Minimum = " + QString::number(hist.Minimum()) + '\n' +
-           "\n  Maximum = " + QString::number(hist.Maximum()) + '\n' +
-           "\n  Stand. Dev.= " + QString::number(hist.StandardDeviation()) + '\n' +
-           "\n  Variance = " + QString::number(hist.Variance()) + '\n' +
-           "\n  Median = " + QString::number(hist.Median()) + '\n' +
-           "\n  Mode = " + QString::number(hist.Mode()) + '\n' +
-           "\n  Skew = " + QString::number(hist.Skew()), plot);
+    QLabel *label = new QLabel("  Average = " + QString::number(hist->Average()) + '\n' +
+           "\n  Minimum = " + QString::number(hist->Minimum()) + '\n' +
+           "\n  Maximum = " + QString::number(hist->Maximum()) + '\n' +
+           "\n  Stand. Dev.= " + QString::number(hist->StandardDeviation()) + '\n' +
+           "\n  Variance = " + QString::number(hist->Variance()) + '\n' +
+           "\n  Median = " + QString::number(hist->Median()) + '\n' +
+           "\n  Mode = " + QString::number(hist->Mode()) + '\n' +
+           "\n  Skew = " + QString::number(hist->Skew()), plot);
     plot->getDockWidget()->setWidget(label);
 
     plot->showWindow();

--- a/isis/src/base/apps/hist/main.cpp
+++ b/isis/src/base/apps/hist/main.cpp
@@ -228,6 +228,6 @@ void IsisMain() {
 
     plot->showWindow();
   }
-
+  delete hist;
   p.EndProcess();
 }


### PR DESCRIPTION
## Description
Added conditional logic such that min/max values are no longer calculated if the user passed in a min/max value on the command line or through the UI.

## Related Issue
Fixes #3881 

## Motivation and Context
Previously, the hist application would calculate the min, max, and number of bins whether or not the user entered values.  After calculation, the values would be overwritten if user-specified values were found.  The unnecessary calculations led to significant slowdown, which decreased usability.

## How Has This Been Tested?
Passed hist app tests.  Additional tests may be needed, but none were added due to the fact that no inputs/outputs should change as a result of this update.  This change should cut out extraneous calculations and nothing more.  I wasn't really sure how to programmatically test that the other steps were cut out.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
