### PR TITLE
Add local solar time option to phocube

### DIFF
--- a/isis/src/base/apps/phocube/main.cpp
+++ b/isis/src/base/apps/phocube/main.cpp
@@ -100,6 +100,7 @@ void IsisMain() {
   bool bodyFixedX = false;
   bool bodyFixedY = false;
   bool bodyFixedZ = false;
+  bool localSolarTime = false;
   int raBandNum = 0;  // 0 based, if RA is 5th band, raBandNum will be 4
 
   if (!noCamera) {
@@ -125,6 +126,7 @@ void IsisMain() {
     if ((bodyFixedX = ui.GetBoolean("BODYFIXED"))) nbands++;
     if ((bodyFixedY = ui.GetBoolean("BODYFIXED"))) nbands++;
     if ((bodyFixedZ = ui.GetBoolean("BODYFIXED"))) nbands++;
+    if ((localSolarTime = ui.GetBoolean("LOCALTIME"))) nbands++;
   }
 
   bool dn;
@@ -259,8 +261,10 @@ void IsisMain() {
   if (bodyFixedZ) {
     name += "Body Fixed Z";
   }
-
-  bool specialPixels = ui.GetBoolean("SPECIALPIXELS");
+  if (localSolarTime) {
+    name += "Local Solar Time";
+  }
+  bool specialPixels = ui.GetBoolean("SPECIALPIXELS"); 
 
   /**
    * Computes all the geometric properties for the output buffer. Certain
@@ -455,6 +459,10 @@ void IsisMain() {
               out[index] = pB[2];
               index += 64 * 64;
             }
+          }
+          if (localSolarTime) {
+            out[index] = cam->LocalSolarTime();
+            index += 64 * 64;
           }
         }
 

--- a/isis/src/base/apps/phocube/phocube.xml
+++ b/isis/src/base/apps/phocube/phocube.xml
@@ -312,6 +312,9 @@ xsi:noNamespaceSchemaLocation=
       merge causes the application to run longer. Changed the process function to be a lambda function
       to get rid of global variables.
     </change>
+    <change name="Kristin Berry" date="2020-06-10">
+      Added the LOCALTIME parameter to output a band with the local solar time for each pixel. Fixes #
+    </change>
   </history>
 
   <category>
@@ -403,6 +406,7 @@ xsi:noNamespaceSchemaLocation=
               <item>NORTHAZIMUTH</item>
               <item>RADEC</item>
               <item>BODYFIXED</item>
+              <item>LOCALTIME</item>
             </exclusions>
           </option>
         </list>
@@ -734,6 +738,16 @@ xsi:noNamespaceSchemaLocation=
 	   the output cube. The output cube labels will contain "Body Fixed X", "Body Fixed Y",
 	   and "Body Fixed Z" in the BandBin group, in the band sequence of the output file.
 	   Body Fixed Coordinates are in kilometers.
+	 </description>
+       </parameter>
+      <parameter name="LOCALTIME">
+         <type>boolean</type>
+         <default><item>FALSE</item></default>
+         <brief>Create a band with local solar time</brief>
+         <description>
+	   If this parameter is true, the <def>Local Solar Time</def> will be calculated for
+	   every pixel in the output cube. The output cube label will contain "Local Solar Time"
+	   in the BandBin group. Local Solar Time is in hours.
 	 </description>
        </parameter>
     </group>

--- a/isis/src/base/apps/phocube/phocube.xml
+++ b/isis/src/base/apps/phocube/phocube.xml
@@ -313,7 +313,7 @@ xsi:noNamespaceSchemaLocation=
       to get rid of global variables.
     </change>
     <change name="Kristin Berry" date="2020-06-10">
-      Added the LOCALTIME parameter to output a band with the local solar time for each pixel. Fixes #
+      Added the LOCALTIME parameter to output a band with the local solar time for each pixel. Fixes #3850
     </change>
   </history>
 

--- a/isis/src/base/apps/phocube/phocube.xml
+++ b/isis/src/base/apps/phocube/phocube.xml
@@ -108,6 +108,7 @@ xsi:noNamespaceSchemaLocation=
      <li>ALBEDORANK</li>
      <li><def link="Body Fixed Coordinate">BODYFIXED</def></li>
      <li>RADEC (<def link="Right Ascension">Right Ascension</def>, <def link="Declination">Declination</def> )</li>
+     <li><def link="Local Solar Time">LOCALTIME</def></li>
      </ul>
 	The following options are available for Level2 images:
      <ul>

--- a/isis/src/base/apps/phocube/tsts/allbands/Makefile
+++ b/isis/src/base/apps/phocube/tsts/allbands/Makefile
@@ -30,4 +30,6 @@ commands:
 	  morphology=true \
 	  albedo=true \
 	  radec=true \
-	  bodyfixed=true> /dev/null;  
+	  bodyfixed=true \
+	  localtime=true > /dev/null;
+


### PR DESCRIPTION
## Description
This PR adds the option to output local solar time to phocube. 

The "allbands" test is updated to include this added band. 

## Related Issue
Fixes #3850

## Motivation and Context
See #3850. There was a request to add a local solar time option to phocube.

## How Has This Been Tested?
Existing phocube tests pass. The updated test passes (with locally updated test data. Will check in after PR is merged.) 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
