### PR TITLE
Update cubeattribute to include an option to supply CubeAttributeInput directly

### DIFF
--- a/isis/src/base/apps/cubeatt/cubeatt.cpp
+++ b/isis/src/base/apps/cubeatt/cubeatt.cpp
@@ -44,6 +44,16 @@ namespace Isis {
     p.EndProcess();
   }
 
+  // Allows specification of both input and output attributes
+  void cubeatt(QString inputCubePath, CubeAttributeInput inAtt, QString outputCubePath, CubeAttributeOutput outputAttributes, bool propTables) {
+    Cube icube;
+    if (inAtt.bands().size() != 0) {
+      icube.setVirtualBands(inAtt.bands());
+    }
+    icube.open(inputCubePath);
+    cubeatt(&icube, outputCubePath, outputAttributes, propTables);
+  }
+
   // Line processing routine
   void cubeattProcess(Buffer &in, Buffer &out) {
     // Loop and copy pixels in the line.

--- a/isis/src/base/apps/cubeatt/cubeatt.h
+++ b/isis/src/base/apps/cubeatt/cubeatt.h
@@ -7,6 +7,7 @@
 
 namespace Isis{
   extern void cubeatt(Cube *icube, QString outputCubePath, CubeAttributeOutput outputAttributes, bool propTables=false);
+  extern void cubeatt(QString inputCubePath, CubeAttributeInput inputAttributes, QString outputCubePath, CubeAttributeOutput outputAttributes, bool propTables=false);
   extern void cubeatt(Cube *icube, UserInterface &ui);
   extern void cubeatt(UserInterface &ui);
 }

--- a/isis/src/base/objs/XmlToJson/XmlToJson.cpp
+++ b/isis/src/base/objs/XmlToJson/XmlToJson.cpp
@@ -155,7 +155,10 @@ namespace Isis {
           // Translated json goal: a:[val1, val2]
           // If the converted json has an array already, append, else make it an array
           if (!output[element.tagName().toStdString()].is_array()) {
-            output[element.tagName().toStdString()] = {output[element.tagName().toStdString()]};
+            json repeatedArray;
+            repeatedArray.push_back(output[element.tagName().toStdString()]);
+            output[element.tagName().toStdString()] = repeatedArray;
+//            output[element.tagName().toStdString()] = {output[element.tagName().toStdString()]};
           }
           output[element.tagName().toStdString()].push_back(converted[element.tagName().toStdString()]);
         }
@@ -171,7 +174,10 @@ namespace Isis {
           json temporaryJson;
           convertXmlToJson(next, temporaryJson);
           if (!output[element.tagName().toStdString()].is_array()) {
-            output[element.tagName().toStdString()] = {output[element.tagName().toStdString()]};
+            json repeatedArray;
+            repeatedArray.push_back(output[element.tagName().toStdString()]);
+            output[element.tagName().toStdString()] = repeatedArray;
+//            output[element.tagName().toStdString()] = {output[element.tagName().toStdString()]};
           }
           output[element.tagName().toStdString()].push_back(temporaryJson);
         }

--- a/isis/src/base/objs/XmlToJson/XmlToJson.cpp
+++ b/isis/src/base/objs/XmlToJson/XmlToJson.cpp
@@ -158,7 +158,6 @@ namespace Isis {
             json repeatedArray;
             repeatedArray.push_back(output[element.tagName().toStdString()]);
             output[element.tagName().toStdString()] = repeatedArray;
-//            output[element.tagName().toStdString()] = {output[element.tagName().toStdString()]};
           }
           output[element.tagName().toStdString()].push_back(converted[element.tagName().toStdString()]);
         }
@@ -177,7 +176,6 @@ namespace Isis {
             json repeatedArray;
             repeatedArray.push_back(output[element.tagName().toStdString()]);
             output[element.tagName().toStdString()] = repeatedArray;
-//            output[element.tagName().toStdString()] = {output[element.tagName().toStdString()]};
           }
           output[element.tagName().toStdString()].push_back(temporaryJson);
         }

