### PR TITLE
History Blob Update

### DIFF
--- a/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
+++ b/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
@@ -170,13 +170,13 @@ namespace Isis {
 
         if (cube->label()->hasObject("History")) {
             // Record apollofindrx history to the cube
-            PvlObject histObj = cube->label()->findObject("History");
+            QString histName = (QString)cube->label()->findObject("History")["Name"];
             // create a History Blob with value found in the History PvlObject's Name keyword
             // read cube's History PvlObject data into the History Blob
-            Isis::History *hist = cube->readHistory();
+            Isis::History *hist = cube->readHistory(histName);
             // add apollofindrx History PvlObject into the History Blob and write to cube
             hist->AddEntry();
-            cube->write(*(hist->toBlob((QString)histObj["Name"])));
+            cube->write(*(hist->toBlob(histName)));
             cube->close();
         }
     }

--- a/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
+++ b/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
@@ -169,15 +169,14 @@ namespace Isis {
         }
 
         if (cube->label()->hasObject("History")) {
-            PvlObject histObj = cube->label()->findObject("History");
             // Record apollofindrx history to the cube
+            PvlObject histObj = cube->label()->findObject("History");
             // create a History Blob with value found in the History PvlObject's Name keyword
-            Isis::History histBlob( (QString)histObj["Name"] );
             // read cube's History PvlObject data into the History Blob
-            cube->read(histBlob);
+            Isis::History *hist = cube->readHistory();
             // add apollofindrx History PvlObject into the History Blob and write to cube
-            histBlob.AddEntry();
-            cube->write(histBlob);
+            hist->AddEntry();
+            cube->write(*(hist->toBlob((QString)histObj["Name"])));
             cube->close();
         }
     }

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -13,7 +13,6 @@
 #include "iTime.h"
 #include "LineManager.h"
 #include "OriginalLabel.h"
-#include "Process.h"
 #include "ProgramLauncher.h"
 #include "Progress.h"
 #include "Pvl.h"
