### PR TITLE
Revert "Changed histogram binning logic"

### DIFF
--- a/isis/src/base/apps/hist/hist.xml
+++ b/isis/src/base/apps/hist/hist.xml
@@ -84,12 +84,6 @@
       Updated logic such that min/max values are no longer calculated from .cub
       if values are provided by the user.  Fixes #3881.
     </change>
-    <change name="Kaitlyn Lee" date="2020-06-11">
-      Added "Pixels Below Min" and "Pixels Above Max" to the CSV output and changed how the data is
-      outputted. Originally, the CSV output and the GUI histogram would use the DN value in the
-      middle of a bin to represent that bin. That is, the CSV output used to have a "DN" value that
-      was the bin's middle pixel DN. This was not intuitive to users. Removed the "DN" value and added "MinInclusive" and "MaxExclusive" to the CSV so that bins are represented by their min/max values. These changes were also reflected in the histrogram creation. The x-axis is now based off of the min value of a bin instead of the middle value. These changes were made alongside changes made to Histogram and cnethist.
-    </change>
   </history>
 
   <oldName>

--- a/isis/src/base/apps/hist/main.cpp
+++ b/isis/src/base/apps/hist/main.cpp
@@ -23,7 +23,7 @@ void IsisMain() {
   Cube *icube = p.SetInputCube("FROM");
 
   UserInterface &ui = Application::GetUserInterface();
-  if (!ui.WasEntered("TO") && !ui.IsInteractive()) {
+  if(!ui.WasEntered("TO") && !ui.IsInteractive()) {
     QString msg = "The [TO] parameter must be entered";
     throw IException(IException::User, msg, _FILEINFO_);
   }
@@ -66,60 +66,53 @@ void IsisMain() {
   p.Progress()->CheckStatus();
   LineManager line(*icube);
 
-  for (int i = 1; i <= icube->lineCount(); i++) {
+  for(int i = 1; i <= icube->lineCount(); i++) {
     line.SetLine(i);
     icube->read(line);
     hist->AddData(line.DoubleBuffer(), line.size());
     p.Progress()->CheckStatus();
   }
 
-  if (!ui.IsInteractive() || ui.WasEntered("TO") ) {
+  if(!ui.IsInteractive() || ui.WasEntered("TO") ) {
     // Write the results
     QString outfile = ui.GetFileName("TO");
     ofstream fout;
     fout.open(outfile.toLatin1().data());
 
-    fout << "Cube:              " << ui.GetFileName("FROM") << endl;
-    fout << "Band:              " << icube->bandCount() << endl;
-    fout << "Average:           " << hist->Average() << endl;
-    fout << "Std Deviation:     " << hist->StandardDeviation() << endl;
-    fout << "Variance:          " << hist->Variance() << endl;
-    fout << "Median:            " << hist->Median() << endl;
-    fout << "Mode:              " << hist->Mode() << endl;
-    fout << "Skew:              " << hist->Skew() << endl;
-    fout << "Minimum:           " << hist->Minimum() << endl;
-    fout << "Maximum:           " << hist->Maximum() << endl;
+    fout << "Cube:           " << ui.GetFileName("FROM") << endl;
+    fout << "Band:           " << icube->bandCount() << endl;
+    fout << "Average:        " << hist->Average() << endl;
+    fout << "Std Deviation:  " << hist->StandardDeviation() << endl;
+    fout << "Variance:       " << hist->Variance() << endl;
+    fout << "Median:         " << hist->Median() << endl;
+    fout << "Mode:           " << hist->Mode() << endl;
+    fout << "Skew:           " << hist->Skew() << endl;
+    fout << "Minimum:        " << hist->Minimum() << endl;
+    fout << "Maximum:        " << hist->Maximum() << endl;
     fout << endl;
-    fout << "Total Pixels:      " << hist->TotalPixels() << endl;
-    fout << "Valid Pixels:      " << hist->ValidPixels() << endl;
-    fout << "Pixels Below Min:  " << hist->UnderRangePixels() << endl;
-    fout << "Pixels Above Max:  " << hist->OverRangePixels() << endl;
-    fout << "Null Pixels:       " << hist->NullPixels() << endl;
-    fout << "Lis Pixels:        " << hist->LisPixels() << endl;
-    fout << "Lrs Pixels:        " << hist->LrsPixels() << endl;
-    fout << "His Pixels:        " << hist->HisPixels() << endl;
-    fout << "Hrs Pixels:        " << hist->HrsPixels() << endl;
+    fout << "Total Pixels:    " << hist->TotalPixels() << endl;
+    fout << "Valid Pixels:    " << hist->ValidPixels() << endl;
+    fout << "Null Pixels:     " << hist->NullPixels() << endl;
+    fout << "Lis Pixels:      " << hist->LisPixels() << endl;
+    fout << "Lrs Pixels:      " << hist->LrsPixels() << endl;
+    fout << "His Pixels:      " << hist->HisPixels() << endl;
+    fout << "Hrs Pixels:      " << hist->HrsPixels() << endl;
 
     //  Write histogram in tabular format
     fout << endl;
     fout << endl;
-    fout << "MinInclusive,MaxExclusive,Pixels,CumulativePixels,Percent,CumulativePercent" << endl;
+    fout << "DN,Pixels,CumulativePixels,Percent,CumulativePercent" << endl;
 
     Isis::BigInt total = 0;
     double cumpct = 0.0;
-    double low;
-    double high;
 
-    for (int i = 0; i < hist->Bins(); i++) {
-      if (hist->BinCount(i) > 0) {
+    for(int i = 0; i < hist->Bins(); i++) {
+      if(hist->BinCount(i) > 0) {
         total += hist->BinCount(i);
         double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.;
         cumpct += pct;
 
-        hist->BinRange(i, low, high);
-
-        fout << low << ",";
-        fout << high << ",";
+        fout << hist->BinMiddle(i) << ",";
         fout << hist->BinCount(i) << ",";
         fout << total << ",";
         fout << pct << ",";
@@ -129,10 +122,10 @@ void IsisMain() {
     fout.close();
   }
   // If we are in gui mode, create a histogram plot
-  if (ui.IsInteractive()) {
+  if(ui.IsInteractive()) {
     // Set the title for the dialog
     QString title;
-    if (ui.WasEntered("TITLE") ) {
+    if(ui.WasEntered("TITLE") ) {
       title = ui.GetString("TITLE");
     }
     else {
@@ -145,19 +138,19 @@ void IsisMain() {
                                                         ui.TheGui());
 
     // Set the xaxis title if they entered one
-    if (ui.WasEntered("XAXIS") ) {
+    if(ui.WasEntered("XAXIS") ) {
       QString xaxis(ui.GetString("XAXIS"));
       plot->setAxisLabel(QwtPlot::xBottom, xaxis.toLatin1().data());
     }
 
     // Set the yLeft axis title if they entered one
-    if (ui.WasEntered("FREQAXIS") ) {
+    if(ui.WasEntered("FREQAXIS") ) {
       QString yaxis(ui.GetString("FREQAXIS"));
       plot->setAxisLabel(QwtPlot::yRight, yaxis.toLatin1().data());
     }
 
     // Set the yRight axis title if they entered one
-    if (ui.WasEntered("PERCENTAXIS") ) {
+    if(ui.WasEntered("PERCENTAXIS") ) {
       QString y2axis(ui.GetString("PERCENTAXIS") );
       plot->setAxisLabel(QwtPlot::yLeft, y2axis.toLatin1().data());
     }
@@ -166,16 +159,13 @@ void IsisMain() {
     QVector<QPointF> binCountData;
     QVector<QPointF> cumPctData;
     double cumpct = 0.0;
-    double low;
-    double high;
-    for (int i = 0; i < hist->Bins(); i++) {
-      if (hist->BinCount(i) > 0) {
-        hist->BinRange(i, low, high);
-        binCountData.append(QPointF(low, hist->BinCount(i) ) );
+    for(int i = 0; i < hist->Bins(); i++) {
+      if(hist->BinCount(i) > 0) {
+        binCountData.append(QPointF(hist->BinMiddle(i), hist->BinCount(i) ) );
 
-        double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.0;
+        double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.;
         cumpct += pct;
-        cumPctData.append(QPointF(low, cumpct) );
+        cumPctData.append(QPointF(hist->BinMiddle(i), cumpct) );
       }
     }
 
@@ -194,13 +184,21 @@ void IsisMain() {
     cdfCurve->setYAxis(QwtPlot::yLeft);
     cdfCurve->setPen(*pen);
 
+    //These are all variables needed in the following for loop.
+    //----------------------------------------------
     QVector<QwtIntervalSample> intervals(binCountData.size() );
-    for (int y = 0; y < binCountData.size(); y++) {
+//     double maxYValue = DBL_MIN;
+//     double minYValue = DBL_MAX;
+//     // ---------------------------------------------
+//
+    for(int y = 0; y < binCountData.size(); y++) {
 
       intervals[y].interval = QwtInterval(binCountData[y].x(),
                                           binCountData[y].x() + hist->BinSize());
 
       intervals[y].value = binCountData[y].y();
+//       if(values[y] > maxYValue) maxYValue = values[y];
+//       if(values[y] < minYValue) minYValue = values[y];
     }
 
     QPen percentagePen(Qt::red);
@@ -213,6 +211,10 @@ void IsisMain() {
 
     plot->add(histCurve);
     plot->add(cdfCurve);
+//     plot->fillTable();
+
+//     plot->setScale(QwtPlot::yLeft, 0, maxYValue);
+//     plot->setScale(QwtPlot::xBottom, hist.Minimum(), hist.Maximum());
 
     QLabel *label = new QLabel("  Average = " + QString::number(hist->Average()) + '\n' +
            "\n  Minimum = " + QString::number(hist->Minimum()) + '\n' +

--- a/isis/src/base/objs/Histogram/Histogram.cpp
+++ b/isis/src/base/objs/Histogram/Histogram.cpp
@@ -50,6 +50,7 @@ namespace Isis {
   Histogram::Histogram(double minimum, double maximum, int nbins) {
 
     SetValidRange(minimum, maximum);
+    //SetBinRange(minimum, maximum);
     SetBins(nbins);
   }
 
@@ -166,8 +167,20 @@ namespace Isis {
 
    rangesFromNet(net,statFunc);
 
+
+   //stretch the domain so that it is an even multiple of binWidth
+   //for some reason Histogram makes the end points of the bin range be at the center of
+   //bins.  Thus the +/-0.5 forces it to point the bin range at the ends of the bins.
+   //SetBinRange(binWidth*( floor(this->ValidMinimum()/binWidth )+0.5),
+   //            binWidth*(ceil( this->ValidMaximum()/binWidth )-0.5) );
+
+
    //Keep an eye on this to see if it breaks anything.  Also, I need to create
    //a dataset to give this constructor for the unit test.
+
+    //tjw:  SetValidRange is moved into SetBinRange
+   //SetValidRange(binWidth*floor(this->ValidMinimum()/binWidth),
+   //              binWidth*ceil(this->ValidMaximum()/binWidth));
 
    //from the domain of the data and the requested bin width calculate the number of bins
    double domain = this->ValidMaximum() - this->ValidMinimum();
@@ -253,6 +266,7 @@ namespace Isis {
     //set up the histogram ranges
 
     SetValidRange(min, max);
+    //SetBinRange(min, max);
   }
 
 
@@ -382,7 +396,7 @@ namespace Isis {
   Histogram::~Histogram() {
   }
 
-  //2015-08-24,  Tyler Wilson:  Added Statistics::SetValidRange call to SetValidRange
+  //2015-08-24,  Tyler Wilson:  Added Statistics::SetValidRange call to SetBinRange
   //So the two functions do not have to be called together when setting
   //up a histogram
 
@@ -448,8 +462,8 @@ namespace Isis {
           index = 0;
         }
         else {
-          index = (int) floor( ((double) nbins / (BinRangeEnd() - BinRangeStart())) *
-                              (data[i] - BinRangeStart()) );
+          index = (int) floor((double)(nbins - 1) / (BinRangeEnd() - BinRangeStart()) *
+                              (data[i] - BinRangeStart() ) + 0.5);
         }
         if (index < 0) index = 0;
         if (index >= nbins) index = nbins - 1;
@@ -476,8 +490,8 @@ namespace Isis {
         index = 0;
       }
       else {
-        index = (int) floor( ((double) nbins / (BinRangeEnd() - BinRangeStart())) *
-                              (data - BinRangeStart()) );
+        index = (int) floor((double)(nbins - 1) / (BinRangeEnd() - BinRangeStart() ) *
+                            (data - BinRangeStart() ) + 0.5);
       }
       if (index < 0) index = 0;
       if (index >= nbins) index = nbins - 1;
@@ -508,8 +522,8 @@ namespace Isis {
           index = 0;
         }
         else {
-          index = (int) floor( ((double) nbins / (BinRangeEnd() - BinRangeStart())) *
-                              (data[i] - BinRangeStart()) );
+          index = (int) floor((double)(nbins - 1) / (BinRangeEnd() - BinRangeStart()) *
+                              (data[i] - BinRangeStart()) + 0.5);
         }
         if (index < 0) index = 0;
         if (index >= nbins) index = nbins - 1;
@@ -577,7 +591,7 @@ namespace Isis {
       }
     }
 
-    return BinMiddle( (int) p_bins.size() - 1);
+    return BinMiddle( (int)p_bins.size() - 1);
   }
 
 
@@ -639,8 +653,8 @@ namespace Isis {
       throw IException(IException::Programmer, message, _FILEINFO_);
     }
 
-    double binSize = (BinRangeEnd() - BinRangeStart()) / (double) p_bins.size();
-    low = BinRangeStart() + binSize * (double) index;
+    double binSize = (BinRangeEnd() - BinRangeStart()) / (double)(p_bins.size() - 1);
+    low = BinRangeStart() - binSize / 2.0 + binSize * (double) index;
     high = low + binSize;
   }
 

--- a/isis/src/base/objs/Histogram/Histogram.h
+++ b/isis/src/base/objs/Histogram/Histogram.h
@@ -81,11 +81,6 @@ namespace Isis {
    *                            #1673.
    *   @history 2018-07-27 Jesse Mapel - Added support for initializing a histogram from
    *                           signed and unsigned word cubes. References #971.
-   *   @history 2020-06-11 Kaitlyn Lee - Changed how to detemine which bin a pixel/measure falls
-   *                           into in AddData(). Changed how the bin range is calculated in
-   *                           BinRange(). The math for these functions were incorrect and not
-   *                           intuitive. These changes were made alongside changes made
-   *                           to cnethist and hist.
    */
 
   class Histogram : public Statistics {

--- a/isis/src/control/apps/cnethist/cnethist.xml
+++ b/isis/src/control/apps/cnethist/cnethist.xml
@@ -17,11 +17,6 @@
     <change name="Orrin Thomas" date="2012-04-19">
       Original version
     </change>
-    <change name="Kaitlyn Lee" date="2020-06-11">
-      Removed "ResidualMagnitude" from the CSV output and added "ResidualMagnitudeMin" and "ResidualMagnitudeMax". This way, the bins are represented by the min/max values of the
-      bins instead of the DN of the pixel in the middle of the bin. These changes were also
-      reflected in the histrogram creation. The x-axis is now based off of the min value of a bin instead of the middle value. These changes were made alongside changes made to Histogram and hist.
-    </change>
   </history>
 
   <groups>

--- a/isis/src/control/apps/cnethist/main.cpp
+++ b/isis/src/control/apps/cnethist/main.cpp
@@ -39,7 +39,7 @@ void IsisMain() {
   HistogramPlotWindow *plot=NULL;
 
   //setup plot tile and axis labels (if any)
-  if(ui.IsInteractive()) {
+  if(ui.IsInteractive()) { 
     // Set the title for the dialog
     QString title;
     if(ui.WasEntered("TITLE")) {
@@ -70,24 +70,24 @@ void IsisMain() {
     }
 
     QString yaxis = "";
-    plot->setAxisLabel(QwtPlot::yRight, yaxis);
+    plot->setAxisLabel(QwtPlot::yRight, yaxis); 
   }
 
   //open text report file (if any)
-  ofstream fout;
-  if(!ui.IsInteractive() || ui.WasEntered("TO")) {
+  ofstream fout; 
+  if(!ui.IsInteractive() || ui.WasEntered("TO")) { 
     // Write the results
 
     if(!ui.WasEntered("TO")) {
       QString msg = "The [TO] parameter must be entered";
       throw IException(IException::User, msg, _FILEINFO_);
     }
-    QString outfile = ui.GetFileName("TO");
+    QString outfile = ui.GetFileName("TO");     
     fout.open(outfile.toLatin1().data());
   }
 
   //loop throught the control nets writing reports and drawing histograms as needed
-  for (int i=0;i<fList.size();i++) {
+  for (int i=0;i<fList.size();i++) {  
     ControlNet net(fList[i].toString(),&progress);
     Histogram *hist;
     // Setup the histogram
@@ -95,7 +95,7 @@ void IsisMain() {
       hist = new Histogram(net, &ControlMeasure::GetResidualMagnitude, ui.GetDouble("BIN_WIDTH"));
     }
     catch (IException &e) {
-      QString msg = "The following error was thrown while building a histogram from netfile [" +
+      QString msg = "The following error was thrown while building a histogram from netfile [" + 
                     fList[i].expanded() + "]: " +e.toString() + "\n";
       if (ui.IsInteractive())  //if in gui mode print the error message to the terminal
         Application::GuiLog(msg);
@@ -107,9 +107,9 @@ void IsisMain() {
 
       continue; //skip to the next next net file
     }
+       
 
-
-    //Tabular Histogram Data
+    //Tabular Histogram Data 
     if(!ui.IsInteractive() || ui.WasEntered("TO")) {
       fout << "Network:        " << fList[i].toString() << endl;
       fout << "Average:        " << hist->Average() << endl;
@@ -121,26 +121,21 @@ void IsisMain() {
       fout << "Minimum:        " << hist->Minimum() << endl;
       fout << "Maximum:        " << hist->Maximum() << endl;
       fout << "Total Measures: " << hist->TotalPixels() << endl;
-
+        
       //  Write histogram in tabular format
       fout << endl;
-      fout << "ResidualMagnitudeMin,ResidualMagnitudeMax,MeasuresInBin,CumulativeMeasures,Percent,CumulativePercent" << endl;
+      fout << "ResidualMagnitude,MeasuresInBin,CumulativeMeasures,Percent,CumulativePercent" << endl;
 
       Isis::BigInt total = 0;
       double cumpct = 0.0;
-      double low;
-      double high;
 
       for(int j = 0; j < hist->Bins(); j++) {
         if(hist->BinCount(j) > 0) {
           total += hist->BinCount(j);
           double pct = (double)hist->BinCount(j) / hist->ValidPixels() * 100.;
           cumpct += pct;
-
-          hist->BinRange(j, low, high);
-
-          fout << low << ",";
-          fout << high << ",";
+    
+          fout << hist->BinMiddle(j) << ",";
           fout << hist->BinCount(j) << ",";
           fout << total << ",";
           fout << pct << ",";
@@ -157,12 +152,9 @@ void IsisMain() {
     if(ui.IsInteractive()) {
       //Transfer data from histogram to the plotcurve
       QVector<QPointF> binCountData;
-      double low;
-      double high;
       for(int j = 0; j < hist->Bins(); j++) {
         if(hist->BinCount(j) > 0) {
-          hist->BinRange(j, low, high);
-          binCountData.append(QPointF(low, hist->BinCount(j)));
+          binCountData.append(QPointF(hist->BinMiddle(j), hist->BinCount(j)));
         }
       }
 
@@ -172,13 +164,13 @@ void IsisMain() {
       QString baseName = FileName(fList[i]).baseName();
       histCurve->setTitle(baseName);
 
-
+ 
       QPen *pen = new QPen(curveColor(i));
       pen->setWidth(2);
       histCurve->setYAxis(QwtPlot::yLeft);
-      histCurve->setPen(*pen);
+      histCurve->setPen(*pen);  
       histCurve->setMarkerSymbol(QwtSymbol::NoSymbol);
-
+  
       histCurve->setData(new QwtPointSeriesData(binCountData));
 
       plot->add(histCurve);


### PR DESCRIPTION
Reverts USGS-Astrogeology/ISIS3#3918

This is being reverted because it caused significant change in the app test outputs and more time it needed to check that it did not break anything. When, all of the changes are signed off on, it can be merged back in.