### PR TITLE
Adds slope calculations to phocube

### DIFF
--- a/isis/src/base/apps/phocube/phocube.xml
+++ b/isis/src/base/apps/phocube/phocube.xml
@@ -110,7 +110,7 @@ xsi:noNamespaceSchemaLocation=
      <li>RADEC (<def link="Right Ascension">Right Ascension</def>, <def link="Declination">Declination</def> )</li>
      <li><def link="Local Solar Time">LOCALTIME</def></li>
      </ul>
-	The following options are available for Level2 images:
+  The following options are available for Level2 images:
      <ul>
      <li>DN</li>
      <li>LATITUDE</li>
@@ -143,7 +143,7 @@ xsi:noNamespaceSchemaLocation=
     <b>
     Group = BandBin
       Name   = ("750 BW 5", "Phase Angle", "Emission Angle", "Incidence Angle",
-        	Latitude, Longitude, Morphology)
+          Latitude, Longitude, Morphology)
       Number = (7, 7, 7, 7, 7, 7, 7)
       Center = (748.7, 748.7, 748.7, 748.7, 748.7, 748.7, 748.7)
       Width  = (5.1, 5.1, 5.1, 5.1, 5.1, 5.1, 5.1)
@@ -300,7 +300,7 @@ xsi:noNamespaceSchemaLocation=
       Added an ObliqueDetectorResolution band.  This is an improvement over the previous DetectorResolution
       function (particularly for images taken near the limb of the target).  References #476, #4100.
     </change>
-		<change name="Kaj Williams" date="2017-06-09">
+    <change name="Kaj Williams" date="2017-06-09">
       Renamed albedo to albedoRank, and morph (or morphology) to morphRank (or MorphologyRank). Ref #4008.
     </change>
     <change name="Kaitlyn Lee" date="2019-02-15">
@@ -308,8 +308,8 @@ xsi:noNamespaceSchemaLocation=
     </change>
     <change name="Kaitlyn Lee" date="2020-06-04">
       Added SPECIALPIXELS parameter to allow users to skip calculations on special pixels, excluding
-      RA and DEC. This changed merged the two process functions, which were created to speed up 
-      the application when copying over DN values. After a few time tests, it doesn't look like the 
+      RA and DEC. This changed merged the two process functions, which were created to speed up
+      the application when copying over DN values. After a few time tests, it doesn't look like the
       merge causes the application to run longer. Changed the process function to be a lambda function
       to get rid of global variables.
     </change>
@@ -333,8 +333,8 @@ xsi:noNamespaceSchemaLocation=
         </brief>
         <description>
           This is the input filename.  The input image cube can be a <def>Level1</def>
-	  or <def>Level2</def> file.  For a Level1 image, spiceinit
-	  must be successfully applied before running phocube.
+    or <def>Level2</def> file.  For a Level1 image, spiceinit
+    must be successfully applied before running phocube.
         </description>
         <filter>
           *.cub
@@ -350,10 +350,10 @@ xsi:noNamespaceSchemaLocation=
         </brief>
         <description>
           This is the output file name.  The cube file will contain a band for
-	  each of the selected options.  The BandBin Group in the image labels
-	  of the output cube file will be updated with the "Name" keyword
-	  containing the output band names (options) in the order that they are
-	  stacked within the cube.
+          each of the selected options.  The BandBin Group in the image labels
+          of the output cube file will be updated with the "Name" keyword
+          containing the output band names (options) in the order that they are
+          stacked within the cube.
         </description>
       </parameter>
 
@@ -362,30 +362,30 @@ xsi:noNamespaceSchemaLocation=
         <brief>Specifies the source of the geometric information</brief>
         <default><item>CAMERA</item></default>
         <description>
-	  Specifies whether the geometric information will be obtained from the
-	  camera model or from the map projection.  If this parameter is set to CAMERA,
-	  all band options are available for the user to select. If this
-	  parameter is set to PROJECTION, then only DN, LATITUDE, LONGITUDE, and
-	  PIXELRESOLUTION band options are available and all other options
-	  will be greyed out. If the user sets this parameter to CAMERA and
-	  the input file does not contain a camera model or SPICE information,
-	  then an error message will occur.
+          Specifies whether the geometric information will be obtained from the
+          camera model or from the map projection.  If this parameter is set to CAMERA,
+          all band options are available for the user to select. If this
+          parameter is set to PROJECTION, then only DN, LATITUDE, LONGITUDE, and
+          PIXELRESOLUTION band options are available and all other options
+          will be greyed out. If the user sets this parameter to CAMERA and
+          the input file does not contain a camera model or SPICE information,
+          then an error message will occur.
         </description>
         <list>
           <option value="CAMERA">
             <brief>Get the geometric information from camera model</brief>
             <description>
               The geometric information is obtained from a camera model and
-	      all band options are available for selection.
+              all band options are available for selection.
             </description>
           </option>
           <option value="PROJECTION">
             <brief>Get the geometric information based on map projection information</brief>
             <description>
               The geometric information is obtained based on the label
-	      keyword values stored under the "Mapping" group in the image
-	      labels.  Only DN, LATITUDE, LONGITUDE, and PIXELRESOLUTION
-	      band options are available.
+              keyword values stored under the "Mapping" group in the image
+              labels.  Only DN, LATITUDE, LONGITUDE, and PIXELRESOLUTION
+              band options are available.
             </description>
             <exclusions>
               <item>PHASE</item>
