### PR TITLE
Added fix to half pixel issue in Camera.cpp - ISIS Issue 4018 

### DIFF
--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -1540,9 +1540,10 @@ namespace Isis {
       // order of points in vector is top, bottom, left, right
       QList< QPair< double, double > > surroundingPoints;
       surroundingPoints.append(qMakePair(samp, line - 0.5));
-      surroundingPoints.append(qMakePair(samp, line + 0.5 - DBL_MIN));
+      //surroundingPoints.append(qMakePair(samp, line + 0.5 - DBL_MIN));
+			surroundingPoints.append(qMakePair(samp, std::nexttoward(line + 0.5 - DBL_MIN)));
       surroundingPoints.append(qMakePair(samp - 0.5, line));
-      surroundingPoints.append(qMakePair(samp + 0.5 - DBL_MIN, line));
+      surroundingPoints.append(qMakePair(std::nexttoward(samp + 0.5 - DBL_MIN, line)));
 
       // save input state to be restored on return
       double originalSample = samp;


### PR DESCRIPTION
In the detector map, the cast to an integer is rounding:

int framelet = (int)((line - 0.5) / actualFrameletHeight) + 1;

In the pixels on the edge of the framelet, this is rounding incorrectly and mapping to the next/previous framelet.

ISIS [issue 4018]