### PR TITLE
Removed compile and deprecation warnings. Fixes #4110

### DIFF
--- a/isis/src/base/objs/StatCumProbDistDynCalc/unitTest.cpp
+++ b/isis/src/base/objs/StatCumProbDistDynCalc/unitTest.cpp
@@ -394,7 +394,10 @@ int main(int argc, char *argv[]) {
     qDebug() << "";
 
     qDebug() << "Testing assignment operator=...";
-    copyStats = copyStats;
+    {
+      StatCumProbDistDynCalc &c = copyStats;
+      copyStats = c;
+    }
     qDebug() << "Min = " << copyStats.min();
     qDebug() << "Max = " << copyStats.max();
     qDebug() << "";

--- a/isis/src/base/objs/Statistics/unitTest.cpp
+++ b/isis/src/base/objs/Statistics/unitTest.cpp
@@ -212,7 +212,10 @@ int main(int argc, char *argv[]) {
     qDebug() << "";
 
     qDebug() << "Testing assignment operator=...";
-    s = s;
+    {
+      Statistics &tstats = s;
+      s = tstats;
+    }
     qDebug() << "Average:             " << s.Average();
     qDebug() << "Variance:            " << s.Variance();
     qDebug() << "Rms:                 " << s.Rms();

--- a/isis/src/control/objs/BundleResults/unitTest.cpp
+++ b/isis/src/control/objs/BundleResults/unitTest.cpp
@@ -127,7 +127,10 @@ int main(int argc, char *argv[]) {
     qDebug() << "";
 
     qDebug() << "Testing assignment operator=...";
-    results = results;
+    {
+      BundleResults &r = results;
+      results = r;
+    }
     printXml(results);
 
     BundleResults assignmentOpResults;

--- a/isis/src/control/objs/BundleSettings/unitTest.cpp
+++ b/isis/src/control/objs/BundleSettings/unitTest.cpp
@@ -159,7 +159,11 @@ int main(int argc, char *argv[]) {
     printXml<BundleSettings>(copySettings);
 
     qDebug() << "Testing assignment operator to set this equal to itself...";
-    settings = settings;
+    {
+      BundleSettings &s = settings;
+      settings = s;
+    }
+
     printXml<BundleSettings>(settings);
 
     qDebug() << "Testing assignment operator to create a new settings object...";

--- a/isis/src/control/objs/BundleUtilities/unitTest.cpp
+++ b/isis/src/control/objs/BundleUtilities/unitTest.cpp
@@ -151,7 +151,10 @@ int main(int argc, char *argv[]) {
     printXml(copySettings);
 
     qDebug() << "Testing assignment operator to set this equal to itself...";
-    boss = boss;
+    {
+      BundleObservationSolveSettings &tboss = boss;
+      boss = tboss;
+    }
     printXml(boss);
 
     qDebug() << "Testing assignment operator to create a new settings object...";
@@ -386,7 +389,10 @@ int main(int argc, char *argv[]) {
     qDebug() << "serial number = " << bi2->serialNumber();
     qDebug() << "file name     = " << bi2->fileName();
     qDebug() << "Testing assignment operator to set this equal to itself...";
-    bi = bi;
+    {
+      BundleImage &tbi = bi;
+      bi = tbi;
+    }
     qDebug() << "serial number = " << bi.serialNumber();
     qDebug() << "file name     = " << bi.fileName();
     qDebug() << "Testing assignment operator to create a new object...";
@@ -430,7 +436,10 @@ int main(int argc, char *argv[]) {
                              bundleTargetBody);
 
     qDebug() << "Testing assignment operator to set this equal to itself...";
-    bo2 = bo2;
+    {
+      BundleObservation &tbo2 = bo2;
+      bo2 = tbo2;
+    }
     qDebug() << "Testing assignment operator to create a new object...";
     bo = bo2;
     qDebug() << "Testing copy constructor...";
@@ -1102,7 +1111,10 @@ settings->setSolveOptions(false, false, false, false, SurfacePoint::Rectangular,
     bundleMeasureRejected.setRejected(true);
 
     // Test self-assignment
-    bundleMeasure = bundleMeasure;
+    {
+      BundleMeasure &tbundleMeasure = bundleMeasure;
+      bundleMeasure = tbundleMeasure;
+    }
 
     qDebug() << "";
     // Verify state and copies
@@ -1394,7 +1406,10 @@ settings->setSolveOptions(false, false, false, false, SurfacePoint::Rectangular,
     qDebug() << "Test assignment operator";
     qDebug() << "";
     qDebug() << "Self assignment";
-    btb3 = btb3;
+    {
+      BundleTargetBody &tbtb3 = btb3;
+      btb3 = tbtb3;
+    }
     qDebug().noquote() << btb3.formatBundleOutputString(true);
     qDebug() << "Assignment to other";
     btb3 = btb1;

--- a/isis/tests/AngleTest.cpp
+++ b/isis/tests/AngleTest.cpp
@@ -139,8 +139,9 @@ TEST(AngleExceptions, LessThanNullAngle){
   Isis::Angle angle1(30., Isis::Angle::Degrees );
   
   try {
-    angle1 < Isis::Angle();
-    FAIL() << "Expected an error";
+    if (angle1 < Isis::Angle()) {
+      FAIL() << "Expected an error";
+    }
    }
    catch(Isis::IException &e) {
      EXPECT_TRUE(e.toString().contains("Cannot compare a invalid angles with the < operator"))
@@ -155,8 +156,9 @@ TEST(AngleExceptions, NullAngleLessThan){
   Isis::Angle angle1(30., Isis::Angle::Degrees );
 
   try {
-    Isis::Angle() < angle1;
-    FAIL() << "Expected an error";
+    if (Isis::Angle() < angle1) {
+      FAIL() << "Expected an error";
+    }
    }
    catch(Isis::IException &e) {
      EXPECT_TRUE(e.toString().contains("Cannot compare a invalid angles with the < operator"))
@@ -171,8 +173,9 @@ TEST(AngleExceptions, NullAngleLessThanOrEqual){
   Isis::Angle angle1(30., Isis::Angle::Degrees );
 
   try {
-    Isis::Angle() <= angle1;
-    FAIL() << "Expected an error";
+    if (Isis::Angle() <= angle1) {
+      FAIL() << "Expected an error";
+    }
    }
    catch(Isis::IException &e) {
      EXPECT_TRUE(e.toString().contains("Cannot compare a invalid angles with the < operator"))
@@ -188,8 +191,9 @@ TEST(AngleExceptions, GreaterThanNullAngle){
   Isis::Angle angle1(30., Isis::Angle::Degrees );
   
   try {
-    angle1 > Isis::Angle();
-    FAIL() << "Expected an error";
+    if (angle1 > Isis::Angle()) {
+      FAIL() << "Expected an error";
+    }
    }
    catch(Isis::IException &e) {
      EXPECT_TRUE(e.toString().contains("Cannot compare a invalid angles with the > operator"))
@@ -205,8 +209,9 @@ TEST(AngleExceptions, GreaterThanOrEqualToNullAngle){
   Isis::Angle angle1(30., Isis::Angle::Degrees );
   
   try {
-    angle1 >= Isis::Angle();
-    FAIL() << "Expected an error";
+    if (angle1 >= Isis::Angle()) {
+      FAIL() << "Expected an error";
+    }
    }
    catch(Isis::IException &e) {
      EXPECT_TRUE(e.toString().contains("Cannot compare a invalid angles with the > operator"))

--- a/isis/tests/BundleObservationSolveSettingsTests.cpp
+++ b/isis/tests/BundleObservationSolveSettingsTests.cpp
@@ -373,7 +373,7 @@ TEST_P(PositionSolveOptionStrings, OptionToString) {
     BundleObservationSolveSettings::instrumentPositionSolveOptionToString(GetParam().first));
 }
 
-INSTANTIATE_TEST_CASE_P(BundleObservationSolveSettings, PointingSolveOptionStrings, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(BundleObservationSolveSettings, PointingSolveOptionStrings, ::testing::Values(
   qMakePair(BundleObservationSolveSettings::NoPointingFactors, QString("None")),
   qMakePair(BundleObservationSolveSettings::AnglesOnly, QString("AnglesOnly")),
   qMakePair(BundleObservationSolveSettings::AnglesVelocity, QString("AnglesAndVelocity")),
@@ -382,7 +382,7 @@ INSTANTIATE_TEST_CASE_P(BundleObservationSolveSettings, PointingSolveOptionStrin
   qMakePair(BundleObservationSolveSettings::AllPointingCoefficients,
             QString("AllPolynomialCoefficients"))));
 
-INSTANTIATE_TEST_CASE_P(BundleObservationSolveSettings, PositionSolveOptionStrings, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(BundleObservationSolveSettings, PositionSolveOptionStrings, ::testing::Values(
   qMakePair(BundleObservationSolveSettings::NoPositionFactors, QString("None")),
   qMakePair(BundleObservationSolveSettings::PositionOnly, QString("PositionOnly")),
   qMakePair(BundleObservationSolveSettings::PositionVelocity, QString("PositionAndVelocity")),

--- a/isis/tests/BundleSettingsTests.cpp
+++ b/isis/tests/BundleSettingsTests.cpp
@@ -362,7 +362,7 @@ TEST_P(BoolTest, saveSolveOptions) {
   );
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
       BundleSettings,
       BoolTest,
       ::testing::Bool()
@@ -411,7 +411,7 @@ TEST_P(BoolTest, saveCoordinateTypes) {
   );
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
       BundleSettings,
       CoordinateTypeTest,
       ::testing::Values(SurfacePoint::Latitudinal, SurfacePoint::Rectangular)
@@ -631,7 +631,7 @@ TEST_P(ConvergenceCriteriaTest, saveConvergenceCriteria) {
   );
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
       BundleSettings,
       ConvergenceCriteriaTest,
       ::testing::Values(BundleSettings::Sigma0, BundleSettings::ParameterCorrections)

--- a/isis/tests/ColorTests.cpp
+++ b/isis/tests/ColorTests.cpp
@@ -68,20 +68,19 @@ namespace Isis{
     EXPECT_FALSE(Color::colorRGBAFormat().exactMatch(GetParam()));
   }
 
-
-  INSTANTIATE_TEST_CASE_P (Color,
+  INSTANTIATE_TEST_SUITE_P (Color,
                            QStringQColorPair,
                            ::testing::Values(std::make_pair(QString("#000000ff"), QColor(0, 0, 0)),
-                                            std::make_pair(QString("#00000000"), QColor(0, 0, 0, 0)),
-                                            std::make_pair(QString("#ff000000"), QColor(255, 0, 0, 0)),
-                                            std::make_pair(QString("#00ff0000"), QColor(0, 255, 0, 0)),
-                                            std::make_pair(QString("#0000ff00"), QColor(0, 0, 255, 0)),
-                                            std::make_pair(QString("#000000ff"), QColor(0, 0, 0, 255)),
-                                            std::make_pair(QString("#ffffffff"), QColor(255, 255, 255, 255)),
-                                            std::make_pair(QString("#0a141e28"), QColor(10, 20, 30, 40))));
+                                             std::make_pair(QString("#00000000"), QColor(0, 0, 0, 0)),
+                                             std::make_pair(QString("#ff000000"), QColor(255, 0, 0, 0)),
+                                             std::make_pair(QString("#00ff0000"), QColor(0, 255, 0, 0)),
+                                             std::make_pair(QString("#0000ff00"), QColor(0, 0, 255, 0)),
+                                             std::make_pair(QString("#000000ff"), QColor(0, 0, 0, 255)),
+                                             std::make_pair(QString("#ffffffff"), QColor(255, 255, 255, 255)),
+                                             std::make_pair(QString("#0a141e28"), QColor(10, 20, 30, 40))));
 
 
-  INSTANTIATE_TEST_CASE_P (Color,
+  INSTANTIATE_TEST_SUITE_P (Color,
                            InvalidColorString,
                            ::testing::Values(QString("#rrggbbaa"),
                                             QString(" 00112233"),

--- a/isis/tests/ColumnTests.cpp
+++ b/isis/tests/ColumnTests.cpp
@@ -63,7 +63,7 @@ TEST_P(Types, Type) {
   EXPECT_EQ(column.DataType(), GetParam());
 }
 
-INSTANTIATE_TEST_CASE_P(Column, Types, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(Column, Types, ::testing::Values(
   Column::NoType, Column::Integer, Column::Real, Column::String, Column::Pixel));
 
 //Tests SetAlignment & Alignment functions with every member of the Align enum
@@ -74,7 +74,7 @@ TEST_P(Align, Alignment) {
   EXPECT_EQ(column.Alignment(), GetParam());
 }
 
-INSTANTIATE_TEST_CASE_P(Column, Align, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(Column, Align, ::testing::Values(
   Column::NoAlign, Column::Right, Column::Left, Column::Decimal));
 
 //Tests SetPrecision & Precision functions with Real type and Pixel type.
@@ -166,7 +166,7 @@ TEST_P(TypeError, SetAlignmentError) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(Column, TypeError, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(Column, TypeError, ::testing::Values(
   Column::Integer, Column::String));
 
 //Tests that Precision's exceptions are working correctly
@@ -187,5 +187,5 @@ TEST_P(PrecisionError, SetPrecisionError) {
     << message.toStdString() <<"\"";
   }
 }
-INSTANTIATE_TEST_CASE_P(Column, PrecisionError, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(Column, PrecisionError, ::testing::Values(
   Column::NoAlign, Column::Right, Column::Left));

--- a/isis/tests/DisplacementTests.cpp
+++ b/isis/tests/DisplacementTests.cpp
@@ -170,7 +170,9 @@ TEST(Displacement, UninitializedComparison)
 {
   try
   {
-    Isis::Displacement() > Isis::Displacement();
+    if (Isis::Displacement() > Isis::Displacement()) {
+      FAIL() << "Expected an error";
+    }
   }
   catch(Isis::IException &e)
   {
@@ -186,7 +188,9 @@ TEST(Displacement, UninitializedComparison)
 
   try
   {
-    Isis::Displacement() < Isis::Displacement();
+    if (Isis::Displacement() < Isis::Displacement()) {
+      FAIL() << "Expected an error";
+    }
   }
   catch(Isis::IException &e)
   {

--- a/isis/tests/EndianTests.cpp
+++ b/isis/tests/EndianTests.cpp
@@ -18,4 +18,4 @@ QPair<QString, Isis::ByteOrder> noOrder("None", Isis::ByteOrder::NoByteOrder);
 QPair<QString, Isis::ByteOrder> lsb("Lsb", Isis::ByteOrder::Lsb);
 QPair<QString, Isis::ByteOrder> msb("Msb", Isis::ByteOrder::Msb);
 
-INSTANTIATE_TEST_CASE_P(Endian, ConversionTest, ::testing::Values(noOrder, lsb, msb));
+INSTANTIATE_TEST_SUITE_P(Endian, ConversionTest, ::testing::Values(noOrder, lsb, msb));

--- a/isis/tests/FileNameTests.cpp
+++ b/isis/tests/FileNameTests.cpp
@@ -240,7 +240,7 @@ const char* versionedFiles[] = {"tttt??????", "tttt??????.tmp", "tttt_?.tmp", "?
                                 "tt{MMM}tt{dd}yy{yy}.tmp", "tt{d}tt{MMM}.tmp", "tt{d}tt{MMMM}.tmp",
                                 "tt{dd}.tmp", "tttt{dd}.tmp", "$TEMPORARY/{MMM}-{dd}-{yy}_v???.tmp"};
 
-INSTANTIATE_TEST_CASE_P(FileName, FileName_Fixture_Versioned, ::testing::ValuesIn(versionedFiles));
+INSTANTIATE_TEST_SUITE_P(FileName, FileName_Fixture_Versioned, ::testing::ValuesIn(versionedFiles));
 
 TEST_P(FileName_Fixture_NotVersioned, IsVersioned) {
   FileName file(GetParam());
@@ -252,4 +252,4 @@ const char* notVersionedFiles[] = {"tttt"};
 //TODO These actually throw errors so they cannot be checked like this
 //"tttt{}.tmp", "ttttt{}.tmp", "??tttt??", "tttt{aaaa}.tmp"};
 
-INSTANTIATE_TEST_CASE_P(FileName, FileName_Fixture_NotVersioned, ::testing::ValuesIn(notVersionedFiles));
+INSTANTIATE_TEST_SUITE_P(FileName, FileName_Fixture_NotVersioned, ::testing::ValuesIn(notVersionedFiles));

--- a/isis/tests/FunctionalTestsJigsaw.cpp
+++ b/isis/tests/FunctionalTestsJigsaw.cpp
@@ -290,7 +290,7 @@ TEST_F(ApolloNetwork, FunctionalTestJigsawBundleXYZ) {
 
   for (int i=0; i < latLatPoints.length(); i++) {
     ControlPoint* latLatPoint = latLatPoints[i];
-    ControlPoint* rectLatPoint;
+    ControlPoint *rectLatPoint = nullptr;
     EXPECT_NO_THROW({
         rectLatPoint = rectLatNet.GetPoint(latLatPoint->GetId());
     }
@@ -368,7 +368,7 @@ TEST_F(ApolloNetwork, FunctionalTestJigsawBundleXYZ) {
 
   for (int i=0; i < rectLatPoints.length(); i++) {
     ControlPoint* rectLatPoint = rectLatPoints[i];
-    ControlPoint* rectRectPoint;
+    ControlPoint* rectRectPoint = nullptr;
     EXPECT_NO_THROW({
         rectRectPoint = rectRectNet.GetPoint(rectLatPoint->GetId());
     }
@@ -447,7 +447,7 @@ TEST_F(ApolloNetwork, FunctionalTestJigsawBundleXYZ) {
 
   for (int i=0; i < latRectPoints.length(); i++) {
     ControlPoint* latRectPoint = latRectPoints[i];
-    ControlPoint* latLatPoint;
+    ControlPoint *latLatPoint = nullptr;
     EXPECT_NO_THROW({
         latLatPoint = latLatNet.GetPoint(latRectPoint->GetId());
     }

--- a/isis/tests/GaussianDistributionTests.cpp
+++ b/isis/tests/GaussianDistributionTests.cpp
@@ -62,6 +62,6 @@ QPair <double, double> pos2point5(2.5, 99.379033467422431);
 QPair <double, double> pos3(3.0, 99.865010196837048);
 
 
-INSTANTIATE_TEST_CASE_P(GaussianDistribution, DoubleTest, ::testing::Values(neg3, neg2point5, 
-                        neg2, neg1point5, neg1, negpoint5, zero, pospoint5, pos1, pos1point5, 
-                        pos2, pos2point5, pos3));
+INSTANTIATE_TEST_SUITE_P(GaussianDistribution, DoubleTest, ::testing::Values(neg3, neg2point5, 
+                         neg2, neg1point5, neg1, negpoint5, zero, pospoint5, pos1, pos1point5, 
+                         pos2, pos2point5, pos3));

--- a/isis/tests/PixelTypeTests.cpp
+++ b/isis/tests/PixelTypeTests.cpp
@@ -28,7 +28,7 @@ TEST_P(PixelEnum, TestEnum) {
   EXPECT_EQ(PixelTypeEnumeration(GetParam().first), GetParam().second);
 }
 
-INSTANTIATE_TEST_CASE_P(PixelType, PixelSize, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(PixelType, PixelSize, ::testing::Values(
   qMakePair(PixelType::None, 0),
   qMakePair(PixelType::UnsignedByte, 1),
   qMakePair(PixelType::SignedByte, 1),
@@ -39,7 +39,7 @@ INSTANTIATE_TEST_CASE_P(PixelType, PixelSize, ::testing::Values(
   qMakePair(PixelType::Real, 4),
   qMakePair(PixelType::Double, 8)));
 
-INSTANTIATE_TEST_CASE_P(PixelType, PixelName, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(PixelType, PixelName, ::testing::Values(
   qMakePair(PixelType::None, QString("None")),
   qMakePair(PixelType::UnsignedByte, QString("UnsignedByte")),
   qMakePair(PixelType::SignedByte, QString("SignedByte")),
@@ -50,7 +50,7 @@ INSTANTIATE_TEST_CASE_P(PixelType, PixelName, ::testing::Values(
   qMakePair(PixelType::Real, QString("Real")),
   qMakePair(PixelType::Double, QString("Double"))));
 
-INSTANTIATE_TEST_CASE_P(PixelType, PixelEnum, ::testing::Values(
+INSTANTIATE_TEST_SUITE_P(PixelType, PixelEnum, ::testing::Values(
   qMakePair(QString("None"), 0),
   qMakePair(QString("UnsignedByte"), 1),
   qMakePair(QString("SignedByte"), 2),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixed many compile warnings and deprecation notices.

## Description
<!--- Describe your changes in detail -->


## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4110

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Remove cluttered output, so we can see errors

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Local tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