@@ -429,11 +429,11 @@ xsi:noNamespaceSchemaLocation=
         <default><item>FALSE</item></default>
         <brief>Propagate the input pixel to the output file</brief>
         <description>
-	  This parameter specifies whether the input image pixel value
+          This parameter specifies whether the input image pixel value
           (<def link="Digital Number">DN</def>) will be propagated to
-	  the output file.  The DN parameter must be set to "true,"
-	  if the output product created is expected to contain the input
-	  image information.
+          the output file.  The DN parameter must be set to "true,"
+          if the output product created is expected to contain the input
+          image information.
         </description>
       </parameter>
       <parameter name="PHASE">
@@ -442,9 +442,9 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a phase angle band</brief>
         <description>
           If this parameter is true, the <def>Phase Angle</def> will be
-	  computed for every pixel and placed in a band in the output cube.
-	  The output cube labels will contain "Phase Angle" in the BandBin
-	  group, in band sequence of the output file.  Phase angles are in degrees.
+          computed for every pixel and placed in a band in the output cube.
+          The output cube labels will contain "Phase Angle" in the BandBin
+          group, in band sequence of the output file.  Phase angles are in degrees.
         </description>
       </parameter>
       <parameter name="EMISSION">
@@ -453,11 +453,11 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create an emission angle band</brief>
         <description>
           If this parameter is true, the <def>Emission Angle</def> will be
-	  computed  for every pixel and placed in a band in the output cube.
-	  The output cube labels will contain "Emission Angle" in the BandBin
-	  group, in band sequence of the output file.  Emission angles are in degrees. There are
-	  certain cases where the emission angle is over 90 degrees. This is allowed as there
-	  are processes that need these data. See main description for details.
+          computed  for every pixel and placed in a band in the output cube.
+          The output cube labels will contain "Emission Angle" in the BandBin
+          group, in band sequence of the output file.  Emission angles are in degrees. There are
+          certain cases where the emission angle is over 90 degrees. This is allowed as there
+          are processes that need these data. See main description for details.
         </description>
       </parameter>
       <parameter name="INCIDENCE">
@@ -466,11 +466,11 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create an incidence angle band</brief>
         <description>
           If this parameter is true, the <def>Incidence Angle</def> will be
-	  computed for every pixel and placed in a band in the output cube.
-	  The output cube labels will contain "Incidence Angle" in the BandBin
-	  group, in band sequence of the output file.  Incidence angles are in degrees. There are
-	  certain cases where the incidence angle is over 90 degrees. This is allowed as there
-	  are processes that need these data. See main description for details.
+          computed for every pixel and placed in a band in the output cube.
+          The output cube labels will contain "Incidence Angle" in the BandBin
+          group, in band sequence of the output file.  Incidence angles are in degrees. There are
+          certain cases where the incidence angle is over 90 degrees. This is allowed as there
+          are processes that need these data. See main description for details.
         </description>
       </parameter>
       <parameter name="LOCALEMISSION">
@@ -479,12 +479,12 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a local emission angle band</brief>
         <description>
           If this parameter is true, the <def link="local emission angle"
-	  >Local Emission Angle</def>  will be computed for every pixel
-	  and placed in a band in the output cube.  The output cube labels
-	  will contain "Local Emission Angle" in the BandBin group, in band
-	  sequence of the output file.  LocalEmissionAngle is in degrees. There are certain
-	  cases where the local emission angle is over 90 degrees. This is allowed as there
-	  are processes that need these data. See main description for details.
+          >Local Emission Angle</def>  will be computed for every pixel
+          and placed in a band in the output cube.  The output cube labels
+          will contain "Local Emission Angle" in the BandBin group, in band
+          sequence of the output file.  LocalEmissionAngle is in degrees. There are certain
+          cases where the local emission angle is over 90 degrees. This is allowed as there
+          are processes that need these data. See main description for details.
         </description>
       </parameter>
       <parameter name="LOCALINCIDENCE">
@@ -493,12 +493,12 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a local incidence angle band</brief>
         <description>
           If this parameter is true, the <def link="Local Incidence Angle">Local
-	  Incidence Angle</def> will be computed for every pixel and placed in
-	  a band in the output cube.  The output cube labels will contain
-	  "Local Incidence Angle" in the BandBin group, in band sequence
-	  of the output file.  LocalIncidenceAngle is in degrees. There are certain
-	  cases where the local incidence angle is over 90 degrees. This is allowed as there
-	  are processes that need these data. See main description for details.
+          Incidence Angle</def> will be computed for every pixel and placed in
+          a band in the output cube.  The output cube labels will contain
+          "Local Incidence Angle" in the BandBin group, in band sequence
+          of the output file.  LocalIncidenceAngle is in degrees. There are certain
+          cases where the local incidence angle is over 90 degrees. This is allowed as there
+          are processes that need these data. See main description for details.
          </description>
       </parameter>
       <parameter name="LATITUDE">
@@ -507,9 +507,9 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a latitude band</brief>
         <description>
           If this parameter is true, the latitude value will be computed for
-	  every pixel and placed in a band in the output cube.  The output cube
-	  labels will contain "Latitude" in the BandBin group, in band sequence
-	  of the output file.  Latitude is in degrees.
+          every pixel and placed in a band in the output cube.  The output cube
+          labels will contain "Latitude" in the BandBin group, in band sequence
+          of the output file.  Latitude is in degrees.
         </description>
       </parameter>
       <parameter name="LONGITUDE">
