### PR TITLE
Add GUI helper to hist for minimum and maximum. Fixes #3880

### DIFF
--- a/isis/src/base/apps/hist/hist.xml
+++ b/isis/src/base/apps/hist/hist.xml
@@ -88,6 +88,9 @@
       Re-added the ability to set number of bins without setting min/max values after the last update. 
       Follow-on to #3881.
     </change>
+    <change name="Stuart Sides" date="2020-09-02">
+      Added GUI helper for filling in computed min/max. Fixed #3880.
+    </change>
   </history>
 
   <oldName>
@@ -138,6 +141,17 @@
         <description>
           Minimum DN value in histogram.  If not entered it will automatically be computed.
         </description>
+        <helpers>
+          <helper name="H1">
+            <function>helperButtonCalcMinMax</function>
+            <brief>Fill in the auto calculated MINIMUM and MAXIMUM for the input cube</brief>
+            <description>
+              This button will calculate what the default MINIMUM and MAXIMUM values would be
+              and fills the respective GUI fields with them.
+            </description>
+            <icon>$ISISROOT/appdata/images/icons/exec.png</icon>
+          </helper>
+        </helpers>
         <lessThan>
           <item>MAXIMUM</item>
         </lessThan>


### PR DESCRIPTION
…N values are of the specified band of the cube

<!--- Provide a general summary of your changes in the Title above -->
Add a GUI helper to hist that calculates the minimum and maximum DN of the first band of a cube (Cube Attributes are used), and populates the parameters with the respective values.

## Description
<!--- Describe your changes in detail -->

## Related Issue
#3880
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Help the user find a good min/max without having to run stats on the cube before running hist

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is a GUI feature. Runs were made with several cubes, and the GUI was changed to the expected state.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ X I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [ ] I have added myself to the [AUTHORS.rst](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/AUTHORS.rst) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
