### PR TITLE
Remove apollo tests

### DIFF
--- a/isis/src/apollo/apps/apollo2isis/tsts/default/Makefile
+++ b/isis/src/apollo/apps/apollo2isis/tsts/default/Makefile
@@ -1,6 +1,0 @@
-APPNAME = apollo2isis
-
-include $(ISISROOT)/make/isismake.tsts
-
-commands:
-	cp $(INPUT)/deferred.txt $(OUTPUT)/deferred.txt > /dev/null;

--- a/isis/tests/ConstantsTests.cpp
+++ b/isis/tests/ConstantsTests.cpp
@@ -1,0 +1,29 @@
+#include "Constants.h"
+#include <gtest/gtest.h>
+
+TEST (ConstantsTests, TestPi){
+  ASSERT_NEAR(Isis::PI, 3.141592653589793, .000000000000001);
+}
+
+
+TEST (ConstantsTests, TestHalfPi){
+  ASSERT_NEAR(Isis::PI/2, 1.570796326794897, .000000000000001);
+}
+
+TEST (ConstantsTests, TestE){
+  ASSERT_NEAR(Isis::E, 2.718281828459045, .000000000000001);
+}
+
+TEST (ConstantsTests, TestDeg2Rad){
+  ASSERT_NEAR(Isis::DEG2RAD, 0.0174532925199433, .000000000000001);
+  ASSERT_EQ(Isis::DEG2RAD * 180, Isis::PI);
+}
+
+TEST (ConstantsTests, TestRad2Deg){
+  ASSERT_NEAR(Isis::RAD2DEG, 57.29577951308232, .000000000000001);
+  ASSERT_EQ(Isis::RAD2DEG * Isis::PI/2, 90);
+}
+
+TEST (ConstantsTests, TestBigInt){
+  ASSERT_EQ(sizeof(Isis::BigInt), 8);
+}


### PR DESCRIPTION
Removes apollo test files as part of the ongoing conversion to gtest.

## Description
The existing apollo tests include 1.2 gigabytes of test data, but there are no actual tests.  There is a note in the default/truth stating that "This test has been deferred until ASU provides a fast test or until the code can be modified to make it more efficient."

## Related Issue
gtest refactors

## Motivation and Context
frees 1.2gb of testing data

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