@@ -518,9 +518,9 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a longitude band</brief>
         <description>
           If this parameter is true, the longitude value will be computed for
-	  every pixel placed in a band in the output cube.  The output cube
-	  labels will contain "Longitude" in the BandBin group, in band
-	  sequence of the output file.  Longitude is in degrees.
+          every pixel placed in a band in the output cube.  The output cube
+          labels will contain "Longitude" in the BandBin group, in band
+          sequence of the output file.  Longitude is in degrees.
         </description>
       </parameter>
       <parameter name="PIXELRESOLUTION">
@@ -530,9 +530,9 @@ xsi:noNamespaceSchemaLocation=
         <description>
           If this parameter is true, the <def>Pixel Resolution</def>
           will be computed for every pixel and placed in a band in the output
-	  cube.  The output cube labels will contain "Pixel Resolution" in the
-	  BandBin group, in band sequence of the output file. PixelResolution
-	  is in meters.
+          cube.  The output cube labels will contain "Pixel Resolution" in the
+          BandBin group, in band sequence of the output file. PixelResolution
+          is in meters.
         </description>
       </parameter>
       <parameter name="LINERESOLUTION">
@@ -541,9 +541,9 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a line resolution band</brief>
         <description>
           If this parameter is true, the <def>Line Resolution</def> will be
-	  computed for every pixel and placed in a band in the output cube.
-	  The output cube labels will contain "Line Resolution" in the BandBin
-	  group, in band sequence of the output file.  LineResolution is in meters.
+          computed for every pixel and placed in a band in the output cube.
+          The output cube labels will contain "Line Resolution" in the BandBin
+          group, in band sequence of the output file.  LineResolution is in meters.
         </description>
       </parameter>
       <parameter name="SAMPLERESOLUTION">
@@ -552,10 +552,10 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a sample resolution band</brief>
         <description>
           If this parameter is true, the <def>Sample Resolution</def> will be
-	  computed for every pixel and placed in a band in the output cube.
-	  The output cube labels will contain "Sample Resolution" in the
-	  BandBin group, in band sequence of the output file.  SampleResolution
-	  is in meters.
+          computed for every pixel and placed in a band in the output cube.
+          The output cube labels will contain "Sample Resolution" in the
+          BandBin group, in band sequence of the output file.  SampleResolution
+          is in meters.
        </description>
       </parameter>
       <parameter name="DETECTORRESOLUTION">
@@ -564,10 +564,10 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a detector resolution band</brief>
         <description>
           If this parameter is true, the <def>Detector Resolution</def> will be
-	  computed for every pixel and placed in a band in the output cube.  The
-	  output cube labels will contain "Detector Resolution" in the BandBin
-	  group, in band sequence of the output file.  DetectorResolution is
-	  in millimeters.
+          computed for every pixel and placed in a band in the output cube.  The
+          output cube labels will contain "Detector Resolution" in the BandBin
+          group, in band sequence of the output file.  DetectorResolution is
+          in millimeters.
         </description>
       </parameter>
 
@@ -577,10 +577,10 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create an oblique detector resolution band</brief>
         <description>
           If this parameter is true, the <def>Oblique Detector Resolution</def> will be
-    computed for every pixel and placed in a band in the output cube.  The
-    output cube labels will contain "Oblique Detector Resolution" in the BandBin
-    group, in band sequence of the output file.  ObliqueDetectorResolution is
-    in millimeters.
+          computed for every pixel and placed in a band in the output cube.  The
+          output cube labels will contain "Oblique Detector Resolution" in the BandBin
+          group, in band sequence of the output file.  ObliqueDetectorResolution is
+          in millimeters.
         </description>
       </parameter>
 
@@ -590,9 +590,9 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a north azimuth band</brief>
         <description>
           If this parameter is true, the <def>North Azimuth</def> will be
-	  computed for every pixel and placed in a band in the output cube.  The
-	  output cube labels will contain "North  Azimuth" in the BandBin group,
-	  in band sequence of the output file.  NorthAzimuth is in degrees.
+          computed for every pixel and placed in a band in the output cube.  The
+          output cube labels will contain "North  Azimuth" in the BandBin group,
+          in band sequence of the output file.  NorthAzimuth is in degrees.
         </description>
       </parameter>
       <parameter name="SUNAZIMUTH">
@@ -601,9 +601,9 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a sun azimuth band</brief>
         <description>
           If this parameter is true, the <def>Sun Azimuth</def> will be computed
-	  for every pixel and placed in a band in the output cube.  The output
-	  cube labels will contain "Sun Azimuth" in the BandBin group, in band
-	  sequence of the output file.  SunAzimuth is in degrees.
+          for every pixel and placed in a band in the output cube.  The output
+          cube labels will contain "Sun Azimuth" in the BandBin group, in band
+          sequence of the output file.  SunAzimuth is in degrees.
         </description>
       </parameter>
       <parameter name="SPACECRAFTAZIMUTH">
@@ -612,10 +612,10 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a spacecraft azimuth band</brief>
         <description>
           If this parameter is true, the <def>Spacecraft Azimuth</def>  will
-	  be computed for every pixel and placed in a band in the output cube.
-	  The output cube labels will contain "Spacecraft Azimuth" in the
-	  BandBin group, in band sequence of the output file.  SpacecraftAzimuth
-	  is in degrees.
+          be computed for every pixel and placed in a band in the output cube.
+          The output cube labels will contain "Spacecraft Azimuth" in the
+          BandBin group, in band sequence of the output file.  SpacecraftAzimuth
+          is in degrees.
         </description>
       </parameter>
       <parameter name="OFFNADIRANGLE">
