### PR TITLE
isis2raw pure export update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ update the Unreleased link so that it compares against the latest release tag.
 
 ## [Unreleased]
 
+### Changed
+
+ - Isis2raw will now output straight to a 32bit file (no stretch) when stretch is set to None and bittype is set to 32bit. [#3878](https://github.com/USGS-Astrogeology/ISIS3/issues/3878)
+
 ### Fixed
 
  - Equalizer now reports the correct equation and values used to perform the adjustment. [#3987](https://github.com/USGS-Astrogeology/ISIS3/issues/3987)

--- a/isis/src/base/apps/isis2raw/isis2raw.xml
+++ b/isis/src/base/apps/isis2raw/isis2raw.xml
@@ -11,12 +11,12 @@
     The raw image may be output into an 8-bit, 16-bit unsigned, 16-bit signed
     or 32-bit raw image.  This raw image can be in BSQ, BIL, or BIP format, and
     can include or exclude Null, LRS, LIS, HIS, and/or HRS specific DN values.
-    If no special pixel parameters are selected, then Low Saturation values and 
+    If no special pixel parameters are selected, then Low Saturation values and
     Null values are set to black and High Saturation values are set to white.
-    To ensure acceptable contrast in the output file, the user may select from 
+    To ensure acceptable contrast in the output file, the user may select from
     three stretch options are given 1) no stretch 2) linear, and 3) manual.
-    A custom maximum and minimum DN value can be specified for all output 
-    bittypes.  For example, if a range of 0 to 1023 is selected in a 16-bit 
+    A custom maximum and minimum DN value can be specified for all output
+    bittypes.  For example, if a range of 0 to 1023 is selected in a 16-bit
     unsigned raw image, the DNs are stretched to an effective 10-bit format.
   </description>
 
@@ -57,7 +57,7 @@
       Fixed problem where the valid data range overlapped the null value.
     </change>
     <change name="Christopher Austin" date ="2007-12-17">
-      Created options to ouput BIL and BIP formats, making BSQ the default, as 
+      Created options to ouput BIL and BIP formats, making BSQ the default, as
       well as added preserve special pixel (NULL) option.
     </change>
     <change name="Christopher Austin" date="2008-06-10">
@@ -71,6 +71,11 @@
       Modified to fix an error when inputing OMIN and OMAX values for a 32-bit
       output image. OMIN and OMAX are now calculated based on the stretch if 32-bit
       is chosen and the OMIN and OMAX fields are left blank. Fixes #2194.
+    </change>
+    <change name="Adam Paquette" date="2020-09-04">
+      Updated application logic to not generate a histogram if stretch is None
+      and the output bit type is 32-bit. Also removes duplicate class to checkRange
+      and setRangeAndPixels. Closes #3878 (github).
     </change>
   </history>
 
@@ -173,15 +178,15 @@
           The minimum output DN value including special pixels.
         </brief>
         <description>
-          If a value is provided, the value will be the minimum DN used (including special 
-          pixels). If left blank and the BITTYPE is not 32BIT, the minimum DN value 
-          will default to the smallest value possible for the provided 
+          If a value is provided, the value will be the minimum DN used (including special
+          pixels). If left blank and the BITTYPE is not 32BIT, the minimum DN value
+          will default to the smallest value possible for the provided
           BITTYPE. If the BITTYPE is 32BIT and OMIN is left blank, the value
-          of OMIN will depend on the STRETCH type chosen. If LINEAR is 
-          chosen, the value for OMIN will be the DN value at the value 
-          entered for MINPERCENT on the data. If MANUAL is chosen, the OMIN 
-          will equal to the value of MINIMUM. If NONE is chosen, the value 
-          will default to the smallest value possible for 32 bit data. 
+          of OMIN will depend on the STRETCH type chosen. If LINEAR is
+          chosen, the value for OMIN will be the DN value at the value
+          entered for MINPERCENT on the data. If MANUAL is chosen, the OMIN
+          will equal to the value of MINIMUM. If NONE is chosen, the value
+          will default to the smallest value possible for 32 bit data.
         </description>
         <internalDefault>
           Refer to Documentation
@@ -193,14 +198,14 @@
           The maximum output DN value including special pixels.
         </brief>
         <description>
