### PR TITLE
ctxcal now uses cam

### DIFF
--- a/isis/src/mro/apps/ctxcal/main.cpp
+++ b/isis/src/mro/apps/ctxcal/main.cpp
@@ -15,6 +15,7 @@ find files of those names at the top level of this repository. **/
 #include "LineManager.h"
 #include "Brick.h"
 #include "Table.h"
+#include "Camera.h"
 
 using namespace std;
 using namespace Isis;
@@ -139,21 +140,30 @@ void IsisMain() {
   //    iof = conversion factor from counts/ms to i/f
   bool convertIOF = ui.GetBoolean("IOF");
   if(convertIOF) {
-    // Get the distance between Mars and the Sun at the given time in
-    // Astronomical Units (AU)
-    QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
-    furnsh_c(bspKernel.toLatin1().data());
-    QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
-    furnsh_c(satKernel.toLatin1().data());
-    QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
-    furnsh_c(pckKernel.toLatin1().data());
-    double sunpos[6], lt;
-    spkezr_c("sun", etStart, "iau_mars", "LT+S", "mars", sunpos, &lt);
-    double dist1 = vnorm_c(sunpos);
-    unload_c(bspKernel.toLatin1().data());
-    unload_c(satKernel.toLatin1().data());
-    unload_c(pckKernel.toLatin1().data());
-
+    double dist1 = 1; 
+    try {
+      Camera *cam;
+      cam = icube->camera();
+      cam->setTime(startTime);
+      dist1 = cam->sunToBodyDist();
+    }
+    catch(IException &e) { 
+      // Get the distance between Mars and the Sun at the given time in
+      // Astronomical Units (AU)
+      QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
+      furnsh_c(bspKernel.toLatin1().data());
+      QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
+      furnsh_c(satKernel.toLatin1().data());
+      QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
+      furnsh_c(pckKernel.toLatin1().data());
+      double sunpos[6], lt;
+      spkezr_c("sun", etStart, "iau_mars", "LT+S", "mars", sunpos, &lt);
+      dist1 = vnorm_c(sunpos);
+      unload_c(bspKernel.toLatin1().data());
+      unload_c(satKernel.toLatin1().data());
+      unload_c(pckKernel.toLatin1().data());
+    }
+    
     double dist = 2.07E8;
     double w0 = 3660.5;
     double w1 = w0 * ((dist * dist) / (dist1 * dist1));

--- a/isis/src/mro/apps/ctxcal/main.cpp
+++ b/isis/src/mro/apps/ctxcal/main.cpp
@@ -16,6 +16,7 @@ find files of those names at the top level of this repository. **/
 #include "Brick.h"
 #include "Table.h"
 #include "Camera.h"
+#include "NaifStatus.h"
 
 using namespace std;
 using namespace Isis;

--- a/isis/src/mro/apps/ctxcal/main.cpp
+++ b/isis/src/mro/apps/ctxcal/main.cpp
@@ -161,11 +161,17 @@ void IsisMain() {
       furnsh_c(pckKernel.toLatin1().data());
       NaifStatus::CheckErrors();
       double sunpos[6], lt;
+
       spkezr_c("sun", etStart, "iau_mars", "LT+S", "mars", sunpos, &lt);
+      NaifStatus::CheckErrors();
+
       dist1 = vnorm_c(sunpos);
+      
+      NaifStatus::CheckErrors();
       unload_c(bspKernel.toLatin1().data());
       unload_c(satKernel.toLatin1().data());
       unload_c(pckKernel.toLatin1().data());
+      NaifStatus::CheckErrors();
     }
     
     double dist = 2.07E8;

--- a/isis/src/mro/apps/ctxcal/main.cpp
+++ b/isis/src/mro/apps/ctxcal/main.cpp
@@ -151,11 +151,15 @@ void IsisMain() {
       // Get the distance between Mars and the Sun at the given time in
       // Astronomical Units (AU)
       QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
+      NaifStatus::CheckErrors();
       furnsh_c(bspKernel.toLatin1().data());
+      NaifStatus::CheckErrors();
       QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
       furnsh_c(satKernel.toLatin1().data());
+      NaifStatus::CheckErrors();
       QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
       furnsh_c(pckKernel.toLatin1().data());
+      NaifStatus::CheckErrors();
       double sunpos[6], lt;
       spkezr_c("sun", etStart, "iau_mars", "LT+S", "mars", sunpos, &lt);
       dist1 = vnorm_c(sunpos);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Part of making calibration apps work without local spice, ctxcal attempts to use the camera before using kernels. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4303

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally, both camera and local spice return the same result. Should we consider adding tests as original tests do not use spice inited cubes? 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