@@ -624,10 +624,48 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create an offNadir angle band</brief>
         <description>
           If this parameter is true, the <def>Off Nadir Angle</def> will be
-	  computed for every pixel and placed in a band in the output cube.
-	  The output cube labels will contain "OffNadir Angle" in the BandBin
-	  group, in band sequence of the output file.  OffNadirAngle is
-	  in degrees.
+          computed for every pixel and placed in a band in the output cube.
+          The output cube labels will contain "OffNadir Angle" in the BandBin
+          group, in band sequence of the output file.  OffNadirAngle is
+          in degrees.
+        </description>
+      </parameter>
+      <parameter name="SLOPE">
+        <type>boolean</type>
+        <default><item>FALSE</item></default>
+        <brief>Create a slope band</brief>
+        <description>
+          If this parameter is true, the slope will be computed for every pixel
+          and placed in a band in the output cube. The output cube labels will
+          contain "Slope" in the BandBin group, in band sequence of the output
+          file. The slope is in degrees with 0 degrees being perfectly flat and
+          90 degrees being sheer vertical.
+
+          If computing slopes, the input image must be a level1 image. To
+          compute slopes for a level2 DEM use
+          <a href="../slpmap/slpmap.html" target="_blank">slpmap</a>.
+        </description>
+      </parameter>
+      <parameter name="SLOPEAZIMUTH">
+        <type>boolean</type>
+        <default><item>FALSE</item></default>
+        <brief>Create a slope azimuth band</brief>
+        <description>
+          This angle is also refered to as the slope aspect.
+
+          If this parameter is true, the slope azimuth will be computed for
+          every pixel and placed in a band in the output cube. The output cube
+          labels will contain "Slope Azimuth" in the BandBin group, in band
+          sequence of the output file. The slope azimuth at a ground point is
+          the compass angle between the vector pointing North and the local
+          surface normal. The slope azimuth is measured in positive clockwise
+          degrees from North; the local surface normal points North at 0
+          degrees, East at 90 degrees, South at 180 degrees, and so on.
+
+          If computing slope azimuths, the input image must be a level1 image.
+          To compute slope azimuths for a level2 DEM use
+          <a href="../slpmap/slpmap.html" target="_blank">slpmap</a>
+          with OUTPUT=ASPECT.
         </description>
       </parameter>
       <parameter name="SUBSPACECRAFTGROUNDAZIMUTH">
@@ -637,8 +675,8 @@ xsi:noNamespaceSchemaLocation=
         <description>
           If this parameter is true, the <def>Spacecraft Ground Azimuth</def>
           will be computed for every pixel and placed in a band in the output
-	  cube.  The output cube labels  will contain "Sub Spacecraft Ground
-	  Azimuth" in the BandBin group, in band sequence of the output file.
+          cube.  The output cube labels  will contain "Sub Spacecraft Ground
+          Azimuth" in the BandBin group, in band sequence of the output file.
           SubSpacecraftGround Azimuth is in degrees.
         </description>
       </parameter>
@@ -648,10 +686,10 @@ xsi:noNamespaceSchemaLocation=
         <brief>Create a sub solar ground azimuth band</brief>
         <description>
           If this parameter is true, the <def>SubSolar Ground Azimuth</def>
-	  will be computed for every pixel and placed in a band in the output
-	  cube.  The output cube labels will contain "Sub Solar Ground Azimuth"
-	  in the BandBin group, in band sequence of the output file.
-	  SubSolarGroundAzimuth is in degrees.
+          will be computed for every pixel and placed in a band in the output
+          cube.  The output cube labels will contain "Sub Solar Ground Azimuth"
+          in the BandBin group, in band sequence of the output file.
+          SubSolarGroundAzimuth is in degrees.
         </description>
       </parameter>
      <parameter name="MORPHOLOGYRANK">
@@ -659,7 +697,7 @@ xsi:noNamespaceSchemaLocation=
         <default><item>FALSE</item></default>
         <brief>Create a morphology rank band, used for ranking images based on favorable local emission angles.</brief>
         <description>
-	  <p>
+          <p>
             This band is computed from the <def link="Pixel Resolution">pixel resolution</def>
             and <def link="Emission Angle">emission angle</def> using the following formula:<br />
             <br />MorphologyRank = PixelResolution / cos(EmissionAngle)<br /> <br />
@@ -668,88 +706,88 @@ xsi:noNamespaceSchemaLocation=
             <def link="Local Emission Angle">local emission angle</def> if the input file
             is initialized (spiceinit) with an elevation model (DEM); otherwise, it
             uses the default calculation (from the ellipsoid).  All computed cosines are
-	    tested for zero.  If the result is zero, then the value is set to a constant
-	    value very close to zero.
+            tested for zero.  If the result is zero, then the value is set to a constant
+            value very close to zero.
           </p>
           <p>
- 	    <dl>
-	    <dt>
+           <dl>
+             <dt>
               Append the following parameters to the <i>automos</i> command line to utilize this backplane band:
-	    </dt>
+            </dt>
             <dd>