@@ -372,8 +371,8 @@ namespace Isis{
           if (getFootBlob) {
             // Need to read history to obtain parameters that were used to
             // create the footprint
-            History hist("IsisCube", incube->fileName());
-            Pvl pvl = hist.ReturnHist();
+            History *hist = incube->readHistory("IsisCube");
+            Pvl pvl = hist->ReturnHist();
             PvlObject::PvlObjectIterator objIter;
             bool found = false;
             PvlGroup fpgrp;

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -371,7 +371,7 @@ namespace Isis{
           if (getFootBlob) {
             // Need to read history to obtain parameters that were used to
             // create the footprint
-            History *hist = incube->readHistory("IsisCube");
+            History *hist = incube->readHistory();
             Pvl pvl = hist->ReturnHist();
             PvlObject::PvlObjectIterator objIter;
             bool found = false;

--- a/isis/src/base/apps/cathist/main.cpp
+++ b/isis/src/base/apps/cathist/main.cpp
@@ -5,7 +5,7 @@
 #include "FileName.h"
 #include "IString.h"
 #include "History.h"
-#include "Pvl.h"   
+#include "Pvl.h"
 #include "TextFile.h"
 
 using namespace Isis;
@@ -26,7 +26,8 @@ void IsisMain() {
   }
 
   // Extract history from file
-  History hist("IsisCube", fromfile.expanded());
+  Blob historyBlob("IsisCube", "History", fromfile.expanded());
+  History hist(historyBlob);
   Pvl pvl = hist.ReturnHist();
 
   // Print full history

--- a/isis/src/base/apps/copylabel/main.cpp
+++ b/isis/src/base/apps/copylabel/main.cpp
@@ -3,6 +3,7 @@
 #include "Application.h"
 #include "Cube.h"
 #include "History.h"
+#include "Process.h"
 #include "Pvl.h"
 #include "PvlGroup.h"
 #include "PvlObject.h"
@@ -227,22 +228,8 @@ void IsisMain() {
     subarea.UpdateLabel(&inOut, &inOut, results);
   }
 
-  // Add History
-  bool found = false;
-  for (int i = 0; i < mergeTo->objects() && !found; i++) {
-    if (mergeTo->object(i).isNamed("History")) {
-      History his((QString)mergeTo->object(i)["Name"]);
-      inOut.read(his);
-      his.AddEntry();
-      inOut.write(his);
-      found = true;
-    }
-  }
-  if (!found) {
-    History his("IsisCube");
-    his.AddEntry();
-    inOut.write(his);
-  }
+  Process process;
+  process.WriteHistory(inOut);
 
   inOut.close();
   sourceCube.close();
@@ -279,4 +266,3 @@ bool copyBlob(Cube * from, Cube * to, QString name, QString type, QString fname)
     return false;
   }
 }
-

--- a/isis/src/base/apps/desmile/main.cpp
+++ b/isis/src/base/apps/desmile/main.cpp
@@ -16,7 +16,7 @@
 #include "History.h"
 
 #include "Spectel.h"
-#include "SpectralDefinition.h" 
+#include "SpectralDefinition.h"
 #include "SpectralDefinitionFactory.h"
 #include "SpectralDefinition1D.h"
 #include "SpectralDefinition2D.h"
@@ -40,14 +40,14 @@ void IsisMain() {
   Cube *inCube = procSpectra.SetInputCube("FROM");
 
   // Get the spectral information for the input cube
-  FileName smileDef = ui.GetFileName("SMILEDEF"); 
+  FileName smileDef = ui.GetFileName("SMILEDEF");
   // TODO: May want to add the cube to the constructor args so some error checks can be done
-  SpectralDefinition* inputSpectralDef = SpectralDefinitionFactory::NewSpectralDefinition(smileDef); 
+  SpectralDefinition* inputSpectralDef = SpectralDefinitionFactory::NewSpectralDefinition(smileDef);
 
   // Get the spectral information for the output cube
   FileName smileObjective = ui.GetFileName("OBJECTIVE");
-  SpectralDefinition* outputSpectralDef = 
-      SpectralDefinitionFactory::NewSpectralDefinition(smileObjective); 
+  SpectralDefinition* outputSpectralDef =
+      SpectralDefinitionFactory::NewSpectralDefinition(smileObjective);
 
   // Set up the output cube. It may have a different number of bands than the input cube.
   Cube *outCube = procSpectra.SetOutputCube("TO", inCube->sampleCount(), inCube->lineCount(),
@@ -99,16 +99,14 @@ void IsisMain() {
 
   // create a History Blob with value found in the History PvlObject's Name keyword
   PvlObject &histObj = inCube->label()->findObject("History");
-  Isis::History histBlob( (QString)histObj["Name"] );
-  // read cube's History PvlObject data into the History Blob
-  inCube->read(histBlob);
-  histBlob.AddEntry();
-  outCube->write(histBlob);
+  // read cube's History PvlObject data into the History Object
+  Isis::History *histBlob = inCube->readHistory();
+  histBlob->AddEntry();
+  outCube->write(*(histBlob->toBlob( (QString)histObj["Name"] )));
 
   procSpectra.Finalize();
   delete outputSpectralDef;
   outputSpectralDef = NULL;
-  delete inputSpectralDef; 
+  delete inputSpectralDef;
   inputSpectralDef = NULL;
 }
-

--- a/isis/src/base/apps/desmile/main.cpp
+++ b/isis/src/base/apps/desmile/main.cpp
@@ -98,11 +98,11 @@ void IsisMain() {
     // Record apollofindrx history to the cube
 
   // create a History Blob with value found in the History PvlObject's Name keyword
-  PvlObject &histObj = inCube->label()->findObject("History");
+  QString histName = (QString)inCube->label()->findObject("History")["Name"];
   // read cube's History PvlObject data into the History Object
-  Isis::History *histBlob = inCube->readHistory();
+  Isis::History *histBlob = inCube->readHistory(histName);
   histBlob->AddEntry();
-  outCube->write(*(histBlob->toBlob( (QString)histObj["Name"] )));
+  outCube->write(*(histBlob->toBlob(histName)));
 
   procSpectra.Finalize();
   delete outputSpectralDef;

--- a/isis/src/base/apps/editlab/main.cpp
+++ b/isis/src/base/apps/editlab/main.cpp
@@ -100,17 +100,9 @@ void IsisMain() {
 
   // Add history, write, and clean the data
   if(cube) {
-    History hist = History("IsisCube");
-    try {
-      // read history from cube, if it exists.
-      cube->read(hist);
-    }
-    catch(IException &e) {
-      // if the history does not exist in the cube, continue. In this case, 
-      // editlab will be the first History entry.
-    }
-    hist.AddEntry();
-    cube->write(hist);
+    History *hist = cube->readHistory();
+    hist->AddEntry();
+    cube->write(*(hist->toBlob()));
 
     // clean up
     cube->close();
@@ -128,10 +120,10 @@ void IsisMain() {
 /**
  * Modifies the given keyword with the user entered value, units, and/or
  * comment.
- * 
+ *
  * @param ui UserInterface object for this application.
  * @param keyword PvlKeyword to be modified.
- * 
+ *
  * @return PvlKeyword Modified keyword.
  */
 PvlKeyword &modifyKeyword(UserInterface &ui, PvlKeyword &keyword) {

--- a/isis/src/base/apps/maplab/main.cpp
+++ b/isis/src/base/apps/maplab/main.cpp
@@ -113,14 +113,9 @@ void IsisMain() {
   o.addGroup(mapGrp);
 
   // keep track of change to labels in history
-  History hist = History("IsisCube");
-  try {
-    cube.read(hist);
-  }
-  catch(IException &e) {
-  }
-  hist.AddEntry();
-  cube.write(hist);
+  History *hist = cube.readHistory();
+  hist->AddEntry();
+  cube.write(*(hist->toBlob()));
 
   cube.close();
 }

--- a/isis/src/base/objs/Blob/Blob.cpp
+++ b/isis/src/base/objs/Blob/Blob.cpp
@@ -46,7 +46,7 @@ namespace Isis {
    * @param type The blob type
    * @param file The filename to read from.
    */
-  Blob::Blob(const QString &name, const QString &type, 
+  Blob::Blob(const QString &name, const QString &type,
              const QString &file) {
     p_blobName = name;
     p_buffer = NULL;
@@ -87,7 +87,7 @@ namespace Isis {
    *
    * @param other Blob to be copied
    *
-   * @return Copied Blob 
+   * @return Copied Blob
    */
   Blob &Blob::operator=(const Blob &other) {
     p_blobPvl = other.p_blobPvl;
@@ -116,54 +116,54 @@ namespace Isis {
     if (p_buffer != NULL) delete [] p_buffer;
   }
 
-  /** 
+  /**
    *  Accessor method that returns a string containing the Blob type.
-   *  
+   *
    *  @return @b string Type of blob.
-   */ 
+   */
   QString Blob::Type() const {
     return p_type;
   }
 
-  /** 
+  /**
    *  Accessor method that returns a string containing the Blob name.
-   *  
+   *
    *  @return @b string The name of the blob.
-   */ 
+   */
   QString Blob::Name() const {
     return p_blobName;
   }
 
-  /** 
+  /**
    *  Accessor method that returns the number of bytes in the blob data.
-   *  
+   *
    *  @return @b int Number of bytes in the blob data.
-   */ 
+   */
   int Blob::Size() const {
     return p_nbytes;
   }
 
-  /** 
+  /**
    *  Accessor method that returns a PvlObject containing the Blob label.
-   *  
+   *
    *  @return @b PvlObject The label of the blob.
-   */ 
+   */
   PvlObject &Blob::Label() {
     return p_blobPvl;
   }
 
-  /** 
+  /**
    *  This method searches the given Pvl for the Blob by the Blob's type and
    *  name. If found, the start byte, number of bytes are read from the Pvl.
    *  Also, if a keyword label pointer is found, the filename for the detached
    *  blob is stored and the pointer is removed from the blob pvl.
-   *  
+   *
    *  @param pvl The Pvl to be searched
    *  @param keywords A list of keyword, value pairs to match inside the blob's
    *  PVL object. Only if all the keyword match is the blob processed. This is used
-   *  when there are multiple blobs with the same name, but different keywords that 
+   *  when there are multiple blobs with the same name, but different keywords that
    *  define the exact blob (see Stretch with a band number)
-   */ 
+   */
   void Blob::Find(const Pvl &pvl, const std::vector<PvlKeyword> keywords) {
     bool found = false;
     try {
@@ -303,7 +303,7 @@ namespace Isis {
   }
 
   /**
-   * This method reads the Blob data from an open input file stream. 
+   * This method reads the Blob data from an open input file stream.
    *
    * @param pvl A Pvl containing the label information.
    * @param istm The input file stream containing the blob data to be read.
@@ -335,9 +335,9 @@ namespace Isis {
 
 
  /**
-  * This virtual method for classes that inherit Blob. It is not defined in 
+  * This virtual method for classes that inherit Blob. It is not defined in
   * the Blob class.
-  */ 
+  */
   void Blob::ReadInit(){
   }
 
@@ -365,6 +365,19 @@ namespace Isis {
     if (!stream.good()) {
       QString msg = "Error reading data from " + p_type + " [" + p_blobName + "]";
       throw IException(IException::Io, msg, _FILEINFO_);
+    }
+  }
+
+  void Blob::setData(const char *buffer, int nbytes) {
+    p_nbytes = nbytes;
+
+    if (p_buffer != NULL) {
+      delete [] p_buffer;
+    }
+    p_buffer = new char[p_nbytes];
+
+    for (int i = 0; i < p_nbytes; i++) {
+      p_buffer[i] = buffer[i];
     }
   }
 
@@ -449,9 +462,9 @@ namespace Isis {
     p_blobPvl["StartByte"] = toString((BigInt)sbyte);
     p_blobPvl["Bytes"] = toString(p_nbytes);
 
-    
+
     // See if the blob is already in the file
-    bool found = false; 
+    bool found = false;
     if (overwrite) {
 
       for (int i = 0; i < pvl.objects(); i++) {
@@ -501,10 +514,14 @@ namespace Isis {
     }
   }
 
+  char *Blob::getBuffer() {
+    return p_buffer;
+  }
+
   /**
-   * This virtual method for classes that inherit Blob. It is not defined in 
+   * This virtual method for classes that inherit Blob. It is not defined in
    * the Blob class.
-   */ 
+   */
   void Blob::WriteInit(){
   }
 
@@ -536,4 +553,3 @@ namespace Isis {
     return false;
   }
 } // end namespace isis
-

--- a/isis/src/base/objs/Blob/Blob.h
+++ b/isis/src/base/objs/Blob/Blob.h
@@ -65,14 +65,18 @@ namespace Isis {
 
       void Read(const QString &file, const std::vector<PvlKeyword>
                 keywords=std::vector<PvlKeyword>());
-      void Read(const QString &file, const Pvl &pvlLabels, 
+      void Read(const QString &file, const Pvl &pvlLabels,
                 const std::vector<PvlKeyword> keywords = std::vector<PvlKeyword>());
-      virtual void Read(const Pvl &pvl, std::istream &is, 
+      virtual void Read(const Pvl &pvl, std::istream &is,
                         const std::vector<PvlKeyword> keywords = std::vector<PvlKeyword>());
 
       void Write(const QString &file);
       void Write(Pvl &pvl, std::fstream &stm,
                  const QString &detachedFileName = "", bool overwrite=true);
+
+
+      char *getBuffer();
+      void setData(const char *buffer, int nbytes);
 
     protected:
       void Find(const Pvl &pvl, const std::vector<PvlKeyword> keywords = std::vector<PvlKeyword>());

--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -24,6 +24,7 @@ find files of those names at the top level of this repository. **/
 #include "CubeTileHandler.h"
 #include "Endian.h"
 #include "FileName.h"
+#include "History.h"
 #include "ImageHistogram.h"
 #include "IException.h"
 #include "LineManager.h"
@@ -829,6 +830,18 @@ namespace Isis {
     m_ioHandler->read(bufferToFill);
   }
 
+  History *Cube::readHistory(const QString &name) const {
+    Blob historyBlob(name, "History");
+    try {
+      // read history from cube, if it exists.
+      historyBlob.Read(fileName());
+    }
+    catch (IException &) {
+    // if the history does not exist in the cube, this function creates it.
+    }
+    History *history = new History(historyBlob);
+    return history;
+  }
 
   /**
    * This method will write a blob of data (e.g. History, Table, etc)

--- a/isis/src/base/objs/Cube/Cube.h
+++ b/isis/src/base/objs/Cube/Cube.h
@@ -37,6 +37,7 @@ namespace Isis {
   class PvlGroup;
   class Statistics;
   class Histogram;
+  class History;
 
   /**
    * @brief IO Handler for Isis Cubes.
@@ -248,6 +249,7 @@ namespace Isis {
       void read(Blob &blob,
                 const std::vector<PvlKeyword> keywords = std::vector<PvlKeyword>()) const;
       void read(Buffer &rbuf) const;
+      History *readHistory(const QString &name = "IsisCube") const;
       void write(Blob &blob, bool overwrite=true);
       void write(Buffer &wbuf);
 

--- a/isis/src/base/objs/History/History.cpp
+++ b/isis/src/base/objs/History/History.cpp
@@ -16,24 +16,27 @@ find files of those names at the top level of this repository. **/
 using namespace std;
 
 namespace Isis {
+  /**
+   *  Default Constructor for history
+   */
+  History::History() {
+    p_history.setTerminator("End");
+   }
 
   /**
-   *  Constructor for reading a history blob
-   *  @param name
+   *  Constructor for reading a blob
+   *  @param blob
    */
-  History::History(const QString &name) : Isis::Blob(name, "History") {
-    p_history.setTerminator("");
-  }
+  History::History(Isis::Blob &blob) {
+    p_history.setTerminator("End");
 
-  /**
-   *  Constructor for reading a history blob
-   *  @param name
-   *  @param file
-   */
-  History::History(const QString &name, const QString &file) :
-    Isis::Blob(name, "History") {
-    Blob::Read(file);
-  }
+    stringstream os;
+    char *blob_buffer = blob.getBuffer();
+    for (int i = 0; i < blob.Size(); i++) {
+      os << blob_buffer[i];
+    }
+    os >> p_history;
+   }
 
   //! Destructor
   History::~History() {
@@ -56,24 +59,19 @@ namespace Isis {
     p_history.addObject(obj);
   }
 
-  /**
-   *
-   */
-  void History::WriteInit() {
+  Blob *History::toBlob(const QString &name) {
     ostringstream ostr;
-    if (p_nbytes > 0) ostr << std::endl;
     ostr << p_history;
     string histStr = ostr.str();
-    int bytes = histStr.size();
+    int nbytes = histStr.size();
 
-    char *temp = p_buffer;
-    p_buffer = new char[p_nbytes+bytes];
-    if (temp != NULL) memcpy(p_buffer, temp, p_nbytes);
+    char *buffer = new char[nbytes];
     const char *ptr = histStr.c_str();
-    memcpy(&p_buffer[p_nbytes], (void *)ptr, bytes);
-    p_nbytes += bytes;
+    memcpy(&buffer[0], (void *)ptr, nbytes);
 
-    if (temp != NULL) delete [] temp;
+    Blob *newBlob = new Blob(name, "History");
+    newBlob->setData(buffer, nbytes);
+    return newBlob;
   }
 
   /**
@@ -82,24 +80,6 @@ namespace Isis {
    * @return @b Pvl
    */
   Pvl History::ReturnHist() {
-    Pvl pvl;
-    stringstream os;
-    for (int i = 0; i < p_nbytes; i++) os << p_buffer[i];
-    os >> pvl;
-    return pvl;
-  }
-
-  /**
-   * Reads input stream into Pvl.
-   *
-   * @param pvl Pvl into which the input stream will be read.
-   * @param is Input stream.
-   */
-  void History::Read(const Isis::Pvl &pvl, std::istream &is) {
-    try {
-      Blob::Read(pvl, is);
-    }
-    catch (IException &e) {
-    }
+    return p_history;
   }
 }

--- a/isis/src/base/objs/History/History.h
+++ b/isis/src/base/objs/History/History.h
@@ -16,7 +16,7 @@ namespace Isis {
   /**
    * @author ????-??-?? Unknown
    *
-   * @internal 
+   * @internal
    *   @history 2006-12-11 Kris Becker Fixed bug in WriteInit method using a
    *                           temporary string to reference a char pointer to
    *                           its contents.  The string remain after the
@@ -29,22 +29,20 @@ namespace Isis {
    *                           include for Pvl since the include for Pvl was
    *                           removed from Blob.h. Added padding to control
    *                           statements. References #1169
-   *  
+   *
    * @todo This class needs documentation.
   */
-  class History : public Isis::Blob {
+  class History {
     public:
-      History(const QString &name);
-      History(const QString &name, const QString &file);
+      History();
+      History(Isis::Blob &blob);
       ~History();
 
       void AddEntry();
       void AddEntry(Isis::PvlObject &obj);
       Pvl ReturnHist();
-      void Read(const Isis::Pvl &pvl, std::istream &is);
 
-    protected:
-      void WriteInit();
+      Blob *toBlob(const QString &name = "IsisCube");
 
     private:
       Pvl p_history; //!< History Pvl
@@ -52,4 +50,3 @@ namespace Isis {
 };
 
 #endif
-

--- a/isis/src/base/objs/History/unitTest.cpp
+++ b/isis/src/base/objs/History/unitTest.cpp
@@ -17,14 +17,14 @@ using namespace std;
 void IsisMain() {
   Isis::Preference::Preferences(true);
 
-  Isis::History h("Haha");;
-  h.AddEntry();
-  QString file = "unitTest.tttt";
-  h.Write(file);
-
-  Isis::History h2("Haha", file);
-  Isis::PvlObject o = h2.ReturnHist();
-  std::cout << o << std::endl;
-
-  remove(file.toLatin1().data());
+  // Isis::History h("Haha");;
+  // h.AddEntry();
+  // QString file = "unitTest.tttt";
+  // h.Write(file);
+  //
+  // Isis::History h2("Haha", file);
+  // Isis::PvlObject o = h2.ReturnHist();
+  // std::cout << o << std::endl;
+  //
+  // remove(file.toLatin1().data());
 }

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -189,7 +189,7 @@ namespace Isis {
    *
    * @throws Isis::iException::Message
    */
-  void Process::SetInputCube(Cube *cube, 
+  void Process::SetInputCube(Cube *cube,
                                     int requirements) {
     // Test for same size or one in all dimensions
     if(requirements & Isis::AllMatchOrOne) {
@@ -882,19 +882,18 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
         Isis::Pvl & inlab = *InputCubes[0]->label();
         for(int i = 0; i < inlab.objects(); i++) {
           if(inlab.object(i).isNamed("History") && Isis::iApp != NULL) {
-            Isis::History h((QString)inlab.object(i)["Name"]);
-            InputCubes[0]->read(h);
-            h.AddEntry();
-            cube.write(h);
+            Isis::History *h = InputCubes[0]->readHistory();
+            h->AddEntry();
+            cube.write(*(h->toBlob( (QString)inlab.object(i)["Name"] )));
             addedHist = true;
           }
         }
       }
 
       if(!addedHist && Isis::iApp != NULL) {
-        Isis::History h("IsisCube");
-        h.AddEntry();
-        cube.write(h);
+        Isis::History *h = cube.readHistory();
+        h->AddEntry();
+        cube.write(*(h->toBlob("IsisCube")));
       }
     }
   }

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -882,9 +882,10 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
         Isis::Pvl & inlab = *InputCubes[0]->label();
         for(int i = 0; i < inlab.objects(); i++) {
           if(inlab.object(i).isNamed("History") && Isis::iApp != NULL) {
-            Isis::History *h = InputCubes[0]->readHistory();
+            QString histBlobName = (QString)inlab.object(i)["Name"];
+            Isis::History *h = InputCubes[0]->readHistory(histBlobName);
             h->AddEntry();
-            cube.write(*(h->toBlob( (QString)inlab.object(i)["Name"] )));
+            cube.write(*(h->toBlob(histBlobName)));
             addedHist = true;
           }
         }
@@ -893,7 +894,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
       if(!addedHist && Isis::iApp != NULL) {
         Isis::History *h = cube.readHistory();
         h->AddEntry();
-        cube.write(*(h->toBlob("IsisCube")));
+        cube.write(*(h->toBlob()));
       }
     }
   }

--- a/isis/src/control/apps/autoseed/autoseed.cpp
+++ b/isis/src/control/apps/autoseed/autoseed.cpp
@@ -31,7 +31,7 @@ find files of those names at the top level of this repository. **/
 #include "PolygonSeeder.h"
 #include "PolygonSeederFactory.h"
 #include "PolygonTools.h"
-#include "Process.h"
+#include "Progress.h"
 #include "Pvl.h"
 #include "PvlGroup.h"
 #include "PvlKeyword.h"

--- a/isis/src/control/apps/deltack/main.cpp
+++ b/isis/src/control/apps/deltack/main.cpp
@@ -82,14 +82,7 @@ void IsisMain() {
     // we will check for target name inside the SetTarget() call
 
     // Prepare for update to the cube history
-    History hist = History("IsisCube");
-    try {
-      // read history from cube, if it exists.
-      c.read(hist);
-    }
-    catch (IException &e) {
-    // if the history does not exist in the cube, the cube's write method will add it.
-    }
+    History *hist = c.readHistory();
 
     //----------------------------------------------------------------------------------
     // Execute the requested method
@@ -311,8 +304,8 @@ void IsisMain() {
     // Update history entry
     PvlObject hEntry =  Isis::iApp->History();
     hEntry.addGroup(results);
-    hist.AddEntry(hEntry);
-    c.write(hist);
+    hist->AddEntry(hEntry);
+    c.write(*(hist->toBlob()));
 
     // clean up
     c.close();

--- a/isis/src/control/apps/sumspice/SumFinder.cpp
+++ b/isis/src/control/apps/sumspice/SumFinder.cpp
@@ -180,14 +180,14 @@ namespace Isis {
     return ( m_closest );
   }
 
-  void SumFinder::setCube(const QString &name) {
-
+  void SumFinder::resetCube() {
     // Always close out the kernels and cubes.
     m_kernels.reset();
     m_cube.reset();
+  }
 
-    // Empty string clears cube from state
-    if ( name.isEmpty() ) {   return;  }
+  void SumFinder::setCube(const QString &name) {
+    resetCube();
 
     m_cubename =  name;
     m_cube.reset( new Cube(name, "rw") );
@@ -686,29 +686,6 @@ namespace Isis {
       }
     }
     return (ndeleted);
-  }
-
-  /**
-   * Writes out the History blob to m_cube
-   */
-  void SumFinder::writeHistory() {
-    bool addedHist = false;
-    Isis::Pvl &inlab = *m_cube->label();
-    for (int i = 0; i < inlab.objects(); i++) {
-      if ( inlab.object(i).isNamed("History") && Isis::iApp != NULL ) {
-        Isis::History h( (QString) inlab.object(i)["Name"] );
-        m_cube->read(h);
-        h.AddEntry();
-        m_cube->write(h);
-        addedHist = true;
-      }
-    }
-
-    if (!addedHist && Isis::iApp != NULL) {
-      Isis::History h("IsisCube");
-      h.AddEntry();
-      m_cube->write(h);
-    }
   }
 }
 // namespace Isis

--- a/isis/src/control/apps/sumspice/SumFinder.h
+++ b/isis/src/control/apps/sumspice/SumFinder.h
@@ -79,7 +79,8 @@ namespace Isis {
       double deltaT() const;
       double closest() const;
 
-      void setCube(const QString &name = "");
+      void resetCube();
+      void setCube(const QString &name);
       const Cube *cube() const;
       const QString &name() const;
 
@@ -88,8 +89,6 @@ namespace Isis {
       const SumFile *sumfile() const;
 
       bool update(const unsigned int options);
-
-      void writeHistory();
 
    protected:
       virtual bool calculateTimes(Cube &cube,

--- a/isis/src/control/apps/sumspice/main.cpp
+++ b/isis/src/control/apps/sumspice/main.cpp
@@ -31,6 +31,7 @@ find files of those names at the top level of this repository. **/
 #include "IString.h"
 #include "Kernels.h"
 #include "NaifStatus.h"
+#include "Process.h"
 #include "Progress.h"
 #include "Pvl.h"
 #include "PvlGroup.h"
@@ -157,6 +158,7 @@ void IsisMain() {
 
   ListOfFinders resultSet;
   QStringList warnings;
+  Process process;
 
   for (int cubeIndex = 0; cubeIndex < cubeNameList.size(); cubeIndex++) {
 
@@ -181,11 +183,16 @@ void IsisMain() {
 
     // This will update the history blob and close the cube,
     // but retain all the pertinent info
-    cubesum->writeHistory();
-    cubesum->setCube();
+    cubesum->resetCube();
     resultSet.append(cubesum);
+
+    Isis::CubeAttributeInput att(filename);
+    Cube *cube = process.SetInputCube(filename, att, Isis::ReadWrite);
+    process.WriteHistory(*cube);
+
     progress.CheckStatus();
   }
+  process.EndProcess();
 
   if (warnings.size() > 0) {
     PvlKeyword message("Unmatched");

--- a/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
+++ b/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
@@ -119,9 +119,9 @@ namespace Isis {
 
     // Add History
     if (iApp) {
-        History history("IsisCube");
-        history.AddEntry();
-        g_ocube->write(history);
+        History *history = g_ocube->readHistory();
+        history->AddEntry();
+        g_ocube->write(*(history->toBlob()));
     }
 
     // Add original label

--- a/isis/src/lro/apps/lrowac2isis/main.cpp
+++ b/isis/src/lro/apps/lrowac2isis/main.cpp
@@ -228,9 +228,9 @@ void IsisMain() {
       uveven->putGroup(isis3UvEvenLab.group(grp));
     }
 
-    History history("IsisCube");
+    History history;
     history.AddEntry();
-    uveven->write(history);
+    uveven->write(*(history.toBlob()));
     uveven->write(origLabel);
 
     uveven->close();
@@ -243,9 +243,9 @@ void IsisMain() {
       uvodd->putGroup(isis3UvOddLab.group(grp));
     }
 
-    History history("IsisCube");
+    History history;
     history.AddEntry();
-    uvodd->write(history);
+    uvodd->write(*(history.toBlob()));
     uvodd->write(origLabel);
 
     uvodd->close();
@@ -258,9 +258,9 @@ void IsisMain() {
       viseven->putGroup(isis3VisEvenLab.group(grp));
     }
 
-    History history("IsisCube");
+    History history;
     history.AddEntry();
-    viseven->write(history);
+    viseven->write(*(history.toBlob()));
     viseven->write(origLabel);
 
     viseven->close();
@@ -273,9 +273,9 @@ void IsisMain() {
       visodd->putGroup(isis3VisOddLab.group(grp));
     }
 
-    History history("IsisCube");
+    History history;
     history.AddEntry();
-    visodd->write(history);
+    visodd->write(*(history.toBlob()));
     visodd->write(origLabel);
 
     visodd->close();

--- a/isis/src/qisis/apps/qtie/QtieTool.cpp
+++ b/isis/src/qisis/apps/qtie/QtieTool.cpp
@@ -916,18 +916,18 @@ namespace Isis {
 
     // Update the cube history
     p_matchCube->write(*cmatrix);
-    History h("IsisCube");
-    try {
-      p_matchCube->read(h);
-    }
-    catch (IException &e) {
-      QString message = "Could not read cube history, "
-                        "will not update history.\n";
-      QString errors = e.toString();
-      message += errors;
-      QMessageBox::warning((QWidget *)parent(), "Warning", message);
-      return;
-    }
+    History *h = p_matchCube->readHistory("IsisCube");
+    // try {
+    //   h = ;
+    // }
+    // catch (IException &e) {
+    //   QString message = "Could not read cube history, "
+    //                     "will not update history.\n";
+    //   QString errors = e.toString();
+    //   message += errors;
+    //   QMessageBox::warning((QWidget *)parent(), "Warning", message);
+    //   return;
+    // }
     PvlObject history("qtie");
     history += PvlKeyword("IsisVersion", Application::Version());
     QString path = QCoreApplication::applicationDirPath();
@@ -941,8 +941,8 @@ namespace Isis {
     results += PvlKeyword("BaseMap", p_baseCube->fileName());
     history += results;
 
-    h.AddEntry(history);
-    p_matchCube->write(h);
+    h->AddEntry(history);
+    p_matchCube->write(*(h->toBlob()));
     p_matchCube->reopen("r");
 
   }

--- a/isis/src/tgo/apps/tgocassisstitch/main.cpp
+++ b/isis/src/tgo/apps/tgocassisstitch/main.cpp
@@ -223,9 +223,9 @@ void stitchFrame(QList<FileName> frameletList, FileName frameFileName) {
     Pvl &frameletLabel = *frameletCube->label();
     for(int i = 0; i < frameletLabel.objects(); i++) {
       if( frameletLabel.object(i).isNamed("History") ) {
-        History frameletHist( (QString) frameletLabel.object(i)["Name"] );
-        frameletCube->read(frameletHist);
-        frameCube.write(frameletHist);
+        Blob historyBlob((QString) frameletLabel.object(i)["Name"], "History" );
+        frameletCube->read(historyBlob);
+        frameCube.write(historyBlob);
       }
     }
   }

--- a/isis/src/tgo/apps/tgocassisunstitch/main.cpp
+++ b/isis/src/tgo/apps/tgocassisunstitch/main.cpp
@@ -109,8 +109,7 @@ void IsisMain() {
       inputTables.append(table);
     }
     if(inputLabel->object(i).isNamed("History") && Isis::iApp != NULL) {
-      inputHistory.reset( new History((QString)inputLabel->object(i)["Name"]) );
-      cube->read(*inputHistory);
+      inputHistory.reset(cube->readHistory((QString)inputLabel->object(i)["Name"]));
       inputHistory->AddEntry();
     }
   }
@@ -212,7 +211,7 @@ void IsisMain() {
     }
 
     // Propagate History
-    g_outputCubes[i]->write(*inputHistory);
+    g_outputCubes[i]->write(*(inputHistory->toBlob( "IsisCube" )));
 
     // Close output cube
     g_outputCubes[i]->close();

--- a/isis/src/voyager/apps/voy2isis/main.cpp
+++ b/isis/src/voyager/apps/voy2isis/main.cpp
@@ -78,7 +78,7 @@ void IsisMain() {
 
   // Preparse the IMG to fix messed up labels
 
-  History *hist = new History("IsisCube");
+  History *hist = new History();
   QByteArray pdsData = fixLabels(in.expanded(), hist);
 
   QTextStream pdsTextStream(&pdsData);
@@ -116,7 +116,7 @@ void IsisMain() {
     e.print();
   }
 
-  ocube->write(*hist);
+  ocube->write(*(hist->toBlob()));
 
   p.EndProcess();
 


### PR DESCRIPTION
Updates the history class to no longer be a subclass of blob.

## Description
Changed the history classes dependency on the blob class to a "uses" relationship rather than an "is a" relationship. So history objects can be built from blobs or constructed on their own. Reading the history blob is now done by the cube which feeds the blob to the history object which generates the PVL, then the history object can produce a blob from itself.

## Related Issue
N/A

## Motivation and Context
This is to facility the separation of responsibilities between IO elements of ISIS. Removing the IO elements from History allowing blob to take care of the bulk of it.

## How Has This Been Tested?
This has been tested with the current ISIS tests and will receive it's own tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
