### PR TITLE
Moved static app xml to local variables

### DIFF
--- a/isis/tests/AutoseedTests.cpp
+++ b/isis/tests/AutoseedTests.cpp
@@ -32,8 +32,6 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/autoseed.xml").expanded();
-
 TEST_F(ThreeImageNetwork, FunctionalTestAutoseedDefault) {
   Pvl *log = NULL;
   QString defFile = tempDir.path()+"/gridPixels.pvl";
@@ -60,7 +58,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestAutoseedDefault) {
                                     "networkid=1",
                                     "pointid=??",
                                     "description=autoseed test network"};
-  UserInterface autoseedUi(APP_XML, autoseedArgs);
+  UserInterface autoseedUi(FileName("$ISISROOT/bin/xml/autoseed.xml").expanded(), autoseedArgs);
 
   autoseed(autoseedUi, log);
   ControlNet onet(outnet);
@@ -97,7 +95,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestAutoseedCnetInput) {
                                     "networkid=1",
                                     "pointid=??",
                                     "description=autoseed test network"};
-  UserInterface autoseedUi(APP_XML, autoseedArgs);
+  UserInterface autoseedUi(FileName("$ISISROOT/bin/xml/autoseed.xml").expanded(), autoseedArgs);
 
   autoseed(autoseedUi, log);
   ControlNet onet(outnet1);
@@ -110,7 +108,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestAutoseedCnetInput) {
   autoseedArgs.removeAt(0);
   autoseedArgs.replace(1, "onet="+outnet2);
   autoseedArgs.replace(3, "overlaplist="+threeImageOverlapFile->original());
-  autoseedUi = UserInterface(APP_XML, autoseedArgs);
+  autoseedUi = UserInterface(FileName("$ISISROOT/bin/xml/autoseed.xml").expanded(), autoseedArgs);
   autoseed(autoseedUi, serialNumList, &onet, log);
   onet = ControlNet(outnet2);
   ASSERT_EQ(onet.GetNumPoints(), 7);
@@ -128,7 +126,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestAutoseedDeffiles) {
                                     "networkid=1",
                                     "pointid=???",
                                     "description=autoseed test network"};
-  UserInterface autoseedUi(APP_XML, autoseedArgs);
+  UserInterface autoseedUi(FileName("$ISISROOT/bin/xml/autoseed.xml").expanded(), autoseedArgs);
 
   // Grid DN
   PvlObject autoseedObject("AutoSeed");

--- a/isis/tests/Cam2mapTests.cpp
+++ b/isis/tests/Cam2mapTests.cpp
@@ -20,8 +20,6 @@ using namespace Isis;
 using ::testing::Return;
 using ::testing::AtLeast;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/cam2map.xml").expanded();
