### PR TITLE
Resolve Test Failure: ThreeImageNetwork.FunctionalTestCnetcheckCamera (SEGFAULT)

### DIFF
--- a/isis/src/control/apps/cnetcheck/cnetcheck.cpp
+++ b/isis/src/control/apps/cnetcheck/cnetcheck.cpp
@@ -635,7 +635,7 @@ namespace Isis {
 
           // Check the exact measure location
           bool setCamera = false;
-          if (createdCamera) {
+          if (createdCamera && !IsSpecial(measure->GetSample()) && !IsSpecial(measure->GetLine())) {
             setCamera = cam->SetImage(measure->GetSample(), measure->GetLine());
           }
 

--- a/isis/src/control/apps/cnetcheck/cnetcheck.cpp
+++ b/isis/src/control/apps/cnetcheck/cnetcheck.cpp
@@ -635,7 +635,7 @@ namespace Isis {
 
           // Check the exact measure location
           bool setCamera = false;
-          if (createdCamera && !IsSpecial(measure->GetSample()) && !IsSpecial(measure->GetLine())) {
+          if (createdCamera && measure->GetSample() != Null && measure->GetLine() != Null) {
             setCamera = cam->SetImage(measure->GetSample(), measure->GetLine());
           }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I was able to resolve the test fail by adding a condition to protect for null values within cnetcheck.cpp noLatLonCheck(). This simply prevents a call to Camera::SetImage(const double sample, const double line) when there are null values for sample or line, which previously caused a segfault way down a nest of function calls. This small change to cnetcheck.cpp does not seem to affect the other cnet tests or break any existing functionality.
I'm unsure if Camera::SetImage() should be made safe for null parameters. After some investigating it seems to me that the changes required to do so would be far outside of the scope of this PR. I'd appreciate input from any reviewers (should an issue be raised?).

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes a test failure so that we can be closer to clean builds before Oct. 1.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Rebuilt and ran `ctest -R ThreeImageNetwork` `ctest -R Cnet` to see tests that may be impacted. The only difference after the changes was that CnetcheckCamera passes instead of failing with SEGFAULT.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