-	      <b>priority=band type=keyword keyname=Name keyvalue=morphologyRank criteria=lesser</b>.
-	    </dd>
-	    </dl>
-            See <i>automos</i> documentation for further details.
-          </p>
-        </description>
-      </parameter>
-     <parameter name="ALBEDORANK">
-        <type>boolean</type>
-        <default><item>FALSE</item></default>
-        <brief>Create an albedo rank band, used for ranking images based on favorable emission and incidence angles.</brief>
-        <description>
-          <p>
-            This band is computed from the <def link="Pixel Resolution">pixel resolution</def>,
-            <def link="Incidence Angle">incidence angle</def> and <def link="Emission Angle">emission angle</def>
-            using the following formula:<br /><br />
-	    AlbedoRank = PixelResolution * [(1 / cos(EmissionAngle)) + (1 / cos(IncidenceAngle))]<br /><br />
-	    The resulting output band can be used by <i>automos</i> to create an albedo-based
-	    mosaic product.  This option always uses the
-	    <def link="Local Emission Angle">local emission angle</def>  and
-	    <def link="Local Incidence Angle">local incidence angle</def> if the input file
-            is initialized (spiceinit) with an elevation model (DEM); otherwise, it
-            uses the default calculation (from the ellipsoid).  All computed cosines are
-	    tested for zero.  If the result is zero, then the value is set to a constant
-	    value very close to zero.
-          </p>
-          <p>
- 	    <dl>
-	    <dt>
+              <b>priority=band type=keyword keyname=Name keyvalue=morphologyRank criteria=lesser</b>.
+            </dd>
+          </dl>
+          See <i>automos</i> documentation for further details.
+        </p>
+      </description>
+    </parameter>
+    <parameter name="ALBEDORANK">
+      <type>boolean</type>
+      <default><item>FALSE</item></default>
+      <brief>Create an albedo rank band, used for ranking images based on favorable emission and incidence angles.</brief>
+      <description>
+        <p>
+          This band is computed from the <def link="Pixel Resolution">pixel resolution</def>,
+          <def link="Incidence Angle">incidence angle</def> and <def link="Emission Angle">emission angle</def>
+          using the following formula:<br /><br />
+          AlbedoRank = PixelResolution * [(1 / cos(EmissionAngle)) + (1 / cos(IncidenceAngle))]<br /><br />
+          The resulting output band can be used by <i>automos</i> to create an albedo-based
+          mosaic product.  This option always uses the
+          <def link="Local Emission Angle">local emission angle</def>  and
+          <def link="Local Incidence Angle">local incidence angle</def> if the input file
+          is initialized (spiceinit) with an elevation model (DEM); otherwise, it
+          uses the default calculation (from the ellipsoid).  All computed cosines are
+          tested for zero.  If the result is zero, then the value is set to a constant
+          value very close to zero.
+        </p>
+        <p>
+          <dl>
+            <dt>
               Append the following parameters to the <i>automos</i> command line to utilize this backplane band:
-	    </dt>
+            </dt>
             <dd>
-            <b>priority=band type=keyword keyname=Name keyvalue=albedoRank
+              <b>priority=band type=keyword keyname=Name keyvalue=albedoRank
               criteria=lesser</b>.
-	    </dd>
-	    </dl>
-            See <i>automos</i> documentation for further details.
-          </p>
-        </description>
-      </parameter>
-      <parameter name="RADEC">
+            </dd>
+          </dl>
+          See <i>automos</i> documentation for further details.
+        </p>
+      </description>
+    </parameter>
+    <parameter name="RADEC">
          <type>boolean</type>
          <default><item>FALSE</item></default>
          <brief>Create bands for Right Ascension and Declination</brief>
          <description>
-	   If this parameter is true, the <def>Right Ascension</def>, and the
-	   <def>Declination</def> will be calculated for every pixel and each will be placed into
-	   their respective bands in the output cube. The output cube labels will contain
-	   "Right Ascension" and "Declination" in the BandBin group, in the band sequence of the
-	   output file. Right Ascension and Declination are in degrees.
-	 </description>
+           If this parameter is true, the <def>Right Ascension</def>, and the
+           <def>Declination</def> will be calculated for every pixel and each will be placed into
+           their respective bands in the output cube. The output cube labels will contain
+           "Right Ascension" and "Declination" in the BandBin group, in the band sequence of the
+           output file. Right Ascension and Declination are in degrees.
+         </description>
        </parameter>
       <parameter name="BODYFIXED">
          <type>boolean</type>
          <default><item>FALSE</item></default>
          <brief>Create bands for the X, Y, and Z Body Fixed Coordinates</brief>
          <description>
-	   If this parameter is true, the <def>Body Fixed Coordinates</def> will be calculated for
-	   every pixel and the values for X, Y, and Z will each be placed into their own bands in
-	   the output cube. The output cube labels will contain "Body Fixed X", "Body Fixed Y",
-	   and "Body Fixed Z" in the BandBin group, in the band sequence of the output file.
-	   Body Fixed Coordinates are in kilometers.
-	 </description>
+           If this parameter is true, the <def>Body Fixed Coordinates</def> will be calculated for
+           every pixel and the values for X, Y, and Z will each be placed into their own bands in
+           the output cube. The output cube labels will contain "Body Fixed X", "Body Fixed Y",
+           and "Body Fixed Z" in the BandBin group, in the band sequence of the output file.
+           Body Fixed Coordinates are in kilometers.
+         </description>
        </parameter>
       <parameter name="LOCALTIME">
          <type>boolean</type>
          <default><item>FALSE</item></default>
          <brief>Create a band with local solar time</brief>
          <description>
