### PR TITLE
Added text to description by Dave Humm. Closes #3860

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ update the Unreleased link so that it compares against the latest release tag.
 -->
 
 ## [Unreleased]
+ - Added documentation to lronaccal and lrowaccal to describe why there are negative DNs in I/F calibrated images.
 
 ## [4.3.0] - 2020-10-02
 

--- a/isis/src/lro/apps/lronaccal/lronaccal.xml
+++ b/isis/src/lro/apps/lronaccal/lronaccal.xml
@@ -58,19 +58,39 @@
     </p>
 
     <p>
-      Let's look at the case of a calibrated image for which the true signal is zero, a dark 
-      image. In calibration, the mean bias and dark current are subtracted, but the random 
-      noise cannot be subtracted, because only the statistical distribution of the random 
-      noise can be known in advance, not the specific value for that pixel for that image. 
-      Because the random noise values are both positive and negative, when the true signal 
-      is zero the calibrated image should have both positive and negative values. If it had 
-      only positive values, the mean would be positive and therefore it would have a 
-      systematic error, since the true signal is zero. It is not possible to eliminate the 
-      random noise entirely, but it is defined as centered around zero to minimize the 
-      systematic error in the calibrated image. That forces calibrated dark images to have 
-      both positive and negative values.
+      The calibration equation is:
+      <pre>  reportedDN = ObservedDN - MeanBias - DarkCurrent </pre>
+
+        Where:
+        <pre>
+   ObservedDN = TrueDN + E
+   E is a randomly sampled value from (mu, sigma^2) and mu=0
+   TrueDN is the signal that would be reported in an idealized case of an instrument with zero noise.</pre>
+     </p>
+
+    <p>
+      Let's look at the case of a calibrated image for which the true signal
+      is zero, a dark image. In calibration the mean bias and dark current are
+      subtracted. The random noise term is then randomly sampled from a known
+      distribution with a mean of zero. Since the distribution has a mean of
+      zero, values for the random noise can be positive or negative.
+      Therefore, the addition of random noise to a pixel with true signal near
+      zero can result in negative DN values.
     </p>
 
+    <p>
+      Negative reported DNs are possible when E < -1 * TrueDN. These are
+      pixels in a very dark image that happen to have a strongly negative
+      random noise value.
+    </p>
+
+    <p>
+      Note: ObservedDN and TrueDN both must be greater than or equal to zero.
+      For ObservedDN, it's because the hardware is not able to report negative
+      DN values . For TrueDN, it's because radiance and reflectivity cannot be
+      negative. The dimmest target is one that is completely dark, and for
+      that target TrueDN = 0.
+    </p>
   </description>
 
   <history>

--- a/isis/src/lro/apps/lronaccal/lronaccal.xml
+++ b/isis/src/lro/apps/lronaccal/lronaccal.xml
@@ -8,41 +8,41 @@
 
   <description>
     <p>
-    lronaccal performs radiometric corrections to images acquired by the Narrow Angle
-    Camera aboard the Lunar Reconnaissance Orbiter spacecraft.
+      lronaccal performs radiometric corrections to images acquired by the Narrow Angle
+      Camera aboard the Lunar Reconnaissance Orbiter spacecraft.
     </p>
 
     <p>
-    The LRO NAC detector has a total of 5064 pixels, divided among an A
-    channel and a B channel.  The pixels alternate between the two channels:
-    ABABABAB, etc.  Images from LROC NAC may or may not include all pixels in the
-    acquired image.  There are special summing modes that are utilized
-    on-board the spacecraft to average detector pixels to combine them into a
-    single output pixel value.  The value of the ISIS label keyord,
-    SpatialSumming, indicates the number of samples that were summed and
-    averaged to result in the pixel values stored in the file.  Note that this
-    will reduce the number of samples in the output image by a factor of at
-    most the SpatialSumming mode value.
+      The LRO NAC detector has a total of 5064 pixels, divided among an A
+      channel and a B channel.  The pixels alternate between the two channels:
+      ABABABAB, etc.  Images from LROC NAC may or may not include all pixels in the
+      acquired image.  There are special summing modes that are utilized
+      on-board the spacecraft to average detector pixels to combine them into a
+      single output pixel value.  The value of the ISIS label keyord,
+      SpatialSumming, indicates the number of samples that were summed and
+      averaged to result in the pixel values stored in the file.  Note that this
+      will reduce the number of samples in the output image by a factor of at
+      most the SpatialSumming mode value.
     </p>
     <p>
-    The LROC NAC camera has the ability to acquire images of differing sizes in
-    both line and sample.  The starting hardware detector pixel for the
-    acquired image is specified by the ISIS label keyword, SampleFirstPixel.
-    The first pixel in the detector is indicated by a value of 0.
+      The LROC NAC camera has the ability to acquire images of differing sizes in
+      both line and sample.  The starting hardware detector pixel for the
+      acquired image is specified by the ISIS label keyword, SampleFirstPixel.
+      The first pixel in the detector is indicated by a value of 0.
     </p>
 
     <p>
