### PR TITLE
Updated wavelength/bandwidth values in TgoCassisMosaicBandBin.trn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ update the Unreleased link so that it compares against the latest release tag.
 
 - Fixed lrowaccal so required SPICE files are reported instead of continuing without them. [#4038](https://github.com/USGS-Astrogeology/ISIS3/issues/4038)
 - Fixed not being able to enable USECOORDLIST argument in mappt. [#4150](https://github.com/USGS-Astrogeology/ISIS3/issues/4150)
+- Updated wavelength and bandbin values in translation files for the TGO CaSSIS BandBin group. [4147](https://github.com/USGS-Astrogeology/ISIS3/issues/4147)
 
 ## [4.3.0] - 2020-10-02
 

--- a/isis/src/tgo/apps/tgocassis2isis/TgoCassisMosaicBandBin.trn
+++ b/isis/src/tgo/apps/tgocassis2isis/TgoCassisMosaicBandBin.trn
@@ -37,6 +37,8 @@
 #
 # history:
 #   2018-06-13 Kristin Berry - Original Version. 
+#   2020-12-22 Kaitlyn Lee - Updated Center and Width translations to match
+                             TgoCassisBandBin.trn.
 
 Group = FilterName
   Auto
@@ -54,10 +56,10 @@ Group = Center
   InputKey       = img:filter_name
   OutputName     = Center
   OutputPosition = (Object, IsisCube, Group, BandBin)
-  Translation    = (675, PAN)
-  Translation    = (485, BLU)
-  Translation    = (840, RED)
-  Translation    = (985, NIR)
+  Translation    = (677.4, PAN)
+  Translation    = (497.4, BLU)
+  Translation    = (835.4, RED)
+  Translation    = (940.2, NIR)
 
 End_Group
 
@@ -67,10 +69,10 @@ Group = Width
   InputKey       = img:filter_name
   OutputName     = Width
   OutputPosition = (Object, IsisCube, Group, BandBin)
-  Translation    = (250, PAN)
-  Translation    = (165, BLU)
-  Translation    = (100, RED)
-  Translation    = (220, NIR)
+  Translation    = (231.5, PAN)
+  Translation    = (134.3, BLU)
+  Translation    = (98.0, RED)
+  Translation    = (120.6, NIR)
 
 End_Group
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes https://github.com/USGS-Astrogeology/ISIS3/issues/4147

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Reingested mosaics will now have the correct values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all tgo tests and these changes do not appear to cause any failures even though the tests are currently failing on Jenkins.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