-	   If this parameter is true, the <def>Local Solar Time</def> will be calculated for
-	   every pixel in the output cube. The output cube label will contain "Local Solar Time"
-	   in the BandBin group. Local Solar Time is in hours.
-	 </description>
+           If this parameter is true, the <def>Local Solar Time</def> will be calculated for
+           every pixel in the output cube. The output cube label will contain "Local Solar Time"
+           in the BandBin group. Local Solar Time is in hours.
+         </description>
        </parameter>
     </group>
   </groups>
@@ -759,21 +797,21 @@ xsi:noNamespaceSchemaLocation=
       <brief>Create latitude and morphologyRank backplane bands</brief>
       <description>
         Within this example, <i>phocube</i> creates an output file with two bands
-	that contain latitude information and computed morphologyRank
-	values, which are shown below as separate snapshots under "Output
-	Images."  The input image file shown below under "Input Image" was
-	not propagated to the <i>phocube</i> output file because DN is set to
-	false.  If the <i>phocube</i> output file is projected and mosaicked,
-	the mosaic file will contain the latitude information for the first
-	band and the "morphologyRank" values for the second band, but no image
-	information from the input image will be included.  The "DN"
-	parameter must be set to "true" if the output product is expected
-	to contain the input image.
+        that contain latitude information and computed morphologyRank
+        values, which are shown below as separate snapshots under "Output
+        Images."  The input image file shown below under "Input Image" was
+        not propagated to the <i>phocube</i> output file because DN is set to
+        false.  If the <i>phocube</i> output file is projected and mosaicked,
+        the mosaic file will contain the latitude information for the first
+        band and the "morphologyRank" values for the second band, but no image
+        information from the input image will be included.  The "DN"
+        parameter must be set to "true" if the output product is expected
+        to contain the input image.
       </description>
       <terminalInterface>
         <commandLine>
-	 from=EW0131773041G_cal.cub to=EW0131773041G_cal.pho.cub phase=no emission=no incidence=no
-	 longitude=no morphologyRank=yes
+         from=EW0131773041G_cal.cub to=EW0131773041G_cal.pho.cub phase=no emission=no incidence=no
+         longitude=no morphologyRank=yes
         </commandLine>
         <description>Run <i>phocube</i> to create latitude and morphologyRank bands.</description>
       </terminalInterface>
@@ -783,9 +821,9 @@ xsi:noNamespaceSchemaLocation=
             <brief>Example GUI</brief>
             <description>
               Screenshot of GUI version of the application.<br />  For this example,
-	      only "LATITUDE" and "MORPHOLOGYRANK" are selected.  The pre-selected
-	      options "PHASE," "EMISSION," "INCIDENCE," and "LONGITUDE" are
-	      deselected to avoid creating these unwanted backplanes.
+              only "LATITUDE" and "MORPHOLOGYRANK" are selected.  The pre-selected
+              options "PHASE," "EMISSION," "INCIDENCE," and "LONGITUDE" are
+              deselected to avoid creating these unwanted backplanes.
             </description>
             <thumbnail src="assets/thumbs/thumb_phocube_gui.jpg" caption="phocube GUI" width="147" height="243"/>
           </image>
@@ -808,8 +846,8 @@ xsi:noNamespaceSchemaLocation=
           <brief>Output file band 1 (Latitude)</brief>
           <description>
             Screenshot of the first band in the output file.  This file contains the
-	    latitude information with -72.2 degree as the minimum, and 6.27 degree
-	    as the maximum value.
+            latitude information with -72.2 degree as the minimum, and 6.27 degree
+            as the maximum value.
           </description>
           <thumbnail src="assets/thumbs/thumb_phocube_lat_band.png" caption="Output image band 1 (latitude)" width="200" height="200"/>
           <parameterName>
@@ -820,10 +858,10 @@ xsi:noNamespaceSchemaLocation=
           <brief>Output file band 2 (MorphologyRank)</brief>
           <description>
             Screenshot of the second band in the output file.  This file contains the
