### PR TITLE
automate copying of init scrips

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -25,6 +25,11 @@
       "name": "Austin, Christopher"
     },
     {
+      "affiliation": "Laboratory for Atmospheric and Space Physic (LASP), University of Colorado Boulder",
+      "name": "Aye, Michael Aye",
+      "orcid": "https://orcid.org/0000-0002-4088-1928"
+    },
+    {
       "name": "Backer, Jeanie"
     },
     {
@@ -40,7 +45,7 @@
     {
       "name": "Beyer, Ross",
       "affiliation": "SETI Institute and NASA Ames Research Center",
-      "orcid": "0000-0003-4503-3335"
+      "orcid": "https://orcid.org/0000-0003-4503-3335"
     },
     {
       "name": "Bonn, John"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ update the Unreleased link so that it compares against the latest release tag.
 
 ## [Unreleased]
 
+- added new switch `--init-other-envs` to scripts/isisVarInit.py for copying the needed init-files to other conda envs.
+
 ### Added
 
 - Added warning to ocams2isis about the model being out of date. [#4200](https://github.com/USGS-Astrogeology/ISIS3/issues/4200)

--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
         #Activate the environment
         #Depending on your version of Anaconda use one of the following:
 
-        #Anaconda 3.4 and up:
+        #Anaconda 3.4 and up (conda>=4.6):
         conda activate isis
 
-        #Prior to Anaconda 3.4:
+        #Prior to Anaconda 3.4 (conda<4.6):
         source activate isis
 
         #Add the following channels to the environment
@@ -77,15 +77,21 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
         conda config --env --add channels usgs-astrogeology
 
+        # If you have followed conda-forges advice to set `channel_priority=strict`,
+        # you need to set it to flexible for the install:
+        conda config --set channel_priority flexible
+
 
 6.  The environment is now ready to download ISIS and its dependencies:
 
-        conda install -c usgs-astrogeology isis
+        # To install e.g. version 4.3
+        conda install isis=4.3
 
     If you would like to work with our latest ISIS version 3, rather than updating
     to ISIS 4, instead run:
 
-	    conda install -c usgs-astrogeology isis=3.10.0
+	    # This will find the latest 3.x.y release
+        conda install isis=3
 
 
 7.  Finally, setup the environment variables:
@@ -110,7 +116,14 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
         python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
 
-    More information about the ISISDATA environment variable and the ISIS Data Area can be found [here]("#The-ISIS-Data-Area"). Now everytime the isis environment is activated, $ISISROOT, $ISISDATA, and $ISISTESTDATA will be set to the values passed to isisVarInit.py. This does not happen retroactively, so re-activate the isis envionment with one of the following commands:
+
+    For the newer version we also support automatic copying of the init files to other conda environment. If you require this, call the script with the optional switch `--init-other-envs`:
+
+        python @CONDA_PREFIX/scripts/isisVarInit.py --init-other-envs
+
+    If you rather want to copy the files manually, see the instructions in the next section.
+
+    More information about the ISISDATA environment variable and the ISIS Data Area can be found [here]("#The-ISIS-Data-Area"). Now everytime the ISIS environment is activated, $ISISROOT, $ISISDATA, and $ISISTESTDATA will be set to the values passed to isisVarInit.py. This does not happen retroactively, so re-activate the isis envionment with one of the following commands:
 
         for Anaconda 3.4 and up - conda activate isis
         prior to Anaconda 3.4 - source activate isis

--- a/isis/scripts/isisVarInit.py
+++ b/isis/scripts/isisVarInit.py
@@ -10,7 +10,9 @@ not specified, they are placed in $ISISROOT.
 
 import argparse
 import os
+import shutil
 from pathlib import Path
+from typing import List, Tuple
 
 # This is free and unencumbered software released into the public domain.
 #
@@ -20,12 +22,50 @@ from pathlib import Path
 #
 # SPDX-License-Identifier: CC0-1.0
 
+# This is the full path to this environment:
+CONDA_PREFIX = os.environ["CONDA_PREFIX"]
+ENVS_DIR = Path(CONDA_PREFIX).parent
+THIS_ENV = Path(CONDA_PREFIX).name
+
+
+def get_conda_envs() -> List[Path]:
+    """Returns a list of paths to the found conda envs.
+
+    This method is used because
+    (1) there is no API for `conda env`,
+    (2) `subprocess.check_output` and `sh.conda` are not producing the same output.
+    """
+    print(f"Searching for other conda envs in {ENVS_DIR} ...")
+    paths = [d for d in ENVS_DIR.iterdir() if d.is_dir()]
+    return [p.name for p in paths if p.name != THIS_ENV]
+
+
+def get_envs_to_init() -> List[Path]:
+    """Find conda envs and ask user which ones should initialize ISIS."""
+    env_names = get_conda_envs()
+    print("Found the following other conda envs:")
+    for i, env in enumerate(env_names):
+        print(i, env)
+    print("Which envs should receive the ISIS path initialization?")
+    print("(Press RETURN for skipping.)")
+    answer = ""
+    answer = input("Comma-separated list of env indexes (e.g. 1,2,4):")
+    if not answer:
+        return []
+    try:
+        envs_to_init = [env_names[int(i)] for i in answer.split(",")]
+    except ValueError:
+        raise ValueError(
+            "Could not parse your answer.\nDid you use a comma-separated list?"
+        )
+    return envs_to_init
+
 
 def mkdir(p: Path) -> str:
-    """Returns a string with a message about the creation or existance
-    of the path, *p*."""
+    """Create directory `p` if not exists, and notify user when created."""
+
     if p.exists():
-        return f"{p} exists, don't need to create."
+        return p
     else:
         p.mkdir(parents=False)
         return f"Created {p}"
@@ -42,6 +82,8 @@ def activate_text(shell: dict, env_vars: dict) -> str:
     if shell["activate_extra"] != "":
         lines.append(shell["activate_extra"])
 
+    lines.append(shell['path_update'])
+    lines.append("echo 'ISIS version info:'")
     lines.append("cat $ISISROOT/version")
 
     return "\n".join(lines)
@@ -58,20 +100,33 @@ def deactivate_text(shell: dict, env_vars: dict) -> str:
     return "\n".join(lines)
 
 
+def get_paths_make_dirs(env: str) -> Tuple[Path]:
+    "Create act/deact paths, create the dirs, and return paths."
+
+    # Create the conda activation and deactivation directories:
+    activate_dir = ENVS_DIR / f"{env}/etc/conda/activate.d"
+    deactivate_dir = ENVS_DIR / f"{env}/etc/conda/deactivate.d"
+
+    mkdir(activate_dir)
+    mkdir(deactivate_dir)
+    return activate_dir, deactivate_dir
+
+
 # Set up and then parse the command line:
 parser = argparse.ArgumentParser(description=__doc__)
+
 
 parser.add_argument(
     "-d",
     "--data-dir",
-    default=os.environ["CONDA_PREFIX"] + "/data",
+    default=CONDA_PREFIX + "/data",
     type=Path,
     help="ISIS Data Directory, default: %(default)s",
 )
 parser.add_argument(
     "-t",
     "--test-dir",
-    default=os.environ["CONDA_PREFIX"] + "/testData",
+    default=CONDA_PREFIX + "/testData",
     type=Path,
     help="ISIS Test Data Directory, default: %(default)s",
 )
@@ -79,10 +134,17 @@ parser.add_argument(
 parser.add_argument(
     "-a",
     "--ale-dir",
-    default=os.environ["CONDA_PREFIX"] + "/aleData",
+    default=CONDA_PREFIX + "/aleData",
     type=Path,
     help="ISIS Ale Data Directory, default: %(default)s",
 )
+
+parser.add_argument(
+    "--init-other-envs",
+    action="store_true",
+    help="Launch dialog to find other conda environments to be initialized.",
+)
+
 args = parser.parse_args()
 
 print("-- ISIS Data Directories --")
@@ -90,57 +152,72 @@ print("-- ISIS Data Directories --")
 print(mkdir(args.data_dir))
 print(mkdir(args.test_dir))
 print(mkdir(args.ale_dir))
+print()
 
-print("-- Conda activation and deactivation scripts --")
-# Create the conda activation and deactivation directories:
-activate_dir = Path(os.environ["CONDA_PREFIX"]) / "etc/conda/activate.d"
-deactivate_dir = Path(os.environ["CONDA_PREFIX"]) / "etc/conda/deactivate.d"
+# always init this env:
+envs_to_init = [THIS_ENV]
 
-print(mkdir(activate_dir))
-print(mkdir(deactivate_dir))
+# if wanted, ask user which other conda envs should get ISIS-initialized
+if args.init_other_envs:
+    envs_to_init += get_envs_to_init()
 
 # Set the environment variables to manage
 env_vars = dict(
-    ISISROOT=os.environ["CONDA_PREFIX"],
+    ISISROOT=CONDA_PREFIX,
     ISISDATA=args.data_dir,
     ISISTESTDATA=args.test_dir,
-    ALESPICEROOT=args.ale_dir
+    ALESPICEROOT=args.ale_dir,
 )
 
 # These dicts define the unique aspects of the shell languages
 # for setting and unsetting the environment variables.
 
 sh = dict(  # this covers bash and zsh
+    name="bash/zsh",
     extension=".sh",
     shebang="#!/usr/bin/env sh",
     activate="export {}={}",
     activate_extra="",
-    deactivate="unset {}"
+    deactivate="unset {}",
+    path_update="export PATH=$PATH:$ISISROOT/bin"
 )
 
 csh = dict(
+    name="csh",
     extension=".csh",
     shebang="#!/usr/bin/env csh",
     activate="setenv {} {}",
     activate_extra="source $CONDA_PREFIX/scripts/tabCompletion.csh",
-    deactivate="unsetenv {}"
+    deactivate="unsetenv {}",
+    path_update="setenv PATH $PATH:$ISISROOT/bin"
 )
 
 fish = dict(
+    name="fish",
     extension=".fish",
     shebang="#!/usr/bin/env fish",
     activate="set -gx {} {}",
     activate_extra="",
-    deactivate="set -e {}"
+    deactivate="set -e {}",
+    path_update="set -agx PATH $ISISROOT/bin"
 )
 
 # Loop over the shell types and create the correct scripts associated with
 # each:
-for shell in (sh, csh, fish):
-    a_path = activate_dir / ("isis-activate" + shell["extension"])
-    a_path.write_text(activate_text(shell, env_vars))
-    print(f"Wrote {a_path}")
+print("\nInit files will be written for the following conda environments:")
+print(envs_to_init)
 
-    d_path = deactivate_dir / ("isis-deactivate" + shell["extension"])
-    d_path.write_text(deactivate_text(shell, env_vars))
-    print(f"Wrote {d_path}")
+for env in envs_to_init:
+    print(f"\n-- Initializing {env} conda env --\n")
+    a_dir, d_dir = get_paths_make_dirs(env)
+    print(f"Activation in {a_dir}")
+    print(f"Deactivaton in {d_dir}")
+    for shell in (sh, csh, fish):
+        print(f"{shell['name']} shell:")
+        a_path = a_dir / ("isis-activate" + shell["extension"])
+        a_path.write_text(activate_text(shell, env_vars))
+        print(f"Wrote {a_path.name}")
+
+        d_path = d_dir / ("isis-deactivate" + shell["extension"])
+        d_path.write_text(deactivate_text(shell, env_vars))
+        print(f"Wrote {d_path.name}")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* scripted identification of existing conda envs
* UI to ask user which envs should be ISIS-initialized
* copying of newly created act/deact scripts to user-provided conda envs
* add `echo "ISIS version info"` at activation time to reduce user confusion
* improve README

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
fixes #4231 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Installation hurdles are one of the biggest stoppers of more user involvement and willingness of installing/updating new versions. 
The less cumbersome the install appears, the less apprehensive users will be for updating.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran script locally and had scripts installed into 3 other envs:

```bash
$ python isisVarInit.py -d ~/big_drive/isisdata                                                                                                      (isis) 
-- ISIS Data Directories --
/home/maye/big_drive/isisdata exists, don't need to create.
/home/maye/miniconda3/envs/isis/testData exists, don't need to create.
/home/maye/miniconda3/envs/isis/aleData exists, don't need to create.
-- Conda activation and deactivation scripts --
/home/maye/miniconda3/envs/isis/etc/conda/activate.d exists, don't need to create.
/home/maye/miniconda3/envs/isis/etc/conda/deactivate.d exists, don't need to create.
Searching for conda envs in /home/maye/miniconda3/envs ...
Found the following conda envs:
0 py38
1 jlab3
2 py37
3 lsp
4 isis
Which envs should receive the ISIS path initialization?
(If you don't want to copy the init scripts to other envs, just press RETURN.)
Comma-separated list of env indexes (e.g. 1,2,4):0,1,2
Wrote /home/maye/miniconda3/envs/isis/etc/conda/activate.d/isis-activate.sh
Wrote /home/maye/miniconda3/envs/isis/etc/conda/deactivate.d/isis-deactivate.sh
Wrote /home/maye/miniconda3/envs/py38/etc/conda/activate.d/isis-activate.sh
Wrote /home/maye/miniconda3/envs/py38/etc/conda/deactivate.d/isis-deactivate.sh
Wrote /home/maye/miniconda3/envs/jlab3/etc/conda/activate.d/isis-activate.sh
Wrote /home/maye/miniconda3/envs/jlab3/etc/conda/deactivate.d/isis-deactivate.sh
Wrote /home/maye/miniconda3/envs/py37/etc/conda/activate.d/isis-activate.sh
Wrote /home/maye/miniconda3/envs/py37/etc/conda/deactivate.d/isis-deactivate.sh
Wrote /home/maye/miniconda3/envs/isis/etc/conda/activate.d/isis-activate.csh
Wrote /home/maye/miniconda3/envs/isis/etc/conda/deactivate.d/isis-deactivate.csh
Wrote /home/maye/miniconda3/envs/py38/etc/conda/activate.d/isis-activate.csh
Wrote /home/maye/miniconda3/envs/py38/etc/conda/deactivate.d/isis-deactivate.csh
Wrote /home/maye/miniconda3/envs/jlab3/etc/conda/activate.d/isis-activate.csh
Wrote /home/maye/miniconda3/envs/jlab3/etc/conda/deactivate.d/isis-deactivate.csh
Wrote /home/maye/miniconda3/envs/py37/etc/conda/activate.d/isis-activate.csh
Wrote /home/maye/miniconda3/envs/py37/etc/conda/deactivate.d/isis-deactivate.csh
Wrote /home/maye/miniconda3/envs/isis/etc/conda/activate.d/isis-activate.fish
Wrote /home/maye/miniconda3/envs/isis/etc/conda/deactivate.d/isis-deactivate.fish
Wrote /home/maye/miniconda3/envs/py38/etc/conda/activate.d/isis-activate.fish
Wrote /home/maye/miniconda3/envs/py38/etc/conda/deactivate.d/isis-deactivate.fish
Wrote /home/maye/miniconda3/envs/jlab3/etc/conda/activate.d/isis-activate.fish
Wrote /home/maye/miniconda3/envs/jlab3/etc/conda/deactivate.d/isis-deactivate.fish
Wrote /home/maye/miniconda3/envs/py37/etc/conda/activate.d/isis-activate.fish
Wrote /home/maye/miniconda3/envs/py37/etc/conda/deactivate.d/isis-deactivate.fish
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
