### PR TITLE
Update gllssical to work without local spice kernels

### DIFF
--- a/isis/src/galileo/apps/gllssical/gllssical.xml
+++ b/isis/src/galileo/apps/gllssical/gllssical.xml
@@ -163,6 +163,9 @@
       Modified code that it doesn't require a camera model to calculate the I/F.
       Fixes #1740.
     </change>
+    <change name="Kristin Berry" date="2021-02-23">
+      Modified code to try to use the camera to get the target-sun distance to calculate the IOF.
+    </change>
   </history>
 
   <groups>     

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -448,22 +448,9 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
       cam->instrumentPosition()->SetAberrationCorrection("LT+S");
       obsStartTime = cam->getClockTime(startTime.toLatin1().data(), -77).Et();
       cam->setTime(obsStartTime);
-      double sunv[3];
-      cam->sunPosition(sunv);
 
-      double sunkm = vnorm_c(sunv);
-
-      //  Convert to AU units
-      rsun = sunkm / 1.49597870691E8 / 5.2;
-
-      /*
-       * We are calculating I/F, so scaleFactor0 is:
-       *
-       *         S1       K
-       *      -------- * --- (D/5.2)**2
-       *         A1       Ko
-       */
-      scaleFactor0 = (s1 * (cubeConversion / gainConversion) * pow(rsun, 2)) / (scaleFactor);
+      // rsun converted to AU
+      rsun = cam->sunToBodyDist() / 1.49597870691E8 / 5.2;
     } 
     catch (IException &e) {
       // try original fallback for previously spiceinited data 
@@ -484,22 +471,21 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
         
         //  Convert to AU units
         rsun = sunkm / 1.49597870691E8 / 5.2;
-        
-        /*
-         * We are calculating I/F, so scaleFactor0 is:
-         *
-         *         S1       K
-         *      -------- * --- (D/5.2)**2
-         *         A1       Ko
-         */
-        scaleFactor0 = (s1 * (cubeConversion / gainConversion) * pow(rsun, 2)) / (scaleFactor);
       } 
       catch (IException &e) {
         QString message = "IOF option does not work with non-spiceinited cubes.";
         throw IException(e, IException::User, message, _FILEINFO_);
       }
     }
