### PR TITLE
Updated unit tests to use data from ISISTESTDATA instead of ISISDATA

### DIFF
--- a/isis/src/base/apps/blend/tsts/default/Makefile
+++ b/isis/src/base/apps/blend/tsts/default/Makefile
@@ -7,10 +7,12 @@ I02609002RDR.lev2.blend.cub.TOLERANCE = 0.001
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/fromlist.lis \
+	$(LS) $(INPUT)/*.cub > fromlist.lis;
+	$(APPNAME) fromlist=fromlist.lis \
 	  tolist=$(INPUT)/tolist.lis \
 	  stop=200 \
 	  > /dev/null;
 	$(MV) I00824006RDR.lev2.blend.cub $(OUTPUT)/I00824006RDR.lev2.blend.cub;
 	$(MV) I01523019RDR.lev2.blend.cub $(OUTPUT)/I01523019RDR.lev2.blend.cub;
 	$(MV) I02609002RDR.lev2.blend.cub $(OUTPUT)/I02609002RDR.lev2.blend.cub;
+	$(RM) fromlist.lis;

--- a/isis/src/base/apps/blend/tsts/themis/Makefile
+++ b/isis/src/base/apps/blend/tsts/themis/Makefile
@@ -6,7 +6,7 @@ I23851018.blend.cub.TOLERANCE = .00001
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(LS) -r $(INPUT)/*.cub > fromlist.lis
+	$(LS) -r $(INPUT)/*.cub > fromlist.lis;
 	$(APPNAME) fromlist=fromlist.lis \
 	  tolist=$(INPUT)/tolist.lis \
 	  stop=200 \

--- a/isis/src/base/apps/cubeit/tsts/badinputs/Makefile
+++ b/isis/src/base/apps/cubeit/tsts/badinputs/Makefile
@@ -7,8 +7,10 @@ include $(ISISROOT)/make/isismake.tsts
 commands:
 #    TEST A: pass in a list of cubes with different sizes
 	echo -e "Different sized cubes:" > $(OUTPUT)/error_temp.txt;
+	$(LS) -r $(INPUT)/isisTruth.cub $(INPUT)/f319b18.cub >> $(OUTPUT)/tmp.lis;
+	$(CAT) $(OUTPUT)/tmp.lis | $(SED) 's/isisTruth.cub/isisTruth.cub+1/' > $(OUTPUT)/input.lis;
 	if [ `$(APPNAME) \
-	  fromlist=$(INPUT)/input.lis \
+	  fromlist=$(OUTPUT)/input.lis \
 	  to=$(OUTPUT)/error.cub \
 	  2>> $(OUTPUT)/error_temp.txt > /dev/null` ]; \
 	  then true; \
@@ -40,6 +42,8 @@ commands:
 	$(SED) 's+\[/.*/output/+\[output/+' $(OUTPUT)/error_temp3.txt > $(OUTPUT)/error.txt;
 
 #    Cleanup
+	$(RM) $(OUTPUT)/tmp.lis;
+	$(RM) $(OUTPUT)/input.lis;
 	$(RM) $(OUTPUT)/error_temp.txt;
 	$(RM) $(OUTPUT)/error_temp2.txt;
 	$(RM) $(OUTPUT)/error_temp3.txt;

--- a/isis/src/base/apps/cubeit/tsts/default/Makefile
+++ b/isis/src/base/apps/cubeit/tsts/default/Makefile
@@ -3,5 +3,9 @@ APPNAME = cubeit
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/inputList.lis \
+	$(ECHO) $(INPUT)/isisTruth.cub+2 > $(OUTPUT)/inputList.lis;
+	$(ECHO) $(INPUT)/isisTruth.cub >> $(OUTPUT)/inputList.lis;
+	$(ECHO) $(INPUT)/isisTruth.cub+1 >> $(OUTPUT)/inputList.lis;
+	$(APPNAME) fromlist=$(OUTPUT)/inputList.lis \
 	  to=$(OUTPUT)/cubeitTruth1.cub > /dev/null;
+	$(RM) $(OUTPUT)/inputList.lis;

--- a/isis/src/base/apps/equalizer/tsts/apply/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/apply/Makefile
@@ -3,10 +3,15 @@ APPNAME = equalizer
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
+	$(LS) -r $(INPUT)/*.cub > $(OUTPUT)/Fromlist.lst;
+	$(CAT) $(INPUT)/instats.pvl | $(SED) "s|FileName = .*odyssey/testData/|FileName = $(INPUT)/|" > $(OUTPUT)/instats.pvl;
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
 	  tolist=$(INPUT)/ToList.lst \
-	  instats=$(INPUT)/instats.pvl \
+	  instats=$(OUTPUT)/instats.pvl \
 	  process=apply \
 	  > /dev/null;
 	$(MV) I00824006RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth1.cub;
 	$(MV) I01523019RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth2.cub;
+	$(RM) $(OUTPUT)/FromList.lst;
+	$(RM) $(OUTPUT)/instats.pvl;
+

--- a/isis/src/base/apps/equalizer/tsts/default/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/default/Makefile
@@ -3,11 +3,16 @@ APPNAME = equalizer
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
-	  holdlist=$(INPUT)/HoldList.lst \
+	$(LS) $(INPUT)/*.cub > $(OUTPUT)/Fromlist.lst;
+	$(ECHO) $(INPUT)/I01523019RDR.lev2.cub > $(OUTPUT)/HoldList.lst;
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
+	  holdlist=$(OUTPUT)/HoldList.lst \
 	  tolist=$(INPUT)/ToList.lst \
 	  solvemethod=qrd \
 	  > /dev/null;
 	$(MV) I00824006RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth1.cub;
 	$(MV) I01523019RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth2.cub;
-	$(MV) I02609002RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth3.cub; 
+	$(MV) I02609002RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth3.cub;
+	$(RM) $(OUTPUT)/FromList.lst;
+	$(RM) $(OUTPUT)/HoldList.lst;
+

--- a/isis/src/base/apps/equalizer/tsts/gain/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/gain/Makefile
@@ -6,8 +6,10 @@ APPNAME = equalizer
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
-	  holdlist=$(INPUT)/HoldList.lst \
+	$(LS) $(INPUT)/I0*.cub > $(OUTPUT)/Fromlist.lst;
+	$(ECHO) $(INPUT)/I01523019RDR.lev2.cub > $(OUTPUT)/HoldList.lst;
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
+	  holdlist=$(OUTPUT)/HoldList.lst \
 	  tolist=$(INPUT)/ToList.lst \
 	  solvemethod=qrd adjust=gain \
 	  > /dev/null;
@@ -22,3 +24,6 @@ commands:
 	$(APPNAME) fromlist=$(OUTPUT)/files.lis holdlist=$(OUTPUT)/hold.lis \
 	  adjust=gain tolist=$(OUTPUT)/tolist.lis > /dev/null;
 	$(RM) $(OUTPUT)/files.lis $(OUTPUT)/hold.lis $(OUTPUT)/tolist.lis;
+	$(RM) $(OUTPUT)/FromList.lst;
+	$(RM) $(OUTPUT)/HoldList.lst;
+

--- a/isis/src/base/apps/equalizer/tsts/holdBothCalculateAndApply/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/holdBothCalculateAndApply/Makefile
@@ -1,25 +1,32 @@
-# This test passes in a holdlist, lets process default to both (i.e. calculate 
-# statistics and apply them), and lets adjust default to both (contrast and 
+# This test passes in a holdlist, lets process default to both (i.e. calculate
+# statistics and apply them), and lets adjust default to both (contrast and
 # brightness).
-# 
+#
 # It is run once without creating the output statistics file and a second time
-# creating the outstats file for test coverage. 
+# creating the outstats file for test coverage.
 APPNAME = equalizer
 
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
-	  holdlist=$(INPUT)/HoldList.lst \
+	$(LS) $(INPUT)/I0*.cub > $(OUTPUT)/Fromlist.lst;
+	$(ECHO) $(INPUT)/I01523019RDR.lev2.cub > $(OUTPUT)/HoldList.lst;
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
+	  holdlist=$(OUTPUT)/HoldList.lst \
 	  tolist=$(INPUT)/ToList.lst \
 	  solvemethod=qrd \
 	  > /dev/null;
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
-	  holdlist=$(INPUT)/HoldList.lst \
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
+	  holdlist=$(OUTPUT)/HoldList.lst \
 	  tolist=$(INPUT)/ToList.lst \
-	  outstats=$(OUTPUT)/outstats.pvl \
+	  outstats=$(OUTPUT)/outstatstmp.pvl \
 	  solvemethod=qrd \
 	  > /dev/null;
+	$(CAT) $(OUTPUT)/outstatstmp.pvl | $(SED) "s|FileName = .*/I0|FileName = I0|" > $(OUTPUT)/outstats.pvl;
+	$(RM) $(OUTPUT)/outstatstmp.pvl;
 	$(MV) I00824006RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth1.cub;
 	$(MV) I01523019RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth2.cub;
-	$(MV) I02609002RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth3.cub; 
+	$(MV) I02609002RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth3.cub;
+	$(RM) $(OUTPUT)/FromList.lst;
+	$(RM) $(OUTPUT)/HoldList.lst;
+

--- a/isis/src/base/apps/equalizer/tsts/holdCalculateStats/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/holdCalculateStats/Makefile
@@ -1,29 +1,34 @@
 # This test passes in a holdlist, lets process=calculate.
-# This will calculate the statistics, but not apply them. 
-# For this test, the program is run three times - once for each adjust option: 
+# This will calculate the statistics, but not apply them.
+# For this test, the program is run three times - once for each adjust option:
 # contrast, brightness, and both.
 APPNAME = equalizer
 
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
-	  holdlist=$(INPUT)/HoldList.lst \
+	$(LS) $(INPUT)/I0*.cub > $(OUTPUT)/Fromlist.lst;
+	$(ECHO) $(INPUT)/I01523019RDR.lev2.cub > $(OUTPUT)/HoldList.lst;
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
+	  holdlist=$(OUTPUT)/HoldList.lst \
 	  outstats=$(OUTPUT)/outstats_contrast.pvl \
 	  process=calculate \
 	  adjust=contrast \
 	  solvemethod=qrd \
 	  > /dev/null;
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
-	  holdlist=$(INPUT)/HoldList.lst \
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
+	  holdlist=$(OUTPUT)/HoldList.lst \
 	  outstats=$(OUTPUT)/outstats_brightness.pvl \
 	  process=calculate \
 	  adjust=brightness \
 	  solvemethod=qrd \
 	  > /dev/null;
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
-	  holdlist=$(INPUT)/HoldList.lst \
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
+	  holdlist=$(OUTPUT)/HoldList.lst \
 	  outstats=$(OUTPUT)/outstats_both.pvl \
 	  process=calculate \
 	  solvemethod=qrd \
 	  > /dev/null;
+	$(RM) $(OUTPUT)/FromList.lst;
+	$(RM) $(OUTPUT)/HoldList.lst;
+

--- a/isis/src/base/apps/equalizer/tsts/noHoldApplyInputStats/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/noHoldApplyInputStats/Makefile
@@ -1,14 +1,18 @@
 # This test does not hold any images and lets process=adjust.
-# This will apply the user entered input statistics. 
+# This will apply the user entered input statistics.
 APPNAME = equalizer
 
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/FromList.lst \
+	$(LS) -r $(INPUT)/I0*.cub > $(OUTPUT)/Fromlist.lst;
+	$(CAT) $(INPUT)/instats.pvl | $(SED) "s|FileName = .*odyssey/testData/|FileName = $(INPUT)/|" > $(OUTPUT)/instats.pvl;
+	$(APPNAME) fromlist=$(OUTPUT)/FromList.lst \
 	  tolist=$(INPUT)/ToList.lst \
-	  instats=$(INPUT)/instats.pvl \
+	  instats=$(OUTPUT)/instats.pvl \
 	  process=apply \
 	  > /dev/null;
 	$(MV) I00824006RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth1.cub;
 	$(MV) I01523019RDR.lev2.equ.cub $(OUTPUT)/equalizerTruth2.cub;
+	$(RM) $(OUTPUT)/FromList.lst;
+	$(RM) $(OUTPUT)/instats.pvl;

--- a/isis/src/base/apps/equalizer/tsts/nonOverlapApplyFixedStats/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/nonOverlapApplyFixedStats/Makefile
@@ -1,4 +1,4 @@
-# This tests applying recaluclated statistics (that were recalculated to 
+# This tests applying recaluclated statistics (that were recalculated to
 # fix non-overlapping images by ADDING new images)
 APPNAME = equalizer
 
@@ -8,9 +8,17 @@ commands:
 	#$(LS) $(INPUT)/*cub > $(OUTPUT)/overlapping.lis;
 	#@$(SED) -e 's#$(INPUT)\(.*\)cub#$(OUTPUT)/\1\equ\.cub#g' $(OUTPUT)/overlapping.lis \
 	#  > $(OUTPUT)/tolist.lis;
-	$(APPNAME) fromlist=$(INPUT)/fixed.lis \
+	$(LS) $(INPUT)/I10047011EDR.proj.reduced.cub > $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I25685003EDR.crop.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I51718010EDR.crop.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I56969027EDR.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I50695002EDR.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(CAT) $(INPUT)/recalculatedStats.pvl | $(SED) "s|FileName = .*odyssey/testData/|FileName = $(INPUT)/|" > $(OUTPUT)/recalculatedStats.pvl;
+	$(APPNAME) fromlist=$(OUTPUT)/fixed.lis \
 	  tolist=$(INPUT)/toList.lis \
-	  instats=$(INPUT)/recalculatedStats.pvl \
+	  instats=$(OUTPUT)/recalculatedStats.pvl \
 	  process=apply \
 	  > /dev/null;
 	$(MV) *cub $(OUTPUT);
+	$(RM) $(OUTPUT)/fixed.lis;
+	$(RM) $(OUTPUT)/recalculatedStats.pvl;

--- a/isis/src/base/apps/equalizer/tsts/nonOverlapRecalculate/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/nonOverlapRecalculate/Makefile
@@ -4,13 +4,13 @@
 #
 # A) First, we simply append the new image to the end of the original list of images to fix the
 #    non-overlapping areas.
-# B) Second, we rearrange the original list of input images and add the new image in the middle, 
+# B) Second, we rearrange the original list of input images and add the new image in the middle,
 #    since order should not matter. This ensures that in the input list, if an existing overlap's
-#    Y (second) image comes before the X (first) image, the overlap is properly added and 
+#    Y (second) image comes before the X (first) image, the overlap is properly added and
 #    normalizations are calculated correctly.
 #
 # The two output statistics pvl files should have identical information, just in a different order.
-# 
+#
 # NOTE: An exception occurs when calculating and there are non-overlaps,
 #       it is redirected to nonOverlapError.txt.
 APPNAME = equalizer
@@ -19,8 +19,12 @@ include $(ISISROOT)/make/isismake.tsts
 
 commands:
 	# Handle the exception: "There are input images that do not overlap..."
+	$(LS) $(INPUT)/I10047011EDR.proj.reduced.cub > $(OUTPUT)/nonOverlap.lis;
+	$(LS) $(INPUT)/I25685003EDR.crop.proj.reduced.cub >> $(OUTPUT)/nonOverlap.lis;
+	$(LS) $(INPUT)/I51718010EDR.crop.proj.reduced.cub >> $(OUTPUT)/nonOverlap.lis;
+	$(LS) $(INPUT)/I56969027EDR.proj.reduced.cub >> $(OUTPUT)/nonOverlap.lis;
 	if [[ `$(APPNAME) \
-	  fromlist=$(INPUT)/nonOverlap.lis \
+	  fromlist=$(OUTPUT)/nonOverlap.lis \
 	  outstats=$(OUTPUT)/nonOverlapStats.pvl \
 	  process=CALCULATE \
 	  2>> $(OUTPUT)/nonOverlapError.txt \
@@ -29,14 +33,29 @@ commands:
 	  true; \
 	fi;
 	# A)
-	$(APPNAME) fromlist=$(INPUT)/fixed.lis \
+	$(LS) $(INPUT)/I10047011EDR.proj.reduced.cub > $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I25685003EDR.crop.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I51718010EDR.crop.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I56969027EDR.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I50695002EDR.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+#	$(CAT) $(INPUT)/nonOverlapStats.pvl | $(SED) "s|FileName = .*odyssey/testData/|FileName = $(INPUT)/|" > $(OUTPUT)/nonOverlapStats.pvl;
+	$(APPNAME) fromlist=$(OUTPUT)/fixed.lis \
 	  instats=$(OUTPUT)/nonOverlapStats.pvl \
 	  outstats=$(OUTPUT)/recalculatedStats.pvl \
 	  process=RECALCULATE \
 	  > /dev/null;
 	# B)
-	$(APPNAME) fromlist=$(INPUT)/fixedDiffOrder.lis \
+	$(LS) $(INPUT)/I25685003EDR.crop.proj.reduced.cub > $(OUTPUT)/fixedDiffOrder.lis;
+	$(LS) $(INPUT)/I50695002EDR.proj.reduced.cub >> $(OUTPUT)/fixedDiffOrder.lis;
+	$(LS) $(INPUT)/I56969027EDR.proj.reduced.cub >> $(OUTPUT)/fixedDiffOrder.lis;
+	$(LS) $(INPUT)/I51718010EDR.crop.proj.reduced.cub >> $(OUTPUT)/fixedDiffOrder.lis;
+	$(LS) $(INPUT)/I10047011EDR.proj.reduced.cub >> $(OUTPUT)/fixedDiffOrder.lis;
+	$(APPNAME) fromlist=$(OUTPUT)/fixedDiffOrder.lis \
 	  instats=$(OUTPUT)/nonOverlapStats.pvl \
 	  outstats=$(OUTPUT)/recalculatedStatsDiffOrder.pvl \
 	  process=RECALCULATE \
 	  > /dev/null;
+	$(RM) $(OUTPUT)/fixed.lis;
+	$(RM) $(OUTPUT)/nonOverlap.lis;
+	$(RM) $(OUTPUT)/fixedDiffOrder.lis;
+

--- a/isis/src/base/apps/equalizer/tsts/nonOverlapRetryBoth/Makefile
+++ b/isis/src/base/apps/equalizer/tsts/nonOverlapRetryBoth/Makefile
@@ -13,8 +13,12 @@ include $(ISISROOT)/make/isismake.tsts
 
 commands:
 	# Handle the exception: "There are input images that do not overlap..."
+	$(LS) $(INPUT)/I10047011EDR.proj.reduced.cub > $(OUTPUT)/nonOverlap.lis;
+	$(LS) $(INPUT)/I25685003EDR.crop.proj.reduced.cub >> $(OUTPUT)/nonOverlap.lis;
+	$(LS) $(INPUT)/I51718010EDR.crop.proj.reduced.cub >> $(OUTPUT)/nonOverlap.lis;
+	$(LS) $(INPUT)/I56969027EDR.proj.reduced.cub >> $(OUTPUT)/nonOverlap.lis;
 	if [[ `$(APPNAME) \
-	  fromlist=$(INPUT)/nonOverlap.lis \
+	  fromlist=$(OUTPUT)/nonOverlap.lis \
 	  outstats=$(OUTPUT)/nonOverlapStats.pvl \
 	  process=CALCULATE \
 	  2>> $(OUTPUT)/nonOverlapError.txt \
@@ -22,10 +26,18 @@ commands:
 	then \
 	  true; \
 	fi
-	$(APPNAME) fromlist=$(INPUT)/fixed.lis \
+	$(LS) $(INPUT)/I10047011EDR.proj.reduced.cub > $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I25685003EDR.crop.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I51718010EDR.crop.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I56969027EDR.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(LS) $(INPUT)/I50695002EDR.proj.reduced.cub >> $(OUTPUT)/fixed.lis;
+	$(APPNAME) fromlist=$(OUTPUT)/fixed.lis \
 	  tolist=$(INPUT)/toList.lis \
 	  instats=$(OUTPUT)/nonOverlapStats.pvl \
 	  outstats=$(OUTPUT)/recalculatedStats.pvl \
 	  process=RETRYBOTH \
 	  > /dev/null;
 	$(MV) *.cub $(OUTPUT);
+	$(RM) $(OUTPUT)/fixed.lis;
+	$(RM) $(OUTPUT)/nonOverlap.lis;
+

--- a/isis/src/base/apps/fx/tsts/filelistattributes/Makefile
+++ b/isis/src/base/apps/fx/tsts/filelistattributes/Makefile
@@ -3,7 +3,10 @@ APPNAME = fx
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/vims.lis \
+	$(ECHO) $(INPUT)/vims1+1 > $(OUTPUT)/vims.lis;
+	$(ECHO) $(INPUT)/vims2+100 >> $(OUTPUT)/vims.lis;
+	$(APPNAME) fromlist=$(OUTPUT)/vims.lis \
 	mode=list \
 	equation=f1*f2 \
 	to=$(OUTPUT)/f1Multf2.cub > /dev/null;
+	$(RM) $(OUTPUT)/vims.lis

--- a/isis/src/base/apps/makeflat/tsts/framing/Makefile
+++ b/isis/src/base/apps/makeflat/tsts/framing/Makefile
@@ -3,6 +3,9 @@ APPNAME = makeflat
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/fromList.lis \
+	$(ECHO) $(INPUT)/ctx_pmoi_i_00003.bottom.cub > $(OUTPUT)/fromList.lis;
+	$(ECHO) $(INPUT)/ctx_pmoi_i_00003.top.cub >> $(OUTPUT)/fromList.lis;
+	$(APPNAME) fromlist=$(OUTPUT)/fromList.lis \
 	  to=$(OUTPUT)/framingFlatTruth.cub STDEV=190 \
 	  IMAGETYPE=FRAMING EXCLUDE=$(OUTPUT)/framingFlatTruth.txt> /dev/null;
+	$(RM) $(OUTPUT)/fromList.lis

--- a/isis/src/base/apps/makeflat/tsts/linescan/Makefile
+++ b/isis/src/base/apps/makeflat/tsts/linescan/Makefile
@@ -5,7 +5,10 @@ linescanFlatTruth.cub.TOLERANCE = 0.0000002
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/fromList.lis \
+	$(ECHO) $(INPUT)/ctx_pmoi_i_00003.bottom.cub > $(OUTPUT)/fromList.lis;
+	$(ECHO) $(INPUT)/ctx_pmoi_i_00003.top.cub >> $(OUTPUT)/fromList.lis;
+	$(APPNAME) fromlist=$(OUTPUT)/fromList.lis \
 	  to=$(OUTPUT)/linescanFlatTruth.cub STDEV=190 \
 	  IMAGETYPE=LINESCAN NUMLINES=10 \
 	  EXCLUDE=$(OUTPUT)/linescanFlatTruth.txt > /dev/null;
+	  $(RM) $(OUTPUT)/fromList.lis

--- a/isis/src/base/apps/makeflat/tsts/pushframe/Makefile
+++ b/isis/src/base/apps/makeflat/tsts/pushframe/Makefile
@@ -3,7 +3,10 @@ APPNAME = makeflat
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
-	$(APPNAME) fromlist=$(INPUT)/fromList.lis \
+	$(ECHO) $(INPUT)/ctx_pmoi_i_00003.bottom.cub > $(OUTPUT)/fromList.lis;
+	$(ECHO) $(INPUT)/ctx_pmoi_i_00003.top.cub >> $(OUTPUT)/fromList.lis;
+	$(APPNAME) fromlist=$(OUTPUT)/fromList.lis \
 	to=$(OUTPUT)/pushFrameFlatTruth.cub STDEV=150 \
-	IMAGETYPE=PUSHFRAME FRAMELETHEIGHT=50 EXCLUDE=$(OUTPUT)/pushFrame.txt \
+	IMAGETYPE=PUSHFRAME FRAMELETHEIGHT=50 EXCLUDE=$(OUTPUT)/pushFrame.pvl \
 	> /dev/null;
+	$(RM) $(OUTPUT)/fromList.lis

--- a/isis/src/base/objs/RollingShutterCamera/unitTest.cpp
+++ b/isis/src/base/objs/RollingShutterCamera/unitTest.cpp
@@ -59,7 +59,7 @@ class TestRollingShutterCamera : public RollingShutterCamera {
           string msg = "SPK Reference ID is unique to mission-specific cameras";
           throw IException(IException::Unknown, msg, _FILEINFO_);
         }
-        
+
         // These are pure virtual within Sensor that must be overriden
         virtual QString instrumentNameLong() const { return QString("RollingShutting"); }
         virtual QString instrumentNameShort() const { return QString("RS"); }
@@ -73,7 +73,7 @@ int main() {
   //NOTE: The following cube is not from a framing camera.  The test returns
   //true for framing camera type since MyCamera is a child class of FramingCamera
   try {
-    Cube cube("$clipper/testData/simulated_clipper_eis_nac_rolling_shutter.cub", "r");
+    Cube cube("$ISISTESTDATA/isis/src/base/unitTestData/simulated_clipper_eis_nac_rolling_shutter.cub", "r");
     TestRollingShutterCamera cam(cube);
 
     // test camera type

--- a/isis/src/clipper/objs/ClipperWacFcCamera/unitTest.cpp
+++ b/isis/src/clipper/objs/ClipperWacFcCamera/unitTest.cpp
@@ -47,9 +47,9 @@ void TestLineSamp(Camera *cam, double samp, double line);
  */
 
 // IMPORTANT NOTE: This test is believed to be failing because the test data has an arbitrary date
-// for the StartTime, which means that the spice probably shows the spacecraft as not being near and 
+// for the StartTime, which means that the spice probably shows the spacecraft as not being near and
 // pointed at Europa. If the spacecraft isn't near and pointed at Europa, there will be no intersection
-// and SetImage will fail. 
+// and SetImage will fail.
 int main(void) {
   Preference::Preferences(true);
 
@@ -62,7 +62,7 @@ int main(void) {
     double knownLon = 0;
 
     qDebug() << "Testing with test image...";
-    Cube c("$clipper/testData/simulated_clipper_eis_wac_rolling_shutter.cub", "r");
+    Cube c("$ISISTESTDATA/isis/src/clipper/unitTestData/simulated_clipper_eis_wac_rolling_shutter.cub", "r");
     ClipperWacFcCamera *cam = (ClipperWacFcCamera *) CameraFactory::Create(c);
     qDebug() << "FileName: " << FileName(c.fileName()).name();
     qDebug() << "CK Frame: " << cam->instrumentRotation()->Frame();

--- a/isis/src/osirisrex/objs/OsirisRexOcamsCamera/unitTest.cpp
+++ b/isis/src/osirisrex/objs/OsirisRexOcamsCamera/unitTest.cpp
@@ -59,14 +59,14 @@ int main(void) {
   try {
 
     cout << "\nTesting PolyCam (backwards compatibility)..." << endl;
-    Cube polyCamCube("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/2019-01-13T23_36_05.000_PCAM_L2b_V001.cub", "r");
+    Cube polyCamCube("$ISISTESTDATA/isis/src/osirisrex/unitTestData/2019-01-13T23_36_05.000_PCAM_L2b_V001.cub", "r");
     double knownLat = 13.9465663689936950;
     double knownLon = 349.0213035062322433;
     double sample = 512.0;
     double line = 512.0;
     testCamera(polyCamCube, sample, line, knownLat, knownLon);
     cout << "\nTesting PolyCam (with PolyCamFocusPositionNaifId keyword)..." << endl;
-    Cube polyCamCube2("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/20190113T191852S740_pol_iofL2pan_V001.cub", "r");
+    Cube polyCamCube2("$ISISTESTDATA/isis/src/osirisrex/unitTestData/20190113T191852S740_pol_iofL2pan_V001.cub", "r");
     knownLat = -5.5191879351483450;
     knownLon = 349.6939492565607566;
     sample = 512.0;
@@ -75,14 +75,14 @@ int main(void) {
     cout << "============================================================================" << endl;
 
     cout << "\nTesting MapCam (backwards compatibility)..." << endl;
-    Cube mapCamCube("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/D19030320000.cub", "r");
+    Cube mapCamCube("$ISISTESTDATA/isis/src/osirisrex/unitTestData/D19030320000.cub", "r");
     knownLat = 73.9976065262802933;
     knownLon = 149.3814386120742768;
     sample = 512.0;
     line = 512.0;
     testCamera(mapCamCube, sample, line, knownLat, knownLon);
     cout << "\nTesting MapCam (with PolyCamFocusPositionNaifId keyword)..." << endl;
-    Cube mapCamCube2("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/20190303T100344S990_map_iofL2pan_V001.cub", "r");
+    Cube mapCamCube2("$ISISTESTDATA/isis/src/osirisrex/unitTestData/20190303T100344S990_map_iofL2pan_V001.cub", "r");
     knownLat = -19.2946930665326732;
     knownLon = 145.9510736765638512;
     sample = 512.0;

--- a/isis/src/osirisrex/objs/OsirisRexOcamsCamera/unitTest.cpp
+++ b/isis/src/osirisrex/objs/OsirisRexOcamsCamera/unitTest.cpp
@@ -2,17 +2,17 @@
  * @file
  *
  *   Unless noted otherwise, the portions of Isis written by the USGS are public
- *   domain. See individual third-party library and package descriptions for 
+ *   domain. See individual third-party library and package descriptions for
  *   intellectual property information,user agreements, and related information.
  *
  *   Although Isis has been used by the USGS, no warranty, expressed or implied,
- *   is made by the USGS as to the accuracy and functioning of such software 
- *   and related material nor shall the fact of distribution constitute any such 
- *   warranty, and no responsibility is assumed by the USGS in connection 
+ *   is made by the USGS as to the accuracy and functioning of such software
+ *   and related material nor shall the fact of distribution constitute any such
+ *   warranty, and no responsibility is assumed by the USGS in connection
  *   therewith.
  *
  *   For additional information, launch
- *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see 
+ *   $ISISROOT/doc//documents/Disclaimers/Disclaimers.html in a browser or see
  *   the Privacy &amp; Disclaimers page on the Isis website,
  *   http://isis.astrogeology.usgs.gov, and the USGS privacy and disclaimers on
  *   http://www.usgs.gov/privacy.html.
@@ -36,7 +36,7 @@ void testCamera(Cube &c, double sample, double line, double knownLat, double kno
 void testLineSamp(Camera *cam, double sample, double line);
 
 /**
- * This is the unit test for the Osiris Rex Camera model. 
+ * This is the unit test for the Osiris Rex Camera model.
  *
  * @author  2015-11-10 Stuart C. Sides
  * @internal
@@ -47,9 +47,9 @@ void testLineSamp(Camera *cam, double sample, double line);
  *                           PolyCamFocusPositionNaifId keyword.
  *   @history 2017-09-18 Kristin Berry - Updated known latitudes and longitudes for the addition of
  *                           the distortion model. (For non-backwards compatibility MapCam cube
- *                           only, since we do not yet have a PolyCam cube with a motor position 
- *                           that we have a distortion solution for.) 
- * 
+ *                           only, since we do not yet have a PolyCam cube with a motor position
+ *                           that we have a distortion solution for.)
+ *
  */
 
 int main(void) {
@@ -59,33 +59,33 @@ int main(void) {
   try {
 
     cout << "\nTesting PolyCam (backwards compatibility)..." << endl;
-    Cube polyCamCube("$osirisrex/testData/2019-01-13T23_36_05.000_PCAM_L2b_V001.cub", "r");
+    Cube polyCamCube("$ISISTESTDATA/isis/src/osirisrex/unitTestData/2019-01-13T23_36_05.000_PCAM_L2b_V001.cub", "r");
     double knownLat = 13.9465663689936950;
     double knownLon = 349.0213035062322433;
-    double sample = 512.0; 
+    double sample = 512.0;
     double line = 512.0;
     testCamera(polyCamCube, sample, line, knownLat, knownLon);
     cout << "\nTesting PolyCam (with PolyCamFocusPositionNaifId keyword)..." << endl;
-    Cube polyCamCube2("$osirisrex/testData/20190113T191852S740_pol_iofL2pan_V001.cub", "r");
+    Cube polyCamCube2("$ISISTESTDATA/isis/src/osirisrex/unitTestData/20190113T191852S740_pol_iofL2pan_V001.cub", "r");
     knownLat = -5.5191879351483450;
     knownLon = 349.6939492565607566;
-    sample = 512.0; 
+    sample = 512.0;
     line = 512.0;
     testCamera(polyCamCube2, sample, line, knownLat, knownLon);
     cout << "============================================================================" << endl;
 
     cout << "\nTesting MapCam (backwards compatibility)..." << endl;
-    Cube mapCamCube("$osirisrex/testData/D19030320000.cub", "r");
+    Cube mapCamCube("$ISISTESTDATA/isis/src/osirisrex/unitTestData/D19030320000.cub", "r");
     knownLat = 73.9976065262802933;
     knownLon = 149.3814386120742768;
-    sample = 512.0; 
+    sample = 512.0;
     line = 512.0;
     testCamera(mapCamCube, sample, line, knownLat, knownLon);
     cout << "\nTesting MapCam (with PolyCamFocusPositionNaifId keyword)..." << endl;
-    Cube mapCamCube2("$osirisrex/testData/20190303T100344S990_map_iofL2pan_V001.cub", "r");
+    Cube mapCamCube2("$ISISTESTDATA/isis/src/osirisrex/unitTestData/20190303T100344S990_map_iofL2pan_V001.cub", "r");
     knownLat = -19.2946930665326732;
     knownLon = 145.9510736765638512;
-    sample = 512.0; 
+    sample = 512.0;
     line = 512.0;
     testCamera(mapCamCube2, sample, line, knownLat, knownLon);
     cout << "============================================================================" << endl;
@@ -95,7 +95,7 @@ int main(void) {
     Cube samCamCube("$osirisrex/testData/20141111T202650_SCAM_L2_V001_SCAM.cub", "r");
     knownLat = 0.0;
     knownLon = 0.0;
-    sample = 512.0; 
+    sample = 512.0;
     line = 512.0;
     testCamera(samCamCube, sample, line, knownLat, knownLon);
     cout << "============================================================================" << endl;
@@ -107,7 +107,7 @@ int main(void) {
   }
 }
 
-void testCamera(Cube &cube, 
+void testCamera(Cube &cube,
                 double sample, double line,
                 double knownLat, double knownLon) {
 
@@ -123,14 +123,14 @@ void testCamera(Cube &cube,
   cout << "CK Reference ID = " << cam->CkReferenceId() << endl;
   cout << "SPK Target ID = " << cam->SpkTargetId() << endl;
   cout << "SPK Reference ID = " << cam->SpkReferenceId() << endl << endl;
-  
+
   // Test name methods
   cout << "Spacecraft Name Long: " << cam->spacecraftNameLong() << endl;
   cout << "Spacecraft Name Short: " << cam->spacecraftNameShort() << endl;
   cout << "Instrument Name Long: " << cam->instrumentNameLong() << endl;
   cout << "Instrument Name Short: " << cam->instrumentNameShort() << endl << endl;
 
-  // Test Shutter Open/Close 
+  // Test Shutter Open/Close
   const PvlGroup &inst = cube.label()->findGroup("Instrument", Pvl::Traverse);
   double exposureDuration = ((double) inst["ExposureDuration"])/1000;
   QString stime = inst["StartTime"];

--- a/isis/src/osirisrex/objs/OsirisRexOcamsCamera/unitTest.cpp
+++ b/isis/src/osirisrex/objs/OsirisRexOcamsCamera/unitTest.cpp
@@ -59,14 +59,14 @@ int main(void) {
   try {
 
     cout << "\nTesting PolyCam (backwards compatibility)..." << endl;
-    Cube polyCamCube("$ISISTESTDATA/isis/src/osirisrex/unitTestData/2019-01-13T23_36_05.000_PCAM_L2b_V001.cub", "r");
+    Cube polyCamCube("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/2019-01-13T23_36_05.000_PCAM_L2b_V001.cub", "r");
     double knownLat = 13.9465663689936950;
     double knownLon = 349.0213035062322433;
     double sample = 512.0;
     double line = 512.0;
     testCamera(polyCamCube, sample, line, knownLat, knownLon);
     cout << "\nTesting PolyCam (with PolyCamFocusPositionNaifId keyword)..." << endl;
-    Cube polyCamCube2("$ISISTESTDATA/isis/src/osirisrex/unitTestData/20190113T191852S740_pol_iofL2pan_V001.cub", "r");
+    Cube polyCamCube2("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/20190113T191852S740_pol_iofL2pan_V001.cub", "r");
     knownLat = -5.5191879351483450;
     knownLon = 349.6939492565607566;
     sample = 512.0;
@@ -75,14 +75,14 @@ int main(void) {
     cout << "============================================================================" << endl;
 
     cout << "\nTesting MapCam (backwards compatibility)..." << endl;
-    Cube mapCamCube("$ISISTESTDATA/isis/src/osirisrex/unitTestData/D19030320000.cub", "r");
+    Cube mapCamCube("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/D19030320000.cub", "r");
     knownLat = 73.9976065262802933;
     knownLon = 149.3814386120742768;
     sample = 512.0;
     line = 512.0;
     testCamera(mapCamCube, sample, line, knownLat, knownLon);
     cout << "\nTesting MapCam (with PolyCamFocusPositionNaifId keyword)..." << endl;
-    Cube mapCamCube2("$ISISTESTDATA/isis/src/osirisrex/unitTestData/20190303T100344S990_map_iofL2pan_V001.cub", "r");
+    Cube mapCamCube2("$ISISTESTDATA/../testDataLocal/isis/src/osirisrex/unitTestData/20190303T100344S990_map_iofL2pan_V001.cub", "r");
     knownLat = -19.2946930665326732;
     knownLon = 145.9510736765638512;
     sample = 512.0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Updated unit tests to use data from ISISTESTDATA instead of ISISDATA## Description

<!--- Describe your changes in detail -->
Updated RollingShutterCamera and ClipperWacCamera to use unitTestData in $ISISTESTDATA. Updated osirisrex ocams unit test to use isis_testDataLocal instead of ISISDATA

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
