### PR TITLE
Added ability to get sun distance from the camera Ref #4303

### DIFF
--- a/isis/src/viking/apps/vikcal/CalParameters.cpp
+++ b/isis/src/viking/apps/vikcal/CalParameters.cpp
@@ -15,9 +15,12 @@ find files of those names at the top level of this repository. **/
 #include <SpiceZmc.h>
 
 #include "CalParameters.h"
+#include "Camera.h"
+#include "Cube.h"
 #include "FileName.h"
 #include "IException.h"
 #include "IString.h"
+#include "iTime.h"
 #include "LeastSquares.h"
 #include "Pvl.h"
 #include "TextFile.h"
@@ -26,7 +29,7 @@ find files of those names at the top level of this repository. **/
 using namespace std;
 namespace Isis {
 
-  CalParameters::CalParameters(const QString &fname) {
+  CalParameters::CalParameters(const QString &fname, Cube *icube) {
     try {
       // Extract Pvl Information from the file
       Pvl pvl(fname.toLatin1().data());
@@ -76,7 +79,7 @@ namespace Isis {
       }
 
       QString startTime = instrument["STARTTIME"];
-      CalcSunDist(startTime);
+      p_dist1 = CalcSunDist(startTime, icube);
       p_labexp = (double)instrument["EXPOSUREDURATION"] * 1000.0;  // convert to msec
       QString target = " ";
       PvlKeyword cs1 = instrument["FLOODMODEID"];
@@ -360,24 +363,44 @@ namespace Isis {
   }
 
   /**
-   * Calculates the distance from the sun at the specified time
+   * Calculates the distance from Mars to the sun at the specified time.
+   * Try to useing the camera assiciated with the cube first, if that
+   * doesn't work fall back to using the SPICE data.
    *
-   * @param t iTime
+   * @param t The UTC time at which the sun distance is being requested
+   * @param iCube The cube we are calibrating
+   *
+   * @return Distance from the Sun to Mars in km
    */
-  void CalParameters::CalcSunDist(QString t) {
-    NaifStatus::CheckErrors();
-    double sunv[3];
-    SpiceDouble lt, et;
-    FileName fname1 = (FileName)"$base/kernels/lsk/naif0007.tls";
-    FileName fname2 = (FileName)"$base/kernels/spk/de405.bsp";
-    QString tempfname1 = fname1.expanded();
-    QString tempfname2 = fname2.expanded();
-    furnsh_c(tempfname1.toLatin1().data());
-    furnsh_c(tempfname2.toLatin1().data());
-    utc2et_c(t.toLatin1().data(), &et);
-    spkezp_c(10, et, "J2000", "LT+S", 499, sunv, &lt);
-    p_dist1 = sqrt(sunv[0] * sunv[0] + sunv[1] * sunv[1] + sunv[2] * sunv[2]);
-    NaifStatus::CheckErrors();
+  double CalParameters::CalcSunDist(QString t, Cube *iCube) {
+    try {
+      Camera *cam;
+      cam = iCube->camera();
+      iTime startTime(t);
+      cam->setTime(startTime);
+      return cam->sunToBodyDist();
+    }
+    catch(IException &e) {
+      // Failed to instantiate a camera, try furnishing kernels directly
+      try {
+        NaifStatus::CheckErrors();
+        double sunv[3];
+        SpiceDouble lt, et;
+        FileName fname1 = (FileName)"$base/kernels/lsk/naif0007.tls";
+        FileName fname2 = (FileName)"$base/kernels/spk/de405.bsp";
+        QString tempfname1 = fname1.expanded();
+        QString tempfname2 = fname2.expanded();
+        furnsh_c(tempfname1.toLatin1().data());
+        furnsh_c(tempfname2.toLatin1().data());
+        utc2et_c(t.toLatin1().data(), &et);
+        spkezp_c(10, et, "J2000", "LT+S", 499, sunv, &lt);
+        return sqrt(sunv[0] * sunv[0] + sunv[1] * sunv[1] + sunv[2] * sunv[2]);
+        NaifStatus::CheckErrors();
+      }
+      catch(IException &e) {
+        QString msg = "Unable to determine the distance from Mars to the Sun";
+        throw IException(e, IException::User, msg, _FILEINFO_);
+      }
+    }
   }
-
 } // end namespace isis

--- a/isis/src/viking/apps/vikcal/CalParameters.h
+++ b/isis/src/viking/apps/vikcal/CalParameters.h
@@ -35,10 +35,12 @@ namespace Isis {
    *                                          were signaled. References #2248
    *
    */
+
+  class Cube;
   class CalParameters {
     public:
       // Constructor
-      CalParameters(const QString &fname);
+      CalParameters(const QString &fname, Cube *icube);
 
       /**
        * Calculates and returns time based offset at specified line and sample
@@ -62,7 +64,7 @@ namespace Isis {
       }
 
       /**
-       * Returns distance value found in the vikcal.sav file
+       * Returns estimated distance from Mars to the Sun found in the vikcal.sav file
        *
        * @return double Approximate distance from the sun
        */
@@ -221,7 +223,7 @@ namespace Isis {
                        int cam, QString wav, int cs1, int cs2, int cs3, int cs4);
       void vikoffSetup(QString mission, int spn, QString target,
                        int cam, double clock, int cs3);
-      void CalcSunDist(QString t);
+      double CalcSunDist(QString t, Cube *icube);
 
       double p_labexp;           //!<Exposure Duration from cube label
       double p_w0;               //!<Omega0 from vikcal.sav file

--- a/isis/src/viking/apps/vikcal/main.cpp
+++ b/isis/src/viking/apps/vikcal/main.cpp
@@ -38,11 +38,10 @@ void IsisMain() {
 // linear = ui.GetBoolean("LINEAR");
   const QString in = ui.GetFileName("FROM");
 
-  calParam = new CalParameters(in);
-
   // Open the input cube
   Cube icube;
   icube.open(in, "r");
+  calParam = new CalParameters(in, &icube);
   Progress prog;
 
   // If the file has already been calibrated, throw an error
@@ -98,14 +97,12 @@ void IsisMain() {
   p.EndProcess();
 }
 
-void cal(vector<Buffer *> &in,
-         vector<Buffer *> &out) {
+void cal(vector<Buffer *> &in, vector<Buffer *> &out) {
 
   Buffer &inp = *in[0];      // Input Cube
   Buffer &dcf = *in[1];      // Dark Current File
   Buffer &fff = *in[2];      // Flat Field File
   Buffer &outp = *out[0];    // Output Cube
-
 
   // Loop for each pixel in the line.
   for(int i = 0; i < inp.size(); i++) {

--- a/isis/src/viking/apps/vikcal/tsts/default/Makefile
+++ b/isis/src/viking/apps/vikcal/tsts/default/Makefile
@@ -5,3 +5,5 @@ include $(ISISROOT)/make/isismake.tsts
 commands:
 	$(APPNAME) from=$(INPUT)/f387a06.cub \
 	  to=$(OUTPUT)/vikcalTruth.cub > /dev/null;
+	$(APPNAME) from=$(INPUT)/f319b18.cub \
+	  to=$(OUTPUT)/vikcalCameraTruth.cub > /dev/null;

--- a/isis/src/viking/apps/vikcal/vikcal.xml
+++ b/isis/src/viking/apps/vikcal/vikcal.xml
@@ -41,10 +41,13 @@
       Fixed poutput pvl to not have spaces in the keyword names
     </change>
     <change name="Steven Lambright" date="2008-05-13">
-      Removed references to CubeInfo 
+      Removed references to CubeInfo
     </change>
     <change name="Christopher Austin" date="2010-06-16">
       Fixed pvl comments
+    </change>
+    <change name="Stuart Sides" date="2021-02-22">
+      Added ability to calibrate using the camera instead of direcly using SPICE kernels
     </change>
   </history>
 
@@ -57,7 +60,7 @@
           Input cube file name
         </brief>
         <description>
-          The cube to be calibrated.  
+          The cube to be calibrated.
         </description>
         <filter>
           *.cub


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Added ability for the calibration to use the distance from Mars to the Sun as calculated by the Camera.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4303

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
vikcal now will run with a spiceinit'ed cube thus not requiring a local copy of the SPICE data.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
By hand, and a test was generated using a cube that had the spice attached.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
