### PR TITLE
Adds PDS4 template callback functions

### DIFF
--- a/isis/src/base/apps/topds4/topds4.cpp
+++ b/isis/src/base/apps/topds4/topds4.cpp
@@ -1,6 +1,9 @@
 #include <iostream>
+#include <time.h>
 
 #include <inja/inja.hpp>
+
+#include "md5wrapper.h"
 
 #include "topds4.h"
 
@@ -26,17 +29,47 @@ namespace Isis {
 
     Pvl &label = *cube->label();
 
+    Environment renderEnv;
 
+    // Call back functions
+    /**
+     * Renders to the current UTC time formatted as YYYY-MM-DDTHH:MM:SS
+     */
+    renderEnv.add_callback("currentTime", 0, [](Arguments& args) {
+      time_t startTime = time(NULL);
+      struct tm *tmbuf = gmtime(&startTime);
+      char timestr[80];
+      strftime(timestr, 80, "%Y-%m-%dT%H:%M:%S", tmbuf);
+      return string(timestr);
+    });
+
+    /**
+     * Renders to the filename of the output img
+     */
+    renderEnv.add_callback("imageFileName", 0, [cube](Arguments& args) {
+      QString cubeFilename = cube->fileName().split("/").back();
+      return (cubeFilename.split(".")[0] + ".img").toStdString();
+    });
+
+    /**
+     * Renders to the MD5 hash for the input cube
+     */
+    renderEnv.add_callback("md5Hash", 0, [cube](Arguments& args) {
+      md5wrapper md5;
+      return md5.getHashFromFile(cube->fileName()).toStdString();
+    });
 
     json data;
     data["name"] = "world";
-    render("Hello {{ name }}!", data); // Returns std::string "Hello world!"
-    render_to(std::cout, "Hello {{ name }}!", data); // Writes "Hello world!" to stream
+    renderEnv.render("Hello {{ name }}!", data); // Returns std::string "Hello world!"
+    renderEnv.write(renderEnv.parse("{{ currentTime() }}\n"), data, ui.GetFileName("TO").toStdString());
+    // renderEnv.write(renderEnv.parse("{{ imageFileName() }}\n"), data, ui.GetFileName("TO").toStdString());
+    // renderEnv.write(renderEnv.parse("{{ md5Hash() }}\n"), data, ui.GetFileName("TO").toStdString());
+    renderEnv.render_to(std::cout, renderEnv.parse("{{ currentTime() }}\n"), data);
+    renderEnv.render_to(std::cout, renderEnv.parse("{{ imageFileName() }}\n"), data);
+    renderEnv.render_to(std::cout, renderEnv.parse("{{ md5Hash() }}\n"), data);
 
-
-
-
-    std::cout << label << std::endl;
+    // std::cout << label << std::endl;
     return label.findGroup("Dimensions", Pvl::Traverse);
   }
 }

--- a/isis/src/base/apps/topds4/topds4.xml
+++ b/isis/src/base/apps/topds4/topds4.xml
@@ -2,7 +2,7 @@
 
 <application name="topds4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Application/application.xsd">
   <brief>
-    dummy 
+    dummy
   </brief>
 
   <description>
@@ -49,7 +49,7 @@
       </parameter>
 
       <parameter name="TO">
-        <type>file</type>
+        <type>filename</type>
         <fileMode>output</fileMode>
         <brief>
           Output PDS4 label

--- a/isis/tests/FunctionalTestsTopds4.cpp
+++ b/isis/tests/FunctionalTestsTopds4.cpp
@@ -1,0 +1,85 @@
+#include <iostream>
+#include <time.h>
+
+#include <QRegExp>
+#include <QString>
+
+#include "Fixtures.h"
+#include "md5wrapper.h"
+
+#include "topds4.h"
+
+#include "gmock/gmock.h"
+
+using namespace Isis;
+
+static QString APP_XML = FileName("$ISISROOT/bin/xml/topds4.xml").expanded();
+
+TEST_F(SmallCube, FunctionalTestTopds4CurrentTime) {
+  QString templateFile = tempDir.path()+"/current_time.tpl";
+  QString renderedFile = tempDir.path()+"/current_time.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{currentTime()}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile, "to=" + renderedFile};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  time_t startTime = time(NULL);
+  struct tm *tmbuf = gmtime(&startTime);
+  char yearstr[80];
+  // Just check that the year is correct
+  strftime(yearstr, 80, "%Y", tmbuf);
+  EXPECT_EQ(yearstr, line.substr(0, 4));
+  // Check that the rest is the correct format
+  // YYYY-MM-DDTHH:MM:SS
+  QRegExp timeRegex("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}");
+  EXPECT_TRUE(QString::fromStdString(line).contains(timeRegex)) << "String [" << line << "] "
+                                                                << "does not match the time format "
+                                                                << "[YYYY-MM-DDTHH:MM:SS].";
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4ImageFileName) {
+  QString templateFile = tempDir.path()+"/current_time.tpl";
+  QString renderedFile = tempDir.path()+"/current_time.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{imageFileName()}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile, "to=" + renderedFile};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  EXPECT_EQ("small.img", line);
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4MD5Hash) {
+  QString templateFile = tempDir.path()+"/current_time.tpl";
+  QString renderedFile = tempDir.path()+"/current_time.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{md5Hash()}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile, "to=" + renderedFile};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  md5wrapper md5;
+  EXPECT_EQ(md5.getHashFromFile(testCube->fileName()).toStdString(), line);
+}


### PR DESCRIPTION
This adds 3 callbacks:

* The current time
* The name of the export img file
* The MD5 hash of the cube file

and tests for each of them to topds4. Because the template reading is not in the branch yet, I hardcoded the templates and would uncomment each to check them. Once #4223 is merged I will get this merged with that and the tests should work properly.