-          If a value is provided, the value will be the maximum DN used (including special 
-          pixels). If left blank and the BITTYPE is not 32BIT, the maximum DN value 
-          will default to the largest value possible for the provided 
+          If a value is provided, the value will be the maximum DN used (including special
+          pixels). If left blank and the BITTYPE is not 32BIT, the maximum DN value
+          will default to the largest value possible for the provided
           BITTYPE. If the BITTYPE is 32BIT and OMAX is left blank, the value
-          of OMAX will depend on the STRETCH type chosen. If LINEAR is 
-          chosen, the value for OMAX will be the DN value at the value 
-          entered for MAXPERCENT on the data. If MANUAL is chosen, the OMIN 
-          will equal to the value of MAXIMUM. If NONE is chosen, the value 
+          of OMAX will depend on the STRETCH type chosen. If LINEAR is
+          chosen, the value for OMAX will be the DN value at the value
+          entered for MAXPERCENT on the data. If MANUAL is chosen, the OMIN
+          will equal to the value of MAXIMUM. If NONE is chosen, the value
           will default to the largest value possible for 32 bit data.
         </description>
         <internalDefault>
@@ -212,7 +217,7 @@
         <default><item>true</item></default>
         <brief>Dedicates the minimum DN value for null pixels.</brief>
         <description>
-          If set to true, the minimum value of the raw output data will be 
+          If set to true, the minimum value of the raw output data will be
           reserved for null pixels.  The actual value used for null pixels will
           be denoted in the print.prt file and displayed onscreen.
         </description>
@@ -403,7 +408,7 @@
         </default>
         <brief>Storage order of output file.</brief>
         <description>
-          Sets the storage order of the raw ouput file to BSQ, BIL, or 
+          Sets the storage order of the raw ouput file to BSQ, BIL, or
           BIP.
         </description>
         <list>

--- a/isis/src/base/apps/isis2raw/isis2raw.xml
+++ b/isis/src/base/apps/isis2raw/isis2raw.xml
@@ -74,7 +74,7 @@
     </change>
     <change name="Adam Paquette" date="2020-09-04">
       Updated application logic to not generate a histogram if stretch is None
-      and the output bit type is 32-bit. Also removes duplicate class to checkRange
+      and the output bit type is 32-bit. Also removes duplicate calls to checkRange
       and setRangeAndPixels. Closes #3878 (github).
     </change>
   </history>

--- a/isis/src/base/apps/isis2raw/main.cpp
+++ b/isis/src/base/apps/isis2raw/main.cpp
@@ -68,6 +68,7 @@ void IsisMain() {
     p.SetOutputType(Isis::Real);
     pixType = NONE;
   }
+  
   if (ui.GetString("STRETCH") != "NONE" || ui.GetString("BITTYPE") != "32BIT") {
     checkRange(ui, min, max);
   }