--- a/isis/tests/FunctionalTestsCubeatt.cpp
+++ b/isis/tests/FunctionalTestsCubeatt.cpp
@@ -107,7 +107,6 @@ TEST_F(SmallCube, FunctionalTestCubeattInputCube) {
   cubeatt(testCube, options);
   Cube outputCube(outputCubePath);
 
-  // Check attributes: pixel type, storage format, label format, storage order, pixel range, bands
   EXPECT_EQ(outputCube.pixelType(), PixelType::UnsignedByte);
   // Setting the pixel range modifies the base/multiplier, so check those.
   EXPECT_NE(outputCube.base(), 0);
@@ -128,7 +127,6 @@ TEST_F(SmallCube, FunctionalTestCubeattInputCubeOutputPath) {
   cubeatt(testCube, outputCubePath, attributeOutput);
   Cube outputCube(outputCubePath);
 
-  // Check attributes: pixel type, storage format, label format, storage order, pixel range, bands
   // Setting the pixel range modifies the base/multiplier, so check those.
   EXPECT_NE(outputCube.base(), 0);
   EXPECT_NE(outputCube.multiplier(), 1);
@@ -155,8 +153,6 @@ TEST_F(SmallCube, FunctionalTestCubeattInputAndOutputAttributes) {
   EXPECT_LE(outputStats->Maximum(), 300);
   EXPECT_EQ(outputCube.bandCount(), 3);  
 
-  // Do need to check the label for this one, since outputCube.physicalBand() will not work
-  // in this context:
   Pvl *label = outputCube.label();
   PvlGroup bandBin = label->findObject("IsisCube").findGroup("BandBin");
   EXPECT_EQ(QString(bandBin["OriginalBand"][0]), "3");

--- a/isis/tests/FunctionalTestsCubeatt.cpp
+++ b/isis/tests/FunctionalTestsCubeatt.cpp
@@ -34,6 +34,7 @@ TEST_F(SmallCube, FunctionalTestCubeattBitttypeAndRange) {
   EXPECT_FLOAT_EQ(outputStats->Maximum(), 1.0);
 }
 
+
 TEST_F(SmallCube, FunctionalTestCubeattNoChange) {
   QString cubePath = tempDir.path() + "/NoChangeCubeatt.cub";
   QVector<QString> args = {"from=" + testCube->fileName(), "to=" + cubePath};
@@ -59,7 +60,6 @@ TEST_F(SmallCube, FunctionalTestCubeattNoChange) {
   EXPECT_DOUBLE_EQ(outputStats->Maximum(), inputStats->Maximum());
   EXPECT_DOUBLE_EQ(outputStats->Average(), inputStats->Average());
 }
-
 
 
 TEST_F(SmallCube, FunctionalTestCubeattVirtualBands) {
@@ -98,3 +98,73 @@ TEST_F(SmallCube, FunctionalTestCubeattVirtualBands) {
 }
 
 
+// Test using an already open cube as input and ui
+TEST_F(SmallCube, FunctionalTestCubeattInputCube) {
+  QString outputCubePath = tempDir.path() + "/bitTypeCubeatt.cub+8bit+0.0:1.0";
+  QVector<QString> args = {"from=" + testCube->fileName(), "to=" + outputCubePath};
+  UserInterface options(APP_XML, args);
+
+  cubeatt(testCube, options);
+  Cube outputCube(outputCubePath);
+
+  // Check attributes: pixel type, storage format, label format, storage order, pixel range, bands
+  EXPECT_EQ(outputCube.pixelType(), PixelType::UnsignedByte);
+  // Setting the pixel range modifies the base/multiplier, so check those.
+  EXPECT_NE(outputCube.base(), 0);
+  EXPECT_NE(outputCube.multiplier(), 1);
+
+  // Test the DNs
+  Statistics *outputStats = outputCube.statistics();
+  EXPECT_FLOAT_EQ(outputStats->Minimum(), 0.0);
+  EXPECT_FLOAT_EQ(outputStats->Maximum(), 1.0);
+}
+
+
+// Test using an already open cube as input and specifying an output path and output attributes
+TEST_F(SmallCube, FunctionalTestCubeattInputCubeOutputPath) {
+  QString outputCubePath = tempDir.path() + "/bitTypeCubeatt.cub";
+  CubeAttributeOutput attributeOutput("+8bit+0.0:1.0");
+
+  cubeatt(testCube, outputCubePath, attributeOutput);
+  Cube outputCube(outputCubePath);
+
+  // Check attributes: pixel type, storage format, label format, storage order, pixel range, bands
+  // Setting the pixel range modifies the base/multiplier, so check those.
+  EXPECT_NE(outputCube.base(), 0);
+  EXPECT_NE(outputCube.multiplier(), 1);
+
+  // Test the DNs
+  Statistics *outputStats = outputCube.statistics();
+  EXPECT_FLOAT_EQ(outputStats->Minimum(), 0.0);
+  EXPECT_FLOAT_EQ(outputStats->Maximum(), 1.0);
+}
+
+// Test using the input/output paths and cube attribute input and output passed in directly
+TEST_F(SmallCube, FunctionalTestCubeattInputAndOutputAttributes) {
+  QString inputCubePath = testCube->fileName();
+  CubeAttributeInput attributeInput("+3,2,4");
+  QString outputCubePath = tempDir.path() + "/bitTypeAndVirtualBandsCubeatt.cub";
+  CubeAttributeOutput attributeOutput("+200:300");
+
+  cubeatt(inputCubePath, attributeInput, outputCubePath, attributeOutput);
+
+  Cube outputCube(outputCubePath);
+
+  Statistics *outputStats = outputCube.statistics();
+  EXPECT_GE(outputStats->Minimum(), 200);
+  EXPECT_LE(outputStats->Maximum(), 300);
+  EXPECT_EQ(outputCube.bandCount(), 3);  
+
+  // Do need to check the label for this one, since outputCube.physicalBand() will not work
+  // in this context:
+  Pvl *label = outputCube.label();
+  PvlGroup bandBin = label->findObject("IsisCube").findGroup("BandBin");
+  EXPECT_EQ(QString(bandBin["OriginalBand"][0]), "3");
+  EXPECT_EQ(QString(bandBin["OriginalBand"][1]), "2");
+  EXPECT_EQ(QString(bandBin["OriginalBand"][2]), "4");
+
+  // Test that DNs for each band have moved appropriately
+  EXPECT_DOUBLE_EQ(outputCube.statistics(1)->Average(), testCube->statistics(3)->Average());
+  EXPECT_DOUBLE_EQ(outputCube.statistics(2)->Average(), testCube->statistics(2)->Average());
+  EXPECT_DOUBLE_EQ(outputCube.statistics(3)->Average(), testCube->statistics(4)->Average());
+}


### PR DESCRIPTION
## Description
I just updated the converted cubeatt to include a function signature with allows one to provide CubeAttributeInput as input.

## Related Issue
Part of PDS4 project

## Motivation and Context
Previous version only allowed specification of cube attribute input via the ui arguments.

## How Has This Been Tested?
Works in the newly added test cases.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
