### PR TITLE
History object tests

### DIFF
--- a/isis/src/base/objs/Blob/Blob.h
+++ b/isis/src/base/objs/Blob/Blob.h
@@ -54,6 +54,7 @@ namespace Isis {
       Blob(const QString &name, const QString &type,
            const QString &file);
       Blob(const Blob &other);
+      Blob() = default;
       Blob &operator=(const Blob &other);
 
       virtual ~Blob();

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -959,4 +959,41 @@ namespace Isis {
     testCam = testCube->camera();
   }
 
+  void HistoryBlob::SetUp() {
+    TempTestingFiles::SetUp();
+
+    std::istringstream hss(R"(
+      Object = mroctx2isis
+        IsisVersion       = "4.1.0  | 2020-07-01"
+        ProgramVersion    = 2016-06-10
+        ProgramPath       = /Users/acpaquette/repos/ISIS3/build/bin
+        ExecutionDateTime = 2020-07-01T16:48:40
+        HostName          = Unknown
+        UserName          = acpaquette
+        Description       = "Import an MRO CTX image as an Isis cube"
+
+        Group = UserParameters
+          FROM    = /Users/acpaquette/Desktop/J03_045994_1986_XN_18N282W.IMG
+          TO      = /Users/acpaquette/Desktop/J03_045994_1986_XN_18N282W_isis.cub
+          SUFFIX  = 18
+          FILLGAP = true
+        End_Group
+      End_Object)");
+
+    hss >> historyPvl;
+
+    std::ostringstream ostr;
+    ostr << historyPvl;
+    std::string histStr = ostr.str();
+    int nbytes = histStr.size();
+
+    // Don't worry about cleaning up this buffer
+    // The blob takes ownership of it and handles freeing the memory in
+    // its decontructor
+    char *buffer = new char[nbytes];
+    memcpy(buffer, histStr.c_str(), nbytes);
+
+    historyBlob = new Blob("IsisCube", "History");
+    historyBlob->setData(buffer, nbytes);
+  }
 }

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -993,7 +993,7 @@ namespace Isis {
     char *buffer = new char[nbytes];
     memcpy(buffer, histStr.c_str(), nbytes);
 
-    historyBlob = new Blob("IsisCube", "History");
-    historyBlob->setData(buffer, nbytes);
+    historyBlob = Blob("IsisCube", "History");
+    historyBlob.setData(buffer, nbytes);
   }
 }

--- a/isis/tests/Fixtures.h
+++ b/isis/tests/Fixtures.h
@@ -249,6 +249,14 @@ class CSMCameraDemFixture : public CSMCubeFixture {
 
     void SetUp() override;
 };
+
+class HistoryBlob : public TempTestingFiles {
+  protected:
+    Blob *historyBlob;
+    PvlObject historyPvl;
+
+    void SetUp() override;
+};
 }
 
 #endif

--- a/isis/tests/Fixtures.h
+++ b/isis/tests/Fixtures.h
@@ -252,7 +252,7 @@ class CSMCameraDemFixture : public CSMCubeFixture {
 
 class HistoryBlob : public TempTestingFiles {
   protected:
-    Blob *historyBlob;
+    Blob historyBlob;
     PvlObject historyPvl;
 
     void SetUp() override;

--- a/isis/tests/HistoryTests.cpp
+++ b/isis/tests/HistoryTests.cpp
@@ -13,7 +13,7 @@ TEST(HistoryTests, HistoryTestsDefaultConstructor) {
 }
 
 TEST_F(HistoryBlob, HistoryTestsFromBlob) {
-  History readHistory(*historyBlob);
+  History readHistory(historyBlob);
 
   Pvl historyPvl = readHistory.ReturnHist();
   ASSERT_TRUE(historyPvl.hasObject("mroctx2isis"));
@@ -31,7 +31,7 @@ TEST_F(HistoryBlob, HistoryTestsAddEntry) {
 }
 
 TEST_F(HistoryBlob, HistoryTeststoBlob) {
-  History history(*historyBlob);
+  History history(historyBlob);
 
   Blob *blob = history.toBlob();
 

--- a/isis/tests/HistoryTests.cpp
+++ b/isis/tests/HistoryTests.cpp
@@ -1,0 +1,48 @@
+#include "Fixtures.h"
+#include "History.h"
+
+#include "gmock/gmock.h"
+
+using namespace Isis;
+
+TEST(HistoryTests, HistoryTestsDefaultConstructor) {
+  History history;
+
+  Pvl historyPvl  = history.ReturnHist();
+  EXPECT_EQ(historyPvl.groups(), 0);
+}
+
+TEST_F(HistoryBlob, HistoryTestsFromBlob) {
+  History readHistory(*historyBlob);
+
+  Pvl historyPvl = readHistory.ReturnHist();
+  ASSERT_TRUE(historyPvl.hasObject("mroctx2isis"));
+  EXPECT_TRUE(historyPvl.findObject("mroctx2isis").hasGroup("UserParameters"));
+}
+
+TEST_F(HistoryBlob, HistoryTestsAddEntry) {
+  History history;
+
+  history.AddEntry(historyPvl);
+
+  Pvl newHistoryPvl = history.ReturnHist();
+  ASSERT_TRUE(newHistoryPvl.hasObject("mroctx2isis"));
+  EXPECT_TRUE(newHistoryPvl.findObject("mroctx2isis").hasGroup("UserParameters"));
+}
+
+TEST_F(HistoryBlob, HistoryTeststoBlob) {
+  History history(*historyBlob);
+
+  Blob *blob = history.toBlob();
+
+  std::stringstream os;
+  char *blob_buffer = blob->getBuffer();
+  Pvl newHistoryPvl;
+  for (int i = 0; i < blob->Size(); i++) {
+    os << blob_buffer[i];
+  }
+  os >> newHistoryPvl;
+
+  ASSERT_TRUE(newHistoryPvl.hasObject("mroctx2isis"));
+  EXPECT_TRUE(newHistoryPvl.findObject("mroctx2isis").hasGroup("UserParameters"));
+}


### PR DESCRIPTION
Adds history object tests for updated history object

## Description
Updates the old history object tests to a gtest and tests the new functionality of the history object

## Related Issue
N/A

## Motivation and Context
Blob refactor and IO improvements

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
