### PR TITLE
Fixed FunctionalTestGetsnAllTrue by creating non-static APP_XML

### DIFF
--- a/isis/tests/FunctionalTestsGetsn.cpp
+++ b/isis/tests/FunctionalTestsGetsn.cpp
@@ -22,18 +22,18 @@ static QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
 
 // check for all correct outputs
 TEST_F(DefaultCube, FunctionalTestGetsnAllTrue) {
+  QString d_APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QString expectedSN = "Viking1/VISB/33322515";
   QString expectedON = "Viking1/VISB/33322515";
-  QVector<QString> args = {
-			               "FILE=TRUE",
+  QVector<QString> args = { "FILE=TRUE",
                            "SN=TRUE",
                            "OBSERVATION=TRUE"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(d_APP_XML, args);
   Pvl appLog;
 
   getsn( testCube, options, &appLog );
-  PvlGroup results = appLog.findGroup("Results");  
-  
+  PvlGroup results = appLog.findGroup("Results");
+
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, results.findKeyword("Filename"), testCube->fileName());
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, results.findKeyword("SerialNumber"), expectedSN);
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, results.findKeyword("ObservationNumber"), expectedON);
@@ -66,9 +66,9 @@ TEST_F(DefaultCube, FunctionalTestGetsnDefaultTrue) {
   Pvl appLog;
   Pvl *testLabel = testCube->label();
   testLabel->findObject( "IsisCube" ).deleteGroup( "Instrument" );
-  
+
   getsn( testCube, options, &appLog );
-  PvlGroup results = appLog.findGroup("Results");  
+  PvlGroup results = appLog.findGroup("Results");
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, fileName , results.findKeyword("SerialNumber"));
 }
@@ -83,9 +83,9 @@ TEST_F(DefaultCube, FunctionalTestGetsnDefaultFalse) {
   Pvl appLog;
   Pvl *testLabel = testCube->label();
   testLabel->findObject( "IsisCube" ).deleteGroup( "Instrument" );
-  
+
   getsn( testCube, options, &appLog );
-  PvlGroup results = appLog.findGroup("Results");  
+  PvlGroup results = appLog.findGroup("Results");
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, fileName , results.findKeyword("SerialNumber"));
 }
@@ -114,7 +114,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnFlat) {
 // Test that append true appends to file
 TEST_F(DefaultCube, FunctionalTestGetsnAppend) {
   QFile flatFile(tempDir.path()+"testOut.txt");
-  QVector<QString> args = { 
+  QVector<QString> args = {
 			                "FORMAT=FLAT",
                             "TO="+flatFile.fileName(),
                             "APPEND=TRUE"};
@@ -133,7 +133,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnAppend) {
 // Test that append false overwrites file
 TEST_F(DefaultCube, FunctionalTestGetsnOverwrite) {
   QFile flatFile(tempDir.path()+"testOut.txt");
-  QVector<QString> args = { 
+  QVector<QString> args = {
 			                "FORMAT=FLAT",
                             "TO="+flatFile.fileName(),
                             "APPEND=FALSE"};

--- a/isis/tests/FunctionalTestsGetsn.cpp
+++ b/isis/tests/FunctionalTestsGetsn.cpp
@@ -17,18 +17,15 @@
 
 using namespace Isis;
 
-
-static QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
-
 // check for all correct outputs
 TEST_F(DefaultCube, FunctionalTestGetsnAllTrue) {
-  QString d_APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QString expectedSN = "Viking1/VISB/33322515";
   QString expectedON = "Viking1/VISB/33322515";
   QVector<QString> args = { "FILE=TRUE",
                            "SN=TRUE",
                            "OBSERVATION=TRUE"};
-  UserInterface options(d_APP_XML, args);
+  UserInterface options(APP_XML, args);
   Pvl appLog;
 
   getsn( testCube, options, &appLog );
@@ -44,6 +41,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnAllTrue) {
 // Set sn=false; so all output params are false
 // resulting data should not contain any of the three output types
 TEST_F(DefaultCube, FunctionalTestGetsnAllFalse) {
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QVector<QString> args = { "SN=FALSE" };
   UserInterface options(APP_XML, args);
   Pvl appLog;
@@ -60,6 +58,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnAllFalse) {
 // Test the param DEFAULT=TRUE
 // when no SN can be generated, the SN should default to the file name
 TEST_F(DefaultCube, FunctionalTestGetsnDefaultTrue) {
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QString fileName = "default.cub";
   QVector<QString> args = { "DEFAULT=TRUE" };
   UserInterface options(APP_XML, args);
@@ -77,6 +76,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnDefaultTrue) {
 // Test the param DEFAULT=FALSE
 // when no SN can be generated, the SN should default to "Unknown"
 TEST_F(DefaultCube, FunctionalTestGetsnDefaultFalse) {
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QString fileName = "Unknown";
   QVector<QString> args = {  "DEFAULT=FALSE" };
   UserInterface options(APP_XML, args);
@@ -93,6 +93,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnDefaultFalse) {
 
 // Test flatfile mode gives expected output
 TEST_F(DefaultCube, FunctionalTestGetsnFlat) {
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QString expectedSN = "Viking1/VISB/33322515";
   QFile flatFile(tempDir.path()+"/testOut.txt");
   QVector<QString> args = {
@@ -113,6 +114,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnFlat) {
 
 // Test that append true appends to file
 TEST_F(DefaultCube, FunctionalTestGetsnAppend) {
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QFile flatFile(tempDir.path()+"testOut.txt");
   QVector<QString> args = {
 			                "FORMAT=FLAT",
@@ -132,6 +134,7 @@ TEST_F(DefaultCube, FunctionalTestGetsnAppend) {
 
 // Test that append false overwrites file
 TEST_F(DefaultCube, FunctionalTestGetsnOverwrite) {
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
   QFile flatFile(tempDir.path()+"testOut.txt");
   QVector<QString> args = {
 			                "FORMAT=FLAT",


### PR DESCRIPTION
Fixed FunctionalTestGetsnAllTrue test by instantiating a non-static APP_XML instance

## Description
FunctionalTestGetsnAllTrue passed locally, but failed in CI.

This is a super weird issue that I really don't understand.  The idea for trying this fix came from a discussion of "leaky tests" found [here](https://objectpartners.com/2018/09/18/why-your-tests-may-pass-locally-but-fail-in-jenkins/).  The post mentioned potential issues regarding persistent data, and it went on to talk about how static classes and static variables sometimes result in data carryover among tests.

This doesn't answer the question of why processing resulted in a "child aborted" exception.  It seems like the carryover from static variables would just result in munged values, not full-on process breaking exceptions.  Maybe this resulted in the right change for the wrong reasons?

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
getsnAllTrue test failure

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Gotta have passing tests!

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Since the failures were CI-side only, this was painfully tested by pushing new commits to a draft PR and waiting for CI to pick up, build, and test the changes. Yikes.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
