### PR TITLE
add warning for inaccurate MeanRadiusValue #4111

### DIFF
--- a/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
+++ b/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
@@ -495,6 +495,30 @@ namespace Isis {
 
     if (m_bundleSettings->solveTargetBody()) {
       m_rank += m_bundleSettings->numberTargetBodyParameters();
+
+      if (m_bundleTargetBody->solveMeanRadius()){
+        // Check if MeanRadiusValue is abnormal compared to observation
+        bool isMeanRadiusValid = true;
+        double localRadius, aprioriRadius;
+
+        // Arbitrary control point containing an observed localRadius
+        BundleControlPointQsp point = m_bundleControlPoints.at(0);
+        SurfacePoint surfacepoint = point->adjustedSurfacePoint();
+
+        localRadius = surfacepoint.GetLocalRadius().meters();
+        aprioriRadius = m_bundleTargetBody->meanRadius().meters();
+
+        // Ensure aprioriRadius is within some threshold
+        // Considered potentially inaccurate if it's off by atleast a factor of two
+        if (aprioriRadius >= 2 * localRadius || aprioriRadius <= localRadius / 2) {
+            isMeanRadiusValid = false;
+        }
+
+        // Warn user for abnormal MeanRadiusValue
+        if (!isMeanRadiusValid) {
+          outputBundleStatus("Warning: User-entered MeanRadiusValue may be inaccurate\n");
+        }
+      }
     }
 
     int num3DPoints = m_bundleControlPoints.size();

--- a/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
+++ b/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
@@ -495,7 +495,12 @@ namespace Isis {
 
     if (m_bundleSettings->solveTargetBody()) {
       m_rank += m_bundleSettings->numberTargetBodyParameters();
-
+      
+      if (m_bundleTargetBody->solveMeanRadius() || m_bundleTargetBody->solveTriaxialRadii()) {
+        outputBundleStatus("Warning: Solving for the target body radii (triaxial or mean) "
+                           "is NOT possible and likely increases error in the solve.\n");
+      }
+      
       if (m_bundleTargetBody->solveMeanRadius()){
         // Check if MeanRadiusValue is abnormal compared to observation
         bool isMeanRadiusValid = true;
@@ -516,7 +521,8 @@ namespace Isis {
 
         // Warn user for abnormal MeanRadiusValue
         if (!isMeanRadiusValid) {
-          outputBundleStatus("Warning: User-entered MeanRadiusValue may be inaccurate\n");
+          outputBundleStatus("Warning: User-entered MeanRadiusValue appears to be inaccurate. "
+                             "This can cause a bundle failure.\n");
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a simple check comparing the user-entered MeanRadiusValue and the localRadius of some control point to see if they are within a reasonable range. If not, a warning is output to the user.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4111

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
