### PR TITLE
Testing Polys

### DIFF
--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
@@ -271,7 +271,22 @@ namespace Isis {
       p_gMap->Camera()->IgnoreElevationModel(false);
   }
 
+  void ImagePolygon::Create(std::vector<std::vector<double>> polyCoordinates) {
+    p_pts = new geos::geom::CoordinateArraySequence();
 
+    for (std::vector<double> coord : polyCoordinates) {
+      p_pts->add(geos::geom::Coordinate(coord[0], coord[1]));
+    }
+
+    std::vector<geos::geom::Geometry *> *polys = new std::vector<geos::geom::Geometry *>;
+    geos::geom::Polygon *poly = globalFactory->createPolygon(globalFactory->createLinearRing(p_pts), nullptr);
+    polys->push_back(poly->clone());
+    p_polygons = globalFactory->createMultiPolygon(polys);
+
+    delete polys;
+
+    Fix360Poly();
+  }
   /**
   * Finds the next point on the image using a left hand rule walking algorithm. To
   * initiate the walk pass it the same point for both currentPoint and lastPoint.

--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.h
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.h
@@ -173,6 +173,8 @@ namespace Isis {
       void Create(Cube &cube, int sinc = 1, int linc = 1,
           int ss = 1, int sl = 1, int ns = 0, int nl = 0, int band = 1,
           bool increasePrecision = false);
+          
+      void Create(std::vector<std::vector<double>> polyCoordinates);
 
       Camera * initCube(Cube &cube, int ss = 1, int sl = 1,
                         int ns = 0, int nl = 0, int band = 1);

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -168,64 +168,27 @@ namespace Isis {
     cube1 = new Cube();
     cube1->fromIsd(tempDir.path() + "/cube1.cub", labelPath1, *isdPath1, "rw");
 
-    lonLatPts = new geos::geom::CoordinateArraySequence();
-    lonLatPts->add(geos::geom::Coordinate(30, 0));
-    lonLatPts->add(geos::geom::Coordinate(30, 10));
-    lonLatPts->add(geos::geom::Coordinate(35, 10));
-    lonLatPts->add(geos::geom::Coordinate(35, 0));
-    lonLatPts->add(geos::geom::Coordinate(30, 0));
-
-    polys = new std::vector<geos::geom::Geometry *>;
-    poly = globalFactory->createPolygon(globalFactory->createLinearRing(lonLatPts), nullptr);
-    polys->push_back(poly->clone());
-    multiPoly = globalFactory->createMultiPolygon(polys);
-
-    geos::io::WKTWriter *wkt = new geos::io::WKTWriter();
-
-    std::string polyStr = wkt->write(multiPoly);
-    int polyStrSize = polyStr.size();
-    std::istringstream polyStream(polyStr);
-
-    Blob pvlBlob("Footprint", "Polygon");
-    Pvl pvl;
-    PvlObject polyObject = PvlObject("Polygon");
-    polyObject.addKeyword(PvlKeyword("Name", "Footprint"));
-    polyObject.addKeyword(PvlKeyword("StartByte", "1"));
-    polyObject.addKeyword(PvlKeyword("Bytes", toString(polyStrSize)));
-    pvl.addObject(polyObject);
-
-    pvlBlob.Read(pvl, polyStream);
-    cube1->write(pvlBlob);
+    ImagePolygon poly;
+    coords = {{30, 0},
+              {30, 10},
+              {35, 10},
+              {35, 0},
+              {30, 0}};
+    poly.Create(coords);
+    cube1->write(poly);
     cube1->reopen("rw");
 
     cube2 = new Cube();
     cube2->fromIsd(tempDir.path() + "/cube2.cub", labelPath2, *isdPath2, "rw");
 
-    lonLatPts = new geos::geom::CoordinateArraySequence();
-    lonLatPts->add(geos::geom::Coordinate(31, 1));
-    lonLatPts->add(geos::geom::Coordinate(31, 11));
-    lonLatPts->add(geos::geom::Coordinate(36, 11));
-    lonLatPts->add(geos::geom::Coordinate(36, 1));
-    lonLatPts->add(geos::geom::Coordinate(31, 1));
-
-    polys->pop_back();
-    poly = globalFactory->createPolygon(globalFactory->createLinearRing(lonLatPts), nullptr);
-    polys->push_back(poly);
-    multiPoly = globalFactory->createMultiPolygon(polys);
-
-    polyStr = wkt->write(multiPoly);
-    polyStrSize = polyStr.size();
-    polyStream.str(polyStr);
-
-    pvlBlob = Blob("Footprint", "Polygon");
-    polyObject.addKeyword(PvlKeyword("Bytes", toString(polyStrSize)));
-    pvl.addObject(polyObject);
-
-    pvlBlob.Read(pvl, polyStream);
-    cube2->write(pvlBlob);
+    coords = {{31, 1},
+              {31, 11},
+              {36, 11},
+              {36, 1},
+              {31, 1}};
+    poly.Create(coords);
+    cube2->write(poly);
     cube2->reopen("rw");
-
-    delete wkt;
 
     cube3 = new Cube();
     cube3->fromIsd(tempDir.path() + "/cube3.cub", labelPath3, *isdPath3, "rw");

--- a/isis/tests/Fixtures.h
+++ b/isis/tests/Fixtures.h
@@ -105,10 +105,7 @@ namespace Isis {
       FileList *cubeList;
       QString cubeListFile;
 
-      geos::geom::CoordinateSequence *lonLatPts;
-      std::vector<geos::geom::Geometry *> *polys;
-      geos::geom::Polygon *poly;
-      geos::geom::MultiPolygon *multiPoly;
+      std::vector<std::vector<double>> coords;
 
       void SetUp() override;
       void TearDown() override;

--- a/isis/tests/FunctionalTestsFindImageOverlaps.cpp
+++ b/isis/tests/FunctionalTestsFindImageOverlaps.cpp
@@ -108,37 +108,15 @@ TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapTwoImageOverlap) {
 
 TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapFullOverlap) {
 
-  lonLatPts = new geos::geom::CoordinateArraySequence();
-  lonLatPts->add(geos::geom::Coordinate(31, 1));
-  lonLatPts->add(geos::geom::Coordinate(31, 9));
-  lonLatPts->add(geos::geom::Coordinate(34, 9));
-  lonLatPts->add(geos::geom::Coordinate(34, 1));
-  lonLatPts->add(geos::geom::Coordinate(31, 1));
-
-  polys = new std::vector<geos::geom::Geometry *>;
-  poly = globalFactory->createPolygon(globalFactory->createLinearRing(lonLatPts), nullptr);
-  polys->push_back(poly->clone());
-  multiPoly = globalFactory->createMultiPolygon(polys);
-
-  geos::io::WKTWriter *wkt = new geos::io::WKTWriter();
-
-  std::string polyStr = wkt->write(multiPoly);
-  int polyStrSize = polyStr.size();
-  std::istringstream polyStream(polyStr);
-
-  Blob pvlBlob("Footprint", "Polygon");
-  Pvl pvl;
-  PvlObject polyObject = PvlObject("Polygon");
-  polyObject.addKeyword(PvlKeyword("Name", "Footprint"));
-  polyObject.addKeyword(PvlKeyword("StartByte", "1"));
-  polyObject.addKeyword(PvlKeyword("Bytes", toString(polyStrSize)));
-  pvl.addObject(polyObject);
-
-  pvlBlob.Read(pvl, polyStream);
-  cube2->write(pvlBlob);
+  ImagePolygon poly;
+  coords = {{31, 1},
+            {31, 9},
+            {34, 9},
+            {34, 1},
+            {31, 1}};
+  poly.Create(coords);
+  cube2->write(poly);
   cube2->reopen("rw");
-
-  delete wkt;
 
   QVector<QString> args = {"OVERLAPLIST=" + tempDir.path() + "/overlaps.txt", "detailed=true", "errors=true"};
   UserInterface ui(APP_XML, args);


### PR DESCRIPTION
Adds the ability to arbitrarily create image polygons from the set of coordinates

## Description
Updates the ImagePoly api to generate a polygon from a set of coordinates. This method also addresses polygons crossing the prime meridian.

## Related Issue
N/A

## Motivation and Context
There needs to be a way to easily create ISIS polygons for testing. This could be better integrated into the polygon generation from a cube but would take more time.

## How Has This Been Tested?
This is being tested in various gtest and fixtures. Mainly the ThreeImageNetwork fixture.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
