### PR TITLE
Blob final clean-up

### DIFF
--- a/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
+++ b/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
@@ -176,7 +176,7 @@ namespace Isis {
             History hist = cube->readHistory(histName);
             // add apollofindrx History PvlObject into the History Blob and write to cube
             hist.AddEntry();
-            cube->write(*(hist.toBlob(histName)));
+            cube->write(hist);
             cube->close();
         }
     }

--- a/isis/src/base/apps/csminit/csminit.cpp
+++ b/isis/src/base/apps/csminit/csminit.cpp
@@ -364,7 +364,7 @@ namespace Isis {
 
     // Save off all old Blobs to restore in the case of csminit failure
     Blob originalCsmStateBlob("CSMState", "String");
-    if (cube->hasBlob("String", "CSMState")) {
+    if (cube->hasBlob("CSMState", "String")) {
       cube->read(originalCsmStateBlob);
     }
 
@@ -394,20 +394,20 @@ namespace Isis {
     }
 
     ImagePolygon originalFootprint;
-    if (cube->hasBlob("Polygon", "ImageFootprint")) {
+    if (cube->hasBlob("ImageFootprint", "Polygon")) {
       originalFootprint = cube->readFootprint();
     }
 
     // Remove blob from old csminit run
-    cube->deleteBlob("String", "CSMState");
+    cube->deleteBlob("CSMState", "String");
 
     // Remove tables from spiceinit before writing to the cube
-    cube->deleteBlob("Table", "InstrumentPointing");
-    cube->deleteBlob("Table", "InstrumentPosition");
-    cube->deleteBlob("Table", "BodyRotation");
-    cube->deleteBlob("Table", "SunPosition");
-    cube->deleteBlob("Table", "CameraStatistics");
-    cube->deleteBlob("Polygon", "Footprint");
+    cube->deleteBlob("InstrumentPointing", "Table");
+    cube->deleteBlob("InstrumentPosition", "Table");
+    cube->deleteBlob("BodyRotation", "Table");
+    cube->deleteBlob("SunPosition", "Table");
+    cube->deleteBlob("CameraStatistics", "Table");
+    cube->deleteBlob("Footprint", "Polygon");
 
     // Create our CSM State blob as a string and add the CSM string to the Blob.
     Blob csmStateBlob("CSMState", "String");
@@ -438,7 +438,7 @@ namespace Isis {
         cube->putGroup(originalCsmInfo);
       }
 
-      cube->deleteBlob("String", "CSMState");
+      cube->deleteBlob("CSMState", "String");
 
       // Restore the original blobs
       if (originalCsmStateBlob.Size() != 0) {
@@ -468,7 +468,7 @@ namespace Isis {
 
       if (originalFootprint.Polys() != NULL){
         if (originalFootprint.Polys()->getNumGeometries() != 0) {
-          cube->write(*(originalFootprint.toBlob()));
+          cube->write(originalFootprint);
         }
       }
 

--- a/isis/src/base/apps/cubeit/main.cpp
+++ b/isis/src/base/apps/cubeit/main.cpp
@@ -179,9 +179,7 @@ void IsisMain() {
   }
 
   // Delete any tracking tables from the input label if necessary
-  if (ocube->hasTable("InputImages")) {
-    ocube->deleteBlob("Table", "InputImages");
-  }
+  ocube->deleteBlob("InputImages", "Table");
 
   // Delete the Tracking group if it exists (3.6.0 and up)
   // The tracking group could be transfered from the first input cube, but it does not
@@ -220,9 +218,7 @@ void IsisMain() {
     Cube *icube = m.SetInputCube(newcubeList[i].toString(), attrib, 1, 1, 1, -1, -1, -1);
 
     // Delete any tracking tables from the input cube if necessary
-    if (icube->hasTable("InputImages")) {
-      icube->deleteBlob("Table", "InputImages");
-    }
+    icube->deleteBlob("InputImages", "Table");
 
     m.SetImageOverlay(ProcessMosaic::PlaceImagesOnTop);
     m.StartProcess(1, 1, sband);

--- a/isis/src/base/apps/desmile/main.cpp
+++ b/isis/src/base/apps/desmile/main.cpp
@@ -102,7 +102,7 @@ void IsisMain() {
   // read cube's History PvlObject data into the History Object
   History histBlob = inCube->readHistory(histName);
   histBlob.AddEntry();
-  outCube->write(*(histBlob.toBlob(histName)));
+  outCube->write(histBlob, histName);
 
   procSpectra.Finalize();
   delete outputSpectralDef;

--- a/isis/src/base/apps/editlab/main.cpp
+++ b/isis/src/base/apps/editlab/main.cpp
@@ -102,7 +102,7 @@ void IsisMain() {
   if(cube) {
     History hist = cube->readHistory();
     hist.AddEntry();
-    cube->write(*(hist.toBlob()));
+    cube->write(hist);
 
     // clean up
     cube->close();

--- a/isis/src/base/apps/footprintinit/footprintinit.cpp
+++ b/isis/src/base/apps/footprintinit/footprintinit.cpp
@@ -137,8 +137,8 @@ namespace Isis {
       }
     }
 
-    cube->deleteBlob("Polygon", sn);
-    cube->write(*(poly.toBlob()));
+    cube->deleteBlob(sn, "Polygon");
+    cube->write(poly);
 
     if (precision) {
       PvlGroup results("Results");

--- a/isis/src/base/apps/maplab/main.cpp
+++ b/isis/src/base/apps/maplab/main.cpp
@@ -115,7 +115,7 @@ void IsisMain() {
   // keep track of change to labels in history
   History hist = cube.readHistory();
   hist.AddEntry();
-  cube.write(*(hist.toBlob()));
+  cube.write(hist);
 
   cube.close();
 }

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -380,12 +380,12 @@ namespace Isis {
 
     // Save off the CSM State so it can be restored if spiceinit fails
     Blob csmState("CSMState", "String");
-    if (icube->hasBlob("String", "CSMState")) {
+    if (icube->hasBlob("CSMState", "String")) {
       icube->read(csmState);
     }
 
     // Delete the CSM State blob so that CameraFactory doesn't try to instantiate a CSMCamera
-    icube->deleteBlob("String", "CSMState");
+    icube->deleteBlob("CSMState", "String");
 
     // report qualities
     PvlKeyword spkQuality("InstrumentPositionQuality");

--- a/isis/src/base/apps/trackextract/main.cpp
+++ b/isis/src/base/apps/trackextract/main.cpp
@@ -170,7 +170,7 @@ void createMosaicCube(QString inputName, QString outputName, QVector<QString> ba
                      _FILEINFO_);
   }
 
-  if (!mosaicCube.deleteBlob("Table", "InputImages")) {
+  if (!mosaicCube.deleteBlob("InputImages", "Table")) {
     QString msg = "The input cube [" + inputName + "] does not have a tracking table.";
     throw IException(IException::Programmer, msg, _FILEINFO_);
   }

--- a/isis/src/base/objs/CameraFactory/CameraFactory.cpp
+++ b/isis/src/base/objs/CameraFactory/CameraFactory.cpp
@@ -50,7 +50,7 @@ namespace Isis {
 
     try {
       // Is there a CSM blob on the cube?
-      if (cube.hasBlob("String", "CSMState")) {
+      if (cube.hasBlob("CSMState", "String")) {
         // Create ISIS CSM Camera Model
         try {
           return new CSMCamera(cube);

--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -836,6 +836,14 @@ namespace Isis {
     m_ioHandler->read(bufferToFill);
   }
 
+
+  /**
+   * Read the History from the Cube.
+   *
+   * @param name The name of the History Blob to read. This is used for reading
+   *             History from Cubes made prior to the History Blob name being
+   *             standardized.
+   */
   History Cube::readHistory(const QString &name) const {
     Blob historyBlob(name, "History");
     try {
@@ -849,6 +857,12 @@ namespace Isis {
     return history;
   }
 
+
+  /**
+   * Read the footprint polygon for the Cube.
+   *
+   * @return @b ImagePolygon
+   */
   ImagePolygon Cube::readFootprint() const {
     Blob footprintBlob("Footprint", "Polygon");
     try {
@@ -864,8 +878,13 @@ namespace Isis {
     return footprint;
   }
 
+
   /**
-   * This method will read an OriginalLabel from a cube.
+   * Read the original PDS3 label from a cube.
+   *
+   * @param name The name of the OriginalLabel Blob
+   *
+   * @return @b OriginalLabel The original PDS3 label as a PVL document
    */
   OriginalLabel Cube::readOriginalLabel(const QString &name) const {
     Blob origLabelBlob(name, "OriginalLabel");
@@ -882,7 +901,13 @@ namespace Isis {
 
 
   /**
-   * This method will read a StretchBlob from a cube.
+   * Read a Stretch from a cube.
+   *
+   * @param name The name of the Stretch Blob
+   * @param keywords A set of keywords and values to match in the Stretch Blob label.
+   *                 This can be used to read the stretch for a specific band.
+   *
+   * @return @b CubeStretch
    */
   CubeStretch Cube::readCubeStretch(QString name, const std::vector<PvlKeyword> keywords) const {
     Blob stretchBlob(name, "Stretch");
@@ -899,7 +924,9 @@ namespace Isis {
 
 
   /**
-   * This method will read an OriginalXmlLabel from a cube.
+   * Read the original PDS4 label from a cube.
+   *
+   * @return @b OriginalXmlLabel The original PDS4 label as an XML document
    */
   OriginalXmlLabel Cube::readOriginalXmlLabel() const {
     Blob origXmlLabelBlob("IsisCube", "OriginalXmlLabel");
@@ -915,6 +942,13 @@ namespace Isis {
   }
 
 
+  /**
+   * Read a Table from the cube.
+   *
+   * @param name The name of the Table to read
+   *
+   * @return @b Table
+   */
   Table Cube::readTable(const QString &name) {
     Blob tableBlob(name, "Table");
     try {
@@ -1019,23 +1053,56 @@ namespace Isis {
   }
 
 
+  /**
+   * Write a Table to the Cube.
+   *
+   * The Table will be written to the Cube as a BLOB and can be accessed
+   * using Cube::readTable.
+   *
+   * @param table The table to write to the Cube
+   */
   void Cube::write(const Table &table) {
     Blob tableBlob = table.toBlob();
     write(tableBlob);
   }
 
+
+  /**
+   * Write a Stretch to the Cube
+   *
+   * The stretch will be written to the Cube as a BLOB and can be accessed
+   * using Cube::readCubeStretch.
+   *
+   * @param cubeStretch The stretch to write to the Cube.
+   */
   void Cube::write(const CubeStretch &cubeStretch) {
     Blob cubeStretchBlob = cubeStretch.toBlob();
     write(cubeStretchBlob);
   }
 
 
+  /**
+   * Write an updated History to the Cube
+   *
+   * The History will be written to the Cube as a BLOB and can be accessed
+   * using Cube::readHistory.
+   *
+   * @param history The history to write to the Cube.
+   * @param name The name for the history BLOB. This is used for backwards compatibility
+   *             with cubes from before the History BLOB name was standardized.
+   */
   void Cube::write(History &history, const QString &name) {
     Blob histBlob = history.toBlob(name);
     write(histBlob);
   }
 
 
+  /**
+   * Write a polygon to the Cube
+   *
+   * The polygon will be written to the Cube as a BLOB and can be accessed
+   * using Cube::readFootprint.
+   */
   void Cube::write(const ImagePolygon &polygon) {
     Blob polyBlob = polygon.toBlob();
     write(polyBlob);

--- a/isis/src/base/objs/Cube/Cube.h
+++ b/isis/src/base/objs/Cube/Cube.h
@@ -261,11 +261,14 @@ namespace Isis {
       OriginalXmlLabel readOriginalXmlLabel() const;
       History readHistory(const QString &name = "IsisCube") const;
       ImagePolygon readFootprint() const;
+      Table readTable(const QString &name);
       void write(Blob &blob, bool overwrite=true);
       void write(const Table &table);
       void write(const CubeStretch &cubeStretch);
-      void write(OriginalLabel lab);
-      void write(OriginalXmlLabel lab);
+      void write(OriginalLabel &lab);
+      void write(const OriginalXmlLabel &lab);
+      void write(History &history, const QString &name = "IsisCube");
+      void write(const ImagePolygon &polygon);
       void write(Buffer &wbuf);
 
       void setBaseMultiplier(double base, double mult);
@@ -312,13 +315,12 @@ namespace Isis {
 
       void addCachingAlgorithm(CubeCachingAlgorithm *);
       void clearIoCache();
-      bool deleteBlob(QString BlobType, QString BlobName);
+      bool deleteBlob(QString BlobName, QString BlobType);
       void deleteGroup(const QString &group);
       PvlGroup &group(const QString &group) const;
       bool hasGroup(const QString &group) const;
       bool hasTable(const QString &name);
-      Table readTable(const QString &name);
-      bool hasBlob(const QString &type, const QString &name);
+      bool hasBlob(const QString &name, const QString &type);
       void putGroup(const PvlGroup &group);
       void latLonRange(double &minLatitude, double &maxLatitude, double &minLongitude,
                        double &maxLongitude);

--- a/isis/src/base/objs/CubeStretch/CubeStretch.cpp
+++ b/isis/src/base/objs/CubeStretch/CubeStretch.cpp
@@ -20,11 +20,16 @@ namespace Isis {
     m_type(stretchType), m_bandNumber(bandNumber) {
   }
 
+
+  /**
+   * Copy constructor for a CubeStretch
+   */
   CubeStretch::CubeStretch(CubeStretch const& stretch): Stretch(stretch) {
     m_name = stretch.getName();
     m_type = stretch.getType();
     m_bandNumber = stretch.getBandNumber();
   }
+
 
   /**
    * Constructs a CubeStretch object from a normal Stretch.
@@ -48,6 +53,12 @@ namespace Isis {
     m_bandNumber = 1;
   }
 
+
+  /**
+   * Constructs a CubeStretch from a Blob.
+   *
+   * @param blob The Blob to read data from.
+   */
   CubeStretch::CubeStretch(Blob blob) : Stretch() {
     char *buff = blob.getBuffer();
     std::string stringFromBuffer(buff, blob.Size());
@@ -57,10 +68,19 @@ namespace Isis {
     setBandNumber(blob.Label()["BandNumber"][0].toInt());
   }
 
-  // Default destructor
+
+  // CubeStretch destructor
   CubeStretch::~CubeStretch() {
   }
 
+
+  /**
+   * Serialize the CubeStretch to a Blob.
+   *
+   * The stretch will be serialized as a string. See Stretch::Text for more information.
+   *
+   * @return @b Blob a Blob containing the stretch data.
+   */
   Isis::Blob CubeStretch::toBlob() const {
     Isis::Blob blob("CubeStretch", "Stretch");
 
@@ -85,6 +105,7 @@ namespace Isis {
            (getName() == stretch2.getName()) &&
            (Text() == stretch2.Text());
   }
+
 
   /**
    * Get the Type of Stretch.

--- a/isis/src/base/objs/CubeStretch/CubeStretch.cpp
+++ b/isis/src/base/objs/CubeStretch/CubeStretch.cpp
@@ -61,8 +61,8 @@ namespace Isis {
   CubeStretch::~CubeStretch() {
   }
 
-  Isis::Blob CubeStretch::toBlob(QString const& name) const {
-    Isis::Blob blob(name, "Stretch");
+  Isis::Blob CubeStretch::toBlob() const {
+    Isis::Blob blob("CubeStretch", "Stretch");
 
     blob.Label()["Name"] = getName();
     blob.Label() += PvlKeyword("StretchType", getType());

--- a/isis/src/base/objs/CubeStretch/CubeStretch.h
+++ b/isis/src/base/objs/CubeStretch/CubeStretch.h
@@ -36,7 +36,7 @@ namespace Isis {
 
       bool operator==(CubeStretch& stretch2);
 
-      Isis::Blob toBlob(QString const& name="CubeStretch") const;
+      Isis::Blob toBlob() const;
 
       QString getType() const;
       void setType(QString stretchType);

--- a/isis/src/base/objs/History/History.cpp
+++ b/isis/src/base/objs/History/History.cpp
@@ -23,6 +23,7 @@ namespace Isis {
     p_history.setTerminator("");
   }
 
+
   /**
    *  Constructor for reading a blob
    *  @param blob
@@ -36,12 +37,14 @@ namespace Isis {
     memcpy(p_histBuffer, blob_buffer, p_bufferSize);
   }
 
+
   //! Destructor
   History::~History() {
     if (p_histBuffer != NULL) {
       delete [] p_histBuffer;
     }
   }
+
 
   /**
    *   Adds History PvlObject
@@ -51,6 +54,7 @@ namespace Isis {
     AddEntry(hist);
   }
 
+
   /**
    * Adds given PvlObject to History Pvl
    *
@@ -59,6 +63,7 @@ namespace Isis {
   void History::AddEntry(Isis::PvlObject &obj) {
     p_history.addObject(obj);
   }
+
 
   /**
    * Converts a history object into a new blob object
@@ -84,6 +89,7 @@ namespace Isis {
     newBlob.takeData(blobBuffer, blobBufferSize);
     return newBlob;
   }
+
 
   /**
    * Reads p_histBuffer into a pvl

--- a/isis/src/base/objs/History/History.cpp
+++ b/isis/src/base/objs/History/History.cpp
@@ -67,7 +67,7 @@ namespace Isis {
    *
    * @return @b Blob
    */
-  Blob *History::toBlob(const QString &name) {
+  Blob History::toBlob(const QString &name) {
     ostringstream ostr;
     if (p_bufferSize > 0) ostr << std::endl;
     ostr << p_history;
@@ -80,8 +80,8 @@ namespace Isis {
     const char *ptr = histStr.c_str();
     memcpy(&blobBuffer[p_bufferSize], (void *)ptr, bytes);
 
-    Blob *newBlob = new Blob(name, "History");
-    newBlob->takeData(blobBuffer, blobBufferSize);
+    Blob newBlob(name, "History");
+    newBlob.takeData(blobBuffer, blobBufferSize);
     return newBlob;
   }
 

--- a/isis/src/base/objs/History/History.h
+++ b/isis/src/base/objs/History/History.h
@@ -45,7 +45,7 @@ namespace Isis {
       void AddEntry(Isis::PvlObject &obj);
       Pvl ReturnHist();
 
-      Blob *toBlob(const QString &name = "IsisCube");
+      Blob toBlob(const QString &name = "IsisCube");
 
     private:
       Pvl p_history; //!< History Pvl

--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
@@ -58,8 +58,9 @@ namespace Isis {
     p_ellipsoid = false;
   }
 
+
   /**
-   *  Constructs a Polygon object, setting the polygon name
+   *  Constructs a Polygon object from a Blob
    *
    */
   ImagePolygon::ImagePolygon(Blob &blob) : ImagePolygon() {
@@ -1336,6 +1337,13 @@ namespace Isis {
   }
 
 
+  /**
+   * Serialize the ImagePolygon to a Blob.
+   *
+   * The polygon will be serialized as a WKT srtring.
+   *
+   * @return @b Blob
+   */
   Blob ImagePolygon::toBlob() const {
     geos::io::WKTWriter *wkt = new geos::io::WKTWriter();
 

--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
@@ -1336,7 +1336,7 @@ namespace Isis {
   }
 
 
-  Blob *ImagePolygon::toBlob() {
+  Blob ImagePolygon::toBlob() const {
     geos::io::WKTWriter *wkt = new geos::io::WKTWriter();
 
     // Check to see p_polygons is valid data
@@ -1348,8 +1348,8 @@ namespace Isis {
     string polyStr = wkt->write(p_polygons);
     delete wkt;
 
-    Blob *newBlob = new Blob("Footprint", "Polygon");
-    newBlob->setData(polyStr.c_str(), polyStr.size());
+    Blob newBlob("Footprint", "Polygon");
+    newBlob.setData(polyStr.c_str(), polyStr.size());
     return newBlob;
   }
 

--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.h
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.h
@@ -233,7 +233,7 @@ namespace Isis {
         return p_pts->size();
       }
 
-      Blob *toBlob();
+      Blob toBlob() const;
 
     private:
       // Please do not add new polygon manipulation methods to this class.

--- a/isis/src/base/objs/OriginalLabel/OriginalLabel.cpp
+++ b/isis/src/base/objs/OriginalLabel/OriginalLabel.cpp
@@ -65,12 +65,12 @@ namespace Isis {
     m_originalLabel = pvl;
   }
 
-  Isis::Blob *OriginalLabel::toBlob() {
+  Isis::Blob OriginalLabel::toBlob() {
     std::stringstream sstream;
     sstream << m_originalLabel;
     string orglblStr = sstream.str();
-    Isis::Blob *blob = new Blob("IsisCube", "OriginalLabel");
-    blob->setData(orglblStr.c_str(), orglblStr.size());
+    Isis::Blob blob("IsisCube", "OriginalLabel");
+    blob.setData(orglblStr.c_str(), orglblStr.size());
     return blob;
   }
 
@@ -79,7 +79,7 @@ namespace Isis {
    *
    * @return (Isis::Pvl) original labels
    */
-  Pvl OriginalLabel::ReturnLabels() {
+  Pvl OriginalLabel::ReturnLabels() const {
     return m_originalLabel;
   }
 }

--- a/isis/src/base/objs/OriginalLabel/OriginalLabel.cpp
+++ b/isis/src/base/objs/OriginalLabel/OriginalLabel.cpp
@@ -28,6 +28,7 @@ namespace Isis {
     fromBlob(blob);
   }
 
+
   /**
    * Constructor for creating an original blob with a given name and file to
    * read labels from.
@@ -39,6 +40,7 @@ namespace Isis {
     blob.Read(file);
     fromBlob(blob);
   }
+
 
   /**
    * Constructor for creating an original blob with a given name and Pvl
@@ -54,6 +56,12 @@ namespace Isis {
   OriginalLabel::~OriginalLabel() {
   }
 
+
+  /**
+   * Initialize the OriginalLabel from a Blob.
+   *
+   * @param blob The Blob to extract data from
+   */
   void OriginalLabel::fromBlob(Isis::Blob blob) {
     Pvl pvl;
     stringstream os;
@@ -65,6 +73,12 @@ namespace Isis {
     m_originalLabel = pvl;
   }
 
+
+  /**
+   * Serialize the OriginalLabel data to a Blob.
+   *
+   * @return @b Blob
+   */
   Isis::Blob OriginalLabel::toBlob() {
     std::stringstream sstream;
     sstream << m_originalLabel;
@@ -73,6 +87,7 @@ namespace Isis {
     blob.setData(orglblStr.c_str(), orglblStr.size());
     return blob;
   }
+
 
   /**
    * Returns the labels in a Pvl object

--- a/isis/src/base/objs/OriginalLabel/OriginalLabel.h
+++ b/isis/src/base/objs/OriginalLabel/OriginalLabel.h
@@ -41,8 +41,8 @@ namespace Isis {
       ~OriginalLabel();
 
       // Return the original labels
-      Pvl ReturnLabels();
-      Isis::Blob *toBlob();
+      Pvl ReturnLabels() const;
+      Isis::Blob toBlob();
 
     protected:
       // prepare data for writing

--- a/isis/src/base/objs/OriginalLabel/unitTest.cpp
+++ b/isis/src/base/objs/OriginalLabel/unitTest.cpp
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
   cout << p << endl;
   Isis::OriginalLabel ol(p);
 
-  ol.toBlob()->Write("olTemp");
+  ol.toBlob().Write("olTemp");
 
   Isis::OriginalLabel ol2("olTemp");
 

--- a/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
+++ b/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
@@ -70,6 +70,11 @@ namespace Isis {
   }
 
 
+  /**
+   * Serialize the OriginalXmlLabel to a Blob.
+   *
+   * @return @b Blob
+   */
   Blob OriginalXmlLabel::toBlob() const {
     std::stringstream sstream;
     sstream << m_originalLabel.toString();

--- a/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
+++ b/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
@@ -70,18 +70,18 @@ namespace Isis {
   }
 
 
-  Blob *OriginalXmlLabel::toBlob() {
+  Blob OriginalXmlLabel::toBlob() const {
     std::stringstream sstream;
     sstream << m_originalLabel.toString();
     string orglblStr = sstream.str();
-    Isis::Blob *blob = new Blob("IsisCube", "OriginalXmlLabel");
-    blob->setData((char*)orglblStr.data(), orglblStr.length());
-    blob->Label() += Isis::PvlKeyword("ByteOrder", "NULL");
+    Isis::Blob blob("IsisCube", "OriginalXmlLabel");
+    blob.setData((char*)orglblStr.data(), orglblStr.length());
+    blob.Label() += Isis::PvlKeyword("ByteOrder", "NULL");
     if (Isis::IsLsb()) {
-      blob->Label()["ByteOrder"] = Isis::ByteOrderName(Isis::Lsb);
+      blob.Label()["ByteOrder"] = Isis::ByteOrderName(Isis::Lsb);
     }
     else {
-      blob->Label()["ByteOrder"] = Isis::ByteOrderName(Isis::Msb);
+      blob.Label()["ByteOrder"] = Isis::ByteOrderName(Isis::Msb);
     }
     return blob;
   }

--- a/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.h
+++ b/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.h
@@ -36,7 +36,7 @@ namespace Isis {
       OriginalXmlLabel(Blob &blob);
       ~OriginalXmlLabel();
 
-      Blob *toBlob();
+      Blob toBlob() const;
 
       void fromBlob(Isis::Blob blob);
       void readFromXmlFile(const FileName &xmlFileName);

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -884,7 +884,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
             QString histBlobName = (QString)inlab.object(i)["Name"];
             History h = InputCubes[0]->readHistory(histBlobName);
             h.AddEntry();
-            cube.write(*(h.toBlob(histBlobName)));
+            cube.write(h, histBlobName);
             addedHist = true;
           }
         }
@@ -894,7 +894,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
         Isis::History h = cube.readHistory();
         h.AddEntry();
 
-        cube.write(*(h.toBlob()));
+        cube.write(h);
       }
     }
   }

--- a/isis/src/base/objs/ProcessMosaic/ProcessMosaic.cpp
+++ b/isis/src/base/objs/ProcessMosaic/ProcessMosaic.cpp
@@ -345,9 +345,7 @@ namespace Isis {
                                        SerialNumber::Compose(*(InputCubes[0])));
 
         //  Write the tracking table to the tracking cube, overwriting if need-be
-        if (m_trackingCube->hasTable(Isis::trackingTableName)) {
-         m_trackingCube->deleteBlob("Table", Isis::trackingTableName);
-        }
+        m_trackingCube->deleteBlob(Isis::trackingTableName, "Table");
         Table table = trackingTable->toTable();
         m_trackingCube->write(table);
       }

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -63,7 +63,7 @@ namespace Isis {
   // TODO: DOCUMENT EVERYTHING
   Spice::Spice(Cube &cube) {
     Pvl &lab = *cube.label();
-    if (cube.hasBlob("String", "CSMState")) {
+    if (cube.hasBlob("CSMState", "String")) {
       csmInit(cube, lab);
     }
     else {

--- a/isis/src/base/objs/Table/Table.cpp
+++ b/isis/src/base/objs/Table/Table.cpp
@@ -138,6 +138,11 @@ namespace Isis {
   }
 
 
+  /**
+   * Initialize a Table from a Blob that has been read from a file.
+   *
+   * @param blob The blob to extract the data for the Table from.
+   */
   void Table::initFromBlob(Blob &blob) {
     Clear();
 
@@ -221,17 +226,37 @@ namespace Isis {
   }
 
 
+  /**
+   * Write the Table to a file.
+   *
+   * This uses a Blob to serialize the Table data, see Blob::Write.
+   *
+   * @param file The file to write the Table to.
+   */
   void Table::Write(const QString &file) {
     Blob blob = toBlob();
     blob.Write(file);
   }
 
 
+  /**
+   * The Table's name
+   *
+   * @return @b QString the name of the Table
+   */
   QString Table::Name() const {
     return p_name;
   }
 
 
+  /**
+   * The Table's label
+   *
+   * Additional information can be stored on the Table's label and will be serialized
+   * in the Blob's label when written out to a file.
+   *
+   * @return @b PvlObject A reference to the label that can be modified
+   */
   PvlObject &Table::Label() {
     return p_label;
   }
@@ -381,6 +406,11 @@ namespace Isis {
   }
 
 
+  /**
+   * Serialze the Table to a Blob that can be written to a file.
+   *
+   * @return @b Blob The Blob contaning the Table's data
+   */
   Blob Table::toBlob() const {
     Blob tableBlob(Name(), "Table");
     PvlObject &blobLabel = tableBlob.Label();
@@ -431,6 +461,18 @@ namespace Isis {
   }
 
 
+  /**
+   * Convert the data from a Table into a string.
+   *
+   * This method will convert all of the Table's records and fields into a
+   * string but will not serialze any label information. See TableRecord::toString
+   * for how the records are converted into a string.
+   *
+   * @param table The Table to serialize
+   * @param fieldDelimiter The delimiter to use between fields
+   *
+   * @return @b QString The Table data as a string
+   */
   QString Table::toString(Table table, QString fieldDelimiter) {
     QString tableValues;
     // add the first record with header, the given delimiter, and a new line after each record

--- a/isis/src/control/apps/deltack/main.cpp
+++ b/isis/src/control/apps/deltack/main.cpp
@@ -305,7 +305,7 @@ void IsisMain() {
     PvlObject hEntry =  Isis::iApp->History();
     hEntry.addGroup(results);
     hist.AddEntry(hEntry);
-    c.write(*(hist.toBlob()));
+    c.write(hist);
 
     // clean up
     c.close();

--- a/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
+++ b/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
@@ -121,7 +121,7 @@ namespace Isis {
     if (iApp) {
         History history = g_ocube->readHistory();
         history.AddEntry();
-        g_ocube->write(*(history.toBlob()));
+        g_ocube->write(history);
     }
 
     // Add original label

--- a/isis/src/lro/apps/lrowac2isis/main.cpp
+++ b/isis/src/lro/apps/lrowac2isis/main.cpp
@@ -230,7 +230,7 @@ void IsisMain() {
 
     History history;
     history.AddEntry();
-    uveven->write(*(history.toBlob()));
+    uveven->write(history);
     uveven->write(origLabel);
 
     uveven->close();
@@ -245,7 +245,7 @@ void IsisMain() {
 
     History history;
     history.AddEntry();
-    uvodd->write(*(history.toBlob()));
+    uvodd->write(history);
     uvodd->write(origLabel);
 
     uvodd->close();
@@ -260,7 +260,7 @@ void IsisMain() {
 
     History history;
     history.AddEntry();
-    viseven->write(*(history.toBlob()));
+    viseven->write(history);
     viseven->write(origLabel);
 
     viseven->close();
@@ -275,7 +275,7 @@ void IsisMain() {
 
     History history;
     history.AddEntry();
-    visodd->write(*(history.toBlob()));
+    visodd->write(history);
     visodd->write(origLabel);
 
     visodd->close();

--- a/isis/src/qisis/apps/qtie/QtieTool.cpp
+++ b/isis/src/qisis/apps/qtie/QtieTool.cpp
@@ -942,7 +942,7 @@ namespace Isis {
     history += results;
 
     h.AddEntry(history);
-    p_matchCube->write(*(h.toBlob()));
+    p_matchCube->write(h);
     p_matchCube->reopen("r");
 
   }

--- a/isis/src/qisis/objs/Image/Image.cpp
+++ b/isis/src/qisis/objs/Image/Image.cpp
@@ -258,8 +258,7 @@ namespace Isis {
     }
 
     if (!result && m_cube) {
-      // TODO: Move this to Blob!
-      Blob example = *(ImagePolygon().toBlob());
+      Blob example = ImagePolygon().toBlob();
 
       QString blobType = example.Type();
       QString blobName = example.Name();

--- a/isis/src/qisis/objs/Shape/Shape.cpp
+++ b/isis/src/qisis/objs/Shape/Shape.cpp
@@ -298,8 +298,7 @@ namespace Isis {
       result = true;
 
     if (!result && m_cube) {
-      // TODO: Move this to Blob!
-      Blob example = *(ImagePolygon().toBlob());
+      Blob example = ImagePolygon().toBlob();
 
       QString blobType = example.Type();
       QString blobName = example.Name();

--- a/isis/src/qisis/objs/StretchTool/StretchTool.cpp
+++ b/isis/src/qisis/objs/StretchTool/StretchTool.cpp
@@ -569,7 +569,7 @@ namespace Isis {
         }
       }
 
-      bool cubeDeleted = icube->deleteBlob("Stretch", toDelete);
+      bool cubeDeleted = icube->deleteBlob(toDelete, "Stretch");
 
       if (!cubeDeleted) {
         QMessageBox msgBox;
@@ -704,7 +704,7 @@ namespace Isis {
 
         // Overwrite an existing stretch with the same name if it exists. The user was warned
         // and decided to overwrite.
-        icube->write(stretch.toBlob());
+        icube->write(stretch);
       }
       else {
         CubeStretch redStretch, greenStretch, blueStretch;

--- a/isis/src/tgo/apps/tgocassisunstitch/main.cpp
+++ b/isis/src/tgo/apps/tgocassisunstitch/main.cpp
@@ -211,7 +211,7 @@ void IsisMain() {
     }
 
     // Propagate History
-    g_outputCubes[i]->write(*(inputHistory.toBlob( "IsisCube" )));
+    g_outputCubes[i]->write(inputHistory);
 
     // Close output cube
     g_outputCubes[i]->close();

--- a/isis/src/voyager/apps/voy2isis/main.cpp
+++ b/isis/src/voyager/apps/voy2isis/main.cpp
@@ -116,7 +116,7 @@ void IsisMain() {
     e.print();
   }
 
-  ocube->write(*(hist->toBlob()));
+  ocube->write(*hist);
 
   p.EndProcess();
 

--- a/isis/tests/CubeStretchTest.cpp
+++ b/isis/tests/CubeStretchTest.cpp
@@ -41,7 +41,7 @@ TEST(CubeStretch, CopyConstructor) {
 TEST(CubeStretch, BlobConstructor) {
   // Set Stretch
   Isis::CubeStretch cubeStretch("TestStretch", "testType", 2);
-  Isis::CubeStretch cubeStretchFromBlob(cubeStretch.toBlob());
+  Isis::CubeStretch cubeStretchFromBlob(cubeStretch);
 
 
   EXPECT_STREQ(cubeStretchFromBlob.getName().toLatin1().data(), cubeStretch.getName().toLatin1().data());

--- a/isis/tests/CubeTests.cpp
+++ b/isis/tests/CubeTests.cpp
@@ -236,6 +236,6 @@ TEST(CubeTest, TestCubeAttachSpiceFromIsd) {
 TEST_F(SmallCube, TestCubeHasBlob) {
   Blob testBlob("TestBlob", "SomeBlob");
   testCube->write(testBlob);
-  EXPECT_TRUE(testCube->hasBlob("SomeBlob", "TestBlob"));
-  EXPECT_FALSE(testCube->hasBlob("SomeBlob", "SomeOtherTestBlob"));
+  EXPECT_TRUE(testCube->hasBlob("TestBlob", "SomeBlob"));
+  EXPECT_FALSE(testCube->hasBlob("SomeOtherTestBlob", "SomeBlob"));
 }

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -326,7 +326,7 @@ namespace Isis {
               {35, 0},
               {30, 0}};
     poly.Create(coords);
-    cube1->write(*(poly.toBlob()));
+    cube1->write(poly);
 
     cube2 = new Cube();
     cube2->fromIsd(tempDir.path() + "/cube2.cub", labelPath2, *isdPath2, "rw");
@@ -337,7 +337,7 @@ namespace Isis {
               {36, 1},
               {31, 1}};
     poly.Create(coords);
-    cube2->write(*(poly.toBlob()));
+    cube2->write(poly);
 
     cube3 = new Cube();
     cube3->fromIsd(tempDir.path() + "/cube3.cub", labelPath3, *isdPath3, "rw");

--- a/isis/tests/FunctionalTestsFindImageOverlaps.cpp
+++ b/isis/tests/FunctionalTestsFindImageOverlaps.cpp
@@ -31,7 +31,7 @@ static QString APP_XML = FileName("$ISISROOT/bin/xml/findimageoverlaps.xml").exp
 TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapsNoOverlap) {
   ImagePolygon fp1;
   fp1.Create(*cube1);
-  cube1->write(*(fp1.toBlob()));
+  cube1->write(fp1);
 
   Cube newCube2;
   json newIsd2;
@@ -43,7 +43,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapsNoOverlap) {
 
   ImagePolygon fp2;
   fp2.Create(newCube2);
-  newCube2.write(*(fp2.toBlob()));
+  newCube2.write(fp2);
 
   FileList cubes;
   cubes.append(cube1->fileName());
@@ -115,7 +115,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestFindImageOverlapFullOverlap) {
             {34, 1},
             {31, 1}};
   poly.Create(coords);
-  cube2->write(*(poly.toBlob()));
+  cube2->write(poly);
   cube2->reopen("rw");
 
   QVector<QString> args = {"OVERLAPLIST=" + tempDir.path() + "/overlaps.txt", "detailed=true", "errors=true"};

--- a/isis/tests/FunctionalTestsOverlapstats.cpp
+++ b/isis/tests/FunctionalTestsOverlapstats.cpp
@@ -57,7 +57,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestOverlapstatsDefault) {
             {35, 0},
             {30, 0}};
   poly.Create(coords);
-  cube3->write(*(poly.toBlob()));
+  cube3->write(poly);
   cube3->reopen("rw");
 
   FileList cubes;
@@ -113,7 +113,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestOverlapstatsFull) {
             {34, 1},
             {31, 1}};
   poly.Create(coords);
-  cube2->write(*(poly.toBlob()));
+  cube2->write(poly);
   cube2->reopen("rw");
 
   FileList cubes;
@@ -167,7 +167,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestOverlapstatsNoOverlap) {
             {40, 50},
             {50, 50}};
   poly.Create(coords);
-  cube3->write(*(poly.toBlob()));
+  cube3->write(poly);
   cube3->reopen("rw");
 
   FileList cubes;

--- a/isis/tests/FunctionalTestsSpiceinit.cpp
+++ b/isis/tests/FunctionalTestsSpiceinit.cpp
@@ -536,7 +536,7 @@ TEST_F(DefaultCube, TestSpiceinitCsmCleanup) {
   spiceinit(testCube, options);
 
   EXPECT_FALSE(testCube->hasGroup("CsmInfo"));
-  EXPECT_FALSE(testCube->hasBlob("String", "CSMState"));
+  EXPECT_FALSE(testCube->hasBlob("CSMState", "String"));
 }
 
 TEST_F(DefaultCube, TestSpiceinitCsmNoCleanup) {
@@ -553,7 +553,7 @@ TEST_F(DefaultCube, TestSpiceinitCsmNoCleanup) {
   ASSERT_ANY_THROW(spiceinit(testCube, options));
 
   EXPECT_TRUE(testCube->hasGroup("CsmInfo"));
-  EXPECT_TRUE(testCube->hasBlob("String", "CSMState"));
+  EXPECT_TRUE(testCube->hasBlob("CSMState", "String"));
 }
 
 TEST_F(DemCube, FunctionalTestSpiceinitWebAndShapeModel) {
@@ -700,7 +700,7 @@ TEST_F(SmallCube, FunctionalTestSpiceinitCsminitRestorationOnFail) {
   Cube outputCube(cubeFile);
 
   ASSERT_NO_THROW(outputCube.camera());
-  EXPECT_TRUE(outputCube.hasBlob("String", "CSMState"));
+  EXPECT_TRUE(outputCube.hasBlob("CSMState", "String"));
   ASSERT_TRUE(outputCube.hasGroup("CsmInfo"));
   EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, csmInfoGroup, outputCube.group("CsmInfo"));
 }

--- a/isis/tests/HistoryTests.cpp
+++ b/isis/tests/HistoryTests.cpp
@@ -33,12 +33,12 @@ TEST_F(HistoryBlob, HistoryTestsAddEntry) {
 TEST_F(HistoryBlob, HistoryTeststoBlob) {
   History history(historyBlob);
 
-  Blob *blob = history.toBlob();
+  Blob blob = history.toBlob();
 
   std::stringstream os;
-  char *blob_buffer = blob->getBuffer();
+  char *blob_buffer = blob.getBuffer();
   Pvl newHistoryPvl;
-  for (int i = 0; i < blob->Size(); i++) {
+  for (int i = 0; i < blob.Size(); i++) {
     os << blob_buffer[i];
   }
   os >> newHistoryPvl;


### PR DESCRIPTION
Made Cube::hadBlob and Cube::deleteBlob consistent with the Blob constructor. Moved all of the writing to be consistent. I experimented with removing the write methods, but because we want to pass the blob by reference, we cannot just do write(blah.toBlob()) because that's an r-value and a not an l-value. So, I instead just made them all write(blah). I also added some docs.