-
 TEST_F(DefaultCube, FunctionalTestCam2mapDefault) {
   std::istringstream labelStrm(R"(
     Group = Mapping
@@ -51,7 +49,7 @@ TEST_F(DefaultCube, FunctionalTestCam2mapDefault) {
   PvlGroup &userGrp = userMap.findGroup("Mapping", Pvl::Traverse);
 
   QVector<QString> args = {"to="+tempDir.path()+"/level2.cub", "pixres=map"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
 
@@ -109,7 +107,7 @@ TEST_F(DefaultCube, FunctionalTestCam2mapMismatch) {
   PvlGroup &userGrp = userMap.findGroup("Mapping", Pvl::Traverse);
 
   QVector<QString> args = {"to="+tempDir.path()+"/level2.cub", "pixres=map"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
   try {
@@ -151,7 +149,7 @@ TEST_F(DefaultCube, FunctionalTestCam2mapUserLatlon) {
   QVector<QString> args = {"to="+tempDir.path()+"/level2.cub", "matchmap=no", "minlon=0",
                            "maxlon=10", "minlat=0", "maxlat=10", "defaultrange=camera",
                            "pixres=map"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
 
@@ -199,7 +197,7 @@ TEST_F(LineScannerCube, FunctionalTestCam2mapMapLatlon) {
 
   QVector<QString> args = {"to="+tempDir.path()+"/level2.cub", "matchmap=no",
                            "defaultrange=map", "pixres=camera"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
 
@@ -316,7 +314,7 @@ TEST_F(DefaultCube, FunctionalTestCam2mapFramerMock) {
   PvlGroup &userGrp = userMap.findGroup("Mapping", Pvl::Traverse);
 
   QVector<QString> args = {"to=" + tempDir.path() + "level2.cub", "matchmap=yes"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
   MockProcessRubberSheet rs;
@@ -364,7 +362,7 @@ TEST_F(LineScannerCube, FunctionalTestCam2mapLineScanMock){
 
   QVector<QString> args = {"to=" + tempDir.path() + "level2.cub", "matchmap=yes"};
 
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
   MockProcessRubberSheet rs;
@@ -415,7 +413,7 @@ TEST_F(DefaultCube, FunctionalTestCam2mapForwardMock) {
                           "matchmap=yes",
                           "warpalgorithm=forwardpatch",
                           "patchsize=0"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
   MockProcessRubberSheet rs;
@@ -466,7 +464,7 @@ TEST_F(DefaultCube, FunctionalTestCam2mapReverseMock) {
                           "matchmap=yes",
                           "warpalgorithm=reversepatch",
                           "patchsize=3"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cam2map.xml").expanded(), args);
 
   Pvl log;
   MockProcessRubberSheet rs;

--- a/isis/tests/CamptFunctionalTests.cpp
+++ b/isis/tests/CamptFunctionalTests.cpp
@@ -13,8 +13,6 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/campt.xml").expanded();
-
 TEST_F(DefaultCube, FunctionalTestCamptBadColumnError) {
   // set up bad coordinates file
   std::ofstream of;
@@ -26,7 +24,7 @@ TEST_F(DefaultCube, FunctionalTestCamptBadColumnError) {
   QVector<QString> args = {"to=" + tempDir.path()+"/output.pvl",
                            "coordlist=" + tempDir.path()+"/badList.lis",
                            "coordtype=image"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   try {
@@ -47,7 +45,7 @@ TEST_F(DefaultCube, FunctionalTestCamptBadColumnError) {
 TEST_F(DefaultCube, FunctionalTestCamptFlatFileError) {
   // configure UserInterface arguments for flat file error
   QVector<QString> args = {"format=flat"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   try {
@@ -65,7 +63,7 @@ TEST_F(DefaultCube, FunctionalTestCamptFlatFileError) {
 
 TEST_F(DefaultCube, FunctionalTestCamptDefaultParameters) {
   QVector<QString> args = {};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
@@ -143,7 +141,7 @@ TEST_F(DefaultCube, FunctionalTestCamptDefaultParameters) {
 
 TEST_F(DefaultCube, FunctionalTestCamptSetSL) {
   QVector<QString> args = {"sample=25.0", "line=25.0"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
@@ -155,7 +153,7 @@ TEST_F(DefaultCube, FunctionalTestCamptSetSL) {
 
 TEST_F(DefaultCube, FunctionalTestCamptSetS) {
   QVector<QString> args = {"sample=25.0"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
@@ -167,7 +165,7 @@ TEST_F(DefaultCube, FunctionalTestCamptSetS) {
 
 TEST_F(DefaultCube, FunctionalTestCamptSetL) {
   QVector<QString> args = {"line=25.0"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
@@ -179,7 +177,7 @@ TEST_F(DefaultCube, FunctionalTestCamptSetL) {
 
 TEST_F(DefaultCube, FunctionalTestCamptSetGround) {
   QVector<QString> args = {"type=ground", "latitude=10.181441241544", "longitude=255.89292858176"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
@@ -195,7 +193,7 @@ TEST_F(DefaultCube, FunctionalTestCamptFlat) {
   QVector<QString> args = {"format=flat",
                            "to="+flatFile.fileName(),
                            "append=false"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
@@ -227,7 +225,7 @@ TEST_F(DefaultCube, FunctionalTestCamptCoordList) {
   QVector<QString> args = {"coordlist="+tempDir.path()+"/coords.txt",
                            "append=false",
                            "coordtype=image"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
@@ -252,7 +250,7 @@ TEST_F(DefaultCube, FunctionalTestCamptCoordList) {
 
 TEST_F(DefaultCube, FunctionalTestCamptAllowOutside) {
   QVector<QString> args = {"sample=-1", "line=-1", "allowoutside=true"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/campt.xml").expanded(), args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);

--- a/isis/tests/CnetWinnowTests.cpp
+++ b/isis/tests/CnetWinnowTests.cpp
@@ -16,13 +16,11 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/cnetwinnow.xml").expanded();
-
 TEST_F(ThreeImageNetwork, FunctionalTestCnetwinnowDefault) {
   QString onetPath = tempDir.path()+"/winnowedNetwork.net";
   QVector<QString> args = {"onet="+onetPath,
                            "file_prefix=winnow"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cnetwinnow.xml").expanded(), args);
 
   int initialMeasureCount = network->GetNumValidMeasures();
   int initialPointCount = network->GetNumValidPoints();

--- a/isis/tests/FootprintinitTests.cpp
+++ b/isis/tests/FootprintinitTests.cpp
@@ -15,11 +15,9 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/footprintinit.xml").expanded();
-
 TEST_F(DefaultCube, FunctionalTestFootprintinitDefault) {
   QVector<QString> footprintArgs = {};
-  UserInterface footprintUi(APP_XML, footprintArgs);
+  UserInterface footprintUi(FileName("$ISISROOT/bin/xml/footprintinit.xml").expanded(), footprintArgs);
 
   footprintinit(testCube, footprintUi);
   ASSERT_TRUE(testCube->label()->hasObject("Polygon"));

--- a/isis/tests/FunctionalTestCnetstats.cpp
+++ b/isis/tests/FunctionalTestCnetstats.cpp
@@ -12,11 +12,9 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/cnetstats.xml").expanded();
-
 TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsDefault) {
   QVector<QString> args = {};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetstats.xml").expanded(), args);
   Pvl log;
 
   QString serialNumList = tempDir.path()+"/cubes.lis";
@@ -74,7 +72,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsImageStats) {
   ASSERT_TRUE(statsFile.open());
 
   QVector<QString> args = {"create_image_stats=yes", "image_stats_file=" + statsFile.fileName()};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetstats.xml").expanded(), args);
   Pvl log;
   QString serialNumList = tempDir.path()+"/cubes.lis";
 
@@ -95,7 +93,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsPointStats) {
   ASSERT_TRUE(statsFile.open());
 
   QVector<QString> args = {"create_point_stats=yes", "point_stats_file=" + statsFile.fileName()};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetstats.xml").expanded(), args);
   Pvl log;
   QString serialNumList = tempDir.path() + "/cubes.lis";
 
@@ -134,10 +132,10 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsCubeFilter) {
   QTemporaryFile flatFile;
   ASSERT_TRUE(flatFile.open());
 
-  QVector<QString> args = {"filter=yes", 
-                           "deffile=" + defFile.fileName(), 
+  QVector<QString> args = {"filter=yes",
+                           "deffile=" + defFile.fileName(),
                            "flatfile=" + flatFile.fileName()};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetstats.xml").expanded(), args);
   Pvl log;
   QString serialNumList = tempDir.path()+"/cubes.lis";
 
@@ -178,10 +176,10 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsPointFilter) {
   QTemporaryFile flatFile;
   ASSERT_TRUE(flatFile.open());
 
-  QVector<QString> args = {"filter=yes", 
-                           "deffile=" + defFile.fileName(), 
+  QVector<QString> args = {"filter=yes",
+                           "deffile=" + defFile.fileName(),
                            "flatfile=" + flatFile.fileName()};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetstats.xml").expanded(), args);
   Pvl log;
   QString serialNumList = tempDir.path()+"/cubes.lis";
 
@@ -193,7 +191,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsPointFilter) {
   while(!stream.atEnd()) {
     QString line = stream.readLine();
     QStringList values = line.split(",");
-    
+
     ASSERT_DOUBLE_EQ(values.size(), 13);
     lineNumber++;
   }
@@ -215,10 +213,10 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsInvalidDefFile) {
   QTemporaryFile flatFile;
   ASSERT_TRUE(flatFile.open());
 
-  QVector<QString> args = {"filter=yes", 
-                           "deffile=" + defFile.fileName(), 
+  QVector<QString> args = {"filter=yes",
+                           "deffile=" + defFile.fileName(),
                            "flatfile=" + flatFile.fileName()};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetstats.xml").expanded(), args);
   Pvl log;
   QString serialNumList = tempDir.path() + "/cubes.lis";
 

--- a/isis/tests/FunctionalTestsCamstats.cpp
+++ b/isis/tests/FunctionalTestsCamstats.cpp
@@ -11,11 +11,9 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/camstats.xml").expanded();
-
 TEST_F(DefaultCube, FunctionalTestCamstatsDefaultParameters) {
   QVector<QString> args = {};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/camstats.xml").expanded(), args);
   Pvl appLog;
 
   camstats(testCube, options, &appLog);
@@ -118,7 +116,7 @@ TEST_F(DefaultCube, FunctionalTestCamstatsDefaultParameters) {
 
 TEST_F(DefaultCube, FunctionalTestCamstatsAttach) {
   QVector<QString> args = {"attach=true", "linc=100", "sinc=100"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/camstats.xml").expanded(), args);
   Pvl appLog;
 
   camstats(testCube, options, &appLog);
@@ -130,9 +128,9 @@ TEST_F(DefaultCube, FunctionalTestCamstatsAttach) {
 TEST_F(DefaultCube, FunctionalTestCamstatsFlat) {
   QTemporaryFile flatFile;
   flatFile.open();
-  
+
   QVector<QString> args = {"to=" + flatFile.fileName(), "format=flat", "linc=100", "sinc=100"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/camstats.xml").expanded(), args);
   Pvl appLog;
 
   camstats(testCube, options, &appLog);

--- a/isis/tests/FunctionalTestsCnetCombinePt.cpp
+++ b/isis/tests/FunctionalTestsCnetCombinePt.cpp
@@ -24,8 +24,6 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded();
-
 class CombineNetworks : public TempTestingFiles {
   protected:
     QString firstNetFile;
@@ -136,7 +134,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptDistance) {
                             "cnetlist="+listFile,
                             "imagetol=1",
                             "onet="+distance1NetFile};
-  UserInterface ui1(APP_XML, args1);
+  UserInterface ui1(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args1);
 
   cnetcombinept(ui1);
 
@@ -177,7 +175,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptDistance) {
                             "cnetlist="+listFile,
                             "imagetol=55",
                             "onet="+distance55NetFile};
-  UserInterface ui2(APP_XML, args2);
+  UserInterface ui2(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args2);
 
   cnetcombinept(ui2);
 
@@ -209,7 +207,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptDistance) {
                             "cnetlist="+listFile,
                             "imagetol=200",
                             "onet="+distance200NetFile};
-  UserInterface ui3(APP_XML, args3);
+  UserInterface ui3(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args3);
 
   cnetcombinept(ui3);
 
@@ -235,7 +233,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptLog) {
                            "imagetol=55",
                            "onet="+mergedNetFile,
                            "logfile="+logFileName};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args);
 
   cnetcombinept(ui);
 
@@ -289,7 +287,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptList) {
   QVector<QString> args1 = {"cnetbase="+firstNetFile,
                             "cnetfrom="+secondNetFile,
                             "onet="+specifiedNetFile};
-  UserInterface ui1(APP_XML, args1);
+  UserInterface ui1(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args1);
 
   cnetcombinept(ui1);
 
@@ -303,7 +301,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptList) {
   QVector<QString> args2 = {"cnetbase="+firstNetFile,
                             "cnetlist="+shortListFile,
                             "onet="+listNetFile};
-  UserInterface ui2(APP_XML, args2);
+  UserInterface ui2(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args2);
 
   cnetcombinept(ui2);
 
@@ -332,7 +330,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptNetworkArgs) {
                            "onet="+outNetFile,
                            "networkid="+networkId,
                            "description="+networkDescription};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args);
 
   cnetcombinept(ui);
 
@@ -348,7 +346,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptSNList) {
   QVector<QString> args = {"cnetbase="+firstNetFile,
                            "onet="+outNetFile,
                            "tosn="+outSNFile};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args);
 
   cnetcombinept(ui);
 
@@ -384,7 +382,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptCleanNet) {
                             "imagetol=1",
                             "onet="+cleanNetFile,
                             "cleannet=true"};
-  UserInterface ui1(APP_XML, args1);
+  UserInterface ui1(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args1);
 
   cnetcombinept(ui1);
 
@@ -397,7 +395,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptCleanNet) {
                             "imagetol=1",
                             "onet="+dirtyNetFile,
                             "cleannet=false"};
-  UserInterface ui2(APP_XML, args2);
+  UserInterface ui2(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args2);
 
   cnetcombinept(ui2);
 
@@ -437,7 +435,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptCleanMeasures) {
                             "imagetol=1",
                             "onet="+cleanNetFile,
                             "cleanmeasures=true"};
-  UserInterface ui1(APP_XML, args1);
+  UserInterface ui1(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args1);
 
   cnetcombinept(ui1);
 
@@ -452,7 +450,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptCleanMeasures) {
                             "imagetol=1",
                             "onet="+dirtyNetFile,
                             "cleanmeasures=false"};
-  UserInterface ui2(APP_XML, args2);
+  UserInterface ui2(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args2);
 
   cnetcombinept(ui2);
 
@@ -486,7 +484,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptSetApriori) {
                             "imagetol=1",
                             "onet="+keepAprioriNetFile,
                             "setaprioribest=false"};
-  UserInterface ui1(APP_XML, args1);
+  UserInterface ui1(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args1);
 
   cnetcombinept(ui1);
 
@@ -498,7 +496,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptSetApriori) {
                             "imagetol=1",
                             "onet="+setAprioriNetFile,
                             "setaprioribest=true"};
-  UserInterface ui2(APP_XML, args2);
+  UserInterface ui2(FileName("$ISISROOT/bin/xml/cnetcombinept.xml").expanded(), args2);
 
   cnetcombinept(ui2);
 

--- a/isis/tests/FunctionalTestsCnetbin2pvl.cpp
+++ b/isis/tests/FunctionalTestsCnetbin2pvl.cpp
@@ -10,13 +10,11 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/cnetbin2pvl.xml").expanded();
-
 TEST_F(ThreeImageNetwork, FunctionalTestCnetbin2pvlDefault) {
   QString pvlOut = tempDir.path()+"/cnetbin2pvlNetwork.pvl";
 
   QVector<QString> args = {"to="+pvlOut};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cnetbin2pvl.xml").expanded(), args);
 
   Progress progress;
   cnetbin2pvl(*network, ui, &progress);

--- a/isis/tests/FunctionalTestsCnetpvl2bin.cpp
+++ b/isis/tests/FunctionalTestsCnetpvl2bin.cpp
@@ -9,13 +9,11 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/cnetpvl2bin.xml").expanded();
-
 TEST_F(ThreeImageNetwork, FunctionalTestCnetpvl2binDefault) {
   QString binOut = tempDir.path()+"/cnetbin2Network.net";
 
   QVector<QString> args = {"to="+binOut};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/cnetpvl2bin.xml").expanded(), args);
 
   Progress progress;
   cnetpvl2bin(*network, ui, &progress);

--- a/isis/tests/FunctionalTestsEnlarge.cpp
+++ b/isis/tests/FunctionalTestsEnlarge.cpp
@@ -12,11 +12,9 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/enlarge.xml").expanded();
-
 TEST_F(SmallCube, FunctionalTestEnlargeDefaultParameters) {
   QVector<QString> args = {"to=" + tempDir.path()+"/output.cub"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/enlarge.xml").expanded(), args);
   Pvl appLog;
   enlarge(testCube, options, &appLog);
 
@@ -36,7 +34,7 @@ TEST_F(SmallCube, FunctionalTestEnlargeDefaultParameters) {
 
 TEST_F(SmallCube, FunctionalTestEnlargeScale) {
   QVector<QString> args = {"to=" + tempDir.path()+"/output.cub", "sscale=2", "lscale=4"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/enlarge.xml").expanded(), args);
   Pvl appLog;
   enlarge(testCube, options, &appLog);
 
@@ -50,7 +48,7 @@ TEST_F(SmallCube, FunctionalTestEnlargeScale) {
 
 TEST_F(SmallCube, FunctionalTestEnlargeTotal) {
   QVector<QString> args = {"to=" + tempDir.path()+"/output.cub", "mode=total", "ons=20", "onl=40"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/enlarge.xml").expanded(), args);
   Pvl appLog;
   enlarge(testCube, options, &appLog);
 
@@ -64,7 +62,7 @@ TEST_F(SmallCube, FunctionalTestEnlargeTotal) {
 
 TEST_F(SmallCube, FunctionalTestEnlargeSmallDimensions) {
   QVector<QString> args = {"to=" + tempDir.path()+"/output.cub", "mode=total", "ons=10", "onl=1"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/enlarge.xml").expanded(), args);
   Pvl appLog;
 
   QString message = "Number of output samples/lines must be greater than or equal";
@@ -82,7 +80,7 @@ TEST_F(SmallCube, FunctionalTestEnlargeSmallDimensions) {
 
 TEST_F(SmallCube, FunctionalTestEnlargeNearestNeighbor) {
   QVector<QString> args = {"to=" + tempDir.path()+"/output.cub", "interp=nearestneighbor"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/enlarge.xml").expanded(), args);
   Pvl appLog;
   enlarge(testCube, options, &appLog);
 
@@ -97,7 +95,7 @@ TEST_F(SmallCube, FunctionalTestEnlargeNearestNeighbor) {
 
 TEST_F(SmallCube, FunctionalTestEnlargeBilinear) {
   QVector<QString> args = {"to=" + tempDir.path()+"/output.cub", "interp=bilinear"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/enlarge.xml").expanded(), args);
   Pvl appLog;
   enlarge(testCube, options, &appLog);
 

--- a/isis/tests/FunctionalTestsIsis2ascii.cpp
+++ b/isis/tests/FunctionalTestsIsis2ascii.cpp
@@ -14,12 +14,10 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/isis2ascii.xml").expanded();
-
 TEST_F(SmallCube, FunctionalTestIsis2asciiDefaultParameters) {
   QString outputFile = tempDir.path()+"/output.txt";
   QVector<QString> args = {"to=" + outputFile};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/isis2ascii.xml").expanded(), args);
 
   isis2ascii(testCube, ui);
 
@@ -61,7 +59,7 @@ TEST_F(SmallCube, FunctionalTestIsis2asciiDefaultParameters) {
 TEST_F(SmallCube, FunctionalTestIsis2asciiNoHeader) {
   QString outputFile = tempDir.path()+"/output.txt";
   QVector<QString> args = {"to=" + outputFile, "header=no"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/isis2ascii.xml").expanded(), args);
 
   isis2ascii(testCube, ui);
 
@@ -83,7 +81,7 @@ TEST_F(SmallCube, FunctionalTestIsis2asciiNoHeader) {
 TEST_F(SmallCube, FunctionalTestIsis2asciiCustomDelimiter) {
   QString outputFile = tempDir.path()+"/output.txt";
   QVector<QString> args = {"to=" + outputFile, "delimiter=,"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/isis2ascii.xml").expanded(), args);
 
   isis2ascii(testCube, ui);
 
@@ -106,7 +104,7 @@ TEST_F(SpecialSmallCube, FunctionalTestIsis2asciiSetPixelValues) {
   QVector<QString> args = {"to=" + outputFile, "setpixelvalues=yes",
                            "nullvalue=0", "lrsvalue=0", "lisvalue=0",
                            "hisvalue=255", "hrsvalue=255"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/isis2ascii.xml").expanded(), args);
   isis2ascii(testCube, ui);
 
   CSVReader::CSVAxis csvLine;

--- a/isis/tests/FunctionalTestsKaguyatc2isis.cpp
+++ b/isis/tests/FunctionalTestsKaguyatc2isis.cpp
@@ -12,15 +12,13 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/kaguyatc2isis.xml").expanded();
-
 TEST(kaguyatc2isisTest, kaguyatc2isisTestDefault) {
   Pvl appLog;
   QTemporaryDir prefix;
   QString cubeFileName = prefix.path() + "/kaguyatc2isisTEMP.cub";
   QVector<QString> args = {"from=data/kaguyatc2isis/TC1S2B0_01_05186N225E0040_mini.lbl", "to="+cubeFileName};
 
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/kaguyatc2isis.xml").expanded(), args);
   try {
     kaguyatc2isis(options, &appLog);
   }

--- a/isis/tests/FunctionalTestsLeisa2isis.cpp
+++ b/isis/tests/FunctionalTestsLeisa2isis.cpp
@@ -10,15 +10,13 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/leisa2isis.xml").expanded();
-
 TEST(leisa2isisTest, leisa2isisTestDefault) {
    Pvl appLog;
    QTemporaryDir prefix;
    QString cubeFileName = prefix.path() + "/leisa2isisTEMP.cub";
    QVector<QString> args = {"from=data/leisa2isis/lsb_0034933739_0x53c_sci_1_cropped.fit", "to=" + cubeFileName };
 
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/leisa2isis.xml").expanded(), args);
   try {
    leisa2isis(options, &appLog);
   }

--- a/isis/tests/FunctionalTestsMappt.cpp
+++ b/isis/tests/FunctionalTestsMappt.cpp
@@ -14,16 +14,14 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/mappt.xml").expanded();
-
 TEST_F(DefaultCube, FunctionalTestMapptImageTest) {
   QVector<QString> args = {"append=false", "type=image", "sample=1", "line=1"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
 
   mappt(projTestCube, options, &appLog);
   PvlGroup mapPoint = appLog.findGroup("Results");
-  
+
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FileName"), projTestCube->fileName());
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FilterName"), "CLEAR");
   EXPECT_EQ( (double) mapPoint.findKeyword("Band"), 1);
@@ -39,10 +37,10 @@ TEST_F(DefaultCube, FunctionalTestMapptImageTest) {
 
 TEST_F(DefaultCube, FunctionalTestMapptGroundTest) {
   QVector<QString> args = {"append=false", "type=ground", "latitude=9.2788326719634", "longitude=0.85471387315749"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
   mappt(projTestCube, options, &appLog);
-  
+
   PvlGroup mapPoint = appLog.findGroup("Results");
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FileName"), projTestCube->fileName());
@@ -62,10 +60,10 @@ TEST_F(DefaultCube, FunctionalTestMapptGroundTest) {
 
 TEST_F(DefaultCube, FunctionalTestMapptProjectionTest) {
   QVector<QString> args = {"append=false", "type=projection", "x=50000.0", "y=550000.0"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
   mappt(projTestCube, options, &appLog);
-  
+
   PvlGroup mapPoint = appLog.findGroup("Results");
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FileName"), projTestCube->fileName());
@@ -78,25 +76,25 @@ TEST_F(DefaultCube, FunctionalTestMapptProjectionTest) {
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest360Longitude"), 359.14528612684);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast360Longitude"), 0.85471387315749);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast180Longitude"), 0.85471387315749);
-  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -0.85471387315751); 
+  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -0.85471387315751);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("x"), 50000);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("y"), 550000);
 }
 
 TEST_F(DefaultCube, FunctionalTestMapptCoordsysTest) {
-  QVector<QString> args = {"append=false", 
-                           "coordsys=userdefined", 
-                           "type=ground", 
+  QVector<QString> args = {"append=false",
+                           "coordsys=userdefined",
+                           "type=ground",
                            "lattype=planetographic"
                            "londir=positivewest",
                            "londom=180",
                            "latitude=9.3870849567571",
                            "longitude=0.85471387315749"};
 
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
   mappt(projTestCube, options, &appLog);
-  
+
   PvlGroup mapPoint = appLog.findGroup("Results");
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FileName"), projTestCube->fileName());
@@ -109,21 +107,21 @@ TEST_F(DefaultCube, FunctionalTestMapptCoordsysTest) {
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest360Longitude"), 359.14528612684);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast360Longitude"), 0.85471387315749);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast180Longitude"), 0.85471387315749);
-  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -0.85471387315751); 
+  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -0.85471387315751);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("x"), 50000);
-  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("y"), 550000); 
+  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("y"), 550000);
 
 }
 
 TEST_F(DefaultCube, FunctionalTestMapptFlatFileTest) {
   QFile flatFile(tempDir.path() + "/testOut.txt");
   QVector<QString> args = {"to="+flatFile.fileName(), "append=false", "type=projection", "x=50000.0", "y=550000.0", "format=flat"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
   mappt(projTestCube, options, &appLog);
 
   PvlGroup mapPoint = appLog.findGroup("Results");
-  
+
   int lineNumber = 0;
   QTextStream flatStream(&flatFile);
 
@@ -131,7 +129,7 @@ TEST_F(DefaultCube, FunctionalTestMapptFlatFileTest) {
     while(!flatStream.atEnd()) {
       QString line = flatStream.readLine();
       QStringList fields = line.split(",");
-      
+
       if(lineNumber == 0) {
         EXPECT_PRED_FORMAT2(AssertQStringsEqual, fields.value(0), "Filename");
         EXPECT_PRED_FORMAT2(AssertQStringsEqual, fields.value(1), "Sample");
@@ -174,14 +172,14 @@ TEST_F(DefaultCube, FunctionalTestMapptFlatFileTest) {
 
 TEST_F(DefaultCube, FunctionalTestMapptAllowOutside) {
   QVector<QString> args = {"type=image", "sample=-1", "line=-1", "allowoutside=true"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
 
   mappt(projTestCube, options, &appLog);
   PvlGroup groundPoint = appLog.findGroup("Results");
   EXPECT_DOUBLE_EQ( (double) groundPoint.findKeyword("Sample"), -1.0);
   EXPECT_DOUBLE_EQ( (double) groundPoint.findKeyword("Line"), -1.0);
-  
+
   args = {"type=image", "sample=-1", "line=-1", "allowoutside=false"};
   mappt(projTestCube, options, &appLog);
 
@@ -192,11 +190,11 @@ TEST_F(DefaultCube, FunctionalTestMapptAllowOutside) {
 
 TEST_F(DefaultCube, FunctionalTestMapptBandTest) {
   QVector<QString> args = { "from="+projTestCube->fileName()+"+2", "append=false", "type=image", "sample=1", "line=1"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
   mappt(options, &appLog);
   PvlGroup mapPoint = appLog.findGroup("Results");
-  
+
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FilterName"), "NIR");
   EXPECT_EQ( (double) mapPoint.findKeyword("Band"), 2);
 }
@@ -207,16 +205,16 @@ TEST_F(DefaultCube, FunctionalTestMapptImageCoordList) {
   of.open(tempDir.path().toStdString()+"/coords.txt");
   of << "1, 1\n2, 2\n 3, 3";
   of.close();
-  
+
   QVector<QString> args = {"coordlist="+tempDir.path()+"/coords.txt",
-                           "UseCoordList=True", 
+                           "UseCoordList=True",
                            "append=false",
                            "type=image"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
 
-  Pvl appLog; 
+  Pvl appLog;
   mappt(projTestCube, options, &appLog);
-  
+
   PvlGroup mapPoint = appLog.group(0);
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FileName"), projTestCube->fileName());
@@ -229,10 +227,10 @@ TEST_F(DefaultCube, FunctionalTestMapptImageCoordList) {
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest360Longitude"), 359.14528612684);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast360Longitude"), 0.85471387315749);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast180Longitude"), 0.85471387315749);
-  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -0.85471387315751); 
+  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -0.85471387315751);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("x"), 50000);
-  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("y"), 550000); 
-  
+  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("y"), 550000);
+
   mapPoint = appLog.group(1);
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FileName"), projTestCube->fileName());
@@ -245,10 +243,10 @@ TEST_F(DefaultCube, FunctionalTestMapptImageCoordList) {
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest360Longitude"), 357.44703128109);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast360Longitude"), 2.5529687189083);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast180Longitude"), 2.5529687189083);
-  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -2.5529687189083); 
+  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -2.5529687189083);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("x"), 150000);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("y"), 450000);
-  
+
   mapPoint = appLog.group(2);
 
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, mapPoint.findKeyword("FileName"), projTestCube->fileName());
@@ -261,7 +259,7 @@ TEST_F(DefaultCube, FunctionalTestMapptImageCoordList) {
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest360Longitude"), 355.75985208984);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast360Longitude"), 4.2401479101647);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveEast180Longitude"), 4.2401479101647);
-  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -4.2401479101646); 
+  EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("PositiveWest180Longitude"), -4.2401479101646);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("x"), 250000);
   EXPECT_DOUBLE_EQ( (double) mapPoint.findKeyword("y"), 350000.0);
 
@@ -272,27 +270,27 @@ TEST_F(DefaultCube, FunctionalTestMapptCoordListFlatFile) {
   of.open(tempDir.path().toStdString()+"/coords.txt");
   of << "1, 1\n2, 2\n 3, 3";
   of.close();
-   
+
   QFile flatFile(tempDir.path() + "/testOut.txt");
-  QVector<QString> args = {"coordlist="+tempDir.path()+"/coords.txt","to=" + flatFile.fileName(), 
-                           "UseCoordList=True", 
+  QVector<QString> args = {"coordlist="+tempDir.path()+"/coords.txt","to=" + flatFile.fileName(),
+                           "UseCoordList=True",
                            "append=false", "format=flat",
                            "type=image"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
 
-  Pvl appLog; 
+  Pvl appLog;
   mappt(projTestCube, options, &appLog);
-  
+
   int lineNumber = 0;
   QTextStream flatStream(&flatFile);
-  
+
   PvlGroup mapPoint = appLog.group(0);
 
   if (flatFile.open(QIODevice::ReadOnly)) {
     while(!flatStream.atEnd()) {
       QString line = flatStream.readLine();
       QStringList fields = line.split(",");
-      
+
       if(lineNumber == 0) {
         EXPECT_PRED_FORMAT2(AssertQStringsEqual, fields.value(0), "Filename");
         EXPECT_PRED_FORMAT2(AssertQStringsEqual, fields.value(1), "Sample");
@@ -310,8 +308,8 @@ TEST_F(DefaultCube, FunctionalTestMapptCoordListFlatFile) {
         EXPECT_PRED_FORMAT2(AssertQStringsEqual, fields.value(13), "PositiveWest180Longitude");
       }
       else {
-        mapPoint = appLog.group(lineNumber-1); 
-        
+        mapPoint = appLog.group(lineNumber-1);
+
         EXPECT_PRED_FORMAT2(AssertQStringsEqual, fields.value(0), mapPoint.findKeyword("FileName"));
         EXPECT_DOUBLE_EQ(fields.value(1).toDouble(), mapPoint.findKeyword("Sample"));
         EXPECT_DOUBLE_EQ(fields.value(2).toDouble(), mapPoint.findKeyword("Line"));
@@ -341,13 +339,13 @@ TEST_F(DefaultCube, FunctionalTestMapptBadColumnError) {
   of.open(tempDir.path().toStdString()+"/coords.txt");
   of << "1, 1\n2\n 3, 3";
   of.close();
-  
+
   QVector<QString> args = {"coordlist="+tempDir.path()+"/coords.txt",
-                           "UseCoordList=True", 
+                           "UseCoordList=True",
                            "append=false",
                            "type=image"};
 
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/mappt.xml").expanded(), args);
   Pvl appLog;
   try {
     mappt(projTestCube, options, &appLog);

--- a/isis/tests/FuntionalTestsFindImageOverlaps.cpp
+++ b/isis/tests/FuntionalTestsFindImageOverlaps.cpp
@@ -26,8 +26,6 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/findimageoverlaps.xml").expanded();
-
 TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapsNoOverlap) {
   ImagePolygon fp1;
   fp1.Create(*cube1);
@@ -55,7 +53,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapsNoOverlap) {
   QString cubeListPath = tempDir.path() + "/cubes.lis";
   cubes.write(cubeListPath);
   QVector<QString> args = {"from="+cubeListPath, "overlapList="+tempDir.path()+"/overlaps.txt"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/findimageoverlaps.xml").expanded(), args);
   Pvl appLog;
 
   try {
@@ -72,7 +70,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapsNoOverlap) {
 TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapTwoImageOverlap) {
 
   QVector<QString> args = {"OVERLAPLIST=" + tempDir.path() + "/overlaps.txt", "detailed=true", "errors=true"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/findimageoverlaps.xml").expanded(), args);
   FileList images;
   images.append(FileName(cube1->fileName()));
   images.append(FileName(cube2->fileName()));
@@ -141,7 +139,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapFullOverlap) {
   delete wkt;
 
   QVector<QString> args = {"OVERLAPLIST=" + tempDir.path() + "/overlaps.txt", "detailed=true", "errors=true"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/findimageoverlaps.xml").expanded(), args);
   FileList images;
   images.append(FileName(cube1->fileName()));
   images.append(FileName(cube2->fileName()));

--- a/isis/tests/Map2camTests.cpp
+++ b/isis/tests/Map2camTests.cpp
@@ -18,11 +18,9 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/map2cam.xml").expanded();
-
 TEST_F(DefaultCube, FunctionalTestMap2camTest) {
   QVector<QString> args = {"from="+projTestCube->fileName(), "match="+testCube->fileName(), "to="+tempDir.path()+"/level1.cub"};
-  UserInterface ui(APP_XML, args);
+  UserInterface ui(FileName("$ISISROOT/bin/xml/map2cam.xml").expanded(), args);
 
   map2cam_f(ui);
   Cube ocube(tempDir.path()+"/level1.cub");

--- a/isis/tests/cnetcheckFunctionalTests.cpp
+++ b/isis/tests/cnetcheckFunctionalTests.cpp
@@ -20,11 +20,9 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/cnetcheck.xml").expanded();
-
 TEST_F(ThreeImageNetwork, FunctionalTestCnetcheckCamera) {
   QVector<QString> args = {"fromlist="+cubeListFile, "prefix="+tempDir.path()+"/", "nocube=false", "lowcoverage=false"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetcheck.xml").expanded(), args);
 
   QString cube1Serial = SerialNumber::Compose(*cube1->label());
   QString cube2Serial = SerialNumber::Compose(*cube2->label());
@@ -77,7 +75,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetcheckNoPoints) {
   }
 
   QVector<QString> args = {"fromlist="+cubeListFile, "prefix="+tempDir.path()+"/", "delimit=comma", "lowcoverage=false", "cnet=test"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetcheck.xml").expanded(), args);
 
   Pvl log;
   cnetcheck(*network, *cubeList, options, &log);
@@ -119,7 +117,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetcheckIgnore) {
   cubeList->append(c.expanded());
 
   QVector<QString> args = {"fromlist="+cubeListFile, "prefix="+tempDir.path()+"/", "tolerance=0.95"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/cnetcheck.xml").expanded(), args);
 
   Pvl log;
   cnetcheck(*network, *cubeList, options, &log);

--- a/isis/tests/spiceinitTests.cpp
+++ b/isis/tests/spiceinitTests.cpp
@@ -18,8 +18,6 @@
 
 using namespace Isis;
 
-static QString APP_XML = FileName("$ISISROOT/bin/xml/spiceinit.xml").expanded();
-
 TEST(Spiceinit, TestSpiceinitPredictAndReconCk) {
 
   std::istringstream labelStrm(R"(
@@ -87,7 +85,7 @@ TEST(Spiceinit, TestSpiceinitPredictAndReconCk) {
   testCube.fromLabel(tempFile.fileName() + ".cub", label, "rw");
 
   QVector<QString> args = {"ckrecon=True", "cksmithed=True", "attach=false"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/spiceinit.xml").expanded(), args);
   spiceinit(&testCube, options);
 
   PvlGroup kernels = testCube.group("Kernels");
@@ -178,7 +176,7 @@ TEST(Spiceinit, TestSpiceinitCkConfigFile) {
   testCube.fromLabel(tempFile.fileName() + ".cub", label, "rw");
 
   QVector<QString> args(0);
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/spiceinit.xml").expanded(), args);
   spiceinit(&testCube, options);
 
   PvlGroup kernels = testCube.group("Kernels");
@@ -291,7 +289,7 @@ TEST(Spiceinit, TestSpiceinitDefault) {
   testCube.fromLabel(tempFile.fileName() + ".cub", label, "rw");
 
   QVector<QString> args(0);
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/spiceinit.xml").expanded(), args);
   spiceinit(&testCube, options);
 
   PvlGroup kernels = testCube.group("Kernels");
@@ -397,7 +395,7 @@ TEST(Spiceinit, TestSpiceinitNadir) {
   testCube.fromLabel(tempFile.fileName() + ".cub", label, "rw");
 
   QVector<QString> args = {"cknadir=True", "tspk=$base/kernels/spk/de405.bsp", "attach=false"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/spiceinit.xml").expanded(), args);
 
   spiceinit(&testCube, options);
 
@@ -496,7 +494,7 @@ TEST(Spiceinit, TestSpiceinitPadding) {
   testCube.fromLabel(tempFile.fileName() + ".cub", label, "rw");
 
   QVector<QString> args = {"startpad=1.1", "endpad=0.5", "fk=$cassini/kernels/fk/cas_v40_usgs.tf", "attach=false"};
-  UserInterface options(APP_XML, args);
+  UserInterface options(FileName("$ISISROOT/bin/xml/spiceinit.xml").expanded(), args);
 
   spiceinit(&testCube, options);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This is a continuation of #4022 that does the same thing for all tests. It's still unclear if this is the correct solution, but the goal of this PR is to test if it helps.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No issue, fixing intermittent test failure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Several of the new functional GTests are failing intermittently with a strange child aborted error. Some previous work identified this as a potential fix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally and I am not seeing the errors on my machine, but the intermittent errors have been rather fickle with Jenkins vs local builds.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
