### PR TITLE
Updated local radius test threshold

### DIFF
--- a/isis/tests/FunctionalTestsCamstats.cpp
+++ b/isis/tests/FunctionalTestsCamstats.cpp
@@ -107,7 +107,7 @@ TEST_F(DefaultCube, FunctionalTestCamstatsDefaultParameters) {
   EXPECT_NEAR( (double) group.findKeyword("LocalRadiusMinimum"), 3410663.3374636001, 1e-8);
   EXPECT_NEAR( (double) group.findKeyword("LocalRadiusMaximum"), 3413492.0662691998, 1e-8);
   EXPECT_NEAR( (double) group.findKeyword("LocalRadiusAverage"), 3412205.8144924999, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("LocalRadiusStandardDeviation"), 648.5763070953, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("LocalRadiusStandardDeviation"), 648.5763070953, 1e-5);
 
   group = appLog.findGroup("NorthAzimuth");
   EXPECT_NEAR( (double) group.findKeyword("NorthAzimuthMinimum"), 312.299406589, 1e-8);
@@ -130,7 +130,7 @@ TEST_F(DefaultCube, FunctionalTestCamstatsAttach) {
 TEST_F(DefaultCube, FunctionalTestCamstatsFlat) {
   QTemporaryFile flatFile;
   flatFile.open();
-  
+
   QVector<QString> args = {"to=" + flatFile.fileName(), "format=flat", "linc=100", "sinc=100"};
   UserInterface options(APP_XML, args);
   Pvl appLog;


### PR DESCRIPTION
Updates the local radius checks to be a little less constrained, specifically for the mac tests.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
