### PR TITLE
Fixed pvl core test config

### DIFF
--- a/isis/src/core/CMakeLists.txt
+++ b/isis/src/core/CMakeLists.txt
@@ -4,7 +4,7 @@ project (core VERSION 0.0.1)
 option(buildStaticCore "Build libisis static as well as dynamic"        OFF )
 option (BUILD_CORE_TESTS "Build core module tests" ON)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 
 # Short and long name of this package
 set(PACKAGE            "CORE")

--- a/isis/src/core/CMakeLists.txt
+++ b/isis/src/core/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 project (core VERSION 0.0.1)
 option(buildStaticCore "Build libisis static as well as dynamic"        OFF )
+option (BUILD_CORE_TESTS "Build core module tests" ON)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
@@ -13,8 +14,45 @@ set(PACKAGE_NAME       "USGS ISIS PVL CORE")
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-FILE(GLOB_RECURSE Pvl_source_files ${PROJECT_SOURCE_DIR}/src *.cpp)
-
+set(Pvl_source_files ${PROJECT_SOURCE_DIR}/src/ArraySubscriptNotInRange.cpp
+                     ${PROJECT_SOURCE_DIR}/src/FileCreate.cpp
+                     ${PROJECT_SOURCE_DIR}/src/FileName.cpp
+                     ${PROJECT_SOURCE_DIR}/src/FileOpen.cpp
+                     ${PROJECT_SOURCE_DIR}/src/FileRead.cpp
+                     ${PROJECT_SOURCE_DIR}/src/FileWrite.cpp
+                     ${PROJECT_SOURCE_DIR}/src/IException.cpp
+                     ${PROJECT_SOURCE_DIR}/src/IString.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordAmbiguous.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordBlockEndMissing.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordBlockInvalid.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordBlockStartMissing.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordDuplicated.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordNotArray.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordNotFound.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordUnrecognized.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordValueBad.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordValueExpected.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordValueNotInList.cpp
+                     ${PROJECT_SOURCE_DIR}/src/KeywordValueNotInRange.cpp
+                     ${PROJECT_SOURCE_DIR}/src/LabelTranslationManager.cpp
+                     ${PROJECT_SOURCE_DIR}/src/MemoryAllocationFailed.cpp
+                     ${PROJECT_SOURCE_DIR}/src/MissingDelimiter.cpp
+                     ${PROJECT_SOURCE_DIR}/src/Preference.cpp
+                     ${PROJECT_SOURCE_DIR}/src/Pvl.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlContainer.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlFlatMap.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlFormat.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlFormatPds.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlGroup.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlKeyword.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlObject.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlSequence.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlToPvlTranslationManager.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlToXmlTranslationManager.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlToken.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlTokenizer.cpp
+                     ${PROJECT_SOURCE_DIR}/src/PvlTranslationTable.cpp
+                     ${PROJECT_SOURCE_DIR}/src/TextFile.cpp)
 # Define a target
 add_library(core "${Pvl_source_files}")
 