--- a/isis/src/base/apps/isis2raw/main.cpp
+++ b/isis/src/base/apps/isis2raw/main.cpp
@@ -63,11 +63,11 @@ void IsisMain() {
   else if(ui.GetString("BITTYPE") == "32BIT") {
     p.SetOutputType(Isis::Real);
   }
-  
+
   if (ui.GetString("STRETCH") != NONE && ui.GetString("BITTYPE") != "32BIT") {
     checkRange(ui, min, max);
-    setRangeAndPixels(ui, p, min, max, NONE);
   }
+  setRangeAndPixels(ui, p, min, max, NONE);
 
   // Set the output endianness
   if(ui.GetString("ENDIAN") == "MSB")

--- a/isis/src/base/apps/isis2raw/main.cpp
+++ b/isis/src/base/apps/isis2raw/main.cpp
@@ -45,29 +45,33 @@ void IsisMain() {
   //  for each line.
   double min = -DBL_MAX;
   double max = DBL_MAX;
+  Pixtype pixType = NONE;
   if(ui.GetString("BITTYPE") == "8BIT") {
     p.SetOutputType(Isis::UnsignedByte);
     min = 0.0;
     max = 255.0;
+    pixType = BOTH;
   }
   else if(ui.GetString("BITTYPE") == "S16BIT") {
     p.SetOutputType(Isis::SignedWord);
     min = -32768.0;
     max = 32767.0;
+    pixType = NEG;
   }
   else if(ui.GetString("BITTYPE") == "U16BIT") {
     p.SetOutputType(Isis::UnsignedWord);
     min = 0.0;
     max = 65535.0;
+    pixType = BOTH;
   }
   else if(ui.GetString("BITTYPE") == "32BIT") {
     p.SetOutputType(Isis::Real);
+    pixType = NONE;
   }
-
-  if (ui.GetString("STRETCH") != NONE && ui.GetString("BITTYPE") != "32BIT") {
+  if (ui.GetString("STRETCH") != "NONE" || ui.GetString("BITTYPE") != "32BIT") {
     checkRange(ui, min, max);
   }
-  setRangeAndPixels(ui, p, min, max, NONE);
+  setRangeAndPixels(ui, p, min, max, pixType);
 
   // Set the output endianness
   if(ui.GetString("ENDIAN") == "MSB")

--- a/isis/src/base/apps/isis2raw/main.cpp
+++ b/isis/src/base/apps/isis2raw/main.cpp
@@ -37,8 +37,9 @@ void IsisMain() {
 //    if(ui.GetString("BITTYPE") != "32BIT")
     p.SetInputRange();
   }
-  if(ui.GetString("STRETCH") == "MANUAL")
+  if(ui.GetString("STRETCH") == "MANUAL") {
     p.SetInputRange(ui.GetDouble("MINIMUM"), ui.GetDouble("MAXIMUM"));
+  }
 
   //  Determine bit size, output range, and calculate number of bytes to write
   //  for each line.
@@ -48,25 +49,22 @@ void IsisMain() {
     p.SetOutputType(Isis::UnsignedByte);
     min = 0.0;
     max = 255.0;
-    checkRange(ui, min, max);
-    setRangeAndPixels(ui, p, min, max, BOTH);
   }
   else if(ui.GetString("BITTYPE") == "S16BIT") {
     p.SetOutputType(Isis::SignedWord);
     min = -32768.0;
     max = 32767.0;
-    checkRange(ui, min, max);
-    setRangeAndPixels(ui, p, min, max, NEG);
   }
   else if(ui.GetString("BITTYPE") == "U16BIT") {
     p.SetOutputType(Isis::UnsignedWord);
     min = 0.0;
     max = 65535.0;
-    checkRange(ui, min, max);
-    setRangeAndPixels(ui, p, min, max, BOTH);
   }
   else if(ui.GetString("BITTYPE") == "32BIT") {
     p.SetOutputType(Isis::Real);
+  }
+  
+  if (ui.GetString("STRETCH") != NONE && ui.GetString("BITTYPE") != "32BIT") {
     checkRange(ui, min, max);
     setRangeAndPixels(ui, p, min, max, NONE);
   }
@@ -117,7 +115,7 @@ void IsisMain() {
 // Validates provided range
 void checkRange(UserInterface &ui, double &min, double &max) {
   Isis::Histogram *hist = p_cube->histogram(0);
-  
+
   if(ui.WasEntered("OMIN")) {
     if(ui.GetDouble("OMIN") < min) {
       QString message = "OMIN [" + toString(min) + "] is too small for the provided BITTYPE [";
@@ -136,7 +134,7 @@ void checkRange(UserInterface &ui, double &min, double &max) {
       min = ui.GetDouble("MINIMUM");
     }
   }
-    
+
   if(ui.WasEntered("OMAX")) {
     if(ui.GetDouble("OMAX") > max) {
       QString message = "OMAX [" + toString(max) + "] is too large for the provided BITTYPE [";


### PR DESCRIPTION
Changes the behavior of isis2raw so when a stretch is not applied and the output pixel type is 32bit no stretch is applied to the image.

## Description
Updates the behavior of isis2raw to not compute a histogram for the output image. This results in the output from isis2raw being a pure conversion from the input image into a 32bit output raw file.

## Related Issue
Closes #3878

## Motivation and Context
Isis2raw was computing a histogram for every it was processing resulting in slower export times for large images. This change addresses this and gives user an option to do a much faster export to a raw image.

## How Has This Been Tested?
Tested by already in place tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added myself to the [AUTHORS.rst](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/AUTHORS.rst) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
