### PR TITLE
Jigsaw hot fix

### DIFF
--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -54,16 +54,18 @@ namespace Isis {
 
     // retrieve settings from jigsaw gui
     BundleSettingsQsp settings = bundleSettings(ui);
-    if(settings->bundleTargetBody()->solveTriaxialRadii() ||
-       settings->bundleTargetBody()->solveMeanRadius()) {
-      PvlGroup radiusSolveWarning("RadiusSolveWarning");
-      radiusSolveWarning.addKeyword(PvlKeyword("Warning", "The radii solve is currently \
-                                                 under review and is likely resulting \
-                                                 in addition error in the bundle adjust. \
-                                                 We recommend that you do not solve for radii at this moment."));
-       if(log) {
-         log->PvlObject::addGroup(radiusSolveWarning);
-       }
+    if(settings->bundleTargetBody()) {
+      if(settings->bundleTargetBody()->solveTriaxialRadii() ||
+         settings->bundleTargetBody()->solveMeanRadius()) {
+        PvlGroup radiusSolveWarning("RadiusSolveWarning");
+        radiusSolveWarning.addKeyword(PvlKeyword("Warning", "The radii solve is currently \
+                                                   under review and is likely resulting \
+                                                   in addition error in the bundle adjust. \
+                                                   We recommend that you do not solve for radii at this moment."));
+         if(log) {
+           log->PvlObject::addGroup(radiusSolveWarning);
+         }
+      }
     }
     settings->setCubeList(cubeList);
     BundleAdjust *bundleAdjustment = NULL;


### PR DESCRIPTION
Added catch around warning if the target body was not defined

## Description
Forgot to add a check around the original warning to make sure that the target body has been defined in the solve settings

## Related Issue
#4220 

## Motivation and Context
Clean up ISIS test failures

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