-    Dark current pixels are taken for each line from the masked pixels
-    that lie along each edge of the image.
+      Dark current pixels are taken for each line from the masked pixels
+      that lie along each edge of the image.
     </p>
     
     <p>
-    If SpatialSumming is 1 the dark current pixels are averaged together then
-    this average is subtracted from all image pixels.  If SpatialSumming is 2,
-    the dark current pixels for the A and B channel are averaged separately,
-    then the A channel dark average is subtracted from the A channel image
-    pixels and the B channel dark average is subtracted from the B channel
-    image pixels.
+      If SpatialSumming is 1 the dark current pixels are averaged together then
+      this average is subtracted from all image pixels.  If SpatialSumming is 2,
+      the dark current pixels for the A and B channel are averaged separately,
+      then the A channel dark average is subtracted from the A channel image
+      pixels and the B channel dark average is subtracted from the B channel
+      image pixels.
     </p>
 
     <p>
@@ -55,7 +55,6 @@
       scene, bias, and dark current with no systematic error. That implies the statistical 
       distribution of the random noise has an average of zero, and therefore the random noise
       has both positive and negative values, except for the trivial case of zero random noise.
-      The random noise is both additive and subtractive to the signal by definition.
     </p>
 
     <p>
@@ -67,9 +66,9 @@
       is zero the calibrated image should have both positive and negative values. If it had 
       only positive values, the mean would be positive and therefore it would have a 
       systematic error, since the true signal is zero. It is not possible to eliminate the 
-      random noise entirely, but it is defined as both additive and subtractive to the signal 
-      to minimize the systematic error in the calibrated image. That forces calibrated dark 
-      images to have both positive and negative values.
+      random noise entirely, but it is defined as centered around zero to minimize the 
+      systematic error in the calibrated image. That forces calibrated dark images to have 
+      both positive and negative values.
     </p>
 
   </description>

--- a/isis/src/lro/apps/lronaccal/lronaccal.xml
+++ b/isis/src/lro/apps/lronaccal/lronaccal.xml
@@ -9,8 +9,7 @@
   <description>
     <p>
     lronaccal performs radiometric corrections to images acquired by the Narrow Angle
-    Camera aboard the Lunar Reconnaissance Orbiter spacecraft.  The LRO NAC camera
-    will make observations simulteously with the HiRise camera.
+    Camera aboard the Lunar Reconnaissance Orbiter spacecraft.
     </p>
 
     <p>
@@ -44,6 +43,33 @@
     then the A channel dark average is subtracted from the A channel image
     pixels and the B channel dark average is subtracted from the B channel
     image pixels.
+    </p>
+
+    <p>
+      The DN level in an uncalibrated image is the sum of the true signal from the scene, 
+      the bias, the dark current, and random noise in all 3 components. The random noise in
+      the true signal and dark current is called shot noise and the random noise in the bias
+      is called read noise. The true signal, bias, and dark current are defined as mean
+      values so that if the random noise were averaged down to insignificance by taking a 
+      very large number of images and averaging them, the resulting image would be the true 
+      scene, bias, and dark current with no systematic error. That implies the statistical 
+      distribution of the random noise has an average of zero, and therefore the random noise
+      has both positive and negative values, except for the trivial case of zero random noise.
+      The random noise is both additive and subtractive to the signal by definition.
+    </p>
+
+    <p>
+      Let's look at the case of a calibrated image for which the true signal is zero, a dark 
+      image. In calibration, the mean bias and dark current are subtracted, but the random 
+      noise cannot be subtracted, because only the statistical distribution of the random 
+      noise can be known in advance, not the specific value for that pixel for that image. 
+      Because the random noise values are both positive and negative, when the true signal 
+      is zero the calibrated image should have both positive and negative values. If it had 
+      only positive values, the mean would be positive and therefore it would have a 
+      systematic error, since the true signal is zero. It is not possible to eliminate the 
+      random noise entirely, but it is defined as both additive and subtractive to the signal 
+      to minimize the systematic error in the calibrated image. That forces calibrated dark 
+      images to have both positive and negative values.
     </p>
 
   </description>

--- a/isis/src/lro/apps/lrowaccal/lrowaccal.xml
+++ b/isis/src/lro/apps/lrowaccal/lrowaccal.xml
@@ -160,7 +160,6 @@
       scene, bias, and dark current with no systematic error. That implies the statistical 
       distribution of the random noise has an average of zero, and therefore the random noise
       has both positive and negative values, except for the trivial case of zero random noise.
-      The random noise is both additive and subtractive to the signal by definition.
     </p>
 
     <p>
@@ -172,11 +171,10 @@
       is zero the calibrated image should have both positive and negative values. If it had 
       only positive values, the mean would be positive and therefore it would have a 
       systematic error, since the true signal is zero. It is not possible to eliminate the 
-      random noise entirely, but it is defined as both additive and subtractive to the signal 
-      to minimize the systematic error in the calibrated image. That forces calibrated dark 
-      images to have both positive and negative values.
+      random noise entirely, but it is defined as centered around zero to minimize the 
+      systematic error in the calibrated image. That forces calibrated dark images to have 
+      both positive and negative values.
     </p>
