### PR TITLE
Added new startup scripts that don't blast existing ISIS environment …

### DIFF
--- a/isis/scripts/isisStartup.csh
+++ b/isis/scripts/isisStartup.csh
@@ -13,7 +13,8 @@
 ################################################################################
 
 if ($?ISISROOT == 0) then
-  setenv ISISROOT /usgs/pkgs/isis3/install
+  echo "ISISROOT environment variable is not set"
+  exit 1
 endif
 
 if ($?ISISDATA == 0) then

--- a/isis/scripts/isisStartup.csh
+++ b/isis/scripts/isisStartup.csh
@@ -1,0 +1,37 @@
+#!/bin/csh
+################################################################################
+# This file should be sourced within your current shell using the "source"
+# command.
+#
+# On the command line type:
+# > setenv ISISROOT ????
+# > source isis3Startup.csh
+#
+# Replace the "????" in the above command line with the path you installed
+# the Isis distribution
+#
+################################################################################
+
+if ($?ISISROOT == 0) then
+  setenv ISISROOT /usgs/pkgs/isis3/install
+endif
+
+if ($?ISISDATA == 0) then
+  if (-d $ISISROOT/../data) then
+    setenv ISISDATA $ISISROOT/../isis_data
+  else
+    setenv ISISDATA /usgs/cpkgs/isis3/isis_data
+  endif
+endif
+
+if ($?ISISTESTDATA == 0) then
+  if (-d $ISISROOT/../testData) then
+    setenv ISISTESTDATA $ISISROOT/../testData
+  else
+    setenv ISISTESTDATA /usgs/cpkgs/isis3/isis_testData
+  endif
+endif
+
+if ( -f $ISISROOT/scripts/tabcomplete.csh ) then
+  source $ISISROOT/scripts/tabcomplete.csh;
+endif

--- a/isis/scripts/isisStartup.sh
+++ b/isis/scripts/isisStartup.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# This file should be executed within your current shell using the "." or "source"
+# command.
+#
+# On the command line type:
+# > set ISISROOT=????
+# > . isis3Startup.sh
+#
+# Replace the "????" in the above command line with the path where you installed
+# the Isis distribution
+#
+if [ ! "$ISISROOT" ]; then
+  ISISROOT=/usgs/pkgs/isis3/install
+  export ISISROOT
+fi
+
+if [ ! "$ISISDATA" ]; then
+  if [ -d $ISISROOT/../data ]; then
+    ISISDATA=$ISISROOT/../isis_data
+  else
+    ISISDATA=/usgs/cpkgs/isis3/isis_data
+  fi
+  export ISISDATA
+fi
+
+if [ ! "$ISISTESTDATA" ]; then
+  if [ -d $ISISROOT/../testData ]; then
+    ISISTESTDATA=$ISISROOT/../testData
+  else
+    ISISTESTDATA=/usgs/cpkgs/isis3/isis_testData
+  fi
+  export ISISTESTDATA
+fi
+
+if [ "$PATH" ]; then
+  PATH="${PATH}:${ISISROOT}/bin"
+else
+  PATH="$ISISROOT/bin"
+fi
+export PATH


### PR DESCRIPTION
New startup scripts that are not destructive to an existing environment

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added new startup scripts that don't overwrite the existing ISIS environment variables. If the variable is already set, the new scripts don't change it.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Developing outside USGS network using the existing scripts is painful. These can be used instead of the ISIS3Startup.XXXX versions to work better.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The scripts were run locally, and the environment was examined to see that only unset variables were modified.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X} I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
