### PR TITLE
moccal now uses Camera for calib

### DIFF
--- a/isis/src/mgs/apps/moccal/main.cpp
+++ b/isis/src/mgs/apps/moccal/main.cpp
@@ -128,8 +128,6 @@ void IsisMain() {
     cam = icube->camera();
     cam->setTime(startTime);
     sunAU = cam->sunToBodyDist() / kmPerAU;
-
-    std::cout << "from Camera: " << sunAU << std::endl;
   }
   catch(IException &e) {
     // Get the distance between Mars and the Sun at the given time in
@@ -154,8 +152,6 @@ void IsisMain() {
     unload_c(satKernel.toLatin1().data());
     unload_c(pckKernel.toLatin1().data());
     NaifStatus::CheckErrors();
-
-    std::cout << "from spice: " << sunAU << std::endl;
   }
 
   // See if the user wants counts/ms or i/f but if w0 is 0 then

--- a/isis/src/mgs/apps/moccal/main.cpp
+++ b/isis/src/mgs/apps/moccal/main.cpp
@@ -14,6 +14,8 @@ find files of those names at the top level of this repository. **/
 #include "IException.h"
 #include "TextFile.h"
 #include "LineManager.h"
+#include "NaifStatus.h"
+#include "Camera.h"
 
 using namespace std;
 using namespace Isis;
@@ -119,22 +121,42 @@ void IsisMain() {
 #endif
   gbl::nullWago = ui.GetBoolean("NULLWAGO");
 
-  // Get the distance between Mars and the Sun at the given time in
-  // Astronomical Units (AU)
-  QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
-  furnsh_c(bspKernel.toLatin1().data());
-  QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
-  furnsh_c(satKernel.toLatin1().data());
-  QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
-  furnsh_c(pckKernel.toLatin1().data());
-  double sunpos[6], lt;
-  spkezr_c("sun", etStart, "iau_mars", "LT+S", "mars", sunpos, &lt);
-  double dist = vnorm_c(sunpos);
   double kmPerAU = 1.4959787066E8;
-  double sunAU = dist / kmPerAU;
-  unload_c(bspKernel.toLatin1().data());
-  unload_c(satKernel.toLatin1().data());
-  unload_c(pckKernel.toLatin1().data());
+  double sunAU = 0;
+  try {
+    Camera *cam;
+    cam = icube->camera();
+    cam->setTime(startTime);
+    sunAU = cam->sunToBodyDist() / kmPerAU;
+
+    std::cout << "from Camera: " << sunAU << std::endl;
+  }
+  catch(IException &e) {
+    // Get the distance between Mars and the Sun at the given time in
+    // Astronomical Units (AU)
+    
+    NaifStatus::CheckErrors();
+    QString bspKernel = p.MissionData("base", "/kernels/spk/de???.bsp", true);
+    furnsh_c(bspKernel.toLatin1().data());
+    QString satKernel = p.MissionData("base", "/kernels/spk/mar???.bsp", true);
+    furnsh_c(satKernel.toLatin1().data());
+    QString pckKernel = p.MissionData("base", "/kernels/pck/pck?????.tpc", true);
+    furnsh_c(pckKernel.toLatin1().data());
+    NaifStatus::CheckErrors();
+
+    double sunpos[6], lt;
+    spkezr_c("sun", etStart, "iau_mars", "LT+S", "mars", sunpos, &lt);
+    double dist = vnorm_c(sunpos);
+    sunAU = dist / kmPerAU;
+    
+    NaifStatus::CheckErrors();
+    unload_c(bspKernel.toLatin1().data());
+    unload_c(satKernel.toLatin1().data());
+    unload_c(pckKernel.toLatin1().data());
+    NaifStatus::CheckErrors();
+
+    std::cout << "from spice: " << sunAU << std::endl;
+  }
 
   // See if the user wants counts/ms or i/f but if w0 is 0 then
   // we must go to counts/ms


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

moccal tries using the Camera for getting sun dist before using kernels. 

## Related Issue
#4303 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
