### PR TITLE
Updated CSMCamera tests to pass

### DIFF
--- a/isis/src/base/objs/CSMCamera/CSMCamera.cpp
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.cpp
@@ -82,8 +82,6 @@ namespace Isis {
     m_spacecraftNameLong = QString::fromStdString(m_model->getPlatformIdentifier());
     m_spacecraftNameShort = QString::fromStdString(m_model->getPlatformIdentifier());
 
-    // TODO: Find out why this is 12 hrs different than ths StartTime in the ISIS label.
-    std::cout << m_model->getReferenceDateAndTime() << std::endl;
     // We have to strip off any trailing Zs and then add separators in order for iTime to work
     // TODO make this work with more time string formats and move to iTime
     QString timeString = QString::fromStdString(m_model->getReferenceDateAndTime());

--- a/isis/src/base/objs/CSMCamera/CSMCamera.cpp
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.cpp
@@ -274,12 +274,6 @@ namespace Isis {
   }
 
 
-  void CSMCamera::setTime(const iTime &time) {
-    QString msg = "Setting the image time is not supported for CSM camera models";
-    throw IException(IException::Programmer, msg, _FILEINFO_);
-  }
-
-
   double CSMCamera::LineResolution() {
     vector<double> imagePartials = ImagePartials();
     return sqrt(imagePartials[0]*imagePartials[0] +
@@ -390,37 +384,6 @@ namespace Isis {
     lon = surfacePoint.GetLongitude().degrees();
   }
 
-
-  /**
-   * Returns the sub-solar latitude/longitude in universal coordinates (0-360
-   * positive east, ocentric)
-   *
-   * This is not supported for CSM sensors because we cannot get the position
-   * of the sun, only the illumination direction
-   *
-   * @param lat Sub-solar latitude
-   * @param lon Sub-solar longitude
-   *
-   * @see setTime()
-   * @throw Isis::IException::Programmer - "You must call SetTime
-   *             first."
-   */
-  void CSMCamera::subSolarPoint(double &lat, double &lon) {
-    QString msg = "Sun position is not supported for CSM camera models";
-    throw IException(IException::Programmer, msg, _FILEINFO_);
-  }
-
-
-  /**
-   * Returns the pixel ifov offsets from center of pixel.  For vims this will be a rectangle or
-   * square, depending on the sampling mode.  The first vertex is the top left.
-   *
-   * The CSM API does not support this type of internal information about the sensor.
-   */
-   QList<QPointF> CSMCamera::PixelIfovOffsets() {
-     QString msg = "Pixel Field of View is not computable for a CSM camera model.";
-     throw IException(IException::User, msg, _FILEINFO_);
-   }
 
   /**
   * Compute the partial derivatives of the ground point with respect to
@@ -610,6 +573,44 @@ namespace Isis {
         sensorPosition[0] * sensorPosition[0] +
         sensorPosition[1] * sensorPosition[1] +
         sensorPosition[2] * sensorPosition[2]);
+  }
+
+
+  void CSMCamera::setTime(const iTime &time) {
+    QString msg = "Setting the image time is not supported for CSM camera models";
+    throw IException(IException::Programmer, msg, _FILEINFO_);
+  }
+
+
+  /**
+   * Returns the sub-solar latitude/longitude in universal coordinates (0-360
+   * positive east, ocentric)
+   *
+   * This is not supported for CSM sensors because we cannot get the position
+   * of the sun, only the illumination direction
+   *
+   * @param lat Sub-solar latitude
+   * @param lon Sub-solar longitude
+   *
+   * @see setTime()
+   * @throw Isis::IException::Programmer - "You must call SetTime
+   *             first."
+   */
+  void CSMCamera::subSolarPoint(double &lat, double &lon) {
+    QString msg = "Sub solar point is not supported for CSM camera models";
+    throw IException(IException::Programmer, msg, _FILEINFO_);
+  }
+
+
+  /**
+   * Returns the pixel ifov offsets from center of pixel.  For vims this will be a rectangle or
+   * square, depending on the sampling mode.  The first vertex is the top left.
+   *
+   * The CSM API does not support this type of internal information about the sensor.
+   */
+  QList<QPointF> CSMCamera::PixelIfovOffsets() {
+    QString msg = "Pixel Field of View is not supported for CSM camera models";
+    throw IException(IException::User, msg, _FILEINFO_);
   }
 
 

--- a/isis/src/base/objs/CSMCamera/CSMCamera.cpp
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.cpp
@@ -552,8 +552,15 @@ namespace Isis {
 
 
   double CSMCamera::PhaseAngle() const {
-    csm::EcefVector sunEcefVec = m_model->getIlluminationDirection(isisToCsmGround(GetSurfacePoint()));
-    std::vector<double> sunVec = {sunEcefVec.x, sunEcefVec.y, sunEcefVec.z};
+    csm::EcefCoord groundPt = isisToCsmGround(GetSurfacePoint());
+    csm::EcefVector sunEcefVec = m_model->getIlluminationDirection(groundPt);
+    // ISIS wants the position of the sun, not just the vector from the ground
+    // point to the sun. So, we approximate this by adding in the ground point.
+    // ISIS wants this in Km so convert
+    std::vector<double> sunVec = {
+        (sunEcefVec.x + groundPt.x) / 1000.0,
+        (sunEcefVec.y + groundPt.y) / 1000.0,
+        (sunEcefVec.z + groundPt.z) / 1000.0};
     return target()->shape()->phaseAngle(sensorPositionBodyFixed(), sunVec);
   }
 
@@ -564,8 +571,15 @@ namespace Isis {
 
 
   double CSMCamera::IncidenceAngle() const {
-    csm::EcefVector sunEcefVec = m_model->getIlluminationDirection(isisToCsmGround(GetSurfacePoint()));
-    std::vector<double> sunVec = {sunEcefVec.x, sunEcefVec.y, sunEcefVec.z};
+    csm::EcefCoord groundPt = isisToCsmGround(GetSurfacePoint());
+    csm::EcefVector sunEcefVec = m_model->getIlluminationDirection(groundPt);
+    // ISIS wants the position of the sun, not just the vector from the ground
+    // point to the sun. So, we approximate this by adding in the ground point.
+    // ISIS wants this in Km so convert
+    std::vector<double> sunVec = {
+        (sunEcefVec.x + groundPt.x) / 1000.0,
+        (sunEcefVec.y + groundPt.y) / 1000.0,
+        (sunEcefVec.z + groundPt.z) / 1000.0};
     return target()->shape()->incidenceAngle(sunVec);
   }
 

--- a/isis/src/base/objs/CSMCamera/CSMCamera.cpp
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.cpp
@@ -521,9 +521,9 @@ namespace Isis {
     // point to the sun. So, we approximate this by adding in the ground point.
     // ISIS wants this in Km so convert
     std::vector<double> sunVec = {
-        (sunEcefVec.x + groundPt.x) / 1000.0,
-        (sunEcefVec.y + groundPt.y) / 1000.0,
-        (sunEcefVec.z + groundPt.z) / 1000.0};
+        (groundPt.x - sunEcefVec.x) / 1000.0,
+        (groundPt.y - sunEcefVec.y) / 1000.0,
+        (groundPt.z - sunEcefVec.z) / 1000.0};
     return target()->shape()->phaseAngle(sensorPositionBodyFixed(), sunVec);
   }
 
@@ -540,9 +540,9 @@ namespace Isis {
     // point to the sun. So, we approximate this by adding in the ground point.
     // ISIS wants this in Km so convert
     std::vector<double> sunVec = {
-        (sunEcefVec.x + groundPt.x) / 1000.0,
-        (sunEcefVec.y + groundPt.y) / 1000.0,
-        (sunEcefVec.z + groundPt.z) / 1000.0};
+        (groundPt.x - sunEcefVec.x) / 1000.0,
+        (groundPt.y - sunEcefVec.y) / 1000.0,
+        (groundPt.z - sunEcefVec.z) / 1000.0};
     return target()->shape()->incidenceAngle(sunVec);
   }
 

--- a/isis/src/base/objs/CameraFactory/CameraFactory.truth
+++ b/isis/src/base/objs/CameraFactory/CameraFactory.truth
@@ -1,32 +1,32 @@
 Unit test for CameraFactory
 Testing missing Instrument Group ...
-Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
+Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
 **ERROR** Unable to find PVL group [Instrument].
 
 **ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** Unable to find PVL group [Instrument].
 
 Testing missing spacecraft name ...
-Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
+Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
 **ERROR** PVL Keyword [SpacecraftName] does not exist in [Group = Instrument].
 
 **ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** PVL Keyword [SpacecraftName] does not exist in [Group = Instrument].
 
 Testing missing instrument id ...
-Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
+Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
 **ERROR** PVL Keyword [InstrumentId] does not exist in [Group = Instrument].
 
 **ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** PVL Keyword [InstrumentId] does not exist in [Group = Instrument].
 
 Testing unsupported camera mode ...
-Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
+Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
 **ERROR** Unsupported camera model, unable to find plugin for SpacecraftName [BOGUS SPACECRAFT] with InstrumentId [BOGUS INSTRUMENT].
 **ERROR** Unable to find PVL group [BOGUSSPACECRAFT/BOGUSINSTRUMENT].
 
 **ERROR** Unable to initialize camera model in Camera Factory.
-**ERROR** Unable to locate latest camera model version number in Camera Factory.
+**ERROR** Unable to locate latest camera model version number from group [Instrument].
 **ERROR** Unsupported camera model, unable to find plugin for SpacecraftName [BOGUS SPACECRAFT] with InstrumentId [BOGUS INSTRUMENT].
 **ERROR** Unable to find PVL group [BOGUSSPACECRAFT/BOGUSINSTRUMENT].
 

--- a/isis/src/base/objs/CameraFactory/CameraFactory.truth
+++ b/isis/src/base/objs/CameraFactory/CameraFactory.truth
@@ -1,32 +1,32 @@
 Unit test for CameraFactory
 Testing missing Instrument Group ...
-Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
+Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
 **ERROR** Unable to find PVL group [Instrument].
 
-**ERROR** Unable to initialize camera model from group [Instrument].
+**ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** Unable to find PVL group [Instrument].
 
 Testing missing spacecraft name ...
-Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
+Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
 **ERROR** PVL Keyword [SpacecraftName] does not exist in [Group = Instrument].
 
-**ERROR** Unable to initialize camera model from group [Instrument].
+**ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** PVL Keyword [SpacecraftName] does not exist in [Group = Instrument].
 
 Testing missing instrument id ...
-Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
+Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
 **ERROR** PVL Keyword [InstrumentId] does not exist in [Group = Instrument].
 
-**ERROR** Unable to initialize camera model from group [Instrument].
+**ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** PVL Keyword [InstrumentId] does not exist in [Group = Instrument].
 
 Testing unsupported camera mode ...
-Version: **ERROR** Unable to locate latest camera model version number from group [Instrument].
+Version: **ERROR** Unable to locate latest camera model version number in Camera Factory.
 **ERROR** Unsupported camera model, unable to find plugin for SpacecraftName [BOGUS SPACECRAFT] with InstrumentId [BOGUS INSTRUMENT].
 **ERROR** Unable to find PVL group [BOGUSSPACECRAFT/BOGUSINSTRUMENT].
 
-**ERROR** Unable to initialize camera model from group [Instrument].
-**ERROR** Unable to locate latest camera model version number from group [Instrument].
+**ERROR** Unable to initialize camera model in Camera Factory.
+**ERROR** Unable to locate latest camera model version number in Camera Factory.
 **ERROR** Unsupported camera model, unable to find plugin for SpacecraftName [BOGUS SPACECRAFT] with InstrumentId [BOGUS INSTRUMENT].
 **ERROR** Unable to find PVL group [BOGUSSPACECRAFT/BOGUSINSTRUMENT].
 
@@ -34,6 +34,6 @@ Testing that newest camera version is read from plugin ...
 (Expecting Version 2)
 Version: 2
 
-**ERROR** Unable to initialize camera model from group [Instrument].
+**ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** The camera model used to create a camera for this cube is out of date, please re-run spiceinit on the file or process with an old Isis version that has the correct camera model.
 

--- a/isis/src/base/objs/CameraPointInfo/CameraPointInfo.cpp
+++ b/isis/src/base/objs/CameraPointInfo/CameraPointInfo.cpp
@@ -241,7 +241,6 @@ namespace Isis {
    *                      Ownership is passed to caller.
    */
   PvlGroup *CameraPointInfo::GetPointInfo(bool passed, bool allowOutside, bool allowErrors) {
-    std::cout << "Starting GetPointInfo" << std::endl;
     PvlGroup *gp = new PvlGroup("GroundPoint");
 
     //Outputting in PVL format
@@ -359,13 +358,11 @@ namespace Isis {
       noErrors = false;
       if (!allowErrors) throw IException(IException::Unknown, error, _FILEINFO_);
     }
-    std::cout << "Checked surface intersection" << std::endl;
     if (!m_camera->InCube() && !allowOutside) {
       error = "Requested position does not project in camera model; not inside cube";
       noErrors = false;
       if (!allowErrors) throw IException(IException::Unknown, error, _FILEINFO_);
     }
-    std::cout << "Checked in image" << std::endl;
 
     if (!noErrors) {
       for (int i = 0; i < gp->keywords(); i++) {
@@ -386,14 +383,11 @@ namespace Isis {
       gp->findKeyword("FileName").setValue(m_currentCube->fileName());
       gp->findKeyword("Sample").setValue(toString(m_camera->Sample()));
       gp->findKeyword("Line").setValue(toString(m_camera->Line()));
-      std::cout << "  Got Camera Sample & Line: " << m_camera->Sample() << ", " << m_camera->Line() << std::endl;
       gp->findKeyword("EphemerisTime").setValue(
                       toString(m_camera->time().Et()), "seconds");
-      std::cout << "  Got Camera Time: " << m_camera->time().Et() << std::endl;
       gp->findKeyword("EphemerisTime").addComment("Time");
       QString utc = m_camera->time().UTC();
       gp->findKeyword("UTC").setValue(utc);
-      std::cout << "  Got Camera Time UTC: " << utc << std::endl;
       gp->findKeyword("SpacecraftPosition").addComment("Spacecraft Information");
       gp->findKeyword("SunPosition").addComment("Sun Information");
       gp->findKeyword("Phase").addComment("Illumination and Other");
@@ -421,27 +415,21 @@ namespace Isis {
                           m_camera->RightAscension()), "DEGREE");
         }
         catch (IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("RightAscension").setValue("Null");
         }
-        std::cout << "  Tried to get Camera RA" << std::endl;
         try {
           gp->findKeyword("Declination").setValue(toString(
                           m_camera->Declination()), "DEGREE");
         }
         catch (IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("Declination").setValue("Null");
         }
-        std::cout << "  Tried to get Camera Dec" << std::endl;
         ocentricLat = m_camera->UniversalLatitude();
         gp->findKeyword("PlanetocentricLatitude").setValue(toString(ocentricLat), "DEGREE");
-        std::cout << "  Got Camera Planetocentric Latitude: " << ocentricLat << std::endl;
 
         // Convert lat to planetographic
         Distance radii[3];
         m_camera->radii(radii);
-        std::cout << "  Got Camera Radii: " << radii[0].meters() << ", " << radii[1].meters() << ", " << radii[2].meters() << std::endl;
         ographicLat = TProjection::ToPlanetographic(ocentricLat,
                                               radii[0].kilometers(),
                                               radii[2].kilometers());
@@ -449,7 +437,6 @@ namespace Isis {
 
         pe360Lon = m_camera->UniversalLongitude();
         gp->findKeyword("PositiveEast360Longitude").setValue(toString(pe360Lon), "DEGREE");
-        std::cout << "  Got Camera 350 Positive East Longitude: " << m_camera->UniversalLongitude() << std::endl;
 
         //Convert lon to -180 - 180 range
         gp->findKeyword("PositiveEast180Longitude").setValue(toString(
@@ -467,30 +454,22 @@ namespace Isis {
         gp->findKeyword("BodyFixedCoordinate").addValue(toString(pB[0]), "km");
         gp->findKeyword("BodyFixedCoordinate").addValue(toString(pB[1]), "km");
         gp->findKeyword("BodyFixedCoordinate").addValue(toString(pB[2]), "km");
-        std::cout << "  Got Camera ground point coordinate: " << pB[0] << ", " << pB[1] << ", " << pB[2] << std::endl;
 
         gp->findKeyword("LocalRadius").setValue(toString(
                         m_camera->LocalRadius().meters()), "meters");
-        std::cout << "  Got Camera local radius: " << m_camera->LocalRadius().meters() << std::endl;
         gp->findKeyword("SampleResolution").setValue(toString(
                         m_camera->SampleResolution()), "meters/pixel");
-        std::cout << "  Got Camera sample resolution: " << m_camera->SampleResolution() << std::endl;
         gp->findKeyword("LineResolution").setValue(toString(
                         m_camera->LineResolution()), "meters/pixel");
-        std::cout << "  Got Camera line resolution: " << m_camera->LineResolution() << std::endl;
 
         gp->findKeyword("ObliqueDetectorResolution").setValue(
                     toString(m_camera->ObliqueDetectorResolution()),"meters");
-        std::cout << "  Got Camera oblique detector resolution: " << m_camera->ObliqueDetectorResolution() << std::endl;
         gp->findKeyword("ObliqueLineResolution").setValue(
                     toString(m_camera->ObliqueLineResolution()),"meters");
-        std::cout << "  Got Camera oblique line resolution: " << m_camera->ObliqueLineResolution() << std::endl;
         gp->findKeyword("ObliqueSampleResolution").setValue(
                     toString(m_camera->ObliqueSampleResolution()),"meters");
-        std::cout << "  Got Camera oblique sample resolution: " << m_camera->ObliqueSampleResolution() << std::endl;
         gp->findKeyword("ObliquePixelResolution").setValue(
                     toString(m_camera->ObliquePixelResolution()), "meters/pix");
-        std::cout << "  Got Camera oblique pixel resolution: " << m_camera->ObliquePixelResolution() << std::endl;
 
 
         //body fixed
@@ -499,7 +478,6 @@ namespace Isis {
         gp->findKeyword("SpacecraftPosition").addValue(toString(spB[1]), "km");
         gp->findKeyword("SpacecraftPosition").addValue(toString(spB[2]), "km");
         gp->findKeyword("SpacecraftPosition").addComment("Spacecraft Information");
-        std::cout << "  Got Camera spacecraft position: " << spB[0] << ", " << spB[1] << ", " << spB[2] << std::endl;
 
         double spacecraftAzi = m_camera->SpacecraftAzimuth();
         if (Isis::IsValidPixel(spacecraftAzi)) {
@@ -508,30 +486,23 @@ namespace Isis {
         else {
           gp->findKeyword("SpacecraftAzimuth").setValue("NULL");
         }
-        std::cout << "  Got spacecraft azimuth: " << spacecraftAzi << std::endl;
 
         gp->findKeyword("SlantDistance").setValue(toString(
                         m_camera->SlantDistance()), "km");
-        std::cout << "  Got slant distance: " << m_camera->SlantDistance() << std::endl;
         gp->findKeyword("TargetCenterDistance").setValue(toString(
                         m_camera->targetCenterDistance()), "km");
-        std::cout << "  Got target center distance: " << m_camera->targetCenterDistance() << std::endl;
         m_camera->subSpacecraftPoint(ssplat, ssplon);
         gp->findKeyword("SubSpacecraftLatitude").setValue(toString(ssplat), "DEGREE");
         gp->findKeyword("SubSpacecraftLongitude").setValue(toString(ssplon), "DEGREE");
-        std::cout << "  Got sub spacecraft lat, lon: " << ssplat << ", " << ssplon << std::endl;
         gp->findKeyword("SpacecraftAltitude").setValue(toString(
                         m_camera->SpacecraftAltitude()), "km");
-        std::cout << "  Got spacecraft altitude: " <<  m_camera->SpacecraftAltitude() << std::endl;
         gp->findKeyword("OffNadirAngle").setValue(toString(
                         m_camera->OffNadirAngle()), "DEGREE");
-        std::cout << "  Got off nadir angle: " <<  m_camera->OffNadirAngle() << std::endl;
         double subspcgrdaz = m_camera->GroundAzimuth(m_camera->UniversalLatitude(),
                                               m_camera->UniversalLongitude(),
                                               ssplat, ssplon);
         gp->findKeyword("SubSpacecraftGroundAzimuth").setValue(
                                                  toString(subspcgrdaz), "DEGREE");
-        std::cout << "  Got sub spacecraft azimuth: " << subspcgrdaz << std::endl;
 
         try {
           m_camera->sunPosition(sB);
@@ -541,13 +512,11 @@ namespace Isis {
           gp->findKeyword("SunPosition").addComment("Sun Information");
         }
         catch (IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("SunPosition").addValue("Null");
           gp->findKeyword("SunPosition").addValue("Null");
           gp->findKeyword("SunPosition").addValue("Null");
           gp->findKeyword("SunPosition").addComment("Sun Information");
         }
-        std::cout << "  Tried to get sun position" << std::endl;
 
         try {
           double sunAzi = m_camera->SunAzimuth();
@@ -559,20 +528,16 @@ namespace Isis {
           }
         }
         catch(IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("SubSolarAzimuth").setValue("NULL");
         }
-        std::cout << "  Tried to get sun azimuth" << std::endl;
 
         try {
           gp->findKeyword("SolarDistance").setValue(toString(
                           m_camera->SolarDistance()), "AU");
         }
         catch(IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("SolarDistance").setValue("NULL");
         }
-        std::cout << "  Tried to get solar distance" << std::endl;
         try {
           double sslat, sslon;
           m_camera->subSolarPoint(sslat, sslon);
@@ -586,28 +551,21 @@ namespace Isis {
             gp->findKeyword("SubSolarGroundAzimuth").setValue(toString(subsolgrdaz), "DEGREE");
           }
           catch(IException &e) {
-            std::cout << e.toString() << std::endl;
             gp->findKeyword("SubSolarGroundAzimuth").setValue("NULL");
           }
-          std::cout << "  Tried to get sub solar ground azimuth" << std::endl;
         }
         catch(IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("SubSolarLatitude").setValue("NULL");
           gp->findKeyword("SubSolarLongitude").setValue("NULL");
           gp->findKeyword("SubSolarGroundAzimuth").setValue("NULL");
         }
-        std::cout << "  Tried to get sub solar lat, lon" << std::endl;
 
         gp->findKeyword("Phase").setValue(toString(m_camera->PhaseAngle()), "DEGREE");
-        std::cout << "  Got phase angle: " << m_camera->PhaseAngle() << std::endl;
         gp->findKeyword("Phase").addComment("Illumination and Other");
         gp->findKeyword("Incidence").setValue(toString(
                         m_camera->IncidenceAngle()), "DEGREE");
-        std::cout << "  Got incidence angle: " << m_camera->IncidenceAngle() << std::endl;
         gp->findKeyword("Emission").setValue(toString(
                         m_camera->EmissionAngle()), "DEGREE");
-        std::cout << "  Got emission angle: " << m_camera->EmissionAngle() << std::endl;
 
         double northAzi = m_camera->NorthAzimuth();
         if (Isis::IsValidPixel(northAzi)) {
@@ -616,40 +574,32 @@ namespace Isis {
         else {
           gp->findKeyword("NorthAzimuth").setValue("NULL");
         }
-        std::cout << "  Got North azimuth: " << northAzi << std::endl;
 
         gp->findKeyword("EphemerisTime").setValue(toString(
                         m_camera->time().Et()), "seconds");
         gp->findKeyword("EphemerisTime").addComment("Time");
-        std::cout << "  Got Camera Time: " << m_camera->time().Et() << std::endl;
         utc = m_camera->time().UTC();
         gp->findKeyword("UTC").setValue(utc);
-        std::cout << "  Got Camera Time utc: " << utc << std::endl;
         try {
           gp->findKeyword("LocalSolarTime").setValue(toString(
                           m_camera->LocalSolarTime()), "hour");
         }
         catch (IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("LocalSolarTime").setValue("Null");
         }
-        std::cout << "  Tried to get the local solar time" << std::endl;
         try {
           gp->findKeyword("SolarLongitude").setValue(toString(
                           m_camera->solarLongitude().degrees()), "DEGREE");
         }
         catch (IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("SolarLongitude").setValue("Null");
         }
-        std::cout << "  Tried to get local longitude" << std::endl;
 
         std::vector<double>lookB = m_camera->lookDirectionBodyFixed();
         gp->findKeyword("LookDirectionBodyFixed").addValue(toString(lookB[0]), "DEGREE");
         gp->findKeyword("LookDirectionBodyFixed").addValue(toString(lookB[1]), "DEGREE");
         gp->findKeyword("LookDirectionBodyFixed").addValue(toString(lookB[2]), "DEGREE");
         gp->findKeyword("LookDirectionBodyFixed").addComment("Look Direction Unit Vectors in Body Fixed, J2000, and Camera Coordinate Systems.");
-        std::cout << "  Got look direction body fixed: " << lookB[0] << ", " << lookB[1] << ", " << lookB[2] << ", " << std::endl;
 
         try {
           std::vector<double>lookJ = m_camera->lookDirectionJ2000();
@@ -658,12 +608,10 @@ namespace Isis {
           gp->findKeyword("LookDirectionJ2000").addValue(toString(lookJ[2]), "DEGREE");
         }
         catch (IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("LookDirectionJ2000").addValue("Null");
           gp->findKeyword("LookDirectionJ2000").addValue("Null");
           gp->findKeyword("LookDirectionJ2000").addValue("Null");
         }
-        std::cout << "  Tried to get look direction J2000" << std::endl;
 
         try {
           double lookC[3];
@@ -673,12 +621,10 @@ namespace Isis {
           gp->findKeyword("LookDirectionCamera").addValue(toString(lookC[2]), "DEGREE");
         }
         catch (IException &e) {
-          std::cout << e.toString() << std::endl;
           gp->findKeyword("LookDirectionCamera").addValue("Null");
           gp->findKeyword("LookDirectionCamera").addValue("Null");
           gp->findKeyword("LookDirectionCamera").addValue("Null");
         }
-        std::cout << "  Tried to get look direction camera" << std::endl;
 
 
         if (allowErrors) gp->findKeyword("Error").setValue("NULL");

--- a/isis/src/base/objs/Chip/Chip.truth
+++ b/isis/src/base/objs/Chip/Chip.truth
@@ -179,14 +179,14 @@ Try to load a cube that is not camera or map projection:
 **USER ERROR** Can not geom chip. Chip cube [] is not a camera or map projection.
 **ERROR** Unable to initialize cube projection from file [].
 **ERROR** Unable to find PVL group [Mapping] in file [].
-**ERROR** Unable to initialize camera model from group [Instrument].
+**ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** Unable to find PVL group [Instrument] in file [].
 
 Try to load a cube with a match cube that is not camera or map projection:
 **USER ERROR** Can not geom chip. Match chip cube [] is not a camera or map projection.
 **ERROR** Unable to initialize cube projection from file [].
 **ERROR** Unable to find PVL group [Mapping] in file [].
-**ERROR** Unable to initialize camera model from group [Instrument].
+**ERROR** Unable to initialize camera model in Camera Factory.
 **ERROR** Unable to find PVL group [Instrument] in file [].
 
 Try to load a cube with match chip and cube that can not find at least 3 points for Affine Transformation:

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -79,7 +79,7 @@ namespace Isis {
   Spice::Spice(Cube &cube) {
     Pvl &lab = *cube.label();
     // TODO: update to check to see if it has a state string
-    if (cube.hasGroup("CsmInfo")) {
+    if (cube.hasBlob("String", "CSMState")) {
       csmInit(cube, lab);
     }
     else {

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -540,3 +540,218 @@ TEST_F(CSMSetCameraFixture, EmissionAngle) {
 
   EXPECT_DOUBLE_EQ(testCam->EmissionAngle(), 0.0);
 }
+
+
+TEST_F(CSMCameraFixture, SetTime) {
+  try
+  {
+    testCam->setTime(iTime("2000-01-01T11:58:55.816"));
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Setting the image time is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Setting the image time is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, SubSolarPoint) {
+  try
+  {
+    double lat, lon;
+    testCam->subSolarPoint(lat ,lon);
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Sub solar point is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Sub solar point is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, PixelIfovOffsets) {
+  try
+  {
+    testCam->PixelIfovOffsets();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Pixel Field of View is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Pixel Field of View is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, SunPosition) {
+  try
+  {
+    double position[3];
+    testCam->sunPosition(position);
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Sun position is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Sun position is not supported for CSM camera models\"";
+  }
+
+  try
+  {
+    testCam->sunPosition();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Sun position is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Sun position is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, InstrumentPosition) {
+  try
+  {
+    testCam->instrumentPosition();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Instrument position is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Instrument position is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, BodyRotation) {
+  try
+  {
+    testCam->bodyRotation();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Target body orientation is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Target body orientation is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, InstrumentRotation) {
+  try
+  {
+    testCam->instrumentRotation();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Instrument orientation is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Instrument orientation is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, SolarLongitude) {
+  try
+  {
+    testCam->solarLongitude();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Solar longitude is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Solar longitude is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, SolarDistance) {
+  try
+  {
+    testCam->SolarDistance();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Solar distance is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Solar distance is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, RightAscension) {
+  try
+  {
+    testCam->RightAscension();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Right Ascension is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Right Ascension is not supported for CSM camera models\"";
+  }
+}
+
+
+TEST_F(CSMCameraFixture, Declination) {
+  try
+  {
+    testCam->Declination();
+  }
+  catch(Isis::IException &e)
+  {
+    EXPECT_TRUE(e.toString().toLatin1().contains("Declination is not supported "
+        "for CSM camera models")) << e.toString().toStdString();
+  }
+  catch(...)
+  {
+      FAIL() << "Expected an IExcpetion with message \""
+      " Declination is not supported for CSM camera models\"";
+  }
+}

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -518,7 +518,7 @@ TEST_F(CSMSetCameraFixture, PhaseAngle) {
       .WillOnce(::testing::Return(csm::EcefCoord(groundPt.x + 50000, groundPt.y, groundPt.z + 50000)));
   EXPECT_CALL(mockModel, getIlluminationDirection(MatchEcefCoord(groundPt)))
       .Times(1)
-      .WillOnce(::testing::Return(csm::EcefVector(0.0, 0.0, 1.0)));
+      .WillOnce(::testing::Return(csm::EcefVector(0.0, 0.0, -1.0)));
 
   EXPECT_DOUBLE_EQ(testCam->PhaseAngle(), 45.0);
 }
@@ -527,7 +527,7 @@ TEST_F(CSMSetCameraFixture, PhaseAngle) {
 TEST_F(CSMSetCameraFixture, IncidenceAngle) {
   EXPECT_CALL(mockModel, getIlluminationDirection(MatchEcefCoord(groundPt)))
       .Times(1)
-      .WillOnce(::testing::Return(csm::EcefVector(0.0, 0.0, 1.0)));
+      .WillOnce(::testing::Return(csm::EcefVector(0.0, 0.0, -1.0)));
 
   EXPECT_DOUBLE_EQ(testCam->IncidenceAngle(), 90.0);
 }

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -251,9 +251,13 @@ class CSMSetCameraFixture : public CSMCameraFixture {
 class CSMDemCameraFixture : public CSMCubeFixture {
   protected:
     Camera *testCam;
+    double demRadius;
 
     void SetUp() override {
       CSMCubeFixture::SetUp();
+
+      // Record the demRadius at 0 lat, 0 lon
+      demRadius = 3394200.43980104;
 
       // Update the shapemodel on the cube
       PvlGroup &kernGroup = testCube->group("Kernels");
@@ -333,7 +337,7 @@ TEST_F(CSMDemCameraFixture, SetImage) {
   EXPECT_CALL(mockModel, imageToRemoteImagingLocus(MatchImageCoord(csm::ImageCoord(4.5, 4.5)), ::testing::_, ::testing::_, ::testing::_))
       .Times(1)
       // looking straight down X-Axis
-      .WillOnce(::testing::Return(csm::EcefLocus(3394200.43980104 + 50000, 0, 0, -1, 0, 0)));
+      .WillOnce(::testing::Return(csm::EcefLocus(demRadius + 50000, 0, 0, -1, 0, 0)));
   EXPECT_CALL(mockModel, computeGroundPartials)
       .WillRepeatedly(::testing::Return(std::vector<double>{1, 2, 3, 4, 5, 6}));
   EXPECT_CALL(mockModel, getImageTime)
@@ -397,8 +401,8 @@ TEST_F(CSMCameraFixture, SetGround) {
 TEST_F(CSMDemCameraFixture, SetGround) {
   // Define some things to match/return
   csm::ImageCoord imagePt(4.5, 4.5);
-  csm::EcefCoord groundPt(3394200.43980104, 0, 0);
-  csm::EcefLocus imageLocus(3394200.43980104 + 50000, 0, 0, -1, 0, 0);
+  csm::EcefCoord groundPt(demRadius, 0, 0);
+  csm::EcefLocus imageLocus(demRadius + 50000, 0, 0, -1, 0, 0);
 
   // Setup expected calls/returns
   EXPECT_CALL(mockModel, groundToImage(MatchEcefCoord(groundPt), ::testing::_, ::testing::_, ::testing::_))
@@ -417,7 +421,7 @@ TEST_F(CSMDemCameraFixture, SetGround) {
 
   EXPECT_TRUE(testCam->SetGround(SurfacePoint(Latitude(0.0, Angle::Degrees),
                                  Longitude(0.0, Angle::Degrees),
-                                 Distance(3394200.43980104, Distance::Meters))));
+                                 Distance(demRadius, Distance::Meters))));
   EXPECT_EQ(testCam->Line(), 5.0);
   EXPECT_EQ(testCam->Sample(), 5.0);
 
@@ -425,7 +429,7 @@ TEST_F(CSMDemCameraFixture, SetGround) {
   EXPECT_EQ(testCam->Line(), 5.0);
   EXPECT_EQ(testCam->Sample(), 5.0);
 
-  EXPECT_TRUE(testCam->SetUniversalGround(0.0, 0.0, 3394200.43980104));
+  EXPECT_TRUE(testCam->SetUniversalGround(0.0, 0.0, demRadius));
   EXPECT_EQ(testCam->Line(), 5.0);
   EXPECT_EQ(testCam->Sample(), 5.0);
 }

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -461,13 +461,82 @@ TEST_F(CSMSetCameraFixture, Resolution) {
 }
 
 
+TEST_F(CSMSetCameraFixture, InstrumentBodyFixedPosition) {
+  EXPECT_CALL(mockModel, getSensorPosition(MatchImageCoord(imagePt)))
+      .Times(1)
+      .WillOnce(::testing::Return(imageLocus.point));
+
+  double position[3];
+  testCam->instrumentBodyFixedPosition(position);
+  EXPECT_EQ(position[0], (imageLocus.point.x) / 1000.0);
+  EXPECT_EQ(position[1], (imageLocus.point.y) / 1000.0);
+  EXPECT_EQ(position[2], (imageLocus.point.z) / 1000.0);
+}
+
+
 TEST_F(CSMSetCameraFixture, SubSpacecraftPoint) {
   EXPECT_CALL(mockModel, getSensorPosition(MatchImageCoord(imagePt)))
       .Times(1)
-      .WillRepeatedly(::testing::Return(csm::EcefCoord(wgs84.getSemiMajorRadius() + 50000, 0, 0)));
+      .WillOnce(::testing::Return(imageLocus.point));
 
   double lat, lon;
   testCam->subSpacecraftPoint(lat, lon);
   EXPECT_EQ(lat, 0.0);
   EXPECT_EQ(lon, 0.0);
+}
+
+
+TEST_F(CSMSetCameraFixture, SlantDistance) {
+  EXPECT_CALL(mockModel, getSensorPosition(MatchImageCoord(imagePt)))
+      .Times(1)
+      .WillOnce(::testing::Return(imageLocus.point));
+
+  double expectedDistance = sqrt(
+      pow(imageLocus.point.x - groundPt.x, 2) +
+      pow(imageLocus.point.y - groundPt.y, 2) +
+      pow(imageLocus.point.z - groundPt.z, 2)) / 1000.0;
+  EXPECT_DOUBLE_EQ(testCam->SlantDistance(), expectedDistance);
+}
+
+
+TEST_F(CSMSetCameraFixture, TargetCenterDistance) {
+  EXPECT_CALL(mockModel, getSensorPosition(MatchImageCoord(imagePt)))
+      .Times(1)
+      .WillOnce(::testing::Return(imageLocus.point));
+
+  double expectedDistance = sqrt(
+      pow(imageLocus.point.x, 2) +
+      pow(imageLocus.point.y, 2) +
+      pow(imageLocus.point.z, 2)) / 1000.0;
+  EXPECT_DOUBLE_EQ(testCam->targetCenterDistance(), expectedDistance);
+}
+
+
+TEST_F(CSMSetCameraFixture, PhaseAngle) {
+  EXPECT_CALL(mockModel, getSensorPosition(MatchImageCoord(imagePt)))
+      .Times(1)
+      .WillOnce(::testing::Return(csm::EcefCoord(groundPt.x + 50000, groundPt.y, groundPt.z + 50000)));
+  EXPECT_CALL(mockModel, getIlluminationDirection(MatchEcefCoord(groundPt)))
+      .Times(1)
+      .WillOnce(::testing::Return(csm::EcefVector(0.0, 0.0, 1.0)));
+
+  EXPECT_DOUBLE_EQ(testCam->PhaseAngle(), 45.0);
+}
+
+
+TEST_F(CSMSetCameraFixture, IncidenceAngle) {
+  EXPECT_CALL(mockModel, getIlluminationDirection(MatchEcefCoord(groundPt)))
+      .Times(1)
+      .WillOnce(::testing::Return(csm::EcefVector(0.0, 0.0, 1.0)));
+
+  EXPECT_DOUBLE_EQ(testCam->IncidenceAngle(), 90.0);
+}
+
+
+TEST_F(CSMSetCameraFixture, EmissionAngle) {
+  EXPECT_CALL(mockModel, getSensorPosition(MatchImageCoord(imagePt)))
+      .Times(1)
+      .WillOnce(::testing::Return(imageLocus.point));
+
+  EXPECT_DOUBLE_EQ(testCam->EmissionAngle(), 0.0);
 }


### PR DESCRIPTION
I got the old tests passing again.

I also split the camera fixture out into 3 different fixtures; one unset, one set, and one unset with a DEM. This should help us avoid code duplication with setting up the Mock.

I am going to leave this as a draft right now, but I want CI to run to check other tests. 