-	    computed morphologyRank values with 0.0 as the minimum, and 15.0 as the maximum
-	    value.  The minimum and maximum values were manually selected to brighten
-	    the image for visual presentation.  The actual range is between 2.8 and 41.5
-	    DN values.
+            computed morphologyRank values with 0.0 as the minimum, and 15.0 as the maximum
+            value.  The minimum and maximum values were manually selected to brighten
+            the image for visual presentation.  The actual range is between 2.8 and 41.5
+            DN values.
           </description>
           <thumbnail src="assets/thumbs/thumb_phocube_morph_band.png" caption="Output image band 2 (morphologyRank)" width="200" height="200"/>
           <parameterName>

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -68,10 +68,10 @@ namespace Isis {
    * @param cube The Pvl label from the cube is used to create the Camera object.
    */
   Camera::Camera(Cube &cube) : Sensor(cube) {
-    
-    m_instrumentId = cube.label()->findGroup("Instrument", 
+
+    m_instrumentId = cube.label()->findGroup("Instrument",
                         PvlObject::FindOptions::Traverse).findKeyword("InstrumentId")[0];
-    
+
     m_instrumentNameLong = "Unknown";
     m_instrumentNameShort = "Unknown";
     m_spacecraftNameLong = "Unknown";
@@ -208,12 +208,12 @@ namespace Isis {
 
     // The projection is a sky map
     else if (p_projection->IsSky()) {
-      return SetImageSkyMapProjection(sample, line, shape); 
+      return SetImageSkyMapProjection(sample, line, shape);
     }
 
     // We have map projected camera model
     else {
-      return SetImageMapProjection(sample, line, shape); 
+      return SetImageMapProjection(sample, line, shape);
     }
 
     // failure
@@ -225,19 +225,19 @@ namespace Isis {
   /**
    * @brief Sets the sample/line values of the image to get the lat/lon values with
    *        a time offset of deltaT.
-   *  
-   * Warning: The deltaT parameter was added specifically for pixel2map to use for 
-   * the Dawn VIR camera. It is used to adjust the pointing to its location at specific 
-   * times like the times at the beginning, middle, and end of exposure for a specific pixel, 
-   * when the correct deltaT can be determined to achieve these results. 
-   *  
-   * Do not use this verstion of SetImage with a deltaT unless you understand exactly what this 
-   * does.  
-   *  
+   *
+   * Warning: The deltaT parameter was added specifically for pixel2map to use for
+   * the Dawn VIR camera. It is used to adjust the pointing to its location at specific
+   * times like the times at the beginning, middle, and end of exposure for a specific pixel,
+   * when the correct deltaT can be determined to achieve these results.
+   *
+   * Do not use this verstion of SetImage with a deltaT unless you understand exactly what this
+   * does.
+   *
    * @param sample Sample coordinate of the cube.
-   * @param line Line coordinate of the cube. 
-   * @param deltaT seconds from the center exposure time 
-   *  
+   * @param line Line coordinate of the cube.
+   * @param deltaT seconds from the center exposure time
+   *
    * @return @b bool Returns True if the image was set successfully and False if it
    *              was not.
    */
@@ -282,12 +282,12 @@ namespace Isis {
 
     // The projection is a sky map
     else if (p_projection->IsSky()) {
-      return SetImageSkyMapProjection(sample, line, shape); 
+      return SetImageSkyMapProjection(sample, line, shape);
     }
-    
+
     // We have map projected camera model
     else {
-      return SetImageMapProjection(sample, line, shape); 
+      return SetImageMapProjection(sample, line, shape);
     }
 
     // failure
@@ -297,13 +297,13 @@ namespace Isis {
 
 
 /**
- * @brief Sets the sample/line values of the image to get the lat/lon values for a Map Projected 
- * image. 
- *  
+ * @brief Sets the sample/line values of the image to get the lat/lon values for a Map Projected
+ * image.
+ *
  * @param sample Sample coordinate of the cube
  * @param line Line coordinate of the cube
  * @param shape shape of the target
- * 
+ *
  * @return bool Returns True if the image was set successfully and False if it
  *              was not.
  */
@@ -353,18 +353,18 @@ namespace Isis {
       }
     }
     shape->clearSurfacePoint();
-    return false; 
+    return false;
   }
 
 
 /**
- * @brief Sets the sample/line values of the image to get the lat/lon values for a Skymap Projected 
- * image. 
- *  
+ * @brief Sets the sample/line values of the image to get the lat/lon values for a Skymap Projected
+ * image.
+ *
  * @param sample Sample coordinate of the cube
  * @param line Line coordinate of the cube
  * @param shape shape of the target
- * 
+ *
  * @return bool Returns True if the image was set successfully and False if it
  *              was not.
  */
@@ -380,7 +380,7 @@ namespace Isis {
       }
     }
     shape->clearSurfacePoint();
-    return false; 
+    return false;
   }
 
 
@@ -600,10 +600,10 @@ namespace Isis {
 
       if(HasSurfaceIntersection()){
 
-          double thetaRad;          
+          double thetaRad;
           thetaRad = EmissionAngle()*DEG2RAD;
 
-          if (thetaRad < HALFPI) {           
+          if (thetaRad < HALFPI) {
             return DetectorResolution()/cos(thetaRad);
 
           }
@@ -1714,6 +1714,41 @@ namespace Isis {
 
 
   /**
+   * Calculates the slope at the current point
+   * by computing the angle between the local surface normal and the ellipsoid
+   * surface normal. If there is a failure during the process, such as there
+   * not being an intersection, then success will be false and slope will not
+   * be modified.
+   *
+   * @param[out] slope The slope angle in degrees
+   * @param[out] success If the slope was successfully calculated
+   */
+  void Camera::Slope(double &slope, bool &success) {
+    ShapeModel *shapeModel = target()->shape();
+    if ( !shapeModel->hasIntersection()) {
+      success = false;
+      return;
+    }
+    shapeModel->calculateSurfaceNormal();
+    if (!shapeModel->hasNormal()) {
+      success = false;
+      return;
+    }
+    std::vector<double> ellipsoidNormal = shapeModel->normal();
+
+    double localNormal[3];
+    GetLocalNormal(localNormal);
+    if (localNormal[0] == 0.0 && localNormal[1] == 0.0 && localNormal[2] == 0.0) {
+      success = false;
+      return;
+    }
+
+    slope = vsep_c(localNormal, &ellipsoidNormal[0]) * 180.0 / PI;;
+    success = true;
+  }
+
+
+  /**
    * Computes the RaDec range
    *
    * @param minra Minimum right ascension value
@@ -2476,7 +2511,7 @@ namespace Isis {
    * close time) is the maximum value of those ephemeris times. This method must
    * be called before a call to the Spice::createCache() method.  It is called
    * in the LoadCache() method.
-   * 
+   *
    * @returns pair<double, double> A pair containing the start and end ephemeris times
    *
    * @throw iException::Programmer - "Unable to find time range for the
@@ -2522,10 +2557,10 @@ namespace Isis {
    * of lines in the beta cube and adds 1, since we need at least 2 points for
    * interpolation. This method must be called before a call to the
    * Spice::createCache() method.  It is called in the LoadCache() method.
-   * 
+   *
    * @param startTime Starting ephemeris time to cache
    * @param endTime Ending ephemeris time to cache
-   * 
+   *
    * @returns int The  calculated spice cache size
    *
    * @throw iException::Programmer - "A cache has already been created."
@@ -2760,7 +2795,7 @@ namespace Isis {
    * Returns the pixel ifov offsets from center of pixel, which defaults to the
    * (pixel pitch * summing mode ) / 2.  If an instrument has a non-square ifov, it must implement
    * this method to return the offsets from the center of the pixel.
-   * 
+   *
    * @returns QList<QPointF> A list of offsets
    *
    */
@@ -2878,8 +2913,8 @@ namespace Isis {
   CameraSkyMap *Camera::SkyMap() {
     return p_skyMap;
   }
-  
-  
+
+
   /**
    * This method returns the InstrumentId as it appears in the cube.
    *
@@ -3069,7 +3104,7 @@ namespace Isis {
 
   /**
    * Return the exposure duration for the pixel that the camera is set to.
-   * 
+   *
    * @return @b double The exposure duration in seconds for the pixel that the camera is set to.
    */
   double Camera::exposureDuration() const {
@@ -3079,11 +3114,11 @@ namespace Isis {
 
   /**
    * Return the exposure duration for the pixel at the given line, sample and band.
-   * 
+   *
    * @param sample The sample of the desired pixel.
    * @param line The line of the desired pixel.
    * @param band The band of the desired pixel. Defaults to 1.
-   * 
+   *
    * @return @b double The exposure duration for the desired pixel in seconds.
    */
   double Camera::exposureDuration(const double sample, const double line, const int band) const {
@@ -3097,5 +3132,3 @@ namespace Isis {
 
 // end namespace isis
 }
-
-

--- a/isis/src/base/objs/Camera/Camera.h
+++ b/isis/src/base/objs/Camera/Camera.h
@@ -239,10 +239,10 @@ namespace Isis {
    *                           an error in the original formula, and updated the documention for this
    *                           function.  Fixes #4614.
    *   @history 2017-08-30 Summer Stapleton - Updated documentation. References #4807.
-   *   @history 2017-01-11 Christopher Combs - Added bool deleteExisting to SetDistortionMap to 
+   *   @history 2017-01-11 Christopher Combs - Added bool deleteExisting to SetDistortionMap to
    *                           prevent a segfault when the distortion map is incomplete. Fixes $5163.
-   *   @history 2018-07-12 Summer Stapleton - Added m_instrumentId and instrumentId() in order to 
-   *                           collect the InstrumentId from the original cube label for 
+   *   @history 2018-07-12 Summer Stapleton - Added m_instrumentId and instrumentId() in order to
+   *                           collect the InstrumentId from the original cube label for
    *                           comparisons related to image imports in ipce. References #5460.
    */
 
@@ -268,6 +268,7 @@ namespace Isis {
 
       void LocalPhotometricAngles(Angle & phase, Angle & incidence,
                                   Angle & emission, bool &success);
+      void Slope(double &slope, bool &success);
 
       void GetLocalNormal(double normal[3]);
 
@@ -331,7 +332,7 @@ namespace Isis {
       CameraDetectorMap *DetectorMap();
       CameraGroundMap *GroundMap();
       CameraSkyMap *SkyMap();
-      
+
       QString instrumentId();
 
       QString instrumentNameLong() const;
@@ -502,7 +503,7 @@ namespace Isis {
       // slant range changes.
       friend class RadarGroundMap;      //!< A friend class to calculate focal length
       friend class RadarSlantRangeMap;  //!< A friend class to calculate focal length
-      
+
       QString m_instrumentId;        //!< The InstrumentId as it appears on the cube.
 
       QString m_instrumentNameLong;  //!< Full instrument name
@@ -516,10 +517,10 @@ namespace Isis {
       void ringRangeResolution();
       double ComputeAzimuth(const double lat, const double lon);
       bool RawFocalPlanetoImage();
-      // SetImage helper functions: 
-      // bool SetImageNoProjection(const double sample, const double line); 
+      // SetImage helper functions:
+      // bool SetImageNoProjection(const double sample, const double line);
       bool SetImageMapProjection(const double sample, const double line, ShapeModel *shape);
-      bool SetImageSkyMapProjection(const double sample, const double line, ShapeModel *shape); 
+      bool SetImageSkyMapProjection(const double sample, const double line, ShapeModel *shape);
 
 
       double p_focalLength;                  //!< The focal length, in units of millimeters
@@ -586,5 +587,3 @@ namespace Isis {
 };
 
 #endif
-
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This adds computation of the slope and slope azimuth/aspect to phocube. The slope computation is sufficiently complex that I put it in Camera similar to the local photometric angle computations. The slope azimuth computation is fairly simple, so I left it in phocube like the other ground azimuth computations.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #3645 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

ISIS supports slope computations in level2, projected, images via the slpmap application. This adds the ability to do these computations in level1 images. Without this, users have to use map2cam to convert slpmap output into a level1 image and that introduces interpolation. These values are of particular interest for photometric analysis.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All tests passed still. The new output was compared against slpmap output here: https://github.com/USGS-Astrogeology/ISIS3/issues/3645#issuecomment-690787489

## Screenshots (if appropriate):

See issue comment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [AUTHORS.rst](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/AUTHORS.rst) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
