### PR TITLE
Create IssueLifecycle.md

### DIFF
--- a/IssueLifecycle.md
+++ b/IssueLifecycle.md
@@ -1,0 +1,15 @@
+# ISIS Issue Lifecycle Policy Document
+
+This document describes the issue lifecycle adopted by this project.
+
+## Policy
+- An issue has a maximum inactivity duration of 12 calendar months. Issues that have not had additional comments, up voting using the GitHub emoji mechanism, or activity on a linked issue will be closed.
+- After six months of inactivity, a comment will be left indicating that the issues is being labelled `inactive` and is a candidate for removal in six months.
+- After 11 months a second comment will be left pinging all watchers to either close the issue or perform some activity to reset the issue close countdown.
+- After 12 months of inactivity the issue will be closed with an `automatically_closed` tag.
+
+## Enacting this policy
+This policy will take effect August 2020. As a one time cleanup all issues >= 11 months in age will be closed with a message to the original poster (sent via GitHub) to reopen the issue, add a reaction emoji, or comment to have the issue go back to being live. In cases of a bug, we will ask the re-opener to confirm they can reproduce on the current ISIS version.
+
+## Associated Issue
+This is policy is a result of input from the community of active project contributors. The issue associated with the initial adoption of this policy is [#3951](https://github.com/USGS-Astrogeology/ISIS3/issues/3951).


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a documentation change to adopt an issue policy in this repository.

## Related Issue
#3951 

## Motivation and Context
- We believe that the project has too many issues that have little to no chance of being addressed for a number of reasons (e.g., the problem no longer exists in the current version, the user that reported is no longer working on a project the issue is impacting due to issue age, the enhancement is now out of scope due to time and project evolution, etc.). We assert that none of these are necessarily inherently negative.
- We do not have a policy document at this point. Having a policy document would be a nice thing to have
- We do not need to be prescriptive of the process, we need a set of guidelines on what/when/how things are pruned

## How Has This Been Tested?
N/A - This is a documentation change

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [AUTHORS.rst](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/AUTHORS.rst) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
