### PR TITLE
Update mdiscal to go through the camera if possible for sun-target distance and time

### DIFF
--- a/isis/src/messenger/apps/mdiscal/main.cpp
+++ b/isis/src/messenger/apps/mdiscal/main.cpp
@@ -315,7 +315,7 @@ void IsisMain() {
     empiricalCorrectionFile = "";
     g_empiricalCorrectionFactor = loadEmpiricalCorrection(startTime, g_filterNumber + 1,
                                                           empiricalCorrectionFile,
-                                                          empiricalCorrectionDate);
+                                                          empiricalCorrectionDate, icube);
     empiricalCorrectionFactor = toString(g_empiricalCorrectionFactor);
   }
   else {
@@ -335,7 +335,7 @@ void IsisMain() {
     PvlGroup& inst = icube->group("Instrument");
     QString target = inst["TargetName"];
     QString startTime = inst["SpacecraftClockCount"];
-    if (sunDistanceAU(startTime, target, g_solarDist)) {
+    if (sunDistanceAU(startTime, target, g_solarDist, icube)) {
       vector<double> sol = loadSolarIrr(g_isNarrowAngleCamera, g_isBinnedData,
                                         g_filterNumber + 1, solirrfile);
       g_Ff = sol[2];

--- a/isis/src/messenger/apps/mdiscal/mdiscal.xml
+++ b/isis/src/messenger/apps/mdiscal/mdiscal.xml
@@ -655,6 +655,10 @@
       was applied.  This will change the output DNs for any images where FLATFIELD=false. 
       Updated documentation. Fixes #2338
     </change>
+    <change name="Kristin Berry" date="2021-02-26">
+      Updated to use camera for the target-sun distance and clock time to ET conversion, if possible.
+      This enables the program to be run without local spice kernels (the spice server can be used for spiceinit.)
+    </change>
   </history>
 
   <groups>

--- a/isis/src/messenger/apps/mdiscal/tsts/contamination/Makefile
+++ b/isis/src/messenger/apps/mdiscal/tsts/contamination/Makefile
@@ -11,12 +11,14 @@ commands:
 	catlab \
 	from=$(OUTPUT)/pre_contamination.cub \
 	to=$(OUTPUT)/pre_contamination_label.pvl > /dev/null;
+
 	# contamination day 1, iof=true
 	$(APPNAME) from=$(INPUT)/EW0217136166F.cub \
 	to=$(OUTPUT)/contamination_day_1.cub \
 	iof=true > /dev/null;
 	catlab from=$(OUTPUT)/contamination_day_1.cub \
 	to=$(OUTPUT)/contamination_day_1_label.pvl > /dev/null;
+
 	# more contamination, iof=true
 	$(APPNAME) \
 	from=$(INPUT)/EW0217310049F.cub \
@@ -25,6 +27,7 @@ commands:
 	catlab \
 	from=$(OUTPUT)/contamination_jun_2011_iof.cub \
 	to=$(OUTPUT)/contamination_jun_2011_iof_label.pvl > /dev/null;
+
 	# more contamination, iof=false
 	$(APPNAME) \
 	from=$(INPUT)/EW0217310055G.cub \
@@ -33,6 +36,7 @@ commands:
 	catlab \
 	from=$(OUTPUT)/contamination_jun_2011_ra.cub \
 	to=$(OUTPUT)/contamination_jun_2011_ra_label.pvl > /dev/null;
+
 	# even more contamination, iof=true
 	$(APPNAME) \
 	from=$(INPUT)/EW0234069364C.cub \
@@ -41,6 +45,7 @@ commands:
 	catlab \
 	from=$(OUTPUT)/contamination_jan_2012_last_day.cub \
 	to=$(OUTPUT)/contamination_jan_2012_last_day_label.pvl > /dev/null;
+
 	# post contamination, iof=true
 	$(APPNAME) \
 	from=$(INPUT)/EW0234155897G.cub \
@@ -49,6 +54,7 @@ commands:
 	catlab \
 	from=$(OUTPUT)/post_contamination.cub \
 	to=$(OUTPUT)/post_contamination_label.pvl > /dev/null;
+
 	# contamination day 1, iof=true, no empirical correction performed
 	$(APPNAME) from=$(INPUT)/EW0217136166F.cub \
 	to=$(OUTPUT)/contamination_day_1_no_ec.cub \
@@ -56,6 +62,7 @@ commands:
 	ecf=false > /dev/null;
 	catlab from=$(OUTPUT)/contamination_day_1_no_ec.cub \
 	to=$(OUTPUT)/contamination_day_1_no_ec_label.pvl > /dev/null;
+
 	# post contamination, iof=true, no empirical correction performed
 	$(APPNAME) \
 	from=$(INPUT)/EW0234155897G.cub \
@@ -65,6 +72,7 @@ commands:
 	catlab \
 	from=$(OUTPUT)/post_contamination_no_ec.cub \
 	to=$(OUTPUT)/post_contamination_no_ec_label.pvl > /dev/null;
+
 	# NAC contamination, iof=true, no empirical correction (because NAC)
 	$(APPNAME) \
 	from=$(INPUT)/EN0228199579M.cub \
@@ -73,5 +81,12 @@ commands:
 	catlab \
 	from=$(OUTPUT)/contamination_NAC.cub \
 	to=$(OUTPUT)/contamination_NAC_label.pvl > /dev/null;
+
+	# Test going through the camera model for sun distance and start time
+	$(APPNAME) from=$(INPUT)/EW0217136166F.spiceinited.cub \
+	to=$(OUTPUT)/contamination_day_1.spiceinited.cub \
+	iof=true > /dev/null;
+	catlab from=$(OUTPUT)/contamination_day_1.spiceinited.cub \
+	to=$(OUTPUT)/contamination_day_1_label.spiceinited.pvl > /dev/null;
 
 


### PR DESCRIPTION
## Description
Updates `mdiscal` to use a camera to determine the sun-target distance and start time in ET if possible (usually if the cube is spiceinited.) This enables `mdiscal` to be run on a spiceinited cube without local spice kernels, for example, if it has been spiceinited using the spice server.

## Related Issue
#4303 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
