### PR TITLE
Added the ability to run spiceinit and csminit in any order

### DIFF
--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -259,6 +259,11 @@ namespace Isis {
         throw IException(IException::Unknown,
                          "Unable to initialize camera model",
                          _FILEINFO_);
+      else {
+        // Remove csminit data from the cube after successful run
+        icube->deleteGroup("CsmInfo");
+        icube->deleteBlob("String","CSMState");
+      }
     }
     p.EndProcess();
   }
@@ -695,5 +700,9 @@ namespace Isis {
 
     delete sunPosTable;
     sunPosTable = NULL;
+
+    // Remove csminit data from the cube after successful run
+    icube->deleteGroup("CsmInfo");
+    icube->deleteBlob("String","CSMState");
   }
 }

--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -279,6 +279,8 @@ TEST_F(CSMPluginFixture, CSMinitFails) {
 }
 
 
+// This test uses the DefaultCube fixture because it has already has attached
+// spice data that csminit should remove.
 TEST_F(DefaultCube, CSMinitSpiceCleanup) {
   // Create an ISD
   json isd;
@@ -311,7 +313,9 @@ TEST_F(DefaultCube, CSMinitSpiceCleanup) {
 }
 
 
-TEST_F(DefaultCube, CSMinitSpiceCleanupFailure) {
+// This test uses the DefaultCube fixture because it has already has attached
+// spice data that csminit should not remove on a failure.
+TEST_F(DefaultCube, CSMinitSpiceNoCleanup) {
   // Create an ISD that will result in no successful models
   json isd;
   isd["name"] = "failing_isd";

--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -1,5 +1,4 @@
 #include "csminit.h"
-#include "spiceinit.h"
 
 #include <QString>
 #include <iostream>
@@ -127,6 +126,11 @@ TEST_F(CSMPluginFixture, CSMInitDefault) {
   ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 2);
   EXPECT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "FICTITIOUS");
   EXPECT_EQ(infoGroup["ModelParameterTypes"][1].toStdString(), "REAL");
+
+  // Check the Kernels group
+  ASSERT_TRUE(testCube->hasGroup("Kernels"));
+  PvlGroup &kernGroup = testCube->group("Kernels");
+  EXPECT_TRUE(kernGroup.hasKeyword("ShapeModel"));
 }
 
 TEST_F(CSMPluginFixture, CSMinitRunTwice) {
@@ -176,6 +180,13 @@ TEST_F(CSMPluginFixture, CSMinitRunTwice) {
   ASSERT_TRUE(testCube->hasGroup("CsmInfo"));
   testCube->deleteGroup("CsmInfo");
   ASSERT_FALSE(testCube->hasGroup("CsmInfo"));
+
+  // Check that there is only one ShapeModel
+  ASSERT_TRUE(testCube->hasGroup("Kernels"));
+  PvlGroup &kernGroup = testCube->group("Kernels");
+  EXPECT_TRUE(kernGroup.hasKeyword("ShapeModel"));
+  kernGroup.deleteKeyword("ShapeModel");
+  EXPECT_FALSE(kernGroup.hasKeyword("ShapeModel"));
 }
 
 TEST_F(CSMPluginFixture, CSMinitMultiplePossibleModels) {
@@ -265,4 +276,65 @@ TEST_F(CSMPluginFixture, CSMinitFails) {
 
   // Expect a failure due to being unable to construct any model from the isd
   EXPECT_ANY_THROW(csminit(options));
+}
+
+
+TEST_F(DefaultCube, CSMinitSpiceCleanup) {
+  // Create an ISD
+  json isd;
+  isd["test_param_one"] = 1.0;
+  isd["test_param_two"] = 2.0;
+
+  QString isdPath = tempDir.path() + "/default.json";
+  std::ofstream file(isdPath.toStdString());
+  file << isd;
+  file.flush();
+
+  QVector<QString> args = {
+    "from="+testCube->fileName(),
+    "isd="+isdPath};
+  QString cubeFile = testCube->fileName();
+
+  UserInterface options(APP_XML, args);
+
+  testCube->close();
+  csminit(options);
+  Cube outputCube(cubeFile);
+
+  EXPECT_FALSE(outputCube.hasTable("InstrumentPointing"));
+  EXPECT_FALSE(outputCube.hasTable("InstrumentPosition"));
+  EXPECT_FALSE(outputCube.hasTable("BodyRotation"));
+  EXPECT_FALSE(outputCube.hasTable("SunPosition"));
+  EXPECT_FALSE(outputCube.hasTable("CameraStatistics"));
+  ASSERT_TRUE(outputCube.hasGroup("Kernels"));
+  EXPECT_EQ(outputCube.group("Kernels").keywords(), 2);
+}
+
+
+TEST_F(DefaultCube, CSMinitSpiceCleanupFailure) {
+  // Create an ISD that will result in no successful models
+  json isd;
+  isd["name"] = "failing_isd";
+  isd["test_param_one"] = "value_one";
+  isd["test_param_does_not_exist"] = "failing_value";
+
+  QString isdPath = tempDir.path() + "/default.json";
+  std::ofstream file(isdPath.toStdString());
+  file << isd;
+  file.flush();
+
+  QVector<QString> args = {
+    "from="+testCube->fileName(),
+    "isd="+isdPath};
+  QString cubeFile = testCube->fileName();
+
+  UserInterface options(APP_XML, args);
+
+  testCube->close();
+  // Expect a failure due to being unable to construct any model from the isd
+  EXPECT_ANY_THROW(csminit(options));
+  Cube outputCube(cubeFile);
+
+  // The cube should still be intact and we should still be able to get a camera
+  EXPECT_NO_THROW(outputCube.camera());
 }

--- a/isis/tests/spiceinitTests.cpp
+++ b/isis/tests/spiceinitTests.cpp
@@ -515,6 +515,7 @@ TEST(Spiceinit, TestSpiceinitPadding) {
 }
 
 TEST_F(DefaultCube, TestSpiceinitCsmCleanup) {
+  // Add stuff from csminit
   testCube->putGroup(PvlGroup("CsmInfo"));
   StringBlob testBlob("test string", "CSMState");
   testCube->write(testBlob);
@@ -525,4 +526,21 @@ TEST_F(DefaultCube, TestSpiceinitCsmCleanup) {
 
   EXPECT_FALSE(testCube->hasGroup("CsmInfo"));
   EXPECT_ANY_THROW(testCube->read(testBlob));
+}
+
+TEST_F(DefaultCube, TestSpiceinitCsmNoCleanup) {
+  // Add stuff from csminit
+  testCube->putGroup(PvlGroup("CsmInfo"));
+  StringBlob testBlob("test string", "CSMState");
+  testCube->write(testBlob);
+
+  // Mangle the cube so that spiceinit failes
+  testCube->deleteGroup("Instrument");
+
+  QVector<QString> args(0);
+  UserInterface options(APP_XML, args);
+  ASSERT_ANY_THROW(spiceinit(testCube, options));
+
+  EXPECT_TRUE(testCube->hasGroup("CsmInfo"));
+  EXPECT_NO_THROW(testCube->read(testBlob));
 }

--- a/isis/tests/spiceinitTests.cpp
+++ b/isis/tests/spiceinitTests.cpp
@@ -9,6 +9,7 @@
 #include "Pvl.h"
 #include "PvlGroup.h"
 #include "PvlKeyword.h"
+#include "StringBlob.h"
 #include "TestUtilities.h"
 #include "FileName.h"
 
@@ -511,4 +512,17 @@ TEST(Spiceinit, TestSpiceinitPadding) {
   ASSERT_EQ(kernels["EndPadding"].size(), 1);
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, kernels["EndPadding"][0], "0.5");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, kernels["EndPadding"].unit(0), "seconds");
+}
+
+TEST_F(DefaultCube, TestSpiceinitCsmCleanup) {
+  testCube->putGroup(PvlGroup("CsmInfo"));
+  StringBlob testBlob("test string", "CSMState");
+  testCube->write(testBlob);
+
+  QVector<QString> args(0);
+  UserInterface options(APP_XML, args);
+  spiceinit(testCube, options);
+
+  EXPECT_FALSE(testCube->hasGroup("CsmInfo"));
+  EXPECT_ANY_THROW(testCube->read(testBlob));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Modified csminit and spiceinit to clean-up after one-another. I also added tests that check the programs properly remove stuff from one another but only on successful runs.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
More CSM support work

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows users to swap back and forth between ISIS and CSM models when both are available for an image.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally on Mac by running csminit -> spiceinit -> csminit -> spiceinit. Also, added automated testing which passed on Mac and Ubuntu.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
