### PR TITLE
Convert input relative paths to absolute in isisVarInit.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ update the Unreleased link so that it compares against the latest release tag.
 - Fixed not being able to enable USECOORDLIST argument in mappt. [#4150](https://github.com/USGS-Astrogeology/ISIS3/issues/4150)
 - Fixed history entry not being added to a cube when running spiceinit with web=true. [4040](https://github.com/USGS-Astrogeology/ISIS3/issues/4040)
 - Updated wavelength and bandbin values in translation files for the TGO CaSSIS BandBin group. [4147](https://github.com/USGS-Astrogeology/ISIS3/issues/4147)
+- Fixed relative paths not being properly converted to absolute paths in isisVarInit.py [4274](https://github.com/USGS-Astrogeology/ISIS3/issues/4274)
 
 ## [4.3.0] - 2020-10-02
 

--- a/isis/scripts/isisVarInit.py
+++ b/isis/scripts/isisVarInit.py
@@ -21,6 +21,26 @@ from pathlib import Path
 # SPDX-License-Identifier: CC0-1.0
 
 
+class ResolveAction(argparse.Action):
+    """A custom action that returns the absolute version of the provided
+    pathlib.Path argument.
+    """
+
+    def __init__(self, option_strings, dest, type=None, **kwargs):
+        if issubclass(Path, type):
+            super(ResolveAction, self).__init__(
+                option_strings, dest, type=type, **kwargs
+            )
+        else:
+            raise TypeError(
+                f"The type= parameter of argument {dest} must be a "
+                f"class or subclass of pathlib.Path."
+            )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        setattr(namespace, self.dest, values.resolve())
+
+
 def mkdir(p: Path) -> str:
     """Returns a string with a message about the creation or existance
     of the path, *p*."""
@@ -64,23 +84,26 @@ parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument(
     "-d",
     "--data-dir",
-    default=os.environ["CONDA_PREFIX"] + "/data",
+    default=Path(os.environ["CONDA_PREFIX"] + "/data"),
     type=Path,
+    action=ResolveAction,
     help="ISIS Data Directory, default: %(default)s",
 )
 parser.add_argument(
     "-t",
     "--test-dir",
-    default=os.environ["CONDA_PREFIX"] + "/testData",
+    default=Path(os.environ["CONDA_PREFIX"] + "/testData"),
     type=Path,
+    action=ResolveAction,
     help="ISIS Test Data Directory, default: %(default)s",
 )
 
 parser.add_argument(
     "-a",
     "--ale-dir",
-    default=os.environ["CONDA_PREFIX"] + "/aleData",
+    default=Path(os.environ["CONDA_PREFIX"] + "/aleData"),
     type=Path,
+    action=ResolveAction,
     help="ISIS Ale Data Directory, default: %(default)s",
 )
 args = parser.parse_args()


### PR DESCRIPTION
## Description
Added a custom argparse Action class to resolve relative paths to an absolute path for each of the optional arguments that a user could specify.

## Related Issue
Would close #4274.

## Motivation and Context
"Does the right thing" even when users may only enter a relative path name.

## How Has This Been Tested?
Tested in an ISIS 4.2.0 and an ISIS 4.3.0 conda environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- Bug fix (non-breaking change which fixes an issue)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
