### PR TITLE
Changed how Histogram separates data into bins 

### DIFF
--- a/isis/src/base/apps/hist/hist.xml
+++ b/isis/src/base/apps/hist/hist.xml
@@ -84,6 +84,12 @@
       Updated logic such that min/max values are no longer calculated from .cub
       if values are provided by the user.  Fixes #3881.
     </change>
+    <change name="Kaitlyn Lee" date="2020-06-11">
+      Added "Pixels Below Min" and "Pixels Above Max" to the CSV output and changed how the data is
+      outputted. Originally, the CSV output and the GUI histogram would use the DN value in the
+      middle of a bin to represent that bin. That is, the CSV output used to have a "DN" value that
+      was the bin's middle pixel DN. This was not intuitive to users. Removed the "DN" value and added "MinInclusive" and "MaxExclusive" to the CSV so that bins are represented by their min/max values. These changes were also reflected in the histrogram creation. The x-axis is now based off of the min value of a bin instead of the middle value. These changes were made alongside changes made to Histogram and cnethist.
+    </change>
   </history>
 
   <oldName>

--- a/isis/src/base/apps/hist/main.cpp
+++ b/isis/src/base/apps/hist/main.cpp
@@ -23,7 +23,7 @@ void IsisMain() {
   Cube *icube = p.SetInputCube("FROM");
 
   UserInterface &ui = Application::GetUserInterface();
-  if(!ui.WasEntered("TO") && !ui.IsInteractive()) {
+  if (!ui.WasEntered("TO") && !ui.IsInteractive()) {
     QString msg = "The [TO] parameter must be entered";
     throw IException(IException::User, msg, _FILEINFO_);
   }
@@ -66,53 +66,60 @@ void IsisMain() {
   p.Progress()->CheckStatus();
   LineManager line(*icube);
 
-  for(int i = 1; i <= icube->lineCount(); i++) {
+  for (int i = 1; i <= icube->lineCount(); i++) {
     line.SetLine(i);
     icube->read(line);
     hist->AddData(line.DoubleBuffer(), line.size());
     p.Progress()->CheckStatus();
   }
 
-  if(!ui.IsInteractive() || ui.WasEntered("TO") ) {
+  if (!ui.IsInteractive() || ui.WasEntered("TO") ) {
     // Write the results
     QString outfile = ui.GetFileName("TO");
     ofstream fout;
     fout.open(outfile.toLatin1().data());
 
-    fout << "Cube:           " << ui.GetFileName("FROM") << endl;
-    fout << "Band:           " << icube->bandCount() << endl;
-    fout << "Average:        " << hist->Average() << endl;
-    fout << "Std Deviation:  " << hist->StandardDeviation() << endl;
-    fout << "Variance:       " << hist->Variance() << endl;
-    fout << "Median:         " << hist->Median() << endl;
-    fout << "Mode:           " << hist->Mode() << endl;
-    fout << "Skew:           " << hist->Skew() << endl;
-    fout << "Minimum:        " << hist->Minimum() << endl;
-    fout << "Maximum:        " << hist->Maximum() << endl;
+    fout << "Cube:              " << ui.GetFileName("FROM") << endl;
+    fout << "Band:              " << icube->bandCount() << endl;
+    fout << "Average:           " << hist->Average() << endl;
+    fout << "Std Deviation:     " << hist->StandardDeviation() << endl;
+    fout << "Variance:          " << hist->Variance() << endl;
+    fout << "Median:            " << hist->Median() << endl;
+    fout << "Mode:              " << hist->Mode() << endl;
+    fout << "Skew:              " << hist->Skew() << endl;
+    fout << "Minimum:           " << hist->Minimum() << endl;
+    fout << "Maximum:           " << hist->Maximum() << endl;
     fout << endl;
-    fout << "Total Pixels:    " << hist->TotalPixels() << endl;
-    fout << "Valid Pixels:    " << hist->ValidPixels() << endl;
-    fout << "Null Pixels:     " << hist->NullPixels() << endl;
-    fout << "Lis Pixels:      " << hist->LisPixels() << endl;
-    fout << "Lrs Pixels:      " << hist->LrsPixels() << endl;
-    fout << "His Pixels:      " << hist->HisPixels() << endl;
-    fout << "Hrs Pixels:      " << hist->HrsPixels() << endl;
+    fout << "Total Pixels:      " << hist->TotalPixels() << endl;
+    fout << "Valid Pixels:      " << hist->ValidPixels() << endl;
+    fout << "Pixels Below Min:  " << hist->UnderRangePixels() << endl;
+    fout << "Pixels Above Max:  " << hist->OverRangePixels() << endl;
+    fout << "Null Pixels:       " << hist->NullPixels() << endl;
+    fout << "Lis Pixels:        " << hist->LisPixels() << endl;
+    fout << "Lrs Pixels:        " << hist->LrsPixels() << endl;
+    fout << "His Pixels:        " << hist->HisPixels() << endl;
+    fout << "Hrs Pixels:        " << hist->HrsPixels() << endl;
 
     //  Write histogram in tabular format
     fout << endl;
     fout << endl;
-    fout << "DN,Pixels,CumulativePixels,Percent,CumulativePercent" << endl;
+    fout << "MinInclusive,MaxExclusive,Pixels,CumulativePixels,Percent,CumulativePercent" << endl;
 
     Isis::BigInt total = 0;
     double cumpct = 0.0;
+    double low;
+    double high;
 
-    for(int i = 0; i < hist->Bins(); i++) {
-      if(hist->BinCount(i) > 0) {
+    for (int i = 0; i < hist->Bins(); i++) {
+      if (hist->BinCount(i) > 0) {
         total += hist->BinCount(i);
         double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.;
         cumpct += pct;
 
-        fout << hist->BinMiddle(i) << ",";
+        hist->BinRange(i, low, high);
+
+        fout << low << ",";
+        fout << high << ",";
         fout << hist->BinCount(i) << ",";
         fout << total << ",";
         fout << pct << ",";
@@ -122,10 +129,10 @@ void IsisMain() {
     fout.close();
   }
   // If we are in gui mode, create a histogram plot
-  if(ui.IsInteractive()) {
+  if (ui.IsInteractive()) {
     // Set the title for the dialog
     QString title;
-    if(ui.WasEntered("TITLE") ) {
+    if (ui.WasEntered("TITLE") ) {
       title = ui.GetString("TITLE");
     }
     else {
@@ -138,19 +145,19 @@ void IsisMain() {
                                                         ui.TheGui());
 
     // Set the xaxis title if they entered one
-    if(ui.WasEntered("XAXIS") ) {
+    if (ui.WasEntered("XAXIS") ) {
       QString xaxis(ui.GetString("XAXIS"));
       plot->setAxisLabel(QwtPlot::xBottom, xaxis.toLatin1().data());
     }
 
     // Set the yLeft axis title if they entered one
-    if(ui.WasEntered("FREQAXIS") ) {
+    if (ui.WasEntered("FREQAXIS") ) {
       QString yaxis(ui.GetString("FREQAXIS"));
       plot->setAxisLabel(QwtPlot::yRight, yaxis.toLatin1().data());
     }
 
     // Set the yRight axis title if they entered one
-    if(ui.WasEntered("PERCENTAXIS") ) {
+    if (ui.WasEntered("PERCENTAXIS") ) {
       QString y2axis(ui.GetString("PERCENTAXIS") );
       plot->setAxisLabel(QwtPlot::yLeft, y2axis.toLatin1().data());
     }
@@ -159,13 +166,16 @@ void IsisMain() {
     QVector<QPointF> binCountData;
     QVector<QPointF> cumPctData;
     double cumpct = 0.0;
-    for(int i = 0; i < hist->Bins(); i++) {
-      if(hist->BinCount(i) > 0) {
-        binCountData.append(QPointF(hist->BinMiddle(i), hist->BinCount(i) ) );
+    double low;
+    double high;
+    for (int i = 0; i < hist->Bins(); i++) {
+      if (hist->BinCount(i) > 0) {
+        hist->BinRange(i, low, high);
+        binCountData.append(QPointF(low, hist->BinCount(i) ) );
 
-        double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.;
+        double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.0;
         cumpct += pct;
-        cumPctData.append(QPointF(hist->BinMiddle(i), cumpct) );
+        cumPctData.append(QPointF(low, cumpct) );
       }
     }
 
@@ -184,21 +194,13 @@ void IsisMain() {
     cdfCurve->setYAxis(QwtPlot::yLeft);
     cdfCurve->setPen(*pen);
 
-    //These are all variables needed in the following for loop.
-    //----------------------------------------------
     QVector<QwtIntervalSample> intervals(binCountData.size() );
-//     double maxYValue = DBL_MIN;
-//     double minYValue = DBL_MAX;
-//     // ---------------------------------------------
-//
-    for(int y = 0; y < binCountData.size(); y++) {
+    for (int y = 0; y < binCountData.size(); y++) {
 
       intervals[y].interval = QwtInterval(binCountData[y].x(),
                                           binCountData[y].x() + hist->BinSize());
 
       intervals[y].value = binCountData[y].y();
-//       if(values[y] > maxYValue) maxYValue = values[y];
-//       if(values[y] < minYValue) minYValue = values[y];
     }
 
     QPen percentagePen(Qt::red);
@@ -211,10 +213,6 @@ void IsisMain() {
 
     plot->add(histCurve);
     plot->add(cdfCurve);
-//     plot->fillTable();
-
-//     plot->setScale(QwtPlot::yLeft, 0, maxYValue);
-//     plot->setScale(QwtPlot::xBottom, hist.Minimum(), hist.Maximum());
 
     QLabel *label = new QLabel("  Average = " + QString::number(hist->Average()) + '\n' +
            "\n  Minimum = " + QString::number(hist->Minimum()) + '\n' +

--- a/isis/src/base/objs/Histogram/Histogram.cpp
+++ b/isis/src/base/objs/Histogram/Histogram.cpp
@@ -167,20 +167,8 @@ namespace Isis {
 
    rangesFromNet(net,statFunc);
 
-
-   //stretch the domain so that it is an even multiple of binWidth
-   //for some reason Histogram makes the end points of the bin range be at the center of
-   //bins.  Thus the +/-0.5 forces it to point the bin range at the ends of the bins.
-   //SetBinRange(binWidth*( floor(this->ValidMinimum()/binWidth )+0.5),
-   //            binWidth*(ceil( this->ValidMaximum()/binWidth )-0.5) );
-
-
    //Keep an eye on this to see if it breaks anything.  Also, I need to create
    //a dataset to give this constructor for the unit test.
-
-    //tjw:  SetValidRange is moved into SetBinRange
-   //SetValidRange(binWidth*floor(this->ValidMinimum()/binWidth),
-   //              binWidth*ceil(this->ValidMaximum()/binWidth));
 
    //from the domain of the data and the requested bin width calculate the number of bins
    double domain = this->ValidMaximum() - this->ValidMinimum();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a continuation of PR #3914. Credit to @kaitlyndlee for the majority of content in this PR.

The math for calculating what bin data should be placed in and how `Histogram` calculated the min/max values of each bin seemed off. The math changed slightly to be more intuitive. In addition, the output of hist and cnethist changed to display the min/max values of each bin instead of the middle pixel's DN. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/USGS-Astrogeology/ISIS3/issues/3882

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Makes hist and cnethist behave in the way users expect them to.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing app tests passed with the exception of hist_app_test_default.  Truth data was updated, is passing locally, and is ready for checkin.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
