### PR TITLE
Added Extra data source parameters to topds4

### DIFF
--- a/isis/src/base/apps/topds4/topds4.cpp
+++ b/isis/src/base/apps/topds4/topds4.cpp
@@ -69,7 +69,7 @@ namespace Isis {
               PvlGroup duplicateWarnings("Warning");
               QString message = "Duplicate key [" + QString::fromStdString(element.key())
                               + "] in extra Pvl file [" + pvlFile + "]. "
-                              + "Previous value [" + QString::fromStdString(element.value().dump())
+                              + "Previous value [" + QString::fromStdString(dataSource["ExtraPvl"][element.key()].dump())
                               + "] will be overwritten.";
               duplicateWarnings += PvlKeyword("Duplicate", message);
               log->addGroup(duplicateWarnings);
@@ -92,7 +92,7 @@ namespace Isis {
               PvlGroup duplicateWarnings("Warning");
               QString message = "Duplicate element [" + QString::fromStdString(element.key())
                               + "] in extra xml file [" + xmlFile + "]. "
-                              + "Previous value [" + QString::fromStdString(element.value().dump())
+                              + "Previous value [" + QString::fromStdString(dataSource["ExtraXml"][element.key()].dump())
                               + "] will be overwritten.";
               duplicateWarnings += PvlKeyword("Duplicate", message);
               log->addGroup(duplicateWarnings);
@@ -116,7 +116,7 @@ namespace Isis {
               PvlGroup duplicateWarnings("Warning");
               QString message = "Duplicate key [" + QString::fromStdString(element.key())
                               + "] in extra json file [" + jsonFile + "]. "
-                              + "Previous value [" + QString::fromStdString(element.value().dump())
+                              + "Previous value [" + QString::fromStdString(dataSource["ExtraJson"][element.key()].dump())
                               + "] will be overwritten.";
               duplicateWarnings += PvlKeyword("Duplicate", message);
               log->addGroup(duplicateWarnings);

--- a/isis/src/base/apps/topds4/topds4.cpp
+++ b/isis/src/base/apps/topds4/topds4.cpp
@@ -3,15 +3,16 @@
 #include <time.h>
 
 #include <inja/inja.hpp>
-
-#include "md5wrapper.h"
-#include "QFile.h"
-
-#include "topds4.h"
+#include <nlohmann/json.hpp>
+#include <QFile>
 
 #include "FileName.h"
+#include "md5wrapper.h"
 #include "OriginalLabel.h"
 #include "PvlToJSON.h"
+#include "XmlToJson.h"
+
+#include "topds4.h"
 
 using namespace std;
 using namespace inja;
@@ -52,6 +53,33 @@ namespace Isis {
     }
     else if (cubeLabel.hasObject("OriginalXmlLabel")) {
       // get the xml label and add it to the template data
+    }
+
+    // Add any extra files to the template engine data
+    if (ui.WasEntered("EXTRAPVL")) {
+      vector<QString> extraPvlFiles;
+      ui.GetFileName("EXTRAPVL", extraPvlFiles);
+      for (QString pvlFile : extraPvlFiles) {
+        Pvl extraPvl(pvlFile);
+        dataSource["ExtraPvl"].update(pvlToJSON(extraPvl));
+      }
+    }
+    if (ui.WasEntered("EXTRAXML")) {
+      vector<QString> extraXmlFiles;
+      ui.GetFileName("EXTRAXML", extraXmlFiles);
+      for (QString xmlFile : extraXmlFiles) {
+        dataSource["ExtraXml"].update(xmlToJson(xmlFile));
+      }
+    }
+    if (ui.WasEntered("EXTRAJSON")) {
+      vector<QString> extraJsonFiles;
+      ui.GetFileName("EXTRAJSON", extraJsonFiles);
+      for (QString jsonFile : extraJsonFiles) {
+        ifstream extraJsonStream(jsonFile.toStdString());
+        json extraJson;
+        extraJsonStream >> extraJson;
+        dataSource["ExtraJson"].update(extraJson);
+      }
     }
 
     Environment env;

--- a/isis/src/base/apps/topds4/topds4.cpp
+++ b/isis/src/base/apps/topds4/topds4.cpp
@@ -61,16 +61,48 @@ namespace Isis {
       ui.GetFileName("EXTRAPVL", extraPvlFiles);
       for (QString pvlFile : extraPvlFiles) {
         Pvl extraPvl(pvlFile);
-        dataSource["ExtraPvl"].update(pvlToJSON(extraPvl));
+        json extraJson = pvlToJSON(extraPvl);
+        // Notify users of duplicate keys that will be overwritten
+        if (log) {
+          for (auto& element : extraJson.items()) {
+            if (dataSource["ExtraPvl"].contains(element.key())) {
+              PvlGroup duplicateWarnings("Warning");
+              QString message = "Duplicate key [" + QString::fromStdString(element.key())
+                              + "] in extra Pvl file [" + pvlFile + "]. "
+                              + "Previous value [" + QString::fromStdString(element.value().dump())
+                              + "] will be overwritten.";
+              duplicateWarnings += PvlKeyword("Duplicate", message);
+              log->addGroup(duplicateWarnings);
+            }
+          }
+        }
+        dataSource["ExtraPvl"].update(extraJson);
       }
     }
+
     if (ui.WasEntered("EXTRAXML")) {
       vector<QString> extraXmlFiles;
       ui.GetFileName("EXTRAXML", extraXmlFiles);
       for (QString xmlFile : extraXmlFiles) {
-        dataSource["ExtraXml"].update(xmlToJson(xmlFile));
+        // Notify users of duplicate keys that will be overwritten
+        json extraJson = xmlToJson(xmlFile);
+        if (log) {
+          for (auto& element : extraJson.items()) {
+            if (dataSource["ExtraXml"].contains(element.key())) {
+              PvlGroup duplicateWarnings("Warning");
+              QString message = "Duplicate element [" + QString::fromStdString(element.key())
+                              + "] in extra xml file [" + xmlFile + "]. "
+                              + "Previous value [" + QString::fromStdString(element.value().dump())
+                              + "] will be overwritten.";
+              duplicateWarnings += PvlKeyword("Duplicate", message);
+              log->addGroup(duplicateWarnings);
+            }
+          }
+        }
+        dataSource["ExtraXml"].update(extraJson);
       }
     }
+
     if (ui.WasEntered("EXTRAJSON")) {
       vector<QString> extraJsonFiles;
       ui.GetFileName("EXTRAJSON", extraJsonFiles);
@@ -78,6 +110,19 @@ namespace Isis {
         ifstream extraJsonStream(jsonFile.toStdString());
         json extraJson;
         extraJsonStream >> extraJson;
+        if (log) {
+          for (auto& element : extraJson.items()) {
+            if (dataSource["ExtraJson"].contains(element.key())) {
+              PvlGroup duplicateWarnings("Warning");
+              QString message = "Duplicate key [" + QString::fromStdString(element.key())
+                              + "] in extra json file [" + jsonFile + "]. "
+                              + "Previous value [" + QString::fromStdString(element.value().dump())
+                              + "] will be overwritten.";
+              duplicateWarnings += PvlKeyword("Duplicate", message);
+              log->addGroup(duplicateWarnings);
+            }
+          }
+        }
         dataSource["ExtraJson"].update(extraJson);
       }
     }

--- a/isis/src/base/apps/topds4/topds4.xml
+++ b/isis/src/base/apps/topds4/topds4.xml
@@ -7,7 +7,7 @@
 
   <description>
     <p>
-      Writes a PDS4 compatible label file and image file. The contents of the label file are 
+      Writes a PDS4 compatible label file and image file. The contents of the label file are
       generated useing the template file specified by the TEMPLATE parameter.
     </p>
     <p>
@@ -50,9 +50,9 @@
           Input template
         </brief>
         <description>
-          The file name of the input template. This file contains "inja" compatible 
-          template syntax inside of a PDS4 XML label. The data used to replace the 
-          template elements comes from the ISIS cube label, the original label 
+          The file name of the input template. This file contains "inja" compatible
+          template syntax inside of a PDS4 XML label. The data used to replace the
+          template elements comes from the ISIS cube label, the original label
           (PDS3, FITS, PDS4), and other input PVL, XML, or JSON files.
         </description>
       </parameter>
@@ -68,7 +68,9 @@
           parameter by removing the last extension and adding .cub
         </description>
       </parameter>
+    </group>
 
+    <group name="Data">
       <parameter name="DATA">
         <type>filename</type>
         <internalDefault>None</internalDefault>
@@ -84,6 +86,47 @@
         </description>
       </parameter>
 
+      <parameter name="EXTRAPVL">
+        <type>filename</type>
+        <internalDefault>None</internalDefault>
+        <fileMode>input</fileMode>
+        <brief>
+          Extra PVL data
+        </brief>
+        <description>
+          The PVL data contained in the file(s) specified by this parameter will
+          be added to the template data source under ExtraPvl. If multiple PVL files
+          are specified, then they will be merged together.
+        </description>
+      </parameter>
+
+      <parameter name="EXTRAXML">
+        <type>filename</type>
+        <internalDefault>None</internalDefault>
+        <fileMode>input</fileMode>
+        <brief>
+          Extra XML data
+        </brief>
+        <description>
+          The XML data contained in the file(s) specified by this parameter will
+          be added to the template data source under ExtraXml. If multiple XML files
+          are specified, then they will be merged together.
+        </description>
+      </parameter>
+
+      <parameter name="EXTRAJSON">
+        <type>filename</type>
+        <internalDefault>None</internalDefault>
+        <fileMode>input</fileMode>
+        <brief>
+          Extra JSON data
+        </brief>
+        <description>
+          The JSON data contained in the file(s) specified by this parameter will
+          be added to the template data source under ExtraJson. If multiple JSON files
+          are specified, then they will be merged together.
+        </description>
+      </parameter>
     </group>
   </groups>
 </application>

--- a/isis/tests/FunctionalTestsTopds4.cpp
+++ b/isis/tests/FunctionalTestsTopds4.cpp
@@ -139,8 +139,9 @@ TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraPvl) {
                            "to=" + renderedFile,
                            "extrapvl=(" + pvlFile1 + "," + pvlfile2 + ")"};
   UserInterface options(APP_XML, args);
+  Pvl log;
 
-  topds4(testCube, options);
+  topds4(testCube, options, &log);
 
   std::ifstream renderedStream;
   renderedStream.open(renderedFile.toStdString());
@@ -151,6 +152,9 @@ TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraPvl) {
   EXPECT_EQ(testKey2[0].toStdString(), line);
   std::getline(renderedStream, line);
   EXPECT_EQ(safeKey[0].toStdString(), line);
+
+  // The duplicate key should generate a warning
+  EXPECT_TRUE(log.hasGroup("Warning"));
 }
 
 TEST_F(SmallCube, FunctionalTestTopds4ExtraJson) {
@@ -213,8 +217,9 @@ TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraJson) {
                            "to=" + renderedFile,
                            "extrajson=(" + jsonFile1 + "," + jsonFile2 + ")"};
   UserInterface options(APP_XML, args);
+  Pvl log;
 
-  topds4(testCube, options);
+  topds4(testCube, options, &log);
 
   std::ifstream renderedStream;
   renderedStream.open(renderedFile.toStdString());
@@ -225,6 +230,9 @@ TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraJson) {
   EXPECT_EQ(testJson2["AdditionalValue"], line);
   std::getline(renderedStream, line);
   EXPECT_EQ(testJson1["SafeValue"], line);
+
+  // The duplicate key should generate a warning
+  EXPECT_TRUE(log.hasGroup("Warning"));
 }
 
 TEST_F(SmallCube, FunctionalTestTopds4ExtraXml) {
@@ -285,8 +293,9 @@ TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraXml) {
                            "to=" + renderedFile,
                            "extraxml=(" + xmlFile1 + "," + xmlFile2 + ", " + xmlFile3 + ")"};
   UserInterface options(APP_XML, args);
