### PR TITLE
Update hist application to accpet nbins when min/max are not set

### DIFF
--- a/isis/src/base/apps/hist/hist.xml
+++ b/isis/src/base/apps/hist/hist.xml
@@ -84,6 +84,10 @@
       Updated logic such that min/max values are no longer calculated from .cub
       if values are provided by the user.  Fixes #3881.
     </change>
+    <change name="Kristin Berry" date="2020-06-25">
+      Re-added the ability to set number of bins without setting min/max values after the last update. 
+      Follow-on to #3881.
+    </change>
   </history>
 
   <oldName>

--- a/isis/src/base/apps/hist/main.cpp
+++ b/isis/src/base/apps/hist/main.cpp
@@ -57,7 +57,12 @@ void IsisMain() {
   }
   else {
     hist = new Histogram(*icube, 1, p.Progress());
+
+    if (ui.WasEntered("NBINS")){
+      hist->SetBins(ui.GetInteger("NBINS"));
+    }
   }
+
   // Setup the histogram
 
   // Loop and accumulate histogram

--- a/isis/src/base/apps/hist/tsts/default/Makefile
+++ b/isis/src/base/apps/hist/tsts/default/Makefile
@@ -1,9 +1,20 @@
+# 2020-06-25 - Kristin Berry - Added a test to check that if nbins is set, it is used.
+#   To make this test, I set the number of bins to much smaller number than the internal default,
+#   and just checked that the output was different from the default test. 
+
 APPNAME = hist
 histTruth.txt.IGNORELINES = Cube
+histTruthNbins.txt.IGNORELINES = Cube
 TEMP = $(OUTPUT)/histTruth.txt
+TEMPNBINS = $(OUTPUT)/histTruthNbins.txt
 
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
+	# Test without additional arguments
 	$(APPNAME) from=$(INPUT)/isisTruth.cub \
-	  to= $(TEMP) > /dev/null;
+	  to=$(TEMP) > /dev/null;
+
+	# Test with setting nbins
+	$(APPNAME) from=$(INPUT)/isisTruth.cub nbins=25\
+	  to=$(TEMPNBINS) > /dev/null;

--- a/isis/src/base/apps/hist/tsts/default/Makefile
+++ b/isis/src/base/apps/hist/tsts/default/Makefile
@@ -1,6 +1,6 @@
 # 2020-06-25 - Kristin Berry - Added a test to check that if nbins is set, it is used.
-#   To make this test, I set the number of bins to much smaller number than the internal default,
-#   and just checked that the output was different from the default test. 
+#   To make the truthdata for this test, I set the number of bins to 25, a number much smaller than 
+#   the internal default, and just checked that the output was different from the default test. 
 
 APPNAME = hist
 histTruth.txt.IGNORELINES = Cube


### PR DESCRIPTION
## Description
PR #3909 introduced a bug in which `nbins` set by the user would be ignored if `minimum` and `maximum` were not also set. This PR fixes this issue and adds a test for `nbins`. (I did not migrate the tests as part of this PR.) 

## Related Issue
See PR #3909. Issue was uncovered by CI, so no ticket number. 

## Motivation and Context
Fixes failing test in CI. 

## How Has This Been Tested?
Existing hist tests pass locally and the `default` test for `hist` was updated to include a run which used `nbins`.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
