### PR TITLE
Isis core, Pvl Swig wrapper

### DIFF
--- a/isis/src/core/include/PvlContainer.h
+++ b/isis/src/core/include/PvlContainer.h
@@ -62,6 +62,7 @@ namespace Isis {
    */
   class PvlContainer {
     public:
+      PvlContainer() = default;
       PvlContainer(const QString &type);
       PvlContainer(const QString &type, const QString &name);
       PvlContainer(const PvlContainer &other);

--- a/isis/src/core/swig/isispvl.i
+++ b/isis/src/core/swig/isispvl.i
@@ -1,9 +1,50 @@
 %module isispvl
-%include "pvlKeyword.i"
+%{
+    #include <string>
+    #include <sstream>
+    #include "Pvl.h"
+%}
 
 %include std_string.i
 %include std_vector.i
 %include exception.i
+
+%include "pvlKeyword.i"
+%include "PvlContainer.h"
+%include "pvlGroup.i"
+
+%include "pvlObject.i"
+%nodefaultdtor Isis::PvlObject;
+
+%include "Pvl.h"
+%nodefaultdtor Isis::Pvl;
+
+%extend Isis::Pvl {
+  const char* __str__() {
+    std::ostringstream out;
+    out << *$self;
+    std::string str = out.str();
+    char * cstr = new char [str.length()+1];
+    std::strcpy (cstr, str.c_str());
+    return cstr;
+  }
+
+  Pvl(const char* file) {
+    QString qfile(file);
+    Isis::Pvl *pvl = new Isis::Pvl(qfile);
+    return pvl;
+  }
+
+  void read(const char* file) {
+    QString qfile(file);
+    $self->read(qfile);
+  }
+
+  void write(const char* file) {
+    QString qfile(file);
+    $self->write(qfile);
+  }
+}
 
 class QString
 {

--- a/isis/src/core/swig/pvlGroup.i
+++ b/isis/src/core/swig/pvlGroup.i
@@ -1,0 +1,23 @@
+%module(package="isispvl") PvlGroup
+%{
+    #include "PvlGroup.h"
+%}
+
+%include "PvlGroup.h"
+
+%extend Isis::PvlGroup {
+  const char* __str__() {
+    std::ostringstream out;
+    out << *$self;
+    std::string str = out.str();
+    char * cstr = new char [str.length()+1];
+    std::strcpy (cstr, str.c_str());
+    return cstr;
+  }
+
+  PvlGroup(const char* groupName) {
+    QString qgroupName(groupName);
+    Isis::PvlGroup *group = new Isis::PvlGroup(qgroupName);
+    return group;
+  }
+}

--- a/isis/src/core/swig/pvlKeyword.i
+++ b/isis/src/core/swig/pvlKeyword.i
@@ -3,11 +3,19 @@
     #include "PvlKeyword.h"
 %}
 
-
 %include "PvlKeyword.h"
 
-%extend Isis::PvlKeyword{
-  PvlKeyword(const char* key, const char* val){
+%extend Isis::PvlKeyword {
+  const char* __str__() {
+    std::ostringstream out;
+    out << *$self;
+    std::string str = out.str();
+    char * cstr = new char [str.length()+1];
+    std::strcpy (cstr, str.c_str());
+    return cstr;
+  }
+
+  PvlKeyword(const char* key, const char* val) {
             QString qkey(key);
             QString qval(val);
             Isis::PvlKeyword *kw = new Isis::PvlKeyword(qkey, qval);

--- a/isis/src/core/swig/pvlObject.i
+++ b/isis/src/core/swig/pvlObject.i
@@ -1,0 +1,23 @@
+%module(package="isispvl") PvlObject
+%{
+    #include "PvlObject.h"
+%}
+
+%include "PvlObject.h"
+
+%extend Isis::PvlObject {
+  const char* __str__() {
+    std::ostringstream out;
+    out << *$self;
+    std::string str = out.str();
+    char * cstr = new char [str.length()+1];
+    std::strcpy (cstr, str.c_str());
+    return cstr;
+  }
+
+  PvlObject(const char* objectName) {
+    QString qobjectName(objectName);
+    Isis::PvlObject *object = new Isis::PvlObject(qobjectName);
+    return object;
+  }
+}

--- a/isis/src/core/swig/python/CMakeLists.txt
+++ b/isis/src/core/swig/python/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_SWIG_FLAGS "")
 set(CMAKE_SWIG_OUTDIR isispvl)
 message(">>>> ${CMAKE_SWIG_OUTDIR}")
 set_source_files_properties(../isispvl.i
-                            PROPERTIES CPLUSPLUS ON)
+                            PROPERTIES CPLUSPLUS ON SWIG_FLAGS "-py3")
 
 #Find dependencies
 message(">>>> ${PROJECT_SOURCE_DIR}")
@@ -16,7 +16,7 @@ find_path(PVL_INCLUDE_DIR NAMES Pvl.h
                           PATH_SUFFIXES include
                           PATHS ${PROJECT_SOURCE_DIR}/)
 find_library(PVL_LIBRARY NAMES core
-            PATHS ${CMAKE_SOURCE_DIR}/../build/objects/core/)
+             PATHS ${CMAKE_SOURCE_DIR}/../build/objects/core/)
 message("-- Found PVL Include: ${PVL_INCLUDE_DIR}")
 message("-- Found PVL Lib: ${PVL_LIBRARY}")
 include_directories(${PVL_INCLUDE_DIR})


### PR DESCRIPTION
Adds the ability to build a swig wrapper over the core module in ISIS.

## Description
Exposes the Pvl components of ISIS using a swig wrapper to generate the python interface layer. Currently a little rough to generate but it can be done.

## Related Issue
N/A

## Motivation and Context
Part of the Pvl blob refactor

## How Has This Been Tested?
Individual testing on a local mac system

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
