### PR TITLE
Jigsaw Target Radii Warning

### DIFF
--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -54,6 +54,17 @@ namespace Isis {
 
     // retrieve settings from jigsaw gui
     BundleSettingsQsp settings = bundleSettings(ui);
+    if(settings->bundleTargetBody()->solveTriaxialRadii() ||
+       settings->bundleTargetBody()->solveMeanRadius()) {
+      PvlGroup radiusSolveWarning("RadiusSolveWarning");
+      radiusSolveWarning.addKeyword(PvlKeyword("Warning", "The radii solve is currently \
+                                                 under review and is likely resulting \
+                                                 in addition error in the bundle adjust. \
+                                                 We recommend that you do not solve for radii at this moment."));
+       if(log) {
+         log->PvlObject::addGroup(radiusSolveWarning);
+       }
+    }
     settings->setCubeList(cubeList);
     BundleAdjust *bundleAdjustment = NULL;
     try {
@@ -147,12 +158,12 @@ namespace Isis {
       if (log) {
         Pvl summary;
         std::istringstream iss (bundleAdjustment->iterationSummaryGroup().toStdString());
-        iss >> summary; 
-        
+        iss >> summary;
+
         for (auto grpIt = summary.beginGroup(); grpIt!= summary.endGroup(); grpIt++) {
           log->addGroup(*grpIt);
         }
-        
+
         log->addGroup(gp);
       }
       delete bundleSolution;

--- a/isis/src/control/apps/jigsaw/jigsaw.xml
+++ b/isis/src/control/apps/jigsaw/jigsaw.xml
@@ -94,23 +94,26 @@
       </blockquote>
 
       <blockquote>
-      <b>Solving for the target body radii (triaxial or mean) is irrelavent and
+      <b>Solving for the target body radii (triaxial or mean) is NOT possible and
       likely increases error in the solve.</b>
       <p>
-        When solving for target body radii both the mean and triaxial solve options
-        are redundantly solving for the target body radii. The radii solve is part of
-        the sequence of equations that the <b>jigsaw</b> uses to compute various partial
-        derivatives to populate the solve matrix. The radii solve is being applied
-        to the target body separately and the partials from this separate application
-        are being added to the solve matrix. This is adding additional computation time
-        to <b>jigsaw</b> and creating additional uncertainty/error in the bundle adjust. We
-        advise this radii solve to be avoided.
+        With the current jigsaw implementation, it is NOT possible to individually
+        solve for either the mean or triaxial radii as seperate calculations in
+        the bundle adjustment. More specifically, the target body radii has no
+        effect when solving for individual points and thus cannot be solved for in the bundle.
+        A local radii solve is already part of the sequence of equations that <b>jigsaw</b>
+        uses to compute various partial derivatives to populate the solve matrix.
+        A seperate mean or triaxial radii solve can be applied to the target body
+        and the partials from this separate application are added to the
+        solve matrix. This option adds additional computation time to <b>jigsaw</b>
+        and creates additional uncertainty/error in the bundle adjust. We advise
+        the mean and triaxial radii solve be avoided.
       </p>
       <p>
-        If you are trying to generate a spheroid from a control network their are
+        If you are trying to generate a spheroid from a control network there are
         other programs that can do this for you. An easier but more naive method
-        is ingesting the <i>OUTPUT_CSV</i> from your network and generating radii
-        information from those points.
+        is ingesting the <i>OUTPUT_CSV</i> from your network, gather local radii
+        information from those points, then generate a sphereiod from those local radii.
       </p>
       </blockquote>
 

--- a/isis/src/control/apps/jigsaw/jigsaw.xml
+++ b/isis/src/control/apps/jigsaw/jigsaw.xml
@@ -64,6 +64,12 @@
      pages.
     </p>
 
+    <h4>Relevant Documentation</h4>
+    <p>
+      For information on what the original <b>jigsaw</b> code was based on checkout
+      <a href="https://www.rand.org/pubs/notes/N3330.html">Rand Notebook</a>
+    </p>
+
     <h4>Known Issues</h4>
       <blockquote>
       <b>Running jigsaw with a control net containing <i>JigsawRejected</i>
@@ -84,6 +90,27 @@
         clear the <i>JigsawRejected</i> flags.</li>
         </ol>
         </blockquote>
+      </p>
+      </blockquote>
+
+      <blockquote>
+      <b>Solving for the target body radii (triaxial or mean) is irrelavent and
+      likely increases error in the solve.</b>
+      <p>
+        When solving for target body radii both the mean and triaxial solve options
+        are redundantly solving for the target body radii. The radii solve is part of
+        the sequence of equations that the <b>jigsaw</b> uses to compute various partial
+        derivatives to populate the solve matrix. The radii solve is being applied
+        to the target body separately and the partials from this separate application
+        are being added to the solve matrix. This is adding additional computation time
+        to <b>jigsaw</b> and creating additional uncertainty/error in the bundle adjust. We
+        advise this radii solve to be avoided.
+      </p>
+      <p>
+        If you are trying to generate a spheroid from a control network their are
+        other programs that can do this for you. An easier but more naive method
+        is ingesting the <i>OUTPUT_CSV</i> from your network and generating radii
+        information from those points.
       </p>
       </blockquote>
 
@@ -282,6 +309,12 @@
       settings for different instrumentIDs. Added logic into the observationSolveSettings
       function to construct BundleObservationSolveSettings objects based off of the settings
       in the pvl file.
+    </change>
+    <change name="Adam Paquette" date="2020-12-23">
+      Added a warning when solving for target body radii/radius that is output to
+      the application log. Updated the documentation to include the original
+      rand notebook that jigsaw was based on. Also added a section in the documentation
+      describing the target body radii solve issue.
     </change>
   </history>
 


### PR DESCRIPTION
Adds a warning about solving for the target body radii and updates the jigsaw docs.

## Description
Adds a new warning if the user is solving for the target body radii that it can negatively effect the bundle adjust. Updated the docs to describe how solving for the target body radii can cause problems and is likely redundant. Also updated the app xml to include the rand notebook that jigsaw was based on.

## Related Issue
Closes #4193
Closes #4132

## Motivation and Context
Jigsaws target body radii solving code has little to no documentation and the resulting radii output from a recent global Europa control network project are extremely fair off from their expected values. That said, there have been other projects in the past that have used this solve and gotten reasonable radii (maybe 100 - 500 meters off expected values).

## How Has This Been Tested?
Currently untested, but this warning could be checked in one of the radii tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