-
   </description>
 
   <category>

--- a/isis/src/lro/apps/lrowaccal/lrowaccal.xml
+++ b/isis/src/lro/apps/lrowaccal/lrowaccal.xml
@@ -15,7 +15,7 @@
     </p>
 
     <p>
-      Corrections are  applied in the following order: Dark, Flat-field, Radiometric, Special pixel mask, and Temperature. 
+      Corrections are applied in the following order: Dark, Flat-field, Radiometric, Special pixel mask, and Temperature. 
     </p>
 
     <h3>Dark Correction:</h3>
@@ -149,6 +149,34 @@
       </pre>
       If TEMPRATUREFILE is not set, the constants are loaded from $lro/calibration/WAC_TempratureConstants.????.pvl
     </p>
+
+    <p>
+      The DN level in an uncalibrated image is the sum of the true signal from the scene, 
+      the bias, the dark current, and random noise in all 3 components. The random noise in
+      the true signal and dark current is called shot noise and the random noise in the bias
+      is called read noise. The true signal, bias, and dark current are defined as mean
+      values so that if the random noise were averaged down to insignificance by taking a 
+      very large number of images and averaging them, the resulting image would be the true 
+      scene, bias, and dark current with no systematic error. That implies the statistical 
+      distribution of the random noise has an average of zero, and therefore the random noise
+      has both positive and negative values, except for the trivial case of zero random noise.
+      The random noise is both additive and subtractive to the signal by definition.
+    </p>
+
+    <p>
+      Let's look at the case of a calibrated image for which the true signal is zero, a dark 
+      image. In calibration, the mean bias and dark current are subtracted, but the random 
+      noise cannot be subtracted, because only the statistical distribution of the random 
+      noise can be known in advance, not the specific value for that pixel for that image. 
+      Because the random noise values are both positive and negative, when the true signal 
+      is zero the calibrated image should have both positive and negative values. If it had 
+      only positive values, the mean would be positive and therefore it would have a 
+      systematic error, since the true signal is zero. It is not possible to eliminate the 
+      random noise entirely, but it is defined as both additive and subtractive to the signal 
+      to minimize the systematic error in the calibrated image. That forces calibrated dark 
+      images to have both positive and negative values.
+    </p>
+
   </description>
 
   <category>

--- a/isis/src/lro/apps/lrowaccal/lrowaccal.xml
+++ b/isis/src/lro/apps/lrowaccal/lrowaccal.xml
@@ -163,18 +163,40 @@
     </p>
 
     <p>
-      Let's look at the case of a calibrated image for which the true signal is zero, a dark 
-      image. In calibration, the mean bias and dark current are subtracted, but the random 
-      noise cannot be subtracted, because only the statistical distribution of the random 
-      noise can be known in advance, not the specific value for that pixel for that image. 
-      Because the random noise values are both positive and negative, when the true signal 
-      is zero the calibrated image should have both positive and negative values. If it had 
-      only positive values, the mean would be positive and therefore it would have a 
-      systematic error, since the true signal is zero. It is not possible to eliminate the 
-      random noise entirely, but it is defined as centered around zero to minimize the 
-      systematic error in the calibrated image. That forces calibrated dark images to have 
-      both positive and negative values.
+      The calibration equation is:
+      <pre>  reportedDN = ObservedDN - MeanBias - DarkCurrent </pre>
+
+        Where:
+        <pre>
+   ObservedDN = TrueDN + E
+   E is a randomly sampled value from (mu, sigma^2) and mu=0
+   TrueDN is the signal that would be reported in an idealized case of an instrument with zero noise.</pre>
+     </p>
+
+    <p>
+      Let's look at the case of a calibrated image for which the true signal
+      is zero, a dark image. In calibration the mean bias and dark current are
+      subtracted. The random noise term is then randomly sampled from a known
+      distribution with a mean of zero. Since the distribution has a mean of
+      zero, values for the random noise can be positive or negative.
+      Therefore, the addition of random noise to a pixel with true signal near
+      zero can result in negative DN values.
     </p>
+
+    <p>
+      Negative reported DNs are possible when E < -1 * TrueDN. These are
+      pixels in a very dark image that happen to have a strongly negative
+      random noise value.
+    </p>
+
+    <p>
+      Note: ObservedDN and TrueDN both must be greater than or equal to zero.
+      For ObservedDN, it's because the hardware is not able to report negative
+      DN values . For TrueDN, it's because radiance and reflectivity cannot be
+      negative. The dimmest target is one that is completely dark, and for
+      that target TrueDN = 0.
+    </p>
+
   </description>
 
   <category>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added documentation to describe why the calibrated image has negative values
## Description
<!--- Describe your changes in detail -->
Added documentation from Dave Humm to describe the reasons the output I/F image
may have negative DNs.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The issue #3860 was created because negative DNs were seen in the output images. 
The LROC team, who wrote the calibration programs, supplied text to describe why those
exist.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Only a documentation change

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
