### PR TITLE
ObservationPair test fix

### DIFF
--- a/isis/tests/data/observationPair/observationImageL.pvl
+++ b/isis/tests/data/observationPair/observationImageL.pvl
@@ -92,7 +92,7 @@ Object = IsisCube
                                  $lro/kernels/ck/moc42r_2009181_2009213_v14.bc,
                                  $lro/kernels/fk/lro_frames_2014049_v01.tf)
     Instrument                = $lro/kernels/ik/lro_lroc_v18.ti
-    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2020287_v00.tsc
+    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2020358_v00.tsc
     InstrumentPosition        = (Table,
                                  $lro/kernels/spk/fdf29r_2009182_2009213_v01.b-
                                  sp)
@@ -381,7 +381,7 @@ End_Object
 Object = History
   Name      = IsisCube
   StartByte = 264667834
-  Bytes     = 21818
+  Bytes     = 22747
 End_Object
 
 Object = OriginalLabel

--- a/isis/tests/data/observationPair/observationImageR.pvl
+++ b/isis/tests/data/observationPair/observationImageR.pvl
@@ -92,7 +92,7 @@ Object = IsisCube
                                  $lro/kernels/ck/moc42r_2009181_2009213_v14.bc,
                                  $lro/kernels/fk/lro_frames_2014049_v01.tf)
     Instrument                = $lro/kernels/ik/lro_lroc_v18.ti
-    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2020287_v00.tsc
+    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2020358_v00.tsc
     InstrumentPosition        = (Table,
                                  $lro/kernels/spk/fdf29r_2009182_2009213_v01.b-
                                  sp)
@@ -383,7 +383,7 @@ End_Object
 Object = History
   Name      = IsisCube
   StartByte = 264667140
-  Bytes     = 21067
+  Bytes     = 21996
 End_Object
 
 Object = OriginalLabel


### PR DESCRIPTION
Updated sclk kernel in observation pair fixture pvl files

## Description
LRO sclk kernel was cleaned up overnight and resulted in test failures as the sclk could no longer be opened

## Related Issue
N/A

## Motivation and Context
Clean ISIS builds

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
