### PR TITLE
Update shadow documentation to mention when SPICE kernels are needed

### DIFF
--- a/isis/src/base/apps/shadow/shadow.xml
+++ b/isis/src/base/apps/shadow/shadow.xml
@@ -20,7 +20,8 @@
 
     <strong>User-Requirements</strong><br/>
       The user must supply an elevation model (DEM) and either an observation time or a cube
-      with raw camera geometry (see 'spiceinit').<br/><br/>
+      with raw camera geometry (see 'spiceinit'). If providing an observation time, the SPICE kernels
+      associated with the image target must have been downloaded and be available on the user's machine.<br/><br/>
 
     <strong>Understanding the Algorithm</strong><br/>
     The 'shade' program's algorithm is called 'hillshade' in this algorithm description.

--- a/isis/src/base/apps/shadow/shadow.xml
+++ b/isis/src/base/apps/shadow/shadow.xml
@@ -20,8 +20,8 @@
 
     <strong>User-Requirements</strong><br/>
       The user must supply an elevation model (DEM) and either an observation time or a cube
-      with raw camera geometry (see 'spiceinit'). If providing an observation time, the SPICE kernels
-      associated with the image target must have been downloaded and be available on the user's machine.<br/><br/>
+      with raw camera geometry (see 'spiceinit'). If providing an observation time, the PCK and SPK SPICE kernels
+      associated with the DEM's target must have been downloaded and be available on the user's machine in the "base" kernels area, or their file paths must be provided as values to the PCK and SPK user parameters.<br/><br/>
 
     <strong>Understanding the Algorithm</strong><br/>
     The 'shade' program's algorithm is called 'hillshade' in this algorithm description.


### PR DESCRIPTION
## Description
`shadow` already supported getting sun position from a spiceinited cube, so this is just a documentation update to explain in what circumstances local kernels are required. 

## Related Issue
#4303 

## Motivation and Context
See #4303 .

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
