### PR TITLE
Allows user to use the web service and specify a shape model with spiceinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ update the Unreleased link so that it compares against the latest release tag.
 
 - Added documentation to lronaccal and lrowaccal to describe why there are negative DNs in I/F calibrated images. [#3860](https://github.com/USGS-Astrogeology/ISIS3/issues/3860)
 - Update qview MeasureTool to add an option to calculate distances using RA/DEC and update qview to show DEC/RA rather than LAT/LON in lower-right corner [#3371](https://github.com/USGS-Astrogeology/ISIS3/issues/3371)
-
+- Updated spiceinit so that a user can specify a shape model and use the spice web service without any errors. [#1986](https://github.com/USGS-Astrogeology/ISIS3/issues/1986) 
 ### Fixed
 
 - Fixed lrowaccal so required SPICE files are reported instead of continuing without them. [#4038](https://github.com/USGS-Astrogeology/ISIS3/issues/4038)

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -612,11 +612,7 @@ namespace Isis {
     QString shape     = QString(ui.GetString("SHAPE")).toLower();
 
     if (shape == "user") {
-      shape = QString(ui.GetAsString("MODEL"));
-
-      // Test for valid labels with mapping group at least
-      Pvl shapeTest(shape);
-      shapeTest.findGroup("Mapping", Pvl::Traverse);
+      shape = "ellipsoid";
     }
 
     double startPad = ui.GetDouble("STARTPAD");
@@ -637,7 +633,6 @@ namespace Isis {
     connectionProgress.CheckStatus();
 
     PvlGroup kernelsGroup = client.kernelsGroup();
-    PvlGroup logGrp = client.applicationLog();
     PvlObject naifKeywords = client.naifKeywordsObject();
     Table *pointingTable = client.pointingTable();
     Table *positionTable = client.positionTable();
@@ -662,12 +657,17 @@ namespace Isis {
         continue;
       }
     }
-
-    if (log) {
-      log->addGroup(logGrp);
+    
+    if (QString(ui.GetString("SHAPE")).toLower() == "user") {
+      kernelsGroup["ShapeModel"] = ui.GetAsString("MODEL");
     }
 
     icube->putGroup(kernelsGroup);
+
+    if (log) {
+      log->addGroup(kernelsGroup);
+    }
+
     icube->label()->addObject(naifKeywords);
 
     icube->write(*pointingTable);

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -658,8 +658,8 @@ namespace Isis {
       }
     }
     
-    if (QString(ui.GetString("SHAPE")).toLower() == "user") {
-      kernelsGroup["ShapeModel"] = ui.GetAsString("MODEL");
+    if (ui.GetString("SHAPE") == "USER") {
+      kernelsGroup["ShapeModel"] = ui.GetFileName("MODEL");
     }
 
     icube->putGroup(kernelsGroup);

--- a/isis/src/base/apps/spiceinit/spiceinit.xml
+++ b/isis/src/base/apps/spiceinit/spiceinit.xml
@@ -295,6 +295,10 @@
       derived from bundle adjustment can be used alongside CKs derived from bundle adjustment.
       Fixes #3669.
     </change>
+    <change name="Kaitlyn Lee" date="2020-12-21">
+      Updated shape model keyword in the kernels group when shape=user and web=true with the user
+      specified model. Fixes #1986
+    </change>
   </history>
 
   <oldName>

--- a/isis/tests/FunctionalTestsSpiceinit.cpp
+++ b/isis/tests/FunctionalTestsSpiceinit.cpp
@@ -518,3 +518,109 @@ TEST(Spiceinit, TestSpiceinitPadding) {
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, kernels["EndPadding"][0], "0.5");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, kernels["EndPadding"].unit(0), "seconds");
 }
+
+TEST_F(DemCube, FunctionalTestSpiceinitWebAndShapeModel) {
+
+  std::istringstream labelStrm(R"(
+    Object = IsisCube
+      Object = Core
+        StartByte   = 65537
+        Format      = Tile
+        TileSamples = 128
+        TileLines   = 128
+
+        Group = Dimensions
+          Samples = 1204
+          Lines   = 1056
+          Bands   = 1
+        End_Group
+
+        Group = Pixels
+          Type       = UnsignedByte
+          ByteOrder  = Lsb
+          Base       = 0.0
+          Multiplier = 1.0
+        End_Group
+      End_Object
+
+      Group = Instrument
+        SpacecraftName       = VIKING_ORBITER_1
+        InstrumentId         = VISUAL_IMAGING_SUBSYSTEM_CAMERA_B
+        TargetName           = MARS
+        StartTime            = 1977-07-09T20:05:51
+        ExposureDuration     = 0.008480 <seconds>
+        SpacecraftClockCount = 33322515
+        FloodModeId          = ON
+        GainModeId           = HIGH
+        OffsetModeId         = ON
+      End_Group
+
+      Group = Archive
+        DataSetId       = VO1/VO2-M-VIS-2-EDR-V2.0
+        ProductId       = 387A06
+        MissonPhaseName = EXTENDED_MISSION
+        ImageNumber     = 33322515
+        OrbitNumber     = 387
+      End_Group
+
+      Group = BandBin
+        FilterName = CLEAR
+        FilterId   = 4
+      End_Group
+
+      Group = Kernels
+        NaifFrameCode = -27002
+      End_Group
+
+      Group = Reseaus
+        Line     = (5, 6, 8, 9, 10, 11, 12, 13, 14, 14, 15, 133, 134, 135, 137,
+                    138, 139, 140, 141, 141, 142, 143, 144, 263, 264, 266, 267,
+                    268, 269, 269, 270, 271, 272, 273, 393, 393, 395, 396, 397,
+                    398, 399, 399, 400, 401, 402, 403, 523, 524, 525, 526, 527,
+                    527, 528, 529, 530, 530, 532, 652, 652, 654, 655, 656, 657,
+                    657, 658, 659, 660, 661, 662, 781, 783, 784, 785, 786, 787,
+                    788, 788, 789, 790, 791, 911, 912, 913, 914, 915, 916, 917,
+                    918, 918, 919, 920, 921, 1040, 1041, 1043, 1044, 1045, 1045,
+                    1046, 1047, 1047, 1048, 1050)
+        Sample   = (24, 142, 259, 375, 491, 607, 723, 839, 954, 1070, 1185, 24,
+                    84, 201, 317, 433, 549, 665, 780, 896, 1011, 1127, 1183, 25,
+                    142, 259, 375, 492, 607, 722, 838, 953, 1068, 1183, 25, 84,
+                    201, 317, 433, 549, 665, 779, 895, 1010, 1125, 1182, 25, 143,
+                    259, 375, 491, 607, 722, 837, 952, 1067, 1182, 25, 84, 201,
+                    317, 433, 548, 664, 779, 894, 1009, 1124, 1181, 25, 142, 258,
+                    374, 490, 605, 720, 835, 951, 1066, 1180, 24, 83, 200, 316,
+                    431, 547, 662, 776, 892, 1007, 1122, 1179, 23, 140, 257, 373,
+                    488, 603, 718, 833, 948, 1063, 1179)
+        Type     = (1, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5,
+                    5, 6, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 4, 5, 5, 5, 5, 5, 5, 5,
+                    5, 5, 5, 6, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 4, 5, 5, 5, 5, 5,
+                    5, 5, 5, 5, 5, 6, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 4, 5, 5, 5,
+                    5, 5, 5, 5, 5, 5, 5, 6, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6)
+        Valid    = (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+        Template = $viking1/reseaus/vo1.visb.template.cub
+        Status   = Nominal
+      End_Group
+    End_Object
+  End
+  )");
+
+  Pvl label;
+  labelStrm >> label;
+
+  QTemporaryFile tempFile;
+  tempFile.open();
+  Cube testCube;
+
+  testCube.fromLabel(tempFile.fileName() + ".cub", label, "rw");
+
+  QVector<QString> args = {"web=true", "shape=user", "model=" + demCube->fileName()};
+  UserInterface options(APP_XML, args);
+  spiceinit(&testCube, options);
+
+  PvlGroup kernels = testCube.label()->findGroup("Kernels", Pvl::Traverse);
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, kernels.findKeyword("ShapeModel"), demCube->fileName());
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The spice server used to error when trying to use a user specified shape model. Refactored the code so that an ellipsoid is used for the web service, then overwrites the shape model keyword in the Kernels group with the user specified model.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes https://github.com/USGS-Astrogeology/ISIS3/issues/1986
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows user to specify a shape model while using the spice server.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran spiceinit on a test cube and DEM and made sure the output cube had the correct shape model in the Kernels group.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