-
+        
+   /*
+    * We are calculating I/F, so scaleFactor0 is:
+    *
+    *         S1       K
+    *      -------- * --- (D/5.2)**2
+    *         A1       Ko
+    */
+    scaleFactor0 = (s1 * (cubeConversion / gainConversion) * pow(rsun, 2)) / (scaleFactor);
   }
   else {
     /*

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -438,10 +438,6 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
   gainConversion = toDouble(conversionFactors["GainRatios"][getGainModeID(gaincube)-1]);
 
   if (iof) {
-    Pvl *label = icube->label();
-    QString startTime = label->findGroup("Instrument",Pvl::Traverse)["SpacecraftClockStartCount"][0];
-    double obsStartTime;
-
     try {
       Camera *cam;
       cam = icube->camera();
@@ -455,13 +451,18 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
     catch (IException &e) {
       // try original fallback for previously spiceinited data 
       try {
+        Pvl *label = icube->label();
+        QString startTime = label->findGroup("Instrument",Pvl::Traverse)["SpacecraftClockStartCount"][0];
+
         Spice spicegll(*icube);
         spicegll.instrumentPosition()->SetAberrationCorrection("LT+S");
         Isis::FileName sclk(label->findGroup("Kernels",Pvl::Traverse)["SpacecraftClock"][0]);
         QString sclkName(sclk.expanded());
+
         NaifStatus::CheckErrors();
         furnsh_c(sclkName.toLatin1().data());
         NaifStatus::CheckErrors();
+
         double obsStartTime;
         scs2e_c(-77, startTime.toLatin1().data(), &obsStartTime);
         spicegll.setTime(obsStartTime);

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -441,7 +441,17 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
     spicegll.instrumentPosition()->SetAberrationCorrection("LT+S");
     QString startTime = label->findGroup("Instrument",Pvl::Traverse)["SpacecraftClockStartCount"][0];
     double obsStartTime;
-    obsStartTime = spicegll.getClockTime(startTime.toLatin1().data(), -77).Et();
+
+    try {
+      obsStartTime = spicegll.getClockTime(startTime.toLatin1().data(), -77).Et();      
+    } 
+    catch (IException &e) {
+      Isis::FileName sclk(label->findGroup("Kernels", Pvl::Traverse)["SpacecraftClock"][0]); 
+      QString sclkName(sclk.expanded()); 
+      furnsh_c(sclkName.toLatin1().data());
+      obsStartTime = spicegll.getClockTime(startTime.toLatin1().data(), -77).Et();
+    }
+
     spicegll.setTime(obsStartTime);
     double sunv[3];
     spicegll.sunPosition(sunv);

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -440,11 +440,8 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
     Spice spicegll(*icube);
     spicegll.instrumentPosition()->SetAberrationCorrection("LT+S");
     QString startTime = label->findGroup("Instrument",Pvl::Traverse)["SpacecraftClockStartCount"][0];
-    Isis::FileName sclk(label->findGroup("Kernels",Pvl::Traverse)["SpacecraftClock"][0]);
-    QString sclkName(sclk.expanded());
-    furnsh_c(sclkName.toLatin1().data());
     double obsStartTime;
-    scs2e_c(-77, startTime.toLatin1().data(), &obsStartTime);
+    obsStartTime = spicegll.getClockTime(startTime.toLatin1().data(), -77).Et();
     spicegll.setTime(obsStartTime);
     double sunv[3];
     spicegll.sunPosition(sunv);

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -437,12 +437,12 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
 
   if (iof) {
     Pvl *label = icube->label();
-    Spice spicegll(*icube);
-    spicegll.instrumentPosition()->SetAberrationCorrection("LT+S");
     QString startTime = label->findGroup("Instrument",Pvl::Traverse)["SpacecraftClockStartCount"][0];
     double obsStartTime;
 
     try {
+      Spice spicegll(*icube);
+      spicegll.instrumentPosition()->SetAberrationCorrection("LT+S");
       obsStartTime = spicegll.getClockTime(startTime.toLatin1().data(), -77).Et();      
     } 
     catch (IException &e) {

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -459,6 +459,7 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
         spicegll.instrumentPosition()->SetAberrationCorrection("LT+S");
         Isis::FileName sclk(label->findGroup("Kernels",Pvl::Traverse)["SpacecraftClock"][0]);
         QString sclkName(sclk.expanded());
+        NaifStatus::CheckErrors();
         furnsh_c(sclkName.toLatin1().data());
         NaifStatus::CheckErrors();
         double obsStartTime;

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -446,8 +446,8 @@ void calculateScaleFactor0(Cube *icube, Cube *gaincube) {
       Camera *cam;
       cam = icube->camera();
       cam->instrumentPosition()->SetAberrationCorrection("LT+S");
-      obsStartTime = cam->getClockTime(startTime.toLatin1().data(), -77).Et();
-      cam->setTime(obsStartTime);
+      // Set time to the starting time of the image by setting image.
+      cam->SetImage(0.5, 0.5);
 
       // rsun converted to AU
       rsun = cam->sunToBodyDist() / 1.49597870691E8 / 5.2;

--- a/isis/src/galileo/apps/gllssical/tsts/default/Makefile
+++ b/isis/src/galileo/apps/gllssical/tsts/default/Makefile
@@ -3,7 +3,30 @@ APPNAME = gllssical
 include $(ISISROOT)/make/isismake.tsts
 
 commands:
+	# Test old spiceinited data
 	$(APPNAME) FROM=$(INPUT)/3439R.cub TO=$(OUTPUT)/3439R.cal.cub > /dev/null;
 	catlab FROM=$(OUTPUT)/3439R.cal.cub TO=$(OUTPUT)/3439R.cal.pvl > /dev/null;
 	$(APPNAME) FROM=$(INPUT)/1213r.cub TO=$(OUTPUT)/1213r.cal.cub > /dev/null;
 	catlab FROM=$(OUTPUT)/1213r.cal.cub TO=$(OUTPUT)/1213r.cal.pvl > /dev/null;
+
+	# Test newly re-spiceinited data
+	$(APPNAME) FROM=$(INPUT)/3439R.respiceinit.cub TO=$(OUTPUT)/3439R.respiceinit.cub > /dev/null;
+	catlab FROM=$(OUTPUT)/3439R.respiceinit.cub TO=$(OUTPUT)/3439R.respiceinit.pvl > /dev/null;
+	$(APPNAME) FROM=$(INPUT)/1213r.respiceinit.cub TO=$(OUTPUT)/1213r.respiceinit.cub > /dev/null;
+	catlab FROM=$(OUTPUT)/1213r.respiceinit.cub TO=$(OUTPUT)/1213r.respiceinit.pvl > /dev/null;
+
+	# Test non-spiceinited data: throws an error
+	if [ `$(APPNAME) \
+	  FROM=$(INPUT)/3439R.nospice.cub TO=$(OUTPUT)/broken.cub 2>> $(OUTPUT)/errors_temp.txt > /dev/null` ]; \
+	  then true; \
+	  fi;
+
+	# Remove everything in brackets like filenames/paths from error messages
+	$(SED) 's/\[\([^"]*\)\]//g' $(OUTPUT)/errors_temp.txt \
+	  > $(OUTPUT)/errors.txt; 
+
+	# Cleanup
+	$(RM) $(OUTPUT)/errors_temp.txt;
+	$(RM) $(OUTPUT)/broken.cub;
+
+

--- a/isis/src/galileo/objs/SsiCamera/SsiCamera.cpp
+++ b/isis/src/galileo/objs/SsiCamera/SsiCamera.cpp
@@ -81,7 +81,7 @@ namespace Isis {
     // Get the start time in et
     PvlGroup inst = lab.findGroup("Instrument", Pvl::Traverse);
 
-    double et = getClockTime((QString)inst["SpacecraftClockStartCount"]).Et();
+    double et = iTime((QString)inst["StartTime"]).Et();
 
     //?????????? NEED THESE??????
     // exposure duration keyword value is measured in seconds

--- a/isis/src/galileo/objs/SsiCamera/SsiCamera.cpp
+++ b/isis/src/galileo/objs/SsiCamera/SsiCamera.cpp
@@ -81,7 +81,7 @@ namespace Isis {
     // Get the start time in et
     PvlGroup inst = lab.findGroup("Instrument", Pvl::Traverse);
 
-    double et = iTime((QString)inst["StartTime"]).Et();
+    double et = getClockTime((QString)inst["SpacecraftClockStartCount"]).Et();
 
     //?????????? NEED THESE??????
     // exposure duration keyword value is measured in seconds


### PR DESCRIPTION
## Description
Updates `gllssical` to use `getClockTime()` function, which will use the already-saved ET for the Start Time of the image if it has already been saved, or fall back to furnishing the `sclk` kernel if this fails. 

## Related Issue
#4303 

## Motivation and Context
See #4303 

## How Has This Been Tested?
Tested by hand and using existing tests. Existing test data needed to be re-spiceinited to work with updates, and the results are slightly different with the new kernels and updates. Anyone have thoughts about whether these changes are reasonable or not? 

Difference in calibration results for default gllssical tests: 

3439R.cal.pvl:
![image](https://user-images.githubusercontent.com/22879031/108765942-b797ba00-7511-11eb-9901-b4d4390cbd5c.png)

1213r.cal.pvl:
![image](https://user-images.githubusercontent.com/22879031/108766053-e3b33b00-7511-11eb-89cb-868283474031.png)

There are also DN changes on the calibrated cubes: 

3439R.cal.cub:
```
Group = Results
  Compare                   = Different
  Sample                    = 2
  Line                      = 1
  Band                      = 1
  AverageDifference         = 1.59002414671235e-08
  StandardDeviation         = 2.29613941470193e-08
  Variance                  = 5.27225621174773e-16
  MinimumDifference         = 9.09494701772928e-13
  MaximumDifference         = 5.96046447753906e-08
  MaxDifferenceSample       = 161
  MaxDifferenceLine         = 2
  MaxDifferenceBand         = 1
  ValidPixelDifferences     = 63568
  SpecialPixelDifferences   = 0
  SigFigAccuracy            = 6
  SigFigMaxDifferenceSample = 711
  SigFigMaxDifferenceLine   = 10
  SigFigMaxDifferenceBand   = 1
End_Group
```
1213r.cal.cub:
```
Group = Results
  Compare                   = Different
  Sample                    = 3
  Line                      = 1
  Band                      = 1
  AverageDifference         = 5.00284445778649e-08
  StandardDeviation         = 1.40651587506991e-08
  Variance                  = 1.97828690682368e-16
  MinimumDifference         = 1.49011611938477e-08
  MaximumDifference         = 1.19209289550781e-07
  MaxDifferenceSample       = 3
  MaxDifferenceLine         = 1
  MaxDifferenceBand         = 1
  ValidPixelDifferences     = 161138
  SpecialPixelDifferences   = 0
  SigFigAccuracy            = 7
  SigFigMaxDifferenceSample = 3
  SigFigMaxDifferenceLine   = 1
  SigFigMaxDifferenceBand   = 1
End_Group
```
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
