### PR TITLE
Removed blob inheritance from stretchblob

### DIFF
--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -37,6 +37,7 @@ find files of those names at the top level of this repository. **/
 #include "Projection.h"
 #include "SpecialPixel.h"
 #include "Statistics.h"
+#include "StretchBlob.h"
 #include "Table.h"
 #include "TProjection.h"
 #include "Longitude.h"
@@ -876,6 +877,23 @@ namespace Isis {
     }
     OriginalLabel origLabel(origLabelBlob);
     return origLabel;
+  }
+
+
+  /**
+   * This method will read a StretchBlob from a cube.
+   */
+  StretchBlob Cube::readStretchBlob(QString name, QString type, const std::vector<PvlKeyword> keywords) const {
+    Blob blob(name, type);
+    //try {
+      blob.Read(fileName(), keywords);
+    //}
+    //catch (IException &){
+      //QString msg = "Unable to locate Stretch information in " + fileName();
+      //throw IException(IException::User, msg, _FILEINFO_);
+    //}
+    StretchBlob stretchBlob(blob);
+    return stretchBlob;
   }
 
   /**

--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -883,15 +883,16 @@ namespace Isis {
   /**
    * This method will read a StretchBlob from a cube.
    */
-  StretchBlob Cube::readStretchBlob(QString name, QString type, const std::vector<PvlKeyword> keywords) const {
-    Blob blob(name, type);
-    //try {
+  StretchBlob Cube::readStretchBlob(QString name, const std::vector<PvlKeyword> keywords) const {
+    Blob blob(name, "Stretch");
+    try {
       blob.Read(fileName(), keywords);
-    //}
-    //catch (IException &){
-      //QString msg = "Unable to locate Stretch information in " + fileName();
-      //throw IException(IException::User, msg, _FILEINFO_);
-    //}
+    }
+    catch (IException &e){
+      std::cout << e.what() << '\n';
+      QString msg = "Unable to locate Stretch information in " + fileName();
+      throw IException(IException::User, msg, _FILEINFO_);
+    }
     StretchBlob stretchBlob(blob);
     return stretchBlob;
   }

--- a/isis/src/base/objs/Cube/Cube.h
+++ b/isis/src/base/objs/Cube/Cube.h
@@ -36,11 +36,13 @@ namespace Isis {
   class Pvl;
   class PvlGroup;
   class Statistics;
+  class StretchBlob;
   class Table;
   class Histogram;
   class History;
   class OriginalLabel;
   class ImagePolygon;
+
 
   /**
    * @brief IO Handler for Isis Cubes.
@@ -253,6 +255,9 @@ namespace Isis {
                 const std::vector<PvlKeyword> keywords = std::vector<PvlKeyword>()) const;
       void read(Buffer &rbuf) const;
       OriginalLabel readOriginalLabel() const;
+      StretchBlob readStretchBlob(QString name="CubeStretch",
+                                  QString type="Stretch",
+                                  const std::vector<PvlKeyword> keywords = std::vector<PvlKeyword>()) const;
       History readHistory(const QString &name = "IsisCube") const;
       ImagePolygon readFootprint() const;
       void write(Blob &blob, bool overwrite=true);

--- a/isis/src/base/objs/Cube/Cube.h
+++ b/isis/src/base/objs/Cube/Cube.h
@@ -256,7 +256,6 @@ namespace Isis {
       void read(Buffer &rbuf) const;
       OriginalLabel readOriginalLabel() const;
       StretchBlob readStretchBlob(QString name="CubeStretch",
-                                  QString type="Stretch",
                                   const std::vector<PvlKeyword> keywords = std::vector<PvlKeyword>()) const;
       History readHistory(const QString &name = "IsisCube") const;
       ImagePolygon readFootprint() const;

--- a/isis/src/base/objs/CubeStretch/CubeStretch.cpp
+++ b/isis/src/base/objs/CubeStretch/CubeStretch.cpp
@@ -12,9 +12,9 @@ namespace Isis {
   /**
    * Constructs a CubeStretch object with default mapping of special pixel values to
    * themselves and a provided name, and a provided stretch type
-   *  
-   * @param name Name to use for Stretch 
-   * @param type Type of stretch 
+   *
+   * @param name Name to use for Stretch
+   * @param type Type of stretch
    */
   CubeStretch::CubeStretch(QString name, QString stretchType, int bandNumber) : m_name(name), 
     m_type(stretchType), m_bandNumber(bandNumber) {
@@ -28,7 +28,7 @@ namespace Isis {
 
   /**
    * Constructs a CubeStretch object from a normal Stretch.
-   *  
+   *
    * @param Stretch Stretch to construct the CubeStretch from.
    */
   CubeStretch::CubeStretch(Stretch const& stretch): Stretch(stretch) {
@@ -40,7 +40,7 @@ namespace Isis {
 
   /**
    * Constructs a CubeStretch object from a normal Stretch.
-   *  
+   *
    * @param Stretch Stretch to construct the CubeStretch from.
    */
   CubeStretch::CubeStretch(Stretch const& stretch, QString stretchType): Stretch(stretch), m_type(stretchType) {
@@ -51,21 +51,21 @@ namespace Isis {
 
   /**
    * Check if the CubeStretches are equal
-   * 
+   *
    * @param stretch2 The stretch to compare with
-   * 
+   *
    * @return bool True if stretches are equal. Else, false.
    */
   bool CubeStretch::operator==(CubeStretch& stretch2) {
-    return (getBandNumber() == stretch2.getBandNumber()) && 
+    return (getBandNumber() == stretch2.getBandNumber()) &&
            (getName() == stretch2.getName()) &&
            (Text() == stretch2.Text());
   }
 
   /**
    * Get the Type of Stretch.
-   * 
-   * @return QString Type of Stretch. 
+   *
+   * @return QString Type of Stretch.
    */
   QString CubeStretch::getType(){
     return m_type;
@@ -74,8 +74,8 @@ namespace Isis {
 
   /**
    * Set the type of Stretch.
-   * 
-   * @param QString Type of Stretch. 
+   *
+   * @param QString Type of Stretch.
    */
   void CubeStretch::setType(QString stretchType){
     m_type = stretchType;
@@ -84,7 +84,7 @@ namespace Isis {
 
   /**
    * Set the Stretch name.
-   * 
+   *
    * @param QString name for stretch
    */
   void CubeStretch::setName(QString name){
@@ -94,7 +94,7 @@ namespace Isis {
 
   /**
    * Get the Stretch name.
-   * 
+   *
    * @return QString name of stretch
    */
   QString CubeStretch::getName(){
@@ -104,7 +104,7 @@ namespace Isis {
 
   /**
    * Get the band number for the stretch.
-   * 
+   *
    * @return int band number
    */
   int CubeStretch::getBandNumber() {
@@ -114,12 +114,10 @@ namespace Isis {
 
   /**
    * Set the band number for the stretch.
-   * 
+   *
    * @param int band number
    */
   void CubeStretch::setBandNumber(int bandNumber) {
     m_bandNumber = bandNumber;
   }
 } // end namespace isis
-
-

--- a/isis/src/base/objs/CubeStretch/CubeStretch.cpp
+++ b/isis/src/base/objs/CubeStretch/CubeStretch.cpp
@@ -16,7 +16,7 @@ namespace Isis {
    * @param name Name to use for Stretch
    * @param type Type of stretch
    */
-  CubeStretch::CubeStretch(QString name, QString stretchType, int bandNumber) : m_name(name), 
+  CubeStretch::CubeStretch(QString name, QString stretchType, int bandNumber) : m_name(name),
     m_type(stretchType), m_bandNumber(bandNumber) {
   }
 
@@ -25,6 +25,11 @@ namespace Isis {
   CubeStretch::~CubeStretch() {
   }
 
+  CubeStretch::CubeStretch(CubeStretch const& stretch): Stretch(stretch) {
+    m_name = stretch.getName();
+    m_type = stretch.getType();
+    m_bandNumber = stretch.getBandNumber();
+  }
 
   /**
    * Constructs a CubeStretch object from a normal Stretch.
@@ -67,7 +72,7 @@ namespace Isis {
    *
    * @return QString Type of Stretch.
    */
-  QString CubeStretch::getType(){
+  QString CubeStretch::getType() const{
     return m_type;
   }
 
@@ -97,7 +102,7 @@ namespace Isis {
    *
    * @return QString name of stretch
    */
-  QString CubeStretch::getName(){
+  QString CubeStretch::getName() const{
     return m_name;
   }
 
@@ -107,7 +112,7 @@ namespace Isis {
    *
    * @return int band number
    */
-  int CubeStretch::getBandNumber() {
+  int CubeStretch::getBandNumber() const{
     return m_bandNumber;
   }
 

--- a/isis/src/base/objs/CubeStretch/CubeStretch.h
+++ b/isis/src/base/objs/CubeStretch/CubeStretch.h
@@ -12,9 +12,9 @@ find files of those names at the top level of this repository. **/
 
 namespace Isis {
   /**
-   * @brief Stores stretch information for a cube. Stores stretch pairs, 
-   * band number associated with the stretch, and the stretch type from 
-   * the Advanced Stretch Tool (or 'Default' if not specified) 
+   * @brief Stores stretch information for a cube. Stores stretch pairs,
+   * band number associated with the stretch, and the stretch type from
+   * the Advanced Stretch Tool (or 'Default' if not specified)
    *
    * @ingroup Utility
    *
@@ -23,31 +23,31 @@ namespace Isis {
    * @internal
    *  @history 2020-07-28 Kristin Berry - Original Version
    */
-  class CubeStretch : public Stretch { 
-    public: 
+  class CubeStretch : public Stretch {
+    public:
       CubeStretch(QString name="DefaultStretch", QString stretchType="Default", int bandNumber = 1);
       ~CubeStretch();
 
+      CubeStretch(CubeStretch const& stretch);
       CubeStretch(Stretch const& stretch);
       CubeStretch(Stretch const& stretch, QString type);
 
       bool operator==(CubeStretch& stretch2);
 
-      QString getType();
+      QString getType() const;
       void setType(QString stretchType);
 
-      QString getName();
+      QString getName() const;
       void setName(QString name);
 
-      int getBandNumber();
+      int getBandNumber() const;
       void setBandNumber(int bandNumber);
-           
-    private:                      
-      QString m_name; //! The name of the stretch. 
+
+    private:
+      QString m_name; //! The name of the stretch.
       QString m_type; //! Type of  stretch. This is only currently used in the AdvancedStretchTool.
       int m_bandNumber; //! The band number associated with this stretch
   };
-};                                
+};
 
 #endif
-

--- a/isis/src/base/objs/StretchBlob/StretchBlob.cpp
+++ b/isis/src/base/objs/StretchBlob/StretchBlob.cpp
@@ -7,6 +7,7 @@ find files of those names at the top level of this repository. **/
 
 #include <iostream>
 #include <fstream>
+#include <sstream>
 
 #include "StretchBlob.h"
 #include "IException.h"
@@ -17,17 +18,16 @@ namespace Isis {
   /**
    * Default constructor
    */
-  StretchBlob::StretchBlob() : Blob("CubeStretch", "Stretch"), m_stretch() {
+  StretchBlob::StretchBlob() {
+    m_stretch = CubeStretch("CubeStretch", "Stretch");
   }
 
 
   /**
    * Construct a StretchBlob from a CubeStretch.
    */
-  StretchBlob::StretchBlob(CubeStretch stretch) : Blob("CubeStretch", "Stretch"), m_stretch(stretch){
-    p_blobPvl["Name"] = m_stretch.getName();
-    p_blobPvl += PvlKeyword("StretchType", m_stretch.getType());
-    p_blobPvl += PvlKeyword("BandNumber", QString::number(m_stretch.getBandNumber()));
+  StretchBlob::StretchBlob(CubeStretch stretch) {
+    m_stretch = CubeStretch(stretch);
   }
 
 
@@ -36,7 +36,16 @@ namespace Isis {
    *
    * @param name Name to use for Stretch
    */
-  StretchBlob::StretchBlob(QString name) : Blob(name, "Stretch"), m_stretch(name) {
+  StretchBlob::StretchBlob(QString name) {
+    m_stretch = CubeStretch(name, "Stretch");
+  }
+
+  StretchBlob::StretchBlob(Blob blob) {
+    stringstream os;
+    char *buff = blob.getBuffer();
+    std::string stringFromBuffer(buff);
+    m_stretch = CubeStretch(blob.Name(), blob.Type());
+    m_stretch.Parse(QString::fromStdString(stringFromBuffer));
   }
 
 
@@ -51,67 +60,52 @@ namespace Isis {
     return m_stretch;
   }
 
-  /**
-   * Read saved Stretch data from a Cube into this object. 
-   *  
-   * This is called by Blob::Read() and is the actual data reading function 
-   * ultimately called when running something like cube->read(stretch);  
-   * 
-   * @param is input stream containing the saved Stretch information
-   */
-  void StretchBlob::ReadData(std::istream &is) {
-    // Set the Stretch Type
-     m_stretch.setType(p_blobPvl["StretchType"][0]);
-     m_stretch.setBandNumber(p_blobPvl["BandNumber"][0].toInt());
 
-     // Read in the Stretch Pairs
-     streampos sbyte = p_startByte - 1;
-     is.seekg(sbyte, std::ios::beg);
-     if (!is.good()) {
-       QString msg = "Error preparing to read data from " + m_stretch.getType() +
-                    " [" + p_blobName + "]";
-       throw IException(IException::Io, msg, _FILEINFO_);
-     }
-
-     char *buf = new char[p_nbytes+1];
-     memset(buf, 0, p_nbytes + 1);
-
-     is.read(buf, p_nbytes);
-
-     // Read buffer data into a QString so we can call Parse()
-     std::string stringFromBuffer(buf);
-     m_stretch.Parse(QString::fromStdString(stringFromBuffer));
-
-     delete [] buf;
-
-     if (!is.good()) {
-       QString msg = "Error reading data from " + p_type + " [" +
-                    p_blobName + "]";
-       throw IException(IException::Io, msg, _FILEINFO_);
-     }
-   }
-
-
-  /**
-   *  Initializes for writing stretch to cube blob
-   */
-  void StretchBlob::WriteInit() {
-    p_nbytes = m_stretch.Text().toStdString().size(); 
+  Isis::Blob *StretchBlob::toBlob() {
+    Isis::Blob *blob = new Blob(m_stretch.getName(), m_stretch.getType());
+    blob->setData((char*)m_stretch.Text().toStdString().c_str(), m_stretch.Text().toStdString().size());
+    return blob;
   }
 
-
-  /**
-   * Writes the stretch information to a cube. 
-   *  
-   * This is called by Blob::write() and is ultimately the function 
-   * called when running something like cube->write(stretch);  
-   *  
-   * @param os output stream to write the stretch data to.
-   */
-  void StretchBlob::WriteData(std::fstream &os) {
-    os.write(m_stretch.Text().toStdString().c_str(), p_nbytes);
-  }
+//  /**
+//   * Read saved Stretch data from a Cube into this object.
+//   *
+//   * This is called by Blob::Read() and is the actual data reading function
+//   * ultimately called when running something like cube->read(stretch);
+//   *
+//   * @param is input stream containing the saved Stretch information
+//   */
+//  void StretchBlob::ReadData(std::istream &is) {
+//    // Set the Stretch Type
+//     m_stretch.setType(p_blobPvl["StretchType"][0]);
+//     m_stretch.setBandNumber(p_blobPvl["BandNumber"][0].toInt());
+//
+//     // Read in the Stretch Pairs
+//     streampos sbyte = p_startByte - 1;
+//     is.seekg(sbyte, std::ios::beg);
+//     if (!is.good()) {
+//       QString msg = "Error preparing to read data from " + m_stretch.getType() +
+//                    " [" + p_blobName + "]";
+//       throw IException(IException::Io, msg, _FILEINFO_);
+//     }
+//
+//     char *buf = new char[p_nbytes+1];
+//     memset(buf, 0, p_nbytes + 1);
+//
+//     is.read(buf, p_nbytes);
+//
+//     // Read buffer data into a QString so we can call Parse()
+//     std::string stringFromBuffer(buf);
+//     m_stretch.Parse(QString::fromStdString(stringFromBuffer));
+//
+//     delete [] buf;
+//
+//     if (!is.good()) {
+//       QString msg = "Error reading data from " + p_type + " [" +
+//                    p_blobName + "]";
+//       throw IException(IException::Io, msg, _FILEINFO_);
+//     }
+//   }
+//
 
 } // end namespace isis
-
-

--- a/isis/src/base/objs/StretchBlob/StretchBlob.cpp
+++ b/isis/src/base/objs/StretchBlob/StretchBlob.cpp
@@ -19,7 +19,7 @@ namespace Isis {
    * Default constructor
    */
   StretchBlob::StretchBlob() {
-    m_stretch = CubeStretch("CubeStretch", "Stretch");
+    m_stretch = CubeStretch();
   }
 
 
@@ -37,15 +37,16 @@ namespace Isis {
    * @param name Name to use for Stretch
    */
   StretchBlob::StretchBlob(QString name) {
-    m_stretch = CubeStretch(name, "Stretch");
+    m_stretch = CubeStretch(name);
   }
 
   StretchBlob::StretchBlob(Blob blob) {
     stringstream os;
     char *buff = blob.getBuffer();
     std::string stringFromBuffer(buff);
-    m_stretch = CubeStretch(blob.Name(), blob.Type());
+    m_stretch = CubeStretch(blob.Label()["Name"][0], blob.Label()["StretchType"][0]);
     m_stretch.Parse(QString::fromStdString(stringFromBuffer));
+    m_stretch.setBandNumber(blob.Label()["BandNumber"][0].toInt());
   }
 
 
@@ -61,8 +62,12 @@ namespace Isis {
   }
 
 
-  Isis::Blob *StretchBlob::toBlob() {
-    Isis::Blob *blob = new Blob(m_stretch.getName(), m_stretch.getType());
+  Isis::Blob *StretchBlob::toBlob(QString const& name) {
+    Isis::Blob *blob = new Blob(name, "Stretch");
+    
+    blob->Label()["Name"] = m_stretch.getName();
+    blob->Label() += PvlKeyword("StretchType", m_stretch.getType());
+    blob->Label() += PvlKeyword("BandNumber", QString::number(m_stretch.getBandNumber()));
     blob->setData((char*)m_stretch.Text().toStdString().c_str(), m_stretch.Text().toStdString().size());
     return blob;
   }

--- a/isis/src/base/objs/StretchBlob/StretchBlob.h
+++ b/isis/src/base/objs/StretchBlob/StretchBlob.h
@@ -26,19 +26,16 @@ namespace Isis {
    * @internal
    *  @history 2020-07-28 Kristin Berry and Stuart Sides - Original Version
    */
-  class StretchBlob : public Isis::Blob {
-    public: 
+  class StretchBlob {
+    public:
       StretchBlob();
       StretchBlob(CubeStretch stretch);
       StretchBlob(QString name);
+      StretchBlob(Blob blob);
+      Isis::Blob *toBlob();
       ~StretchBlob();
 
-      CubeStretch getStretch(); 
-
-    protected:
-      void WriteInit();
-      void ReadData(std::istream &is);
-      void WriteData(std::fstream &os);
+      CubeStretch getStretch();
 
     private:
       CubeStretch m_stretch; //! Stretch associated with the blob
@@ -46,4 +43,3 @@ namespace Isis {
 };
 
 #endif
-

--- a/isis/src/base/objs/StretchBlob/StretchBlob.h
+++ b/isis/src/base/objs/StretchBlob/StretchBlob.h
@@ -32,7 +32,7 @@ namespace Isis {
       StretchBlob(CubeStretch stretch);
       StretchBlob(QString name);
       StretchBlob(Blob blob);
-      Isis::Blob *toBlob();
+      Isis::Blob *toBlob(QString const& name="CubeStretch");
       ~StretchBlob();
 
       CubeStretch getStretch();

--- a/isis/src/qisis/objs/StretchTool/StretchTool.cpp
+++ b/isis/src/qisis/objs/StretchTool/StretchTool.cpp
@@ -495,9 +495,9 @@ namespace Isis {
 
         std::vector<PvlKeyword> keywordValueBlue;
         keywordValueBlue.push_back(PvlKeyword("BandNumber", QString::number(cvp->blueBand())));
-        StretchBlob redStretchBlob = icube->readStretchBlob(stretchName, "Stretch", keywordValueRed);
-        StretchBlob greenStretchBlob = icube->readStretchBlob(stretchName, "Stretch", keywordValueGreen);
-        StretchBlob blueStretchBlob = icube->readStretchBlob(stretchName, "Stretch", keywordValueBlue);
+        StretchBlob redStretchBlob = icube->readStretchBlob(stretchName, keywordValueRed);
+        StretchBlob greenStretchBlob = icube->readStretchBlob(stretchName, keywordValueGreen);
+        StretchBlob blueStretchBlob = icube->readStretchBlob(stretchName, keywordValueBlue);
 
         CubeStretch redStretch = redStretchBlob.getStretch();
         CubeStretch greenStretch = greenStretchBlob.getStretch();

--- a/isis/src/qisis/objs/StretchTool/StretchTool.cpp
+++ b/isis/src/qisis/objs/StretchTool/StretchTool.cpp
@@ -292,7 +292,7 @@ namespace Isis {
     connect(m_flashButton, SIGNAL(released()), this, SLOT(stretchChanged()));
 
     // Buttons migrated out of Advanced Stretch Tool
-    QPushButton *saveToCubeButton = new QPushButton("Save"); 
+    QPushButton *saveToCubeButton = new QPushButton("Save");
     connect(saveToCubeButton, SIGNAL(clicked(bool)), this, SLOT(saveStretchToCube()));
 
     QPushButton *deleteFromCubeButton = new QPushButton("Delete");
@@ -406,11 +406,11 @@ namespace Isis {
    * Restores a saved stretch from the cube
    */
   void StretchTool::loadStretchFromCube(){
-    MdiCubeViewport *cvp = cubeViewport(); 
+    MdiCubeViewport *cvp = cubeViewport();
     Cube* icube = cvp->cube();
     Pvl* lab = icube->label();
 
-    QStringList namelist; 
+    QStringList namelist;
 
     // Create a list of existing Stretch names
     if (cvp->isGray()) {
@@ -420,8 +420,8 @@ namespace Isis {
           PvlKeyword tempKeyword = objIter->findKeyword("Name");
           int bandNumber = int(objIter->findKeyword("BandNumber"));
           if (cvp->grayBand() == bandNumber) {
-            QString tempName = tempKeyword[0]; 
-            namelist.append(tempName); 
+            QString tempName = tempKeyword[0];
+            namelist.append(tempName);
           }
         }
       }
@@ -437,9 +437,9 @@ namespace Isis {
         if (objIter->name() == "Stretch") {
           PvlKeyword tempKeyword = objIter->findKeyword("Name");
           int bandNumber = int(objIter->findKeyword("BandNumber"));
-          if (bandNumber == redBandNumber || bandNumber == greenBandNumber 
+          if (bandNumber == redBandNumber || bandNumber == greenBandNumber
               || bandNumber == blueBandNumber) {
-            QString tempName = tempKeyword[0]; 
+            QString tempName = tempKeyword[0];
             if (tempNameMap.contains(tempName)) {
               tempNameMap[tempName].append(bandNumber);
             }
@@ -464,34 +464,29 @@ namespace Isis {
     QString stretchName;
     // Only display load stretch dialog if there are stretches saved to the cube
     if (namelist.size() >=1) {
-      stretchName = QInputDialog::getItem((QWidget *)parent(), tr("Load Stretch"), 
+      stretchName = QInputDialog::getItem((QWidget *)parent(), tr("Load Stretch"),
                                           tr("Name of Stretch to Load:"), namelist, 0,
                                           false, &ok);
     }
     else {
-      QMessageBox::information((QWidget *)parent(), "Information", 
+      QMessageBox::information((QWidget *)parent(), "Information",
                                    "There are no saved stretches to restore.");
     }
 
     if (ok) {
       if (cvp->isGray()) {
-        StretchBlob stretchBlob(stretchName); 
-        icube->read(stretchBlob);
+        StretchBlob stretchBlob = icube->readStretchBlob(stretchName);
         CubeStretch cubeStretch = stretchBlob.getStretch();
         if (m_advancedStretch->isVisible()) {
           m_advancedStretch->restoreGrayStretch(cubeStretch);
         }
-        // Get the current cube stretche and copy the new stretch pairs over so that the 
+        // Get the current cube stretche and copy the new stretch pairs over so that the
         // special pixel values set in the viewport are maintained.
         CubeStretch grayOriginal = cvp->grayStretch();
         grayOriginal.CopyPairs(cubeStretch);
         cvp->stretchGray(grayOriginal);
       }
       else {
-        StretchBlob redStretchBlob(stretchName); 
-        StretchBlob greenStretchBlob(stretchName); 
-        StretchBlob blueStretchBlob(stretchName); 
-        
         std::vector<PvlKeyword> keywordValueRed;
         keywordValueRed.push_back(PvlKeyword("BandNumber",  QString::number(cvp->redBand())));
 
@@ -500,10 +495,9 @@ namespace Isis {
 
         std::vector<PvlKeyword> keywordValueBlue;
         keywordValueBlue.push_back(PvlKeyword("BandNumber", QString::number(cvp->blueBand())));
-
-        icube->read(redStretchBlob, keywordValueRed);
-        icube->read(greenStretchBlob, keywordValueGreen);
-        icube->read(blueStretchBlob, keywordValueBlue);
+        StretchBlob redStretchBlob = icube->readStretchBlob(stretchName, "Stretch", keywordValueRed);
+        StretchBlob greenStretchBlob = icube->readStretchBlob(stretchName, "Stretch", keywordValueGreen);
+        StretchBlob blueStretchBlob = icube->readStretchBlob(stretchName, "Stretch", keywordValueBlue);
 
         CubeStretch redStretch = redStretchBlob.getStretch();
         CubeStretch greenStretch = greenStretchBlob.getStretch();
@@ -513,7 +507,7 @@ namespace Isis {
           m_advancedStretch->restoreRgbStretch(redStretch, greenStretch, blueStretch);
         }
 
-        // Get the current cube stretches and copy the new stretch pairs over so that the 
+        // Get the current cube stretches and copy the new stretch pairs over so that the
         // special pixel values set in the viewport are maintained.
         CubeStretch redOriginal = cvp->redStretch();
         CubeStretch greenOriginal = cvp->greenStretch();
@@ -536,20 +530,20 @@ namespace Isis {
    * Deletes a saved stretch from the cube
    */
   void StretchTool::deleteFromCube() {
-    MdiCubeViewport *cvp = cubeViewport(); 
+    MdiCubeViewport *cvp = cubeViewport();
     Cube* icube = cvp->cube();
     Pvl* lab = icube->label();
 
     // Create a list of existing Stretch names
-    QStringList namelist; 
+    QStringList namelist;
     PvlObject::PvlObjectIterator objIter;
     for (objIter=lab->beginObject(); objIter<lab->endObject(); objIter++) {
       if (objIter->name() == "Stretch") {
         PvlKeyword tempKeyword = objIter->findKeyword("Name");
         int bandNumber = int(objIter->findKeyword("BandNumber"));
         if (cvp->grayBand() == bandNumber) {
-          QString tempName = tempKeyword[0]; 
-          namelist.append(tempName); 
+          QString tempName = tempKeyword[0];
+          namelist.append(tempName);
         }
       }
     }
@@ -558,12 +552,12 @@ namespace Isis {
     QString toDelete;
     // Only display list of stretches to delete if there are stretches saved to the cube
     if (namelist.size() >= 1) {
-      toDelete = QInputDialog::getItem((QWidget *)parent(), tr("Delete Stretch"), 
+      toDelete = QInputDialog::getItem((QWidget *)parent(), tr("Delete Stretch"),
                                        tr("Name of Stretch to Delete:"), namelist, 0,
                                        false, &ok);
     }
     else {
-      QMessageBox::information((QWidget *)parent(), "Information", 
+      QMessageBox::information((QWidget *)parent(), "Information",
                                "There are no saved stretches to delete.");
     }
 
@@ -574,7 +568,7 @@ namespace Isis {
         }
         catch(IException &) {
           cvp->cube()->reopen("r");
-          QMessageBox::information((QWidget *)parent(), "Error", 
+          QMessageBox::information((QWidget *)parent(), "Error",
                                    "Cannot open cube read/write to delete stretch");
           return;
         }
@@ -585,14 +579,14 @@ namespace Isis {
       if (!cubeDeleted) {
         QMessageBox msgBox;
         msgBox.setText("Stretch Could Not Be Deleted!");
-        msgBox.setInformativeText("A stretch with name: \"" + toDelete + 
+        msgBox.setInformativeText("A stretch with name: \"" + toDelete +
             "\" Could not be found, so there was nothing to delete from the Cube.");
         msgBox.setStandardButtons(QMessageBox::Ok);
         msgBox.setIcon(QMessageBox::Critical);
         msgBox.exec();
       }
 
-      // Don't leave open rw -- not optimal. 
+      // Don't leave open rw -- not optimal.
       cvp->cube()->reopen("r");
     }
   }
@@ -607,29 +601,29 @@ namespace Isis {
     Pvl* lab = icube->label();
 
     // Create a list of existing Stretch names
-    QStringList namelist; 
+    QStringList namelist;
     PvlObject::PvlObjectIterator objIter;
     for (objIter=lab->beginObject(); objIter<lab->endObject(); objIter++) {
       if (objIter->name() == "Stretch") {
         PvlKeyword tempKeyword = objIter->findKeyword("Name");
         QString tempName = tempKeyword[0];
-        namelist.append(tempName); 
+        namelist.append(tempName);
       }
     }
 
     bool ok;
-    QString name; 
+    QString name;
 
-    // 
-    // At this time, it is NOT possible to save an RGB stretch with the same band number 
+    //
+    // At this time, it is NOT possible to save an RGB stretch with the same band number
     // multiple times, if the saved stretch for each is different. If the saved stretch is the same
     // this is okay.
-    // 
+    //
     // For example, r=1, g=1, b=1, with the same stretch for each is okay
-    //              r=1, g=1, b=2, where the stretches for band 1 are the same, is okay 
+    //              r=1, g=1, b=2, where the stretches for band 1 are the same, is okay
     //              r=1, g=1, b=1, where the the stretches for band 1 are different (red stretch !=
     //                                                                               green stretch)
-    // 
+    //
     if (!cvp->isGray()) {
       CubeStretch redStretch, greenStretch, blueStretch;
       if (m_advancedStretch->isVisible()) {
@@ -644,13 +638,13 @@ namespace Isis {
       }
 
       int redBand = cvp->redBand();
-      int greenBand = cvp->greenBand(); 
+      int greenBand = cvp->greenBand();
       int blueBand = cvp->blueBand();
 
       if (((redBand == greenBand) && !(redStretch == greenStretch)) ||
           ((redBand == blueBand)  && !(redBand == blueBand)) ||
           ((greenBand == blueBand) && !(greenBand == blueBand))) {
-        QMessageBox::information((QWidget *)parent(), "Error", "Sorry, cannot save RGB stretches which include the same band multiple times, but have different stretches for each"); 
+        QMessageBox::information((QWidget *)parent(), "Error", "Sorry, cannot save RGB stretches which include the same band multiple times, but have different stretches for each");
         return;
       }
     }
@@ -706,9 +700,9 @@ namespace Isis {
           stretch = m_advancedStretch->getGrayStretch();
         }
         else {
-          stretch = cvp->grayStretch(); 
+          stretch = cvp->grayStretch();
         }
-        
+
         // Write single stretch to cube
         stretch.setName(text);
         stretch.setBandNumber(cvp->grayBand());
@@ -716,7 +710,7 @@ namespace Isis {
 
         // Overwrite an existing stretch with the same name if it exists. The user was warned
         // and decided to overwrite.
-        icube->write(stretchBlob);
+        icube->write(*(stretchBlob.toBlob()));
       }
       else {
         CubeStretch redStretch, greenStretch, blueStretch;
@@ -734,20 +728,20 @@ namespace Isis {
         redStretch.setName(text);
         redStretch.setBandNumber(cvp->redBand());
         StretchBlob redStretchBlob(redStretch);
-        icube->write(redStretchBlob, false);
+        icube->write(*(redStretchBlob.toBlob()), false);
 
         greenStretch.setName(text);
         greenStretch.setBandNumber(cvp->greenBand());
         StretchBlob greenStretchBlob(greenStretch);
-        icube->write(greenStretchBlob, false);
+        icube->write(*(greenStretchBlob.toBlob()), false);
 
         blueStretch.setName(text);
         blueStretch.setBandNumber(cvp->blueBand());
         StretchBlob blueStretchBlob(blueStretch);
-        icube->write(blueStretchBlob, false);
+        icube->write(*(blueStretchBlob.toBlob()), false);
       }
 
-      // Don't leave open rw -- not optimal. 
+      // Don't leave open rw -- not optimal.
       cvp->cube()->reopen("r");
     }
   }

--- a/isis/tests/StretchBlobTest.cpp
+++ b/isis/tests/StretchBlobTest.cpp
@@ -28,11 +28,11 @@ TEST(StretchBlob, Constructors) {
   // Test retrieval of cubeStretch from StretchBlob
   CubeStretch retrievedStretch = stretchStretchBlob.getStretch();
 
-  EXPECT_STREQ(stretchBlob.getStretch().getName().toLatin1().data(), "CubeStretch");
-  EXPECT_STREQ(stretchBlob.getStretch().getType().toLatin1().data(), "Stretch");
+  EXPECT_STREQ(stretchBlob.getStretch().getName().toLatin1().data(), "DefaultStretch");
+  EXPECT_STREQ(stretchBlob.getStretch().getType().toLatin1().data(), "Default");
 
   EXPECT_STREQ(nameStretchBlob.getStretch().getName().toLatin1().data(), "name");
-  EXPECT_STREQ(nameStretchBlob.getStretch().getType().toLatin1().data(), "Stretch");
+  EXPECT_STREQ(nameStretchBlob.getStretch().getType().toLatin1().data(), "Default");
 
   EXPECT_STREQ(stretchStretchBlob.getStretch().getName().toLatin1().data(), "TestStretch");
   EXPECT_STREQ(stretchStretchBlob.getStretch().getType().toLatin1().data(), "testType");
@@ -58,9 +58,10 @@ TEST_F(DefaultCube, StretchBlobWriteRead) {
 
   // Write to Cube
   testCube->write(*(stretchBlob.toBlob()));
+  testCube->reopen("rw");
+  
   // Set up stretch and blob to restore to
-
-  StretchBlob restoreBlob = testCube->readStretchBlob(stretchName, "testType");
+  StretchBlob restoreBlob = testCube->readStretchBlob(stretchName);
   CubeStretch restoredStretch = stretchBlob.getStretch();
   EXPECT_TRUE(restoredStretch == cubeStretch);
 };

--- a/isis/tests/StretchBlobTest.cpp
+++ b/isis/tests/StretchBlobTest.cpp
@@ -6,7 +6,7 @@
 #include "Fixtures.h"
 
 #include <QString>
-#include <QDebug> 
+#include <QDebug>
 
 #include <gtest/gtest.h>
 #include "gmock/gmock.h"
@@ -23,21 +23,24 @@ TEST(StretchBlob, Constructors) {
   // Set Stretch
   CubeStretch cubeStretch("TestStretch", "testType", 2);
   StretchBlob stretchStretchBlob(cubeStretch);
+  StretchBlob stretchFromBlob(*(stretchStretchBlob.toBlob()));
 
   // Test retrieval of cubeStretch from StretchBlob
   CubeStretch retrievedStretch = stretchStretchBlob.getStretch();
 
-  EXPECT_STREQ(stretchBlob.Name().toLatin1().data(), "CubeStretch");
-  EXPECT_STREQ(stretchBlob.Type().toLatin1().data(), "Stretch"); 
+  EXPECT_STREQ(stretchBlob.getStretch().getName().toLatin1().data(), "CubeStretch");
+  EXPECT_STREQ(stretchBlob.getStretch().getType().toLatin1().data(), "Stretch");
 
-  EXPECT_STREQ(nameStretchBlob.Name().toLatin1().data(), "name");
-  EXPECT_STREQ(nameStretchBlob.Type().toLatin1().data(), "Stretch"); 
+  EXPECT_STREQ(nameStretchBlob.getStretch().getName().toLatin1().data(), "name");
+  EXPECT_STREQ(nameStretchBlob.getStretch().getType().toLatin1().data(), "Stretch");
 
-  EXPECT_STREQ(stretchStretchBlob.Name().toLatin1().data(), "CubeStretch");
-  EXPECT_STREQ(stretchStretchBlob.Type().toLatin1().data(), "Stretch");
+  EXPECT_STREQ(stretchStretchBlob.getStretch().getName().toLatin1().data(), "TestStretch");
+  EXPECT_STREQ(stretchStretchBlob.getStretch().getType().toLatin1().data(), "testType");
 
   EXPECT_STREQ(retrievedStretch.getName().toLatin1().data(), cubeStretch.getName().toLatin1().data());
   EXPECT_STREQ(retrievedStretch.getType().toLatin1().data(), cubeStretch.getType().toLatin1().data());
+
+  EXPECT_STREQ(stretchFromBlob.getStretch().getType().toLatin1().data(), cubeStretch.getType().toLatin1().data());
   EXPECT_EQ(retrievedStretch.getBandNumber(), cubeStretch.getBandNumber());
 };
 
@@ -54,10 +57,10 @@ TEST_F(DefaultCube, StretchBlobWriteRead) {
   Isis::StretchBlob stretchBlob(cubeStretch);
 
   // Write to Cube
-  testCube->write(stretchBlob);
+  testCube->write(*(stretchBlob.toBlob()));
   // Set up stretch and blob to restore to
-  StretchBlob restoreBlob(stretchName);
-  testCube->read(restoreBlob);
+
+  StretchBlob restoreBlob = testCube->readStretchBlob(stretchName, "testType");
   CubeStretch restoredStretch = stretchBlob.getStretch();
   EXPECT_TRUE(restoredStretch == cubeStretch);
 };


### PR DESCRIPTION
Removed blob inheritance from stretchblob.  One test failure.  I think it's something to do with the toBlob function.

## Description
Removed blob inheritance from stretchblob
## Related Issue
None

## Motivation and Context
Factors out blob inheritance.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
