### PR TITLE
Update Camera.cpp to fix local norm for pushbroom cameras (old PR#4214)

### DIFF
--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -1520,10 +1520,10 @@ namespace Isis {
 
       // order of points in vector is top, bottom, left, right
       QList< QPair< double, double > > surroundingPoints;
-      surroundingPoints.append(qMakePair(samp, line - 0.5));
-      surroundingPoints.append(qMakePair(samp, line + 0.5 - DBL_MIN));
-      surroundingPoints.append(qMakePair(samp - 0.5, line));
-      surroundingPoints.append(qMakePair(samp + 0.5 - DBL_MIN, line));
+      surroundingPoints.append(qMakePair(samp, std::nexttoward(line - 0.5, line)));
+      surroundingPoints.append(qMakePair(samp, std::nexttoward(line + 0.5, line)));
+      surroundingPoints.append(qMakePair(std::nexttoward(samp - 0.5, samp), line));
+      surroundingPoints.append(qMakePair(std::nexttoward(samp + 0.5, samp), line));
 
       // save input state to be restored on return
       double originalSample = samp;

--- a/isis/src/base/objs/Camera/Camera.h
+++ b/isis/src/base/objs/Camera/Camera.h
@@ -228,11 +228,14 @@ namespace Isis {
    *   @history 2018-07-12 Summer Stapleton - Added m_instrumentId and instrumentId() in order to
    *                           collect the InstrumentId from the original cube label for
    *                           comparisons related to image imports in ipce. References #5460.
+   *   @history 2021-03-04 Victor Silva - Made changes to GetLocalNormal to calculate local normal
+   *                           accurately for LRO by changing 4 corner surrounding points from adding
+   *                           0.5 to line and sample and wrapping value with nexttoward.Fixes #4018.
    */
 
   class Camera : public Sensor {
     public:
-      // constructors
+      // constructors 
       Camera(Cube &cube);
 
       // destructor


### PR DESCRIPTION
Originally the fix was submitted via PR [#4214](https://github.com/USGS-Astrogeology/ISIS3/pull/4214) for branch 3.10.2 but since that branch is no longer active, changes will be submitted to dev.

Although this does fix this function when phocube uses it with integer sample/line values, it does not fix it when other applications use non-integer sample/line values.  A new issue has been created [#4256](https://github.com/USGS-Astrogeology/ISIS3/issues/4256) to address what we believe to be a fix for the other cases.


## Description
Currently, the DBL_MIN is not operating as expected. The functionality that is intended is:
Calculate normal by grabbing elevation values at the edges of the pixel in question.

What is actually happening:
The values gathered are still not from the same pixel. It appears as though the DBL_MIN is not subtracting more than the rounding error, and this is essentially returning the same value as if the code was:

      QList< QPair< double, double > > surroundingPoints;
      surroundingPoints.append(qMakePair(samp, line - 0.5));
      surroundingPoints.append(qMakePair(samp, line + 0.5));
      surroundingPoints.append(qMakePair(samp - 0.5, line));
      surroundingPoints.append(qMakePair(samp + 0.5, line));

This change was made to version 3.10.2 originally but is not being submitted to dev branch.

## Motivation and Context
This is detrimental when calculating photometric angles for push-broom and push-frame cameras because 1.0 could be the pixel center, 0.5 is the edge of pixel 1, but 1.5 is the edge of pixel 2. This does not work well when a push-broom imager is flying in a reverse direction, or for frame boundaries of a push-frame camera. The calculation is using a completely wrong location on the body.


## How Has This Been Tested?
The LROC team has tested the fix. Will provide details in the comments below but a test (GTest) has not been created for this yet.

## Screenshots (if appropriate):
Please see the issue. Several screenshots and examples have been included.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user-impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.