### PR TITLE
Added error checking around spicelib furnsh call. Closes #4038

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ update the Unreleased link so that it compares against the latest release tag.
 
 ## [Unreleased]
 
+
+- Fixed so required files are reported instead of continuing without them. [#4038](https://github.com/USGS-Astrogeology/ISIS3/issues/4038)
+
 ## [4.3.0] - 2020-10-02
 
 ### Changed
@@ -48,7 +51,7 @@ update the Unreleased link so that it compares against the latest release tag.
 
  - mro/hideal2pds app now writes the correct SAMPLE_BIT_MASK values to the output label. [#3978](https://github.com/USGS-Astrogeology/ISIS3/issues/3978)
 
-  - For Histograms in ISIS, updated the math for calculating what bin data should be placed in and the min/max values of each bin to be more intuitive. In addition, the output of hist and cnethist were changed to display the min/max values of each bin instead of the middle pixel's DN. [#3882](https://github.com/USGS-Astrogeology/ISIS3/issues/3882)
+ - For Histograms in ISIS, updated the math for calculating what bin data should be placed in and the min/max values of each bin to be more intuitive. In addition, the output of hist and cnethist were changed to display the min/max values of each bin instead of the middle pixel's DN. [#3882](https://github.com/USGS-Astrogeology/ISIS3/issues/3882)
 
 ### Added
 

--- a/isis/src/lro/apps/lrowaccal/main.cpp
+++ b/isis/src/lro/apps/lrowaccal/main.cpp
@@ -13,6 +13,7 @@
 #include "CubeAttribute.h"
 #include "iTime.h"
 #include "Message.h"
+#include "NaifStatus.h"
 #include "Preference.h"
 #include "ProcessByBrick.h"
 #include "PvlGroup.h"
@@ -206,14 +207,21 @@ void IsisMain () {
         // Astronomical Units (AU)
         QString bspKernel1 = p.MissionData("lro", "/kernels/tspk/moon_pa_de421_1900-2050.bpc", false);
         QString bspKernel2 = p.MissionData("lro", "/kernels/tspk/de421.bsp", false);
+        NaifStatus::CheckErrors();
         furnsh_c(bspKernel1.toLatin1().data());
+        NaifStatus::CheckErrors();
         furnsh_c(bspKernel2.toLatin1().data());
+        NaifStatus::CheckErrors();
         QString pckKernel1 = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
         QString pckKernel2 = p.MissionData("lro", "/kernels/pck/moon_080317.tf", false);
         QString pckKernel3 = p.MissionData("lro", "/kernels/pck/moon_assoc_me.tf", false);
+        NaifStatus::CheckErrors();
         furnsh_c(pckKernel1.toLatin1().data());
+        NaifStatus::CheckErrors();
         furnsh_c(pckKernel2.toLatin1().data());
+        NaifStatus::CheckErrors();
         furnsh_c(pckKernel3.toLatin1().data());
+        NaifStatus::CheckErrors();
         double sunpos[6], lt;
         spkezr_c("sun", etStart, "MOON_ME", "LT+S", "MOON", sunpos, &lt);
         g_solarDistance = vnorm_c(sunpos) / KM_PER_AU;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added error checking around calls to spicelib furnsh_c, so missing files would be reported instead of continuing without an error.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The program was continuing on and creating invalid output when it was unable to find SPICE kernel files required for proper calibration.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://usgs-astrogeology.github.io/code/)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
