### PR TITLE
Update README.md to indicate that isis3VarInit.py is still the script name to use for the current relelase

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,16 +89,26 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
 7.  Finally, setup the environment variables:
 
+For versions of ISIS 4.2.0 and earlier, use: 
+
         #Execute the ISIS variable initialization script with default arguments.
         #This script prepares default values for:  $ISISROOT, $ISISDATA, $ISISTESTDATA
 
-        python $CONDA_PREFIX/scripts/isisVarInit.py
+        python $CONDA_PREFIX/scripts/isis3VarInit.py
 
+For version of ISIS after 4.2.0, use:
+
+	python $CONDA_PREFIX/scripts/isisVarInit.py
 
     Executing this script with no arguments will result in $ISISDATA=$CONDA\_PREFIX/data, and $ISISTESTDATA=$CONDA\_PREFIX/testdata. The user can specify different directories for both of these optional values:
 
+For ISIS 4.2.0 and earlier, use: 
+
         python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
 
+For versions of ISIS after 4.2.0, use: 
+
+        python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
 
     More information about the ISISDATA environment variable and the ISIS Data Area can be found [here]("#The-ISIS-Data-Area"). Now everytime the isis environment is activated, $ISISROOT, $ISISDATA, and $ISISTESTDATA will be set to the values passed to isisVarInit.py. This does not happen retroactively, so re-activate the isis envionment with one of the following commands:
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
         python $CONDA_PREFIX/scripts/isis3VarInit.py
 
-    For version of ISIS after 4.2.0, use:
+    For versions of ISIS after 4.2.0, use:
 
 	python $CONDA_PREFIX/scripts/isisVarInit.py
 
@@ -104,7 +104,7 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
     For ISIS 4.2.0 and earlier, use: 
 
-        python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
+        python $CONDA_PREFIX/scripts/isis3VarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
 
     For versions of ISIS after 4.2.0, use: 
 

--- a/README.md
+++ b/README.md
@@ -89,24 +89,24 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
 7.  Finally, setup the environment variables:
 
-For versions of ISIS 4.2.0 and earlier, use: 
+    For versions of ISIS 4.2.0 and earlier, use: 
 
         #Execute the ISIS variable initialization script with default arguments.
         #This script prepares default values for:  $ISISROOT, $ISISDATA, $ISISTESTDATA
 
         python $CONDA_PREFIX/scripts/isis3VarInit.py
 
-For version of ISIS after 4.2.0, use:
+    For version of ISIS after 4.2.0, use:
 
 	python $CONDA_PREFIX/scripts/isisVarInit.py
 
     Executing this script with no arguments will result in $ISISDATA=$CONDA\_PREFIX/data, and $ISISTESTDATA=$CONDA\_PREFIX/testdata. The user can specify different directories for both of these optional values:
 
-For ISIS 4.2.0 and earlier, use: 
+    For ISIS 4.2.0 and earlier, use: 
 
         python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
 
-For versions of ISIS after 4.2.0, use: 
+    For versions of ISIS after 4.2.0, use: 
 
         python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
     For versions of ISIS after 4.2.0, use:
 
-	python $CONDA_PREFIX/scripts/isisVarInit.py
+        python $CONDA_PREFIX/scripts/isisVarInit.py
 
     Executing this script with no arguments will result in $ISISDATA=$CONDA\_PREFIX/data, and $ISISTESTDATA=$CONDA\_PREFIX/testdata. The user can specify different directories for both of these optional values:
 

--- a/README.md
+++ b/README.md
@@ -89,10 +89,9 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
 7.  Finally, setup the environment variables:
 
-    For versions of ISIS 4.2.0 and earlier, use: 
+    To use the default values for: `$ISISROOT, $ISISDATA, $ISISTESTDATA`, run the ISIS variable initialization script with default arguments.
 
-        #Execute the ISIS variable initialization script with default arguments.
-        #This script prepares default values for:  $ISISROOT, $ISISDATA, $ISISTESTDATA
+    To do this, for versions of ISIS 4.2.0 and earlier, use: 
 
         python $CONDA_PREFIX/scripts/isis3VarInit.py
 


### PR DESCRIPTION
## Description
ISIS 4.2.0 (being released today) has an older version of the script `isisVarInit.py` in dev, which is still named `isis3VarInit.py`. The installation instructions in the README are updated to reflect this. 

## Related Issue
Public release process.

## Motivation and Context
README should explain how to install the current release of ISIS, in addition to dev.

## How Has This Been Tested?
No testing 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
