### PR TITLE
changed map2cam to use virtual bands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,8 @@ update the Unreleased link so that it compares against the latest release tag.
 ### Fixed
 
  - Equalizer now reports the correct equation and values used to perform the adjustment. [#3987](https://github.com/USGS-Astrogeology/ISIS3/issues/3987)
- 
+ - Map2cam now uses virtual bands when swithing bands to enable cube attributes. [#3856](https://github.com/USGS-Astrogeology/ISIS3/issues/3856)
+
  ### Added
  
  - A Gui Helper gear was added to hist to fill in the minimum and maximum parameters with what would have been automatically calculated. [#3880](https://github.com/USGS-Astrogeology/ISIS3/issues/3880) 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ update the Unreleased link so that it compares against the latest release tag.
 ### Fixed
 
  - Equalizer now reports the correct equation and values used to perform the adjustment. [#3987](https://github.com/USGS-Astrogeology/ISIS3/issues/3987)
- - Map2cam now uses virtual bands when swithing bands to enable cube attributes. [#3856](https://github.com/USGS-Astrogeology/ISIS3/issues/3856)
+ - Map2cam now works correctly when specifying bands for input cubes. [#3856](https://github.com/USGS-Astrogeology/ISIS3/issues/3856)
 
  ### Added
  

--- a/isis/src/base/apps/map2cam/map2cam.cpp
+++ b/isis/src/base/apps/map2cam/map2cam.cpp
@@ -13,7 +13,6 @@ namespace Isis{
   Cube *mcube;
   Camera *outcam;
 
-
   void map2cam_f(UserInterface &ui) {
 
     // Open the input camera cube that we will be matching and create
@@ -41,6 +40,7 @@ namespace Isis{
                                        mcube->lineCount(),
                                        outcam);
 
+   
     // Allocate the output cube but don't propagate any labels from the map
     // file. Instead propagate from the camera file
     rub.PropagateLabels(false);
@@ -49,7 +49,7 @@ namespace Isis{
     rub.SetOutputCube(fname, outputAtt,
                       transform->OutputSamples(),
                       transform->OutputLines(),
-                      icube->bandCount());
+                      mcube->bandCount());
     rub.PropagateLabels(match.expanded());
     rub.PropagateTables(match.expanded());
 
@@ -69,7 +69,7 @@ namespace Isis{
     if(!outcam->IsBandIndependent()) {
       rub.BandChange(BandChange);
     }
-
+    
     // Warp the cube
     rub.StartProcess(*transform, *interp);
     rub.EndProcess();
@@ -127,6 +127,6 @@ namespace Isis{
   }
 
   void BandChange(const int band) {
-    outcam->SetBand(mcube->physicalBand(band));
+    outcam->SetBand(band);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

map2cam was using physical bands when switching and setting output cube band count. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/USGS-Astrogeology/ISIS3/issues/3856


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Picked images from the PDS archive and ran it through map2cam as match cubes, couldn't replicate the band out of range error and verified band written to output. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [AUTHORS.rst](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/AUTHORS.rst) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
