### PR TITLE
Port #3910 to 4.1

### DIFF
--- a/isis/src/base/apps/isis2ascii/isis2ascii.xml
+++ b/isis/src/base/apps/isis2ascii/isis2ascii.xml
@@ -4,9 +4,9 @@
 
   <description>
     This program converts sn ISIS cube to ASCII file format.  Special pixels such as
-    <def>NULL</def>, <def>LIS</def>, <def>LRS</def>, <def>HIS</def> and <def>HRS</def> 
-    have predetermined pixel values. You may opt to assign a range of pixel values to 
-    the individual <def>Special Pixels</def> using the SETPIXELVALUES parameter. Bands in the cube 
+    <def>NULL</def>, <def>LIS</def>, <def>LRS</def>, <def>HIS</def> and <def>HRS</def>
+    have predetermined pixel values. You may opt to assign a range of pixel values to
+    the individual <def>Special Pixels</def> using the SETPIXELVALUES parameter. Bands in the cube
     will be output in band sequential format.
     <br />
     <br />
@@ -63,13 +63,17 @@
         Documentation fixes
     </change>
     <change name="Steven Lambright" date="2008-05-12">
-      Removed references to CubeInfo 
+      Removed references to CubeInfo
     </change>
     <change name="Makayla Shepherd" date="2015-01-30">
       Increased precision of the DNs in the output text file from 6 to 7
     </change>
     <change name="Adam Paquette" date="2016-06-15">
       Added the ability for a user to specify the special pixel values
+    </change>
+    <change name="Adam Paquette" date="2020-06-09">
+      Changed output formatting to use a delimiter that is placed after each
+      entry, rather than depending on a set width.
     </change>
   </history>
 
@@ -108,6 +112,17 @@
           <item>YES</item>
         </default>
       </parameter>
+      <parameter name="DELIMITER">
+        <type>string</type>
+        <brief>Output Delimiter</brief>
+        <description>
+          Sets the value to place between entries in the output file. This will
+          default to a space if nothing is entered.
+        </description>
+        <default>
+          <item></item>
+        </default>
+      </parameter>
     </group>
 
     <group name="Special Pixels">
@@ -118,7 +133,7 @@
 	</default>
 	<brief>User defined output for special pixels</brief>
 	<description>
-	      Determine whether the user would like a 
+	      Determine whether the user would like a
 	      specific output for the special pixels in the image.
 	</description>
 	<inclusions>
@@ -129,7 +144,7 @@
 	  <item>HRSVALUE</item>
 	</inclusions>
       </parameter>
-      
+
       <parameter name="NULLVALUE">
 	<type>string</type>
 	<default>
@@ -215,12 +230,12 @@
 
     <example>
       <brief> Header default </brief>
-      <description> 
+      <description>
 	Demonstrate the isis2ascii application with header
       </description>
       <terminalInterface>
         <commandLine> f=../IN/f332s28.cub t=OUT/isis2ascii.txt </commandLine>
-        <description> 
+        <description>
 	  Convert Viking ISIS image to ascii file.  Let header default to yes.
         </description>
       </terminalInterface>
@@ -237,7 +252,7 @@
       <outputImages>
         <image src="assets/image/isis2asciiTxt.jpg" width="500" height="523">
           <brief> Example output ascii text from isis2ascii run</brief>
-          <description> 
+          <description>
 	    This is the output ascii text file isis2ascii.txt with the header.
           </description>
           <thumbnail caption="Output image showing results of the isis2ascii application." src="assets/thumb/isis2asciiTxt.jpg" width="200" height="209"/>

--- a/isis/src/base/apps/isis2ascii/main.cpp
+++ b/isis/src/base/apps/isis2ascii/main.cpp
@@ -33,12 +33,12 @@ public:
                                  QString hrs,
                                  QString his,
                                  QString lrs,
-                                 QString lis) :
-        null(null), hrs(hrs), his(his), lrs(lrs), lis(lis) {}
+                                 QString lis,
+                                 QString delimiter) :
+        null(null), hrs(hrs), his(his), lrs(lrs), lis(lis), delimiter(delimiter) {}
 
     void operator() (Buffer &in) const {
         for(int i = 0; i < in.size(); i++) {
-          fout.width(13);        //  Width must be set everytime
           if(IsSpecial(in[i])) {
             if(IsNullPixel(in[i])) fout << null;
             if(IsHrsPixel(in[i])) fout << hrs;
@@ -49,6 +49,9 @@ public:
           else {
             fout << in[i];
           }
+          if (i != in.size() - 1) {
+            fout << delimiter;
+          }
         }
         fout << endl;
     }
@@ -58,6 +61,7 @@ private:
     QString his;
     QString lrs;
     QString lis;
+    QString delimiter;
 };
 
 void IsisMain() {
@@ -77,6 +81,11 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   QString to = ui.GetFileName("TO", "txt");
   fout.open(to.toLatin1().data());
+
+  QString delimiter = ui.GetString("DELIMITER");
+  if (delimiter.isEmpty()) {
+    delimiter = " ";
+  }
 
   // Print header if needed
   if(ui.GetBoolean("HEADER")) {
@@ -101,10 +110,10 @@ void IsisMain() {
     lis = "LIS";
   }
 
-  SpecialPixelFunctor isis2ascii(null, hrs, his, lrs, lis);
-  
+  SpecialPixelFunctor isis2ascii(null, hrs, his, lrs, lis, delimiter);
+
   fout << std::setprecision(7);
-  
+
   // List the cube
   p.ProcessCubeInPlace(isis2ascii, false);
   p.EndProcess();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
#3910 was made after isis2ascii was ported to the new app format so I had to hand patch over the changes.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3859 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ISIS 4.1.1 release prep

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All tests passed on Ubuntu 18 and isis2ascii tests passed on MAC OS 10.13

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