@@ -45,16 +83,6 @@ find_package(Geos REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(CSPICE    65      REQUIRED)
 
-#include_directories(SYSTEM
-#                    ${Qt5Widgets_INCLUDE_DIRS}
-#                    ${Qt5Concurrent_INCLUDE_DIRS}
-#                    ${Qt5Network_INCLUDE_DIRS}
-#                    ${Qt5Xml_INCLUDE_DIRS}
-#                    ${CSPICE_INCLUDE_DIR}
-#                    ${JSON_INCLUDE_DIR})
-#include_directories(${CMAKE_BINARY_DIR}/inc)
-#link_directories(${JSON_LIBRARY} ${CSPICE_LIBRARY} {Qt5_Library})
-
 target_link_libraries(core PUBLIC Qt5::Core
                                   Qt5::Concurrent
                                   Qt5::Widgets
@@ -66,3 +94,8 @@ target_link_libraries(core PUBLIC ${GEOS_LIBRARY} ${CSPICE_LIBRARY})
 target_include_directories(core PUBLIC ${GEOS_INCLUDE_DIR} ${CSPICE_INCLUDE_DIR})
 install(DIRECTORY ${PROJECT_SOURCE_DIR}/include DESTINATION  ${CMAKE_INSTALL_PREFIX}/include/isis)
 install(TARGETS core DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+
+if (BUILD_CORE_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/isis/src/core/cmake/gtest.cmake
+++ b/isis/src/core/cmake/gtest.cmake
@@ -1,5 +1,5 @@
 if (NOT TARGET gtest)
-  set(GOOGLETEST_ROOT ${CMAKE_SOURCE_DIR}/../../../gtest/googletest CACHE STRING "Google Test source root")
+  set(GOOGLETEST_ROOT ${PROJECT_SOURCE_DIR}/../../../gtest/googletest CACHE STRING "Google Test source root")
 
   include_directories(SYSTEM
       ${GOOGLETEST_ROOT}
@@ -19,7 +19,7 @@ if (NOT TARGET gtest)
 endif()
 
 if (NOT TARGET gmock)
-  set(GOOGLEMOCK_ROOT ${CMAKE_SOURCE_DIR}/../../../gtest/googlemock CACHE STRING "Google Mock source root")
+  set(GOOGLEMOCK_ROOT ${PROJECT_SOURCE_DIR}/../../../gtest/googlemock CACHE STRING "Google Mock source root")
 
   include_directories(SYSTEM
       ${GOOGLEMOCK_ROOT}

--- a/isis/src/core/cmake/gtest.cmake
+++ b/isis/src/core/cmake/gtest.cmake
@@ -1,0 +1,39 @@
+if (NOT TARGET gtest)
+  set(GOOGLETEST_ROOT ${CMAKE_SOURCE_DIR}/../../../gtest/googletest CACHE STRING "Google Test source root")
+
+  include_directories(SYSTEM
+      ${GOOGLETEST_ROOT}
+      ${GOOGLETEST_ROOT}/include
+      )
+
+  set(GOOGLETEST_SOURCES
+      ${GOOGLETEST_ROOT}/src/gtest-all.cc
+      ${GOOGLETEST_ROOT}/src/gtest_main.cc
+      )
+
+  foreach(_source ${GOOGLETEST_SOURCES})
+      set_source_files_properties(${_source} PROPERTIES GENERATED 1)
+  endforeach()
+
+  add_library(gtest ${GOOGLETEST_SOURCES})
+endif()
+
+if (NOT TARGET gmock)
+  set(GOOGLEMOCK_ROOT ${CMAKE_SOURCE_DIR}/../../../gtest/googlemock CACHE STRING "Google Mock source root")
+
+  include_directories(SYSTEM
+      ${GOOGLEMOCK_ROOT}
+      ${GOOGLEMOCK_ROOT}/include
+      )
+
+  set(GOOGLEMOCK_SOURCES
+      ${GOOGLEMOCK_ROOT}/src/gmock-all.cc
+      ${GOOGLEMOCK_ROOT}/src/gmock_main.cc
+      )
+
+  foreach(_source ${GOOGLEMOCK_SOURCES})
+      set_source_files_properties(${_source} PROPERTIES GENERATED 1)
+  endforeach()
+
+  add_library(gmock ${GOOGLEMOCK_SOURCES})
+endif()

--- a/isis/src/core/tests/CMakeLists.txt
+++ b/isis/src/core/tests/CMakeLists.txt
@@ -1,11 +1,17 @@
 cmake_minimum_required(VERSION 3.10)
 
-file(GLOB test_source "${CMAKE_SOURCE_DIR}/tests/*.cpp")
+find_package(Threads)
+
+include(../cmake/gtest.cmake)
+include(GoogleTest)
+
+set(test_source ${CMAKE_SOURCE_DIR}/tests/ConstantsTests.cpp
+                ${CMAKE_SOURCE_DIR}/tests/IsisCoreTestMain.cpp)
 
 # Link runISISTests with what we want to test and the GTest and pthread library
 add_executable(runISISCoreTests
                ${test_source})
 
-target_link_libraries(runISISCoreTests core ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} Threads::Threads)
+target_link_libraries(runISISCoreTests core gtest Threads::Threads)
 
 gtest_discover_tests(runISISCoreTests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)

--- a/isis/src/core/tests/CMakeLists.txt
+++ b/isis/src/core/tests/CMakeLists.txt
@@ -5,8 +5,8 @@ find_package(Threads)
 include(../cmake/gtest.cmake)
 include(GoogleTest)
 
-set(test_source ${CMAKE_SOURCE_DIR}/tests/ConstantsTests.cpp
-                ${CMAKE_SOURCE_DIR}/tests/IsisCoreTestMain.cpp)
+set(test_source ${PROJECT_SOURCE_DIR}/tests/ConstantsTests.cpp
+                ${PROJECT_SOURCE_DIR}/tests/IsisCoreTestMain.cpp)
 
 # Link runISISTests with what we want to test and the GTest and pthread library
 add_executable(runISISCoreTests
@@ -14,4 +14,4 @@ add_executable(runISISCoreTests
 
 target_link_libraries(runISISCoreTests core gtest Threads::Threads)
 
-gtest_discover_tests(runISISCoreTests WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/tests)
+gtest_discover_tests(runISISCoreTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests)


### PR DESCRIPTION
This sets up the PVL core tests so that they both properly build and link gtest if it's not already available and they can be enabled/disabled.