+  Pvl log;
 
-  topds4(testCube, options);
+  topds4(testCube, options, &log);
 
   std::ifstream renderedStream;
   renderedStream.open(renderedFile.toStdString());
@@ -295,6 +304,9 @@ TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraXml) {
   EXPECT_EQ("b", line);
   std::getline(renderedStream, line);
   EXPECT_EQ("10", line);
+
+  // The duplicate key should generate a warning
+  EXPECT_TRUE(log.hasGroup("Warning"));
 }
 
 TEST_F(SmallCube, FunctionalTestTopds4CurrentTime) {

--- a/isis/tests/FunctionalTestsTopds4.cpp
+++ b/isis/tests/FunctionalTestsTopds4.cpp
@@ -3,6 +3,7 @@
 
 #include <QRegExp>
 #include <QString>
+#include <nlohmann/json.hpp>
 
 #include "Fixtures.h"
 #include "md5wrapper.h"
@@ -16,6 +17,7 @@
 #include "gmock/gmock.h"
 
 using namespace Isis;
+using json = nlohmann::json;
 
 static QString APP_XML = FileName("$ISISROOT/bin/xml/topds4.xml").expanded();
 
@@ -79,6 +81,220 @@ TEST_F(SmallCube, FunctionalTestTopds4NoOriginalLabel) {
   UserInterface options(APP_XML, args);
 
   EXPECT_ANY_THROW(topds4(testCube, options));
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4ExtraPvl) {
+  QString pvlFile = tempDir.path()+"/extra.pvl";
+  Pvl testPvl;
+  PvlKeyword testKey("TestValue", "a");
+  testPvl += testKey;
+  testPvl.write(pvlFile);
+
+  QString templateFile = tempDir.path()+"/test_result.tpl";
+  QString renderedFile = tempDir.path()+"/test_result.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{ExtraPvl.TestValue.Value}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile,
+                           "to=" + renderedFile,
+                           "extrapvl=" + pvlFile};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  EXPECT_EQ(testKey[0].toStdString(), line);
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraPvl) {
+  QString pvlFile1 = tempDir.path()+"/extra1.pvl";
+  Pvl testPvl1;
+  PvlKeyword testKey1("TestValue", "a");
+  PvlKeyword safeKey("SafeValue", "true");
+  testPvl1 += testKey1;
+  testPvl1 += safeKey;
+  testPvl1.write(pvlFile1);
+
+  QString pvlfile2 = tempDir.path()+"/extra2.pvl";
+  Pvl testPvl2;
+  PvlKeyword duplicateKey("TestValue", "b");
+  PvlKeyword testKey2("AnotherValue", "10");
+  testPvl2 += duplicateKey;
+  testPvl2 += testKey2;
+  testPvl2.write(pvlfile2);
+
+  QString templateFile = tempDir.path()+"/test_result.tpl";
+  QString renderedFile = tempDir.path()+"/test_result.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{ExtraPvl.TestValue.Value}}\n"
+     << "{{ExtraPvl.AnotherValue.Value}}\n"
+     << "{{ExtraPvl.SafeValue.Value}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile,
+                           "to=" + renderedFile,
+                           "extrapvl=(" + pvlFile1 + "," + pvlfile2 + ")"};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  EXPECT_EQ(duplicateKey[0].toStdString(), line);
+  std::getline(renderedStream, line);
+  EXPECT_EQ(testKey2[0].toStdString(), line);
+  std::getline(renderedStream, line);
+  EXPECT_EQ(safeKey[0].toStdString(), line);
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4ExtraJson) {
+  QString jsonFile = tempDir.path()+"/extra.json";
+  json testJson;
+  testJson["TestValue"] = "a";
+  std::ofstream jsonStream;
+  jsonStream.open(jsonFile.toStdString());
+  jsonStream << testJson.dump();
+  jsonStream.close();
+
+  QString templateFile = tempDir.path()+"/test_result.tpl";
+  QString renderedFile = tempDir.path()+"/test_result.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{ExtraJson.TestValue}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile,
+                           "to=" + renderedFile,
+                           "extrajson=" + jsonFile};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  EXPECT_EQ(testJson["TestValue"], line);
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraJson) {
+  QString jsonFile1 = tempDir.path()+"/extra1.json";
+  json testJson1;
+  testJson1["TestValue"] = "a";
+  testJson1["SafeValue"] = "true";
+  std::ofstream jsonStream1;
+  jsonStream1.open(jsonFile1.toStdString());
+  jsonStream1 << testJson1.dump();
+  jsonStream1.close();
+
+  QString jsonFile2 = tempDir.path()+"/extra2.json";
+  json testJson2;
+  testJson2["TestValue"] = "b";
+  testJson2["AdditionalValue"] = "10";
+  std::ofstream jsonStream2;
+  jsonStream2.open(jsonFile2.toStdString());
+  jsonStream2 << testJson2.dump();
+  jsonStream2.close();
+
+  QString templateFile = tempDir.path()+"/test_result.tpl";
+  QString renderedFile = tempDir.path()+"/test_result.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{ExtraJson.TestValue}}\n"
+     << "{{ExtraJson.AdditionalValue}}\n"
+     << "{{ExtraJson.SafeValue}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile,
+                           "to=" + renderedFile,
+                           "extrajson=(" + jsonFile1 + "," + jsonFile2 + ")"};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  EXPECT_EQ(testJson2["TestValue"], line);
+  std::getline(renderedStream, line);
+  EXPECT_EQ(testJson2["AdditionalValue"], line);
+  std::getline(renderedStream, line);
+  EXPECT_EQ(testJson1["SafeValue"], line);
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4ExtraXml) {
+  QString xmlFile = tempDir.path()+"/extra.xml";
+  std::ofstream xmlStream;
+  xmlStream.open(xmlFile.toStdString());
+  xmlStream << "<TestValue>a</TestValue>";
+  xmlStream.close();
+
+  QString templateFile = tempDir.path()+"/test_result.tpl";
+  QString renderedFile = tempDir.path()+"/test_result.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{ExtraXml.TestValue}}";
+  of.close();
+  QVector<QString> args = {"template=" + templateFile,
+                           "to=" + renderedFile,
+                           "extraxml=" + xmlFile};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  EXPECT_EQ("a", line);
+}
+
+TEST_F(SmallCube, FunctionalTestTopds4MultipleExtraXml) {
+  QString xmlFile1 = tempDir.path()+"/extra1.xml";
+  std::ofstream xmlStream1;
+  xmlStream1.open(xmlFile1.toStdString());
+  xmlStream1 << "<TestValue>a</TestValue>";
+  xmlStream1.close();
+
+  QString xmlFile2 = tempDir.path()+"/extra2.xml";
+  std::ofstream xmlStream2;
+  xmlStream2.open(xmlFile2.toStdString());
+  xmlStream2 << "<AdditionalValue>10</AdditionalValue>";
+  xmlStream2.close();
+
+  QString xmlFile3 = tempDir.path()+"/extra3.xml";
+  std::ofstream xmlStream3;
+  xmlStream3.open(xmlFile3.toStdString());
+  xmlStream3 << "<TestValue>b</TestValue>";
+  xmlStream3.close();
+
+  QString templateFile = tempDir.path()+"/test_result.tpl";
+  QString renderedFile = tempDir.path()+"/test_result.txt";
+  std::ofstream of;
+  of.open(templateFile.toStdString());
+  of << "{{ExtraXml.TestValue}}\n"
+     << "{{ExtraXml.AdditionalValue}}";
+  of.close();
+
+  QVector<QString> args = {"template=" + templateFile,
+                           "to=" + renderedFile,
+                           "extraxml=(" + xmlFile1 + "," + xmlFile2 + ", " + xmlFile3 + ")"};
+  UserInterface options(APP_XML, args);
+
+  topds4(testCube, options);
+
+  std::ifstream renderedStream;
+  renderedStream.open(renderedFile.toStdString());
+  std::string line;
+  std::getline(renderedStream, line);
+  EXPECT_EQ("b", line);
+  std::getline(renderedStream, line);
+  EXPECT_EQ("10", line);
 }
 
 TEST_F(SmallCube, FunctionalTestTopds4CurrentTime) {


### PR DESCRIPTION
Added extra pvl, xml, and json data source parameters. They can be a single file or multiple files. In the case of multiple files, duplicate keys/elements in later files overwrite previous files. If this happens, a user warning is logged like this:

```
Group = Warning
  Duplicate = "Duplicate key [TestValue] in extra Pvl file
               [/var/folders/s2/r22kzkt91ms_t4j5b90g5k1w002dkh/T/qt_temp-bLxZd-
               t/extra2.pvl]. Previous value [{"Value":"b"}] will be
               overwritten."
End_Group
End
```

I also re-arranged the included in topds4.cpp and added the xml to json header because I needed it for the extra xml data.