### PR TITLE
added initial CSMCamera test

### DIFF
--- a/isis/src/base/objs/CSMCamera/CSMCamera.h
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.h
@@ -88,7 +88,7 @@ namespace Isis {
       void subSpacecraftPoint(double &lat, double &lon, double line, double sample);
 
     protected:
-      virtual Target *setTarget(Pvl label);
+      void setTarget(Pvl label);
 
       std::vector<double> sensorPositionBodyFixed();
       std::vector<double> sensorPositionBodyFixed(double line, double sample);

--- a/isis/src/base/objs/CameraFactory/CameraFactory.cpp
+++ b/isis/src/base/objs/CameraFactory/CameraFactory.cpp
@@ -64,14 +64,16 @@ namespace Isis {
     initPlugin();
 
     try {
-      // Is there a CSM blob on the cube? 
+      // Is there a CSM blob on the cube?
       // Key off of the CSM state blob, rather than the info group
       // hasBlob() add to Cube!
       if (cube.hasGroup("CsmInfo")) {
+        std::cout << "Creating CSM Camera" << std::endl;
         // Create ISIS CSM Camera Model
         return new CSMCamera(cube);
       }
       else {
+        std::cout << "Creating ISIS Camera" << std::endl;
         // First get the spacecraft and instrument and combine them
         Pvl &lab = *cube.label();
         PvlGroup &inst = lab.findGroup("Instrument", Isis::Pvl::Traverse);
@@ -81,23 +83,23 @@ namespace Isis {
         name = name.toUpper();
         QString group = spacecraft + "/" + name;
         group = group.remove(" ");
-       
+
         PvlGroup &kerns = lab.findGroup("Kernels", Isis::Pvl::Traverse);
         // Default version 1 for backwards compatibility (spiceinit'd cubes before camera model versioning)
         if (!kerns.hasKeyword("CameraVersion")) {
           kerns.addKeyword(PvlKeyword("CameraVersion", "1"));
         }
-       
+
         int cameraOriginalVersion = (int)kerns["CameraVersion"];
         int cameraNewestVersion = CameraVersion(cube);
-       
+
         if (cameraOriginalVersion != cameraNewestVersion) {
           string msg = "The camera model used to create a camera for this cube is out of date, " \
                        "please re-run spiceinit on the file or process with an old Isis version " \
                        "that has the correct camera model.";
           throw IException(IException::Unknown, msg, _FILEINFO_);
         }
-       
+
         // See if we have a camera model plugin
         QFunctionPointer ptr;
         try {
@@ -109,11 +111,11 @@ namespace Isis {
           msg += name + "]";
           throw IException(e, IException::Unknown, msg, _FILEINFO_);
         }
-       
+
         // Now cast that pointer in the proper way
         Camera * (*plugin)(Isis::Cube &cube);
         plugin = (Camera * ( *)(Isis::Cube &cube)) ptr;
-       
+
         // Create the camera as requested
         return (*plugin)(cube);
       }

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -117,7 +117,7 @@ namespace Isis {
   // TODO: docs
   void Spice::csmInit(Cube &cube, Pvl label) {
     defaultInit();
-    m_target = setTarget(label);
+    m_target = new Target;
     NaifStatus::CheckErrors();
   }
 
@@ -278,7 +278,7 @@ namespace Isis {
       // NAIF keywords have been pulled from the cube labels, so we can find target body codes
       // that are defined in kernels and not just body codes build into spicelib
       // TODO: Move this below the else once the rings code below has been refactored
-      m_target = setTarget(lab);
+      m_target = new Target(this, lab);
 
       // This should not be here. Consider having spiceinit add the necessary rings kernels to the
       // Extra parameter if the user has set the shape model to RingPlane.
@@ -298,7 +298,7 @@ namespace Isis {
       // that are defined in kernels and not just body codes build into spicelib
       // TODO: Move this below the else once the rings code above has been refactored
 
-      m_target = setTarget(lab);
+      m_target = new Target(this, lab);
     }
 
     // Get NAIF ik, spk, sclk, and ck codes
@@ -490,12 +490,6 @@ namespace Isis {
       m_instrumentPosition->LoadCache(t);
     }
     NaifStatus::CheckErrors();
-  }
-
-
-  // New function to set m_target
-  Target *Spice::setTarget(Pvl label) {
-    return new Target(this, label);
   }
 
 

--- a/isis/src/base/objs/Spice/Spice.h
+++ b/isis/src/base/objs/Spice/Spice.h
@@ -389,7 +389,6 @@ namespace Isis {
                                   space so that conversions between double and
                                   SpiceDouble do not have to occur in inheriting
                                   classes.*/
-      virtual Target *setTarget(Pvl label);
       Target *m_target; //!< Target of the observation
 
     private:

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -243,9 +243,6 @@ TEST_F(CSMCameraFixture, SetGround) {
   csm::Ellipsoid wgs84;
   csm::ImageCoord imagePt(4.5, 4.5);
   csm::EcefCoord groundPt(wgs84.getSemiMajorRadius(), 0, 0);
-  SurfacePoint surfPoint(Latitude(0.0, Angle::Degrees),
-                         Longitude(0.0, Angle::Degrees),
-                         Distance(wgs84.getSemiMajorRadius(), Distance::Meters));
   csm::EcefCoord observerPos(wgs84.getSemiMajorRadius() + 50000, 0, 0);
 
   // Setup expected calls/returns
@@ -260,7 +257,9 @@ TEST_F(CSMCameraFixture, SetGround) {
   EXPECT_EQ(testCam->Line(), 5.0);
   EXPECT_EQ(testCam->Sample(), 5.0);
 
-  EXPECT_TRUE(testCam->SetGround(surfPoint));
+  EXPECT_TRUE(testCam->SetGround(SurfacePoint(Latitude(0.0, Angle::Degrees),
+                                 Longitude(0.0, Angle::Degrees),
+                                 Distance(wgs84.getSemiMajorRadius(), Distance::Meters))));
   EXPECT_EQ(testCam->Line(), 5.0);
   EXPECT_EQ(testCam->Sample(), 5.0);
 

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -243,17 +243,32 @@ TEST_F(CSMCameraFixture, SetGround) {
   csm::Ellipsoid wgs84;
   csm::ImageCoord imagePt(4.5, 4.5);
   csm::EcefCoord groundPt(wgs84.getSemiMajorRadius(), 0, 0);
+  SurfacePoint surfPoint(Latitude(0.0, Angle::Degrees),
+                         Longitude(0.0, Angle::Degrees),
+                         Distance(wgs84.getSemiMajorRadius(), Distance::Meters));
   csm::EcefCoord observerPos(wgs84.getSemiMajorRadius() + 50000, 0, 0);
 
   // Setup expected calls/returns
   EXPECT_CALL(mockModel, groundToImage(MatchEcefCoord(groundPt), ::testing::_, ::testing::_, ::testing::_))
-      .Times(1)
-      .WillOnce(::testing::Return(imagePt));
+      .Times(4)
+      .WillRepeatedly(::testing::Return(imagePt));
   EXPECT_CALL(mockModel, getSensorPosition(MatchImageCoord(imagePt)))
-      .Times(1)
-      .WillOnce(::testing::Return(observerPos));
+      .Times(4)
+      .WillRepeatedly(::testing::Return(observerPos));
 
-  testCam->SetGround(Latitude(0.0, Angle::Degrees), Longitude(0.0, Angle::Degrees));
+  EXPECT_TRUE(testCam->SetGround(Latitude(0.0, Angle::Degrees), Longitude(0.0, Angle::Degrees)));
+  EXPECT_EQ(testCam->Line(), 5.0);
+  EXPECT_EQ(testCam->Sample(), 5.0);
+
+  EXPECT_TRUE(testCam->SetGround(surfPoint));
+  EXPECT_EQ(testCam->Line(), 5.0);
+  EXPECT_EQ(testCam->Sample(), 5.0);
+
+  EXPECT_TRUE(testCam->SetUniversalGround(0.0, 0.0));
+  EXPECT_EQ(testCam->Line(), 5.0);
+  EXPECT_EQ(testCam->Sample(), 5.0);
+
+  EXPECT_TRUE(testCam->SetUniversalGround(0.0, 0.0, wgs84.getSemiMajorRadius()));
   EXPECT_EQ(testCam->Line(), 5.0);
   EXPECT_EQ(testCam->Sample(), 5.0);
 }

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -1,0 +1,223 @@
+#include <QString>
+#include <QUuid>
+#include <iostream>
+
+#include "csm/CorrelationModel.h"
+#include "csm/Ellipsoid.h"
+#include "csm/RasterGM.h"
+
+#include "AlternativeTestCsmModel.h"
+#include "TestCsmPlugin.h"
+#include "MockCsmPlugin.h"
+#include "Fixtures.h"
+#include "TestUtilities.h"
+#include "TestCsmModel.h"
+#include "StringBlob.h"
+#include "FileName.h"
+
+#include <nlohmann/json.hpp>
+using json = nlohmann::json;
+
+#include "gmock/gmock.h"
+
+using namespace Isis;
+
+// Mock CSM Model class
+class MockRasterGM : public csm::RasterGM {
+  public:
+    // csm::Model
+    MOCK_METHOD(csm::Version, getVersion, (), (const, override));
+    MOCK_METHOD(std::string, getModelName, (), (const, override));
+    MOCK_METHOD(std::string, getPedigree, (), (const, override));
+    MOCK_METHOD(std::string, getImageIdentifier, (), (const, override));
+    MOCK_METHOD(void, setImageIdentifier, (const std::string&, csm::WarningList*), (override));
+    MOCK_METHOD(std::string, getSensorIdentifier, (), (const, override));
+    MOCK_METHOD(std::string, getPlatformIdentifier, (), (const, override));
+    MOCK_METHOD(std::string, getCollectionIdentifier, (), (const, override));
+    MOCK_METHOD(std::string, getTrajectoryIdentifier, (), (const, override));
+    MOCK_METHOD(std::string, getSensorType, (), (const, override));
+    MOCK_METHOD(std::string, getSensorMode, (), (const, override));
+    MOCK_METHOD(std::string, getReferenceDateAndTime, (), (const, override));
+    MOCK_METHOD(std::string, getModelState, (), (const, override));
+    MOCK_METHOD(void, replaceModelState, (const std::string&), (override));
+    // csm::GeometricModel methods
+    MOCK_METHOD(csm::EcefCoord, getReferencePoint, (), (const, override));
+    MOCK_METHOD(void, setReferencePoint, (const csm::EcefCoord&), (override));
+    MOCK_METHOD(int, getNumParameters, (), (const, override));
+    MOCK_METHOD(std::string, getParameterName, (int), (const, override));
+    MOCK_METHOD(std::string, getParameterUnits, (int), (const, override));
+    MOCK_METHOD(bool, hasShareableParameters, (), (const, override));
+    MOCK_METHOD(bool, isParameterShareable, (int), (const, override));
+    MOCK_METHOD(csm::SharingCriteria, getParameterSharingCriteria, (int), (const, override));
+    MOCK_METHOD(double, getParameterValue, (int), (const, override));
+    MOCK_METHOD(void, setParameterValue, (int, double), (override));
+    MOCK_METHOD(csm::param::Type, getParameterType, (int), (const, override));
+    MOCK_METHOD(void, setParameterType, (int, csm::param::Type), (override));
+    MOCK_METHOD(double, getParameterCovariance, (int, int), (const, override));
+    MOCK_METHOD(void, setParameterCovariance, (int, int, double), (override));
+    MOCK_METHOD(int, getNumGeometricCorrectionSwitches, (), (const, override));
+    MOCK_METHOD(std::string, getGeometricCorrectionName, (int), (const, override));
+    MOCK_METHOD(void, setGeometricCorrectionSwitch, (int, bool, csm::param::Type), (override));
+    MOCK_METHOD(bool, getGeometricCorrectionSwitch, (int), (const, override));
+    MOCK_METHOD(std::vector<double>,
+                getCrossCovarianceMatrix,
+                (const csm::GeometricModel&, csm::param::Set, const csm::GeometricModel::GeometricModelList&),
+                (const, override));
+    // RasterGM methods
+    MOCK_METHOD(csm::ImageCoord, groundToImage, (const csm::EcefCoord&, double, double*, csm::WarningList*), (const, override));
+    MOCK_METHOD(csm::ImageCoordCovar,
+                groundToImage,
+                (const csm::EcefCoordCovar&, double, double*, csm::WarningList*),
+                (const, override));
+    MOCK_METHOD(csm::EcefCoord,
+                imageToGround,
+                (const csm::ImageCoord&, double, double, double*, csm::WarningList*),
+                (const, override));
+    MOCK_METHOD(csm::EcefCoordCovar,
+                imageToGround,
+                (const csm::ImageCoordCovar&, double, double, double, double*, csm::WarningList*),
+                (const, override));
+    MOCK_METHOD(csm::EcefLocus,
+                imageToProximateImagingLocus,
+                (const csm::ImageCoord&, const csm::EcefCoord&, double, double*, csm::WarningList*),
+                (const, override));
+    MOCK_METHOD(csm::EcefLocus,
+                imageToRemoteImagingLocus,
+                (const csm::ImageCoord&, double, double*, csm::WarningList*),
+                (const, override));
+    MOCK_METHOD(csm::ImageCoord, getImageStart, (), (const, override));
+    MOCK_METHOD(csm::ImageVector, getImageSize, (), (const, override));
+    MOCK_METHOD((std::pair<csm::ImageCoord, csm::ImageCoord>), getValidImageRange, (), (const, override));
+    MOCK_METHOD((std::pair<double,double>), getValidHeightRange, (), (const, override));
+    MOCK_METHOD(csm::EcefVector, getIlluminationDirection, (const csm::EcefCoord&), (const, override));
+    MOCK_METHOD(double, getImageTime, (const csm::ImageCoord&), (const, override));
+    MOCK_METHOD(csm::EcefCoord, getSensorPosition, (const csm::ImageCoord&), (const, override));
+    MOCK_METHOD(csm::EcefCoord, getSensorPosition, (double), (const, override));
+    MOCK_METHOD(csm::EcefVector, getSensorVelocity, (const csm::ImageCoord&), (const, override));
+    MOCK_METHOD(csm::EcefVector, getSensorVelocity, (double), (const, override));
+    MOCK_METHOD(csm::RasterGM::SensorPartials,
+                computeSensorPartials,
+                (int, const csm::EcefCoord&, double, double*, csm::WarningList*),
+                (const, override));
+    MOCK_METHOD(csm::RasterGM::SensorPartials,
+                computeSensorPartials,
+                (int, const csm::ImageCoord&, const csm::EcefCoord&, double, double*, csm::WarningList*),
+                (const, override));
+    MOCK_METHOD(std::vector<double>, computeGroundPartials, (const csm::EcefCoord&), (const, override));
+    MOCK_METHOD(const csm::CorrelationModel&, getCorrelationModel, (), (const, override));
+    MOCK_METHOD(std::vector<double>,
+                getUnmodeledCrossCovariance,
+                (const csm::ImageCoord&, const csm::ImageCoord&),
+                (const, override));
+};
+
+class CSMCameraFixture : public SmallCube {
+  protected:
+    QString filename;
+    MockRasterGM mockModel;
+
+    void SetUp() override {
+      SmallCube::SetUp();
+
+      // Instrument group
+      // Just need a target name
+      PvlGroup instGroup("Instrument");
+      instGroup += PvlKeyword("TargetName", "TestTarget");
+      instGroup += PvlKeyword("InstrumentId", "TestId");
+      testCube->putGroup(instGroup);
+
+      // CSMInfo group
+      // This just has to exist, but fill it out for completeness and incase it
+      // ever does matter
+      PvlGroup infoGroup("CsmInfo");
+      infoGroup += PvlKeyword("CSMPlatformID", "TestPlatform");
+      infoGroup += PvlKeyword("CSMInstrumentId", "TestInstrument");
+      infoGroup += PvlKeyword("ReferenceTime", "2000-01-01T11:58:55.816"); // J2000 epoch
+
+      PvlKeyword paramNames("ModelParameterNames");
+      paramNames += "TestNoneParam";
+      paramNames += "TestFictitiousParam";
+      paramNames += "TestRealParam";
+      paramNames += "TestFixedParam";
+      PvlKeyword paramUnits("ModelParameterUnits");
+      paramUnits += "unitless";
+      paramUnits += "m";
+      paramUnits += "rad";
+      paramUnits += "lines/sec";
+      PvlKeyword paramTypes("ModelParameterTypes");
+      paramTypes += "NONE";
+      paramTypes += "FICTITIOUS";
+      paramTypes += "REAL";
+      paramTypes += "FIXED";
+
+      infoGroup += paramNames;
+      infoGroup += paramUnits;
+      infoGroup += paramTypes;
+
+      testCube->putGroup(infoGroup);
+
+      // Register the mock with our plugin
+      std::string mockModelName = QUuid().toString().toStdString();
+      MockCsmPlugin loadablePlugin;
+      loadablePlugin.registerModel(mockModelName, &mockModel);
+
+      // Account for calls that happen while making a CSMCamera
+      EXPECT_CALL(mockModel, getSensorIdentifier())
+          .Times(2)
+          .WillRepeatedly(::testing::Return("MockSensorID"));
+      EXPECT_CALL(mockModel, getPlatformIdentifier())
+          .Times(2)
+          .WillRepeatedly(::testing::Return("MockPlatformID"));
+
+      // CSMState BLOB
+      StringBlob csmStateBlob(mockModelName, "CSMState");
+      csmStateBlob.Label() += PvlKeyword("ModelName", QString::fromStdString(mockModelName));
+      csmStateBlob.Label() += PvlKeyword("PluginName", QString::fromStdString(loadablePlugin.getPluginName()));
+      testCube->write(csmStateBlob);
+      filename = testCube->fileName();
+      testCube->close();
+      testCube->open(filename);
+    }
+};
+
+TEST(CSMCameraTest, MockTest) {
+  MockRasterGM mockModel;
+  EXPECT_CALL(mockModel, getVersion())
+      .Times(1)
+      .WillOnce(::testing::Return(csm::Version(1, 2, 3)));
+  csm::Version mockVersion = mockModel.getVersion();
+  EXPECT_EQ(mockVersion.major(), 1);
+  EXPECT_EQ(mockVersion.minor(), 2);
+  EXPECT_EQ(mockVersion.revision(), 3);
+}
+
+TEST(CSMCameraTest, LoadMockTest) {
+  MockRasterGM mockModel;
+  EXPECT_CALL(mockModel, getVersion())
+      .Times(1)
+      .WillOnce(::testing::Return(csm::Version(1, 2, 3)));
+
+  // Use a universally unique identifier for thread safety
+  std::string mockModelName = QUuid().toString().toStdString();
+  MockCsmPlugin loadablePlugin;
+  loadablePlugin.registerModel(mockModelName, &mockModel);
+
+  csm::Model *returnedModel = csm::Plugin::findPlugin(MockCsmPlugin::PLUGIN_NAME)->constructModelFromState(mockModelName);
+  csm::Version mockVersion = returnedModel->getVersion();
+  EXPECT_EQ(mockVersion.major(), 1);
+  EXPECT_EQ(mockVersion.minor(), 2);
+  EXPECT_EQ(mockVersion.revision(), 3);
+}
+
+TEST_F(CSMCameraFixture, SetImage) {
+  Camera *testCam = testCube->camera();
+  csm::Ellipsoid wgs84;
+  // EXPECT_CALL(mockModel, imageToRemoteImagingLocus(csm::ImageCoord(4.5, 4.5), _, _, _))
+  EXPECT_CALL(mockModel, imageToRemoteImagingLocus)
+      .Times(1)
+      .WillOnce(::testing::Return(csm::EcefLocus(wgs84.getSemiMajorRadius() + 50000, 0, 0, -1, 0, 0))); // looking straight down X-Axis
+
+  testCam->SetImage(5, 5);
+  EXPECT_EQ(testCam->UniversalLatitude(), 0.0);
+  EXPECT_EQ(testCam->UniversalLongitude(), 0.0);
+}

--- a/isis/tests/MockCsmPlugin.cpp
+++ b/isis/tests/MockCsmPlugin.cpp
@@ -1,0 +1,261 @@
+#include <iostream>
+
+#include "MockCsmPlugin.h"
+
+// Static Instance of itself
+const MockCsmPlugin MockCsmPlugin::m_registeredPlugin;
+
+// Declaration of static variables
+const std::string MockCsmPlugin::PLUGIN_NAME = "MockCsmPlugin";
+const std::string MockCsmPlugin::MANUFACTURER_NAME = "MockCsmPluginCreator";
+const std::string MockCsmPlugin::RELEASE_DATE = "20210201";
+QMap<std::string, csm::Model*> MockCsmPlugin::m_registeredModels = QMap<std::string, csm::Model*>();
+
+/**
+ * Default constructor
+ */
+MockCsmPlugin::MockCsmPlugin() {
+  // deliberately blank for testing
+}
+
+
+/**
+ * Default destructor
+ */
+MockCsmPlugin::~MockCsmPlugin() {}
+
+
+/**
+ * Gets the name of the plugin.
+ *
+ * @return std::string name of the plugin
+ */
+std::string MockCsmPlugin::getPluginName() const {
+  return MockCsmPlugin::PLUGIN_NAME;
+}
+
+
+/**
+ * Gets the name of the manufacturer of the plugin.
+ *
+ * @return std::string the name of the manufacturer of the plugin
+ */
+std::string MockCsmPlugin::getManufacturer() const {
+  return MockCsmPlugin::MANUFACTURER_NAME;
+}
+
+
+/**
+ * Gets the release date of the plugin.
+ *
+ * @return std::string release date
+ */
+std::string MockCsmPlugin::getReleaseDate() const {
+  return MockCsmPlugin::RELEASE_DATE;
+}
+
+
+/**
+ * Returns the version of CSM the Plugin uses.
+ *
+ * @return csm::Version CSM version plugin uses
+ */
+csm::Version MockCsmPlugin::getCsmVersion() const {
+  return csm::Version(3,0,3);
+}
+
+
+/**
+ * Returns the number of sensor models in the plugin
+ *
+ * @return size_t Number of sensor models in the plugin
+ */
+size_t MockCsmPlugin::getNumModels() const {
+  // This will change as models are loaded into the plugin,
+  // and we cannot access the model registry by index so just say it's empty
+  return 0;
+}
+
+
+/**
+ * Returns the model name at the given index.
+ *
+ * @param modelIndex The index number for the sensor model
+ *
+ * @return std::string model name
+ */
+std::string MockCsmPlugin::getModelName(size_t modelIndex) const {
+  // We cannot access the model registry by index so just return a dummy value
+  return "Dummy Model Name";
+}
+
+
+/**
+ * Returns the sensor model family at the given index.
+ *
+ * @param modelIndex the index number for the sensor model family
+ *
+ * @return std::string sensor model family
+ */
+std::string MockCsmPlugin::getModelFamily(size_t modelIndex) const {
+  // We cannot access the model registry by index so just return a dummy value
+  return "TestModelFamily";
+}
+
+
+/**
+ * Returns the CSM sensor model version for a given model.
+ *
+ * @param modelName the model name
+ *
+ * @return csm::Version the version of the csm sensor model
+ */
+csm::Version MockCsmPlugin::getModelVersion(const std::string& modelName) const {
+  return csm::Version(1,0,0);
+}
+
+
+/**
+ * Tests if the sensor model can be created from a given state.
+ *
+ * @param modelName the model name
+ * @param modelState the model state
+ * @param warnings the warning list
+ *
+ * @return bool if the model can be constructed from the state
+ */
+bool MockCsmPlugin::canModelBeConstructedFromState(const std::string& modelName,
+                                    const std::string& modelState,
+                                    csm::WarningList* warnings) const {
+  return m_registeredModels.contains(modelState);
+}
+
+
+/**
+ * Checks to see if the CSM sensor model can be constructed from
+ * a given ISD.
+ *
+ * @param imageSupportData isd for the image
+ * @param modelName name of the sensor model
+ * @param warnings warnings list
+ *
+ * @return bool true if the model can be constructed from the isd
+ */
+bool MockCsmPlugin::canModelBeConstructedFromISD(
+    const csm::Isd& imageSupportData,
+    const std::string& modelName,
+    csm::WarningList* warnings) const {
+  // Do not do anything with ISDs so that we don't interfere with csminit testing
+  return false;
+}
+
+
+/**
+ * True if the ISD can be converted to a state.
+ *
+ * @param imageSupportData the image support data
+ * @param modelName the name of the model
+ * @param warnings the warnings list
+ *
+ * @return bool true if the ISD can be converted to a state.
+ */
+bool MockCsmPlugin::canISDBeConvertedToModelState(
+    const csm::Isd& imageSupportData,
+    const std::string& modelName,
+    csm::WarningList* warnings) const{
+  // Do not do anything with ISDs so that we don't interfere with csminit testing
+  return false;
+}
+
+
+/**
+ * Conver an ISD (Image Support Data) to a model state.
+ *
+ * @param imageSupportData The ISD
+ * @param modelName The name of the model.
+ * @param warnings The warnings list.
+ *
+ * @return std::string the model state converted from the ISD
+ */
+std::string MockCsmPlugin::convertISDToModelState(
+    const csm::Isd& imageSupportData,
+    const std::string& modelName,
+    csm::WarningList* warnings) const {
+  // Do not do anything with ISDs so return a dummy value
+  return "Dummy model state";
+}
+
+
+/**
+ * Extracts and returns the model name from the model state.
+ *
+ * @param modelState State of the sensor model
+ * @param warnings The warnings list
+ *
+ * @return std::string The sensor model name
+ */
+std::string MockCsmPlugin::getModelNameFromModelState(
+    const std::string& modelState,
+    csm::WarningList* warnings) const {
+  // The state strings are just the model name so return that
+  return modelState;
+}
+
+
+/**
+ * Register a new model with the plugin.
+ * The model can be accessed by calling constructModelFromState with the modelName
+ * as the state string.
+ *
+ * @param modelName The name of the model to be used to access it
+ * @param model The model to register
+ */
+void MockCsmPlugin::registerModel(std::string modelName, csm::Model* model) {
+  m_registeredModels.insert(modelName, model);
+}
+
+
+/**
+ * Creates and returns a sensor model from a state string.
+ * This will access the internal model registry and return a pointer to the model
+ * whose name is the state string. This will also remove the model from the model registry.
+ *
+ * @param modelState State of the sensor model
+ * @param warnings The csm warnings list
+ *
+ * @return csm::Model* The constructed sensor model
+ */
+csm::Model* MockCsmPlugin::constructModelFromState(
+      const std::string& modelState,
+      csm::WarningList* warnings) const {
+  // QMap::take will return a default value if the key is not in the map
+  // so check that it's there before calling take.
+  if (m_registeredModels.contains(modelState)) {
+    return m_registeredModels.take(modelState);
+  }
+  csm::Error::ErrorType errorType = csm::Error::SENSOR_MODEL_NOT_SUPPORTED;
+  std::string msg = "MockCsmPlugin failed to construct model from State";
+  std::string func = "MockCsmPlugin::constructModelFromState";
+  throw csm::Error(errorType, msg, func);
+}
+
+
+/**
+ * Constructs and returns a sensor model from an ISD.
+ *
+ * @param imageSupportData The image support data for an image
+ * @param modelName The sensor model name
+ *
+ * @return csm::Model* the model constructed from the ISD
+ */
+csm::Model* MockCsmPlugin::constructModelFromISD(
+    const csm::Isd& imageSupportData,
+    const std::string& modelName,
+    csm::WarningList* ) const {
+  // Do not do anything with ISDs so that we don't interfere with csminit testing
+  csm::Error::ErrorType errorType = csm::Error::SENSOR_MODEL_NOT_SUPPORTED;
+  std::string msg = "TstCsmPlugin does not support constructing modeles from ISD";
+  std::string func = "MockCsmPlugin::constructModelFromIsd";
+  throw csm::Error(errorType, msg, func);
+}
+

--- a/isis/tests/MockCsmPlugin.h
+++ b/isis/tests/MockCsmPlugin.h
@@ -1,0 +1,83 @@
+#ifndef MockCsmPlugin_h
+#define MockCsmPlugin_h
+
+#include <string>
+
+#include <QMap>
+
+#include "csm/Plugin.h"
+#include "csm/Model.h"
+#include "csm/Version.h"
+
+#include <nlohmann/json.hpp>
+
+/**
+ * Test Community Sensor Model (CSM) plugin class to use for loading specific camera models.
+ */
+class MockCsmPlugin : public csm::Plugin {
+ public:
+  // Static variables that describe the plugin
+  static const std::string PLUGIN_NAME;
+  static const std::string MANUFACTURER_NAME;
+  static const std::string RELEASE_DATE;
+  static const int N_SENSOR_MODELS;
+
+  MockCsmPlugin();
+  ~MockCsmPlugin();
+
+  std::string getPluginName() const;
+
+  std::string getManufacturer() const;
+
+  std::string getReleaseDate() const;
+
+  csm::Version getCsmVersion() const;
+
+  size_t getNumModels() const;
+
+  std::string getModelName(size_t modelIndex) const;
+
+  std::string getModelFamily(size_t modelIndex) const;
+
+  csm::Version getModelVersion(const std::string& modelName) const;
+
+  bool canModelBeConstructedFromState(const std::string& modelName,
+      const std::string& modelState,
+      csm::WarningList* warnings = NULL) const;
+
+  bool canModelBeConstructedFromISD(
+      const csm::Isd& imageSupportData,
+      const std::string& modelName,
+      csm::WarningList* warnings = NULL) const;
+
+  bool canISDBeConvertedToModelState(
+      const csm::Isd& imageSupportData,
+      const std::string& modelName,
+      csm::WarningList* warnings = NULL) const;
+
+  std::string convertISDToModelState(
+      const csm::Isd& imageSupportData,
+      const std::string& modelName,
+      csm::WarningList* warnings = NULL) const;
+
+  csm::Model* constructModelFromState(
+      const std::string& modelState,
+      csm::WarningList* warnings = NULL) const;
+
+  csm::Model* constructModelFromISD(
+      const csm::Isd& imageSupportData,
+      const std::string& modelName,
+      csm::WarningList* warnings = NULL) const;
+
+  std::string getModelNameFromModelState(
+      const std::string& modelState,
+      csm::WarningList* warnings = NULL) const;
+
+  void registerModel(std::string stateString, csm::Model* model);
+
+  private:
+    static const MockCsmPlugin m_registeredPlugin; //! static instance of plugin
+    static QMap<std::string, csm::Model*> m_registeredModels;
+};
+
+#endif


### PR DESCRIPTION
Created mock csm::RasterGM objects to test our API calls through Gmock. Also, added a new plugin that allows us to register the mocks so that the CSMCamera class can get them properly.

Wrote a simple test for SetImage. We ran out of time before we could get the Matcher stuff for csm::ImageCoord in the imaging locus call working. It will be in a follow on PR.

Done with @scsides 