### PR TITLE
modified csminit to put model info in a separate group

### DIFF
--- a/isis/tests/AlternativeTestCsmModel.cpp
+++ b/isis/tests/AlternativeTestCsmModel.cpp
@@ -6,10 +6,10 @@ using json = nlohmann::json;
 
 const std::string AlternativeTestCsmModel::SENSOR_MODEL_NAME = "AlternativeTestCsmModelName";
 const std::vector<std::string> AlternativeTestCsmModel::PARAM_NAMES = {
-  "TestParam1",
-  "TestParam2",
-  "TestParam3",
-  "TestParam4"
+  "test_param_one",
+  "test_param_two",
+  "test_param_three",
+  "test_param_four"
 };
 const std::vector<std::string> AlternativeTestCsmModel::PARAM_UNITS = {
   "m",
@@ -92,33 +92,35 @@ std::string AlternativeTestCsmModel::getReferenceDateAndTime() const {
 
 std::string AlternativeTestCsmModel::getModelState() const {
   json state;
-  state["test_param_one"] = m_param_values[0];
-  state["test_param_two"] = m_param_values[1];
-  state["test_param_three"] = m_param_values[2];
-  state["test_param_four"] = m_param_values[3];
+  for (size_t param_index = 0; param_index < m_param_values.size(); param_index++) {
+    state[AlternativeTestCsmModel::PARAM_NAMES[param_index]] = m_param_values[param_index];
+  }
   return AlternativeTestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 
 void AlternativeTestCsmModel::replaceModelState(const std::string& argState) {
   // Get the JSON substring
   json state = json::parse(argState.substr(argState.find("\n") + 1));
-  m_param_values[0] = state.at("test_param_one");
-  m_param_values[1] = state.at("test_param_two");
-  m_param_values[2] = state.at("test_param_three");
-  m_param_values[3] = state.at("test_param_four");
+  for (size_t param_index = 0; param_index < m_param_values.size(); param_index++) {
+    m_param_values[param_index] = state.at(AlternativeTestCsmModel::PARAM_NAMES[param_index]);
+  }
 }
 
 std::string AlternativeTestCsmModel::constructStateFromIsd(const csm::Isd isd){
   std::string filename = isd.filename();
   std::ifstream isdFile(filename);
+
+  if (isdFile.fail()) {
+    std::cout << "Could not open file: " << filename << std::endl;
+  }
+
   json parsedIsd;
   isdFile >> parsedIsd;
 
   json state;
-  state["test_param_one"] = parsedIsd.at("test_param_one");
-  state["test_param_two"] = parsedIsd.at("test_param_two");
-  state["test_param_three"] = parsedIsd.at("test_param_three");
-  state["test_param_four"] = parsedIsd.at("test_param_four");
+  for (size_t param_index = 0; param_index < m_param_values.size(); param_index++) {
+    state[AlternativeTestCsmModel::PARAM_NAMES[param_index]] = parsedIsd.at(AlternativeTestCsmModel::PARAM_NAMES[param_index]);
+  }
   return AlternativeTestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 

--- a/isis/tests/AlternativeTestCsmModel.cpp
+++ b/isis/tests/AlternativeTestCsmModel.cpp
@@ -4,26 +4,33 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
-const std::string AlternativeTestCsmModel::SENSOR_MODEL_NAME = "TestCsmModelName";
+const std::string AlternativeTestCsmModel::SENSOR_MODEL_NAME = "AlternativeTestCsmModelName";
 const std::vector<std::string> AlternativeTestCsmModel::PARAM_NAMES = {
   "TestParam1",
-  "TestParam2"
+  "TestParam2",
+  "TestParam3",
+  "TestParam4"
 };
 const std::vector<std::string> AlternativeTestCsmModel::PARAM_UNITS = {
   "m",
-  "rad"
+  "rad",
+  "K",
+  "unitless"
 };
 const std::vector<csm::param::Type> AlternativeTestCsmModel::PARAM_TYPES = {
   csm::param::FICTITIOUS,
-  csm::param::REAL
+  csm::param::REAL,
+  csm::param::FIXED,
+  csm::param::NONE
 };
 const std::vector<csm::SharingCriteria> AlternativeTestCsmModel::PARAM_SHARING_CRITERIA = {
+  csm::SharingCriteria(),
+  csm::SharingCriteria(),
   csm::SharingCriteria(),
   csm::SharingCriteria()
 };
 
 AlternativeTestCsmModel::AlternativeTestCsmModel() {
-  m_modelState = "AlternativeTestCsmModel_ModelState";
   m_param_values.resize(AlternativeTestCsmModel::PARAM_NAMES.size(), 0.0);
 };
 
@@ -84,11 +91,21 @@ std::string AlternativeTestCsmModel::getReferenceDateAndTime() const {
 }
 
 std::string AlternativeTestCsmModel::getModelState() const {
-  return m_modelState;
+  json state;
+  state["test_param_one"] = m_param_values[0];
+  state["test_param_two"] = m_param_values[1];
+  state["test_param_three"] = m_param_values[2];
+  state["test_param_four"] = m_param_values[3];
+  return AlternativeTestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 
 void AlternativeTestCsmModel::replaceModelState(const std::string& argState) {
-  m_modelState = argState;
+  // Get the JSON substring
+  json state = json::parse(argState.substr(argState.find("\n") + 1));
+  m_param_values[0] = state.at("test_param_one");
+  m_param_values[1] = state.at("test_param_two");
+  m_param_values[2] = state.at("test_param_three");
+  m_param_values[3] = state.at("test_param_four");
 }
 
 std::string AlternativeTestCsmModel::constructStateFromIsd(const csm::Isd isd){
@@ -98,11 +115,11 @@ std::string AlternativeTestCsmModel::constructStateFromIsd(const csm::Isd isd){
   isdFile >> parsedIsd;
 
   json state;
-  state["name"] = parsedIsd.at("name");
   state["test_param_one"] = parsedIsd.at("test_param_one");
   state["test_param_two"] = parsedIsd.at("test_param_two");
   state["test_param_three"] = parsedIsd.at("test_param_three");
-  return state.dump();
+  state["test_param_four"] = parsedIsd.at("test_param_four");
+  return AlternativeTestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 
 csm::EcefCoord AlternativeTestCsmModel::getReferencePoint() const {

--- a/isis/tests/AlternativeTestCsmModel.cpp
+++ b/isis/tests/AlternativeTestCsmModel.cpp
@@ -39,7 +39,7 @@ csm::Version AlternativeTestCsmModel::getVersion() const {
 }
 
 std::string AlternativeTestCsmModel::getModelName() const {
-  return "AlternativeTestCsmModelName";
+  return AlternativeTestCsmModel::SENSOR_MODEL_NAME;
 }
 
 std::string AlternativeTestCsmModel::getPedigree() const {

--- a/isis/tests/AlternativeTestCsmModel.cpp
+++ b/isis/tests/AlternativeTestCsmModel.cpp
@@ -4,8 +4,27 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
+const std::string AlternativeTestCsmModel::SENSOR_MODEL_NAME = "TestCsmModelName";
+const std::vector<std::string> AlternativeTestCsmModel::PARAM_NAMES = {
+  "TestParam1",
+  "TestParam2"
+};
+const std::vector<std::string> AlternativeTestCsmModel::PARAM_UNITS = {
+  "m",
+  "rad"
+};
+const std::vector<csm::param::Type> AlternativeTestCsmModel::PARAM_TYPES = {
+  csm::param::FICTITIOUS,
+  csm::param::REAL
+};
+const std::vector<csm::SharingCriteria> AlternativeTestCsmModel::PARAM_SHARING_CRITERIA = {
+  csm::SharingCriteria(),
+  csm::SharingCriteria()
+};
+
 AlternativeTestCsmModel::AlternativeTestCsmModel() {
   m_modelState = "AlternativeTestCsmModel_ModelState";
+  m_param_values.resize(AlternativeTestCsmModel::PARAM_NAMES.size(), 0.0);
 };
 
 AlternativeTestCsmModel::~AlternativeTestCsmModel() {
@@ -84,4 +103,110 @@ std::string AlternativeTestCsmModel::constructStateFromIsd(const csm::Isd isd){
   state["test_param_two"] = parsedIsd.at("test_param_two");
   state["test_param_three"] = parsedIsd.at("test_param_three");
   return state.dump();
+}
+
+csm::EcefCoord AlternativeTestCsmModel::getReferencePoint() const {
+  return csm::EcefCoord(0.0, 0.0, 0.0);
+}
+
+void AlternativeTestCsmModel::setReferencePoint(const csm::EcefCoord& groundPt) {
+  // do nothing for test
+}
+
+int AlternativeTestCsmModel::getNumParameters() const {
+  return m_param_values.size();
+}
+
+std::string AlternativeTestCsmModel::getParameterName(int index) const {
+  return AlternativeTestCsmModel::PARAM_NAMES[index];
+}
+
+
+std::string AlternativeTestCsmModel::getParameterUnits(int index) const {
+  return AlternativeTestCsmModel::PARAM_UNITS[index];
+}
+
+bool AlternativeTestCsmModel::hasShareableParameters() const {
+  return false;
+}
+
+bool AlternativeTestCsmModel::isParameterShareable(int index) const {
+  return false;
+}
+
+csm::SharingCriteria AlternativeTestCsmModel::getParameterSharingCriteria(int index) const {
+  return AlternativeTestCsmModel::PARAM_SHARING_CRITERIA[index];
+}
+
+double AlternativeTestCsmModel::getParameterValue(int index) const {
+  return m_param_values[index];
+}
+
+void AlternativeTestCsmModel::setParameterValue(int index, double value) {
+  m_param_values[index] = value;
+}
+
+csm::param::Type AlternativeTestCsmModel::getParameterType(int index) const {
+  return AlternativeTestCsmModel::PARAM_TYPES[index];
+}
+
+void AlternativeTestCsmModel::setParameterType(int index, csm::param::Type pType) {
+  // do nothing for test
+}
+
+double AlternativeTestCsmModel::getParameterCovariance(int index1,
+                                            int index2) const {
+  // default to identity covariance matrix
+  if (index1 == index2) {
+    return 1.0;
+  }
+  return 0.0;
+                              }
+void AlternativeTestCsmModel::setParameterCovariance(int index1,
+                                          int index2,
+                                          double covariance) {
+  // do nothing for test
+}
+
+int AlternativeTestCsmModel::getNumGeometricCorrectionSwitches() const {
+  return 0;
+}
+
+std::string AlternativeTestCsmModel::getGeometricCorrectionName(int index) const {
+  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
+                   "AlternativeTestCsmModel::getGeometricCorrectionName");
+}
+
+void AlternativeTestCsmModel::setGeometricCorrectionSwitch(int index,
+                                  bool value,
+                                  csm::param::Type pType) {
+  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
+                  "AlternativeTestCsmModel::setGeometricCorrectionSwitch");
+}
+
+bool AlternativeTestCsmModel::getGeometricCorrectionSwitch(int index) const {
+  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
+                   "AlternativeTestCsmModel::getGeometricCorrectionSwitch");
+}
+
+std::vector<double> AlternativeTestCsmModel::getCrossCovarianceMatrix(
+      const csm::GeometricModel& comparisonModel,
+      csm::param::Set pSet,
+      const csm::GeometricModel::GeometricModelList& otherModels) const {
+  const std::vector<int>& rowIndices = getParameterSetIndices(pSet);
+  size_t numRows = rowIndices.size();
+  const std::vector<int>& colIndices = comparisonModel.getParameterSetIndices(pSet);
+  size_t numCols = colIndices.size();
+  std::vector<double> covariance(numRows * numCols, 0.0);
+
+  if (&comparisonModel == this) {
+    for (size_t rowIndex = 0; rowIndex <  numRows; numRows++) {
+      for (size_t colIndex = 0; colIndex < numCols; colIndex++) {
+        covariance[rowIndex * numCols + colIndex] = getParameterCovariance(rowIndices[rowIndex],
+                                                                           colIndices[colIndex]);
+      }
+    }
+  }
+
+  return covariance;
 }

--- a/isis/tests/AlternativeTestCsmModel.h
+++ b/isis/tests/AlternativeTestCsmModel.h
@@ -4,33 +4,69 @@
 #include <string>
 
 #include "csm/Plugin.h"
-#include "csm/Model.h"
+#include "csm/GeometricModel.h"
 #include "csm/Version.h"
 
-class AlternativeTestCsmModel : public csm::Model {
- public:
-   AlternativeTestCsmModel();
-   ~AlternativeTestCsmModel();
+class AlternativeTestCsmModel : public csm::GeometricModel {
+  public:
+    // Static variables that describe the model
+    static const std::string SENSOR_MODEL_NAME;
+    static const std::vector<std::string> PARAM_NAMES;
+    static const std::vector<std::string> PARAM_UNITS;
+    static const std::vector<csm::param::Type> PARAM_TYPES;
+    static const std::vector<csm::SharingCriteria> PARAM_SHARING_CRITERIA;
 
-   std::string getFamily() const;
-   csm::Version getVersion() const;
-   std::string getModelName() const;
-   std::string getPedigree() const;
-   std::string getImageIdentifier() const;
-   void setImageIdentifier(const std::string& imageId,
-                           csm::WarningList* warnings = NULL);
-   std::string getSensorIdentifier() const;
-   std::string getPlatformIdentifier() const; 
-   std::string getCollectionIdentifier() const;
-   std::string getTrajectoryIdentifier() const;
-   std::string getSensorType() const;
-   std::string getSensorMode() const;
-   std::string getReferenceDateAndTime() const;
-   std::string getModelState() const;
-   void replaceModelState(const std::string& argState);
-   std::string constructStateFromIsd(const csm::Isd stringIsd);
+    AlternativeTestCsmModel();
+    ~AlternativeTestCsmModel();
+    // csm::Model methods
+    std::string getFamily() const;
+    csm::Version getVersion() const;
+    std::string getModelName() const;
+    std::string getPedigree() const;
+    std::string getImageIdentifier() const;
+    void setImageIdentifier(const std::string& imageId,
+                            csm::WarningList* warnings = NULL);
+    std::string getSensorIdentifier() const;
+    std::string getPlatformIdentifier() const;
+    std::string getCollectionIdentifier() const;
+    std::string getTrajectoryIdentifier() const;
+    std::string getSensorType() const;
+    std::string getSensorMode() const;
+    std::string getReferenceDateAndTime() const;
+    std::string getModelState() const;
+    void replaceModelState(const std::string& argState);
+    std::string constructStateFromIsd(const csm::Isd stringIsd);
+    // csm::GeometricModel methods
+    csm::EcefCoord getReferencePoint() const;
+    void setReferencePoint(const csm::EcefCoord& groundPt);
+    int getNumParameters() const;
+    std::string getParameterName(int index) const;
+    std::string getParameterUnits(int index) const;
+    bool hasShareableParameters() const;
+    bool isParameterShareable(int index) const;
+    csm::SharingCriteria getParameterSharingCriteria(int index) const;
+    double getParameterValue(int index) const;
+    void setParameterValue(int index, double value);
+    csm::param::Type getParameterType(int index) const;
+    void setParameterType(int index, csm::param::Type pType);
+    double getParameterCovariance(int index1,
+                                  int index2) const;
+    void setParameterCovariance(int index1,
+                                int index2,
+                                double covariance);
+    int getNumGeometricCorrectionSwitches() const;
+    std::string getGeometricCorrectionName(int index) const;
+    void setGeometricCorrectionSwitch(int index,
+                                      bool value,
+                                      csm::param::Type pType);
+    bool getGeometricCorrectionSwitch(int index) const;
+    std::vector<double> getCrossCovarianceMatrix(
+          const csm::GeometricModel& comparisonModel,
+          csm::param::Set pSet = csm::param::VALID,
+          const csm::GeometricModel::GeometricModelList& otherModels = GeometricModel::GeometricModelList()) const;
 
   private:
-    std::string m_modelState; 
+    std::string m_modelState;
+    std::vector<double> m_param_values;
 };
 #endif

--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -7,6 +7,7 @@
 #include "TestCsmPlugin.h"
 #include "Fixtures.h"
 #include "TestUtilities.h"
+#include "TestCsmModel.h"
 #include "StringBlob.h"
 #include "FileName.h"
 
@@ -26,6 +27,7 @@ class CSMPluginFixture : public TempTestingFiles {
     Pvl label;
     QString isdPath;
     QString filename;
+    TestCsmModel model;
 
     void SetUp() override {
       TempTestingFiles::SetUp();
@@ -47,8 +49,7 @@ class CSMPluginFixture : public TempTestingFiles {
         filename = tempDir.path() + "/csminitCube.cub";
         testCube->fromLabel(filename, label, "rw");
         testCube->close();
-        
-        // There should only be one plugin, so get the first one
+
         plugin = csm::Plugin::findPlugin("TestCsmPlugin");
       }
 
@@ -80,22 +81,32 @@ TEST_F(CSMPluginFixture, CSMInitDefault) {
   testCube->read(stateString);
 
   // Verify contents of the StringBlob's PVL label
-  PvlObject blobPvl = stateString.Label(); 
+  PvlObject blobPvl = stateString.Label();
   EXPECT_EQ(stateString.Name().toStdString(), "CSMState");
-  EXPECT_EQ(stateString.Type().toStdString(), "String"); 
+  EXPECT_EQ(stateString.Type().toStdString(), "String");
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
   EXPECT_TRUE(plugin->canModelBeConstructedFromState(stateString.string(), modelName));
 
-  // Check blob label ModelName and Plugin Name 
+  // Check blob label ModelName and Plugin Name
   EXPECT_EQ(QString(blobPvl.findKeyword("PluginName")).toStdString(), plugin->getPluginName());
-  EXPECT_EQ(modelName, "TestCsmModelName");
+  EXPECT_EQ(modelName, model.getModelName());
+
+  // Check the CsmInfo group
+  ASSERT_TRUE(testCube->hasGroup("CsmInfo"));
+  PvlGroup &infoGroup = testCube->group("CsmInfo");
+  ASSERT_TRUE(infoGroup.hasKeyword("CSMPlatformID"));
+  EXPECT_EQ(infoGroup["CSMPlatformID"][0].toStdString(), model.getPlatformIdentifier());
+  ASSERT_TRUE(infoGroup.hasKeyword("CSMInstrumentId"));
+  EXPECT_EQ(infoGroup["CSMInstrumentId"][0].toStdString(), model.getSensorIdentifier());
+  ASSERT_TRUE(infoGroup.hasKeyword("ReferenceTime"));
+  EXPECT_EQ(infoGroup["ReferenceTime"][0].toStdString(), model.getReferenceDateAndTime());
 }
 
 TEST_F(CSMPluginFixture, CSMinitRunTwice) {
-  // Run csminit twice in a row with the same options each time. Verify that end result is 
-  // as if csminit were only run once. 
+  // Run csminit twice in a row with the same options each time. Verify that end result is
+  // as if csminit were only run once.
   QVector<QString> args = {
     "from="+filename,
     "isd="+isdPath};
@@ -110,7 +121,7 @@ TEST_F(CSMPluginFixture, CSMinitRunTwice) {
   StringBlob stateString("", "CSMState");
   testCube->read(stateString);
   PvlObject blobPvl = stateString.Label();
-  
+
   // Make sure there is only one CSMState Blob on the label
   PvlObject *label = testCube->label();
   label->deleteObject("String");
@@ -118,20 +129,20 @@ TEST_F(CSMPluginFixture, CSMinitRunTwice) {
 
   // Verify contents of the StringBlob's PVL label
   EXPECT_EQ(stateString.Name().toStdString(), "CSMState");
-  EXPECT_EQ(stateString.Type().toStdString(), "String"); 
+  EXPECT_EQ(stateString.Type().toStdString(), "String");
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
   EXPECT_TRUE(plugin->canModelBeConstructedFromState(stateString.string(), modelName));
 
-  // Check blob label ModelName and Plugin Name 
+  // Check blob label ModelName and Plugin Name
   EXPECT_EQ(QString(blobPvl.findKeyword("PluginName")).toStdString(), plugin->getPluginName());
   EXPECT_EQ(QString(blobPvl.findKeyword("ModelName")).toStdString(), "TestCsmModelName");
 }
 
 TEST_F(CSMPluginFixture, CSMinitMultiplePossibleModels) {
   // Test csminit when multiple possible models can be created. First, verify that this will fail
-  // without specifying the MODELNAME, then specify the MODELNAME and check the results. 
+  // without specifying the MODELNAME, then specify the MODELNAME and check the results.
 
   // Create a test ISD could work for 2 models
   json isd;
@@ -152,7 +163,7 @@ TEST_F(CSMPluginFixture, CSMinitMultiplePossibleModels) {
   UserInterface options(APP_XML, args);
 
   // If there are two possible models, csminit will fail and prompt the user to specify the model
-  // and/or plugin name. 
+  // and/or plugin name.
   EXPECT_ANY_THROW(csminit(options));
 
   // Re-run with the model name specified
@@ -160,24 +171,24 @@ TEST_F(CSMPluginFixture, CSMinitMultiplePossibleModels) {
     "from="+filename,
     "isd="+isdPath,
     "modelName=AlternativeTestCsmModelName"};
-  
+
   UserInterface betterOptions(APP_XML, args);
   csminit(betterOptions);
 
   testCube->open(filename);
   StringBlob stateString("", "CSMState");
   testCube->read(stateString);
-  PvlObject blobPvl = stateString.Label(); 
+  PvlObject blobPvl = stateString.Label();
 
   // Check blobPvl contents
   EXPECT_EQ(stateString.Name().toStdString(), "CSMState");
-  EXPECT_EQ(stateString.Type().toStdString(), "String"); 
+  EXPECT_EQ(stateString.Type().toStdString(), "String");
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
   EXPECT_TRUE(plugin->canModelBeConstructedFromState(stateString.string(), modelName));
 
-  // check blob label ModelName and Plugin Name 
+  // check blob label ModelName and Plugin Name
   EXPECT_EQ(QString(blobPvl.findKeyword("PluginName")).toStdString(), plugin->getPluginName());
   EXPECT_EQ(QString(blobPvl.findKeyword("ModelName")).toStdString(), "AlternativeTestCsmModelName");
 }
@@ -200,7 +211,7 @@ TEST_F(CSMPluginFixture, CSMinitFails) {
     "isd="+isdPath};
 
   UserInterface options(APP_XML, args);
-  
+
   // Expect a failure due to being unable to construct any model from the isd
   EXPECT_ANY_THROW(csminit(options));
 }

--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -37,9 +37,8 @@ class CSMPluginFixture : public TempTestingFiles {
 
       // Create and populate test ISDs
       json isd;
-      isd["name"] = "test_isd";
-      isd["test_param_one"] = "value_one";
-      isd["test_param_two"] = "value_two";
+      isd["test_param_one"] = 1.0;
+      isd["test_param_two"] = 2.0;
 
       isdPath = tempDir.path() + "/default.json";
       std::ofstream file(isdPath.toStdString());
@@ -47,10 +46,10 @@ class CSMPluginFixture : public TempTestingFiles {
       file.flush();
 
       json altIsd;
-      altIsd["name"] = "test_isd";
-      altIsd["test_param_one"] = "value_one";
-      altIsd["test_param_two"] = "value_two";
-      altIsd["test_param_three"] = "value_three";
+      altIsd["test_param_one"] = 1.0;
+      altIsd["test_param_two"] = 2.0;
+      altIsd["test_param_three"] = 3.0;
+      altIsd["test_param_four"] = 4.0;
 
       altIsdPath = tempDir.path() + "/alternate.json";
       std::ofstream altFile(altIsdPath.toStdString());
@@ -101,7 +100,7 @@ TEST_F(CSMPluginFixture, CSMInitDefault) {
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
-  EXPECT_TRUE(plugin->canModelBeConstructedFromState(stateString.string(), modelName));
+  EXPECT_TRUE(plugin->canModelBeConstructedFromState(modelName, stateString.string()));
 
   // Check blob label ModelName and Plugin Name
   EXPECT_EQ(QString(blobPvl.findKeyword("PluginName")).toStdString(), plugin->getPluginName());
@@ -117,20 +116,17 @@ TEST_F(CSMPluginFixture, CSMInitDefault) {
   ASSERT_TRUE(infoGroup.hasKeyword("ReferenceTime"));
   EXPECT_EQ(infoGroup["ReferenceTime"][0].toStdString(), model.getReferenceDateAndTime());
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterNames"));
-  ASSERT_EQ(infoGroup["ModelParameterNames"].size(), 3);
-  ASSERT_EQ(infoGroup["ModelParameterNames"][0].toStdString(), TestCsmModel::PARAM_NAMES[0]);
-  ASSERT_EQ(infoGroup["ModelParameterNames"][1].toStdString(), TestCsmModel::PARAM_NAMES[1]);
-  ASSERT_EQ(infoGroup["ModelParameterNames"][2].toStdString(), TestCsmModel::PARAM_NAMES[2]);
+  ASSERT_EQ(infoGroup["ModelParameterNames"].size(), 2);
+  EXPECT_EQ(infoGroup["ModelParameterNames"][0].toStdString(), TestCsmModel::PARAM_NAMES[0]);
+  EXPECT_EQ(infoGroup["ModelParameterNames"][1].toStdString(), TestCsmModel::PARAM_NAMES[1]);
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterUnits"));
-  ASSERT_EQ(infoGroup["ModelParameterUnits"].size(), 3);
-  ASSERT_EQ(infoGroup["ModelParameterUnits"][0].toStdString(), TestCsmModel::PARAM_UNITS[0]);
-  ASSERT_EQ(infoGroup["ModelParameterUnits"][1].toStdString(), TestCsmModel::PARAM_UNITS[1]);
-  ASSERT_EQ(infoGroup["ModelParameterUnits"][2].toStdString(), TestCsmModel::PARAM_UNITS[2]);
+  ASSERT_EQ(infoGroup["ModelParameterUnits"].size(), 2);
+  EXPECT_EQ(infoGroup["ModelParameterUnits"][0].toStdString(), TestCsmModel::PARAM_UNITS[0]);
+  EXPECT_EQ(infoGroup["ModelParameterUnits"][1].toStdString(), TestCsmModel::PARAM_UNITS[1]);
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterTypes"));
-  ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 3);
-  ASSERT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "FICTITIOUS");
-  ASSERT_EQ(infoGroup["ModelParameterTypes"][1].toStdString(), "REAL");
-  ASSERT_EQ(infoGroup["ModelParameterTypes"][2].toStdString(), "FIXED");
+  ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 2);
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "FICTITIOUS");
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][1].toStdString(), "REAL");
 }
 
 TEST_F(CSMPluginFixture, CSMinitRunTwice) {
@@ -169,7 +165,7 @@ TEST_F(CSMPluginFixture, CSMinitRunTwice) {
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
-  EXPECT_TRUE(plugin->canModelBeConstructedFromState(stateString.string(), modelName));
+  EXPECT_TRUE(plugin->canModelBeConstructedFromState(modelName, stateString.string()));
 
   // Make sure there is only one CSMState Blob on the label
   PvlObject *label = testCube->label();
@@ -216,7 +212,7 @@ TEST_F(CSMPluginFixture, CSMinitMultiplePossibleModels) {
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
-  EXPECT_TRUE(plugin->canModelBeConstructedFromState(stateString.string(), modelName));
+  EXPECT_TRUE(plugin->canModelBeConstructedFromState(modelName, stateString.string()));
 
   // check blob label ModelName and Plugin Name
   EXPECT_EQ(QString(blobPvl.findKeyword("PluginName")).toStdString(), plugin->getPluginName());
@@ -232,17 +228,20 @@ TEST_F(CSMPluginFixture, CSMinitMultiplePossibleModels) {
   ASSERT_TRUE(infoGroup.hasKeyword("ReferenceTime"));
   EXPECT_EQ(infoGroup["ReferenceTime"][0].toStdString(), altModel.getReferenceDateAndTime());
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterNames"));
-  ASSERT_EQ(infoGroup["ModelParameterNames"].size(), 2);
-  ASSERT_EQ(infoGroup["ModelParameterNames"][0].toStdString(), AlternativeTestCsmModel::PARAM_NAMES[0]);
-  ASSERT_EQ(infoGroup["ModelParameterNames"][1].toStdString(), AlternativeTestCsmModel::PARAM_NAMES[1]);
+  ASSERT_EQ(infoGroup["ModelParameterNames"].size(), 3);
+  EXPECT_EQ(infoGroup["ModelParameterNames"][0].toStdString(), AlternativeTestCsmModel::PARAM_NAMES[0]);
+  EXPECT_EQ(infoGroup["ModelParameterNames"][1].toStdString(), AlternativeTestCsmModel::PARAM_NAMES[1]);
+  EXPECT_EQ(infoGroup["ModelParameterNames"][2].toStdString(), AlternativeTestCsmModel::PARAM_NAMES[2]);
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterUnits"));
-  ASSERT_EQ(infoGroup["ModelParameterUnits"].size(), 2);
-  ASSERT_EQ(infoGroup["ModelParameterUnits"][0].toStdString(), AlternativeTestCsmModel::PARAM_UNITS[0]);
-  ASSERT_EQ(infoGroup["ModelParameterUnits"][1].toStdString(), AlternativeTestCsmModel::PARAM_UNITS[1]);
+  ASSERT_EQ(infoGroup["ModelParameterUnits"].size(), 3);
+  EXPECT_EQ(infoGroup["ModelParameterUnits"][0].toStdString(), AlternativeTestCsmModel::PARAM_UNITS[0]);
+  EXPECT_EQ(infoGroup["ModelParameterUnits"][1].toStdString(), AlternativeTestCsmModel::PARAM_UNITS[1]);
+  EXPECT_EQ(infoGroup["ModelParameterUnits"][2].toStdString(), AlternativeTestCsmModel::PARAM_UNITS[2]);
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterTypes"));
-  ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 2);
-  ASSERT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "FICTITIOUS");
-  ASSERT_EQ(infoGroup["ModelParameterTypes"][1].toStdString(), "REAL");
+  ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 3);
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "FICTITIOUS");
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][1].toStdString(), "REAL");
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][2].toStdString(), "FIXED");
 }
 
 

--- a/isis/tests/TestCsmModel.cpp
+++ b/isis/tests/TestCsmModel.cpp
@@ -7,31 +7,22 @@ using json = nlohmann::json;
 const std::string TestCsmModel::SENSOR_MODEL_NAME = "TestCsmModelName";
 const std::vector<std::string> TestCsmModel::PARAM_NAMES = {
   "TestParam1",
-  "TestParam2",
-  "TestParam3",
-  "TestParam4"
+  "TestParam2"
 };
 const std::vector<std::string> TestCsmModel::PARAM_UNITS = {
   "m",
-  "rad",
-  "K",
-  "unitless"
+  "rad"
 };
 const std::vector<csm::param::Type> TestCsmModel::PARAM_TYPES = {
   csm::param::FICTITIOUS,
-  csm::param::REAL,
-  csm::param::FIXED,
-  csm::param::NONE
+  csm::param::REAL
 };
 const std::vector<csm::SharingCriteria> TestCsmModel::PARAM_SHARING_CRITERIA = {
-  csm::SharingCriteria(),
-  csm::SharingCriteria(),
   csm::SharingCriteria(),
   csm::SharingCriteria()
 };
 
 TestCsmModel::TestCsmModel() {
-  m_modelState = "TestCsmModel_ModelState";
   m_param_values.resize(TestCsmModel::PARAM_NAMES.size(), 0.0);
 };
 
@@ -92,11 +83,17 @@ std::string TestCsmModel::getReferenceDateAndTime() const {
 }
 
 std::string TestCsmModel::getModelState() const {
-  return m_modelState;
+  json state;
+  state["test_param_one"] = m_param_values[0];
+  state["test_param_two"] = m_param_values[1];
+  return TestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 
 void TestCsmModel::replaceModelState(const std::string& argState) {
-  m_modelState = argState;
+  // Get the JSON substring
+  json state = json::parse(argState.substr(argState.find("\n") + 1));
+  m_param_values[0] = state.at("test_param_one");
+  m_param_values[1] = state.at("test_param_two");
 }
 
 std::string TestCsmModel::constructStateFromIsd(const csm::Isd isd){
@@ -109,11 +106,11 @@ std::string TestCsmModel::constructStateFromIsd(const csm::Isd isd){
 
   json parsedIsd;
   isdFile >> parsedIsd;
+  // Only extract the first 2 parameters from the file
   json state;
-  state["name"] = parsedIsd.at("name");
   state["test_param_one"] = parsedIsd.at("test_param_one");
   state["test_param_two"] = parsedIsd.at("test_param_two");
-  return state.dump();
+  return TestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 
 

--- a/isis/tests/TestCsmModel.cpp
+++ b/isis/tests/TestCsmModel.cpp
@@ -6,8 +6,8 @@ using json = nlohmann::json;
 
 const std::string TestCsmModel::SENSOR_MODEL_NAME = "TestCsmModelName";
 const std::vector<std::string> TestCsmModel::PARAM_NAMES = {
-  "TestParam1",
-  "TestParam2"
+  "test_param_one",
+  "test_param_two"
 };
 const std::vector<std::string> TestCsmModel::PARAM_UNITS = {
   "m",
@@ -84,16 +84,18 @@ std::string TestCsmModel::getReferenceDateAndTime() const {
 
 std::string TestCsmModel::getModelState() const {
   json state;
-  state["test_param_one"] = m_param_values[0];
-  state["test_param_two"] = m_param_values[1];
+  for (size_t param_index = 0; param_index < m_param_values.size(); param_index++) {
+    state[TestCsmModel::PARAM_NAMES[param_index]] = m_param_values[param_index];
+  }
   return TestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 
 void TestCsmModel::replaceModelState(const std::string& argState) {
   // Get the JSON substring
   json state = json::parse(argState.substr(argState.find("\n") + 1));
-  m_param_values[0] = state.at("test_param_one");
-  m_param_values[1] = state.at("test_param_two");
+  for (size_t param_index = 0; param_index < m_param_values.size(); param_index++) {
+    m_param_values[param_index] = state.at(TestCsmModel::PARAM_NAMES[param_index]);
+  }
 }
 
 std::string TestCsmModel::constructStateFromIsd(const csm::Isd isd){
@@ -108,8 +110,9 @@ std::string TestCsmModel::constructStateFromIsd(const csm::Isd isd){
   isdFile >> parsedIsd;
   // Only extract the first 2 parameters from the file
   json state;
-  state["test_param_one"] = parsedIsd.at("test_param_one");
-  state["test_param_two"] = parsedIsd.at("test_param_two");
+  for (size_t param_index = 0; param_index < m_param_values.size(); param_index++) {
+    state[TestCsmModel::PARAM_NAMES[param_index]] = parsedIsd.at(TestCsmModel::PARAM_NAMES[param_index]);
+  }
   return TestCsmModel::SENSOR_MODEL_NAME + "\n" + state.dump();
 }
 

--- a/isis/tests/TestCsmModel.cpp
+++ b/isis/tests/TestCsmModel.cpp
@@ -4,8 +4,35 @@
 #include <nlohmann/json.hpp>
 using json = nlohmann::json;
 
+const std::string TestCsmModel::SENSOR_MODEL_NAME = "TestCsmModelName";
+const std::vector<std::string> TestCsmModel::PARAM_NAMES = {
+  "TestParam1",
+  "TestParam2",
+  "TestParam3",
+  "TestParam4"
+};
+const std::vector<std::string> TestCsmModel::PARAM_UNITS = {
+  "m",
+  "rad",
+  "K",
+  "unitless"
+};
+const std::vector<csm::param::Type> TestCsmModel::PARAM_TYPES = {
+  csm::param::FICTITIOUS,
+  csm::param::REAL,
+  csm::param::FIXED,
+  csm::param::NONE
+};
+const std::vector<csm::SharingCriteria> TestCsmModel::PARAM_SHARING_CRITERIA = {
+  csm::SharingCriteria(),
+  csm::SharingCriteria(),
+  csm::SharingCriteria(),
+  csm::SharingCriteria()
+};
+
 TestCsmModel::TestCsmModel() {
   m_modelState = "TestCsmModel_ModelState";
+  m_param_values.resize(TestCsmModel::PARAM_NAMES.size(), 0.0);
 };
 
 TestCsmModel::~TestCsmModel() {
@@ -20,7 +47,7 @@ csm::Version TestCsmModel::getVersion() const {
 }
 
 std::string TestCsmModel::getModelName() const {
-  return "TestCsmModelName";
+  return TestCsmModel::SENSOR_MODEL_NAME;
 }
 
 std::string TestCsmModel::getPedigree() const {
@@ -87,6 +114,113 @@ std::string TestCsmModel::constructStateFromIsd(const csm::Isd isd){
   state["test_param_one"] = parsedIsd.at("test_param_one");
   state["test_param_two"] = parsedIsd.at("test_param_two");
   return state.dump();
+}
+
+
+csm::EcefCoord TestCsmModel::getReferencePoint() const {
+  return csm::EcefCoord(0.0, 0.0, 0.0);
+}
+
+void TestCsmModel::setReferencePoint(const csm::EcefCoord& groundPt) {
+  // do nothing for test
+}
+
+int TestCsmModel::getNumParameters() const {
+  return m_param_values.size();
+}
+
+std::string TestCsmModel::getParameterName(int index) const {
+  return TestCsmModel::PARAM_NAMES[index];
+}
+
+
+std::string TestCsmModel::getParameterUnits(int index) const {
+  return TestCsmModel::PARAM_UNITS[index];
+}
+
+bool TestCsmModel::hasShareableParameters() const {
+  return false;
+}
+
+bool TestCsmModel::isParameterShareable(int index) const {
+  return false;
+}
+
+csm::SharingCriteria TestCsmModel::getParameterSharingCriteria(int index) const {
+  return TestCsmModel::PARAM_SHARING_CRITERIA[index];
+}
+
+double TestCsmModel::getParameterValue(int index) const {
+  return m_param_values[index];
+}
+
+void TestCsmModel::setParameterValue(int index, double value) {
+  m_param_values[index] = value;
+}
+
+csm::param::Type TestCsmModel::getParameterType(int index) const {
+  return TestCsmModel::PARAM_TYPES[index];
+}
+
+void TestCsmModel::setParameterType(int index, csm::param::Type pType) {
+  // do nothing for test
+}
+
+double TestCsmModel::getParameterCovariance(int index1,
+                                            int index2) const {
+  // default to identity covariance matrix
+  if (index1 == index2) {
+    return 1.0;
+  }
+  return 0.0;
+                              }
+void TestCsmModel::setParameterCovariance(int index1,
+                                          int index2,
+                                          double covariance) {
+  // do nothing for test
+}
+
+int TestCsmModel::getNumGeometricCorrectionSwitches() const {
+  return 0;
+}
+
+std::string TestCsmModel::getGeometricCorrectionName(int index) const {
+  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
+                   "TestCsmModel::getGeometricCorrectionName");
+}
+
+void TestCsmModel::setGeometricCorrectionSwitch(int index,
+                                  bool value,
+                                  csm::param::Type pType) {
+  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
+                  "TestCsmModel::setGeometricCorrectionSwitch");
+}
+
+bool TestCsmModel::getGeometricCorrectionSwitch(int index) const {
+  throw csm::Error(csm::Error::INDEX_OUT_OF_RANGE, "Index out of range.",
+                   "TestCsmModel::getGeometricCorrectionSwitch");
+}
+
+std::vector<double> TestCsmModel::getCrossCovarianceMatrix(
+      const csm::GeometricModel& comparisonModel,
+      csm::param::Set pSet,
+      const csm::GeometricModel::GeometricModelList& otherModels) const {
+  const std::vector<int>& rowIndices = getParameterSetIndices(pSet);
+  size_t numRows = rowIndices.size();
+  const std::vector<int>& colIndices = comparisonModel.getParameterSetIndices(pSet);
+  size_t numCols = colIndices.size();
+  std::vector<double> covariance(numRows * numCols, 0.0);
+
+  if (&comparisonModel == this) {
+    for (size_t rowIndex = 0; rowIndex <  numRows; numRows++) {
+      for (size_t colIndex = 0; colIndex < numCols; colIndex++) {
+        covariance[rowIndex * numCols + colIndex] = getParameterCovariance(rowIndices[rowIndex],
+                                                                           colIndices[colIndex]);
+      }
+    }
+  }
+
+  return covariance;
 }
 
 

--- a/isis/tests/TestCsmModel.h
+++ b/isis/tests/TestCsmModel.h
@@ -3,36 +3,72 @@
 
 #include <string>
 
+#include "csm/GeometricModel.h"
 #include "csm/Plugin.h"
-#include "csm/Model.h"
 #include "csm/Version.h"
 
 #include <nlohmann/json.hpp>
 
-class TestCsmModel : public csm::Model {
- public:
-   TestCsmModel();
-   ~TestCsmModel();
+class TestCsmModel : public csm::GeometricModel {
+  public:
+    // Static variables that describe the model
+    static const std::string SENSOR_MODEL_NAME;
+    static const std::vector<std::string> PARAM_NAMES;
+    static const std::vector<std::string> PARAM_UNITS;
+    static const std::vector<csm::param::Type> PARAM_TYPES;
+    static const std::vector<csm::SharingCriteria> PARAM_SHARING_CRITERIA;
 
-   std::string getFamily() const;
-   csm::Version getVersion() const;
-   std::string getModelName() const;
-   std::string getPedigree() const;
-   std::string getImageIdentifier() const;
-   void setImageIdentifier(const std::string& imageId,
-                           csm::WarningList* warnings = NULL);
-   std::string getSensorIdentifier() const;
-   std::string getPlatformIdentifier() const; 
-   std::string getCollectionIdentifier() const;
-   std::string getTrajectoryIdentifier() const;
-   std::string getSensorType() const;
-   std::string getSensorMode() const;
-   std::string getReferenceDateAndTime() const;
-   std::string getModelState() const;
-   void replaceModelState(const std::string& argState);
-   std::string constructStateFromIsd(const csm::Isd stringIsd);
+    TestCsmModel();
+    ~TestCsmModel();
+    // csm::Model methods
+    std::string getFamily() const;
+    csm::Version getVersion() const;
+    std::string getModelName() const;
+    std::string getPedigree() const;
+    std::string getImageIdentifier() const;
+    void setImageIdentifier(const std::string& imageId,
+                            csm::WarningList* warnings = NULL);
+    std::string getSensorIdentifier() const;
+    std::string getPlatformIdentifier() const;
+    std::string getCollectionIdentifier() const;
+    std::string getTrajectoryIdentifier() const;
+    std::string getSensorType() const;
+    std::string getSensorMode() const;
+    std::string getReferenceDateAndTime() const;
+    std::string getModelState() const;
+    void replaceModelState(const std::string& argState);
+    std::string constructStateFromIsd(const csm::Isd stringIsd);
+    // csm::GeometricModel methods
+    csm::EcefCoord getReferencePoint() const;
+    void setReferencePoint(const csm::EcefCoord& groundPt);
+    int getNumParameters() const;
+    std::string getParameterName(int index) const;
+    std::string getParameterUnits(int index) const;
+    bool hasShareableParameters() const;
+    bool isParameterShareable(int index) const;
+    csm::SharingCriteria getParameterSharingCriteria(int index) const;
+    double getParameterValue(int index) const;
+    void setParameterValue(int index, double value);
+    csm::param::Type getParameterType(int index) const;
+    void setParameterType(int index, csm::param::Type pType);
+    double getParameterCovariance(int index1,
+                                  int index2) const;
+    void setParameterCovariance(int index1,
+                                int index2,
+                                double covariance);
+    int getNumGeometricCorrectionSwitches() const;
+    std::string getGeometricCorrectionName(int index) const;
+    void setGeometricCorrectionSwitch(int index,
+                                      bool value,
+                                      csm::param::Type pType);
+    bool getGeometricCorrectionSwitch(int index) const;
+    std::vector<double> getCrossCovarianceMatrix(
+          const csm::GeometricModel& comparisonModel,
+          csm::param::Set pSet = csm::param::VALID,
+          const csm::GeometricModel::GeometricModelList& otherModels = GeometricModel::GeometricModelList()) const;
 
   private:
-    std::string m_modelState; 
+    std::string m_modelState;
+    std::vector<double> m_param_values;
 };
 #endif

--- a/isis/tests/TestCsmModel.h
+++ b/isis/tests/TestCsmModel.h
@@ -68,7 +68,6 @@ class TestCsmModel : public csm::GeometricModel {
           const csm::GeometricModel::GeometricModelList& otherModels = GeometricModel::GeometricModelList()) const;
 
   private:
-    std::string m_modelState;
     std::vector<double> m_param_values;
 };
 #endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This moved the user info about the csm model into a separate group called CsmInfo to make clean up easier. It also adds more info to the labels and updates the test CSM models to be geometric models and not just models.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
csm support in ISIS project

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes it much easier to clean-up what csminit adds to the label in future runs of csminit or spiceinit. A PR with modification to make them clean-up each-other is coming after this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested all csminit tests on Mac and Ubuntu.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
