### PR TITLE
Added writing string to a blob interface to enforce including a null terminator

### DIFF
--- a/isis/src/base/apps/csminit/csminit.cpp
+++ b/isis/src/base/apps/csminit/csminit.cpp
@@ -411,7 +411,7 @@ namespace Isis {
 
     // Create our CSM State blob as a string and add the CSM string to the Blob.
     Blob csmStateBlob("CSMState", "String");
-    csmStateBlob.setData(modelState.c_str(), modelState.size());
+    csmStateBlob.setData(modelState);
     PvlObject &blobLabel = csmStateBlob.Label();
     blobLabel += PvlKeyword("ModelName", modelName);
     blobLabel += PvlKeyword("PluginName", pluginName);

--- a/isis/src/base/objs/Blob/Blob.cpp
+++ b/isis/src/base/objs/Blob/Blob.cpp
@@ -370,6 +370,18 @@ namespace Isis {
 
 
   /**
+   * Store a string in the BLOB.
+   *
+   * This function will copy the string as a null terminated C String.
+   *
+   * @param data The string to store in the BLOB.
+   */
+  void Blob::setData(const string data) {
+    setData(data.c_str(), data.size() + 1); // Add 1 to get the null terminator
+  }
+
+
+  /**
    * Set the data stored in the BLOB.
    *
    * This function will copy the data buffer, if you want to avoid that use

--- a/isis/src/base/objs/Blob/Blob.h
+++ b/isis/src/base/objs/Blob/Blob.h
@@ -77,6 +77,7 @@ namespace Isis {
 
 
       char *getBuffer();
+      void setData(const std::string data);
       void setData(const char *buffer, int nbytes);
       void takeData(char *buffer, int nbytes);
 

--- a/isis/src/base/objs/Blob/Blob.h
+++ b/isis/src/base/objs/Blob/Blob.h
@@ -45,6 +45,11 @@ namespace Isis {
    *                           in very large cubes.  This was caused by calling the wrong number
    *                           to string conversion function.  Introduced when refactoring the
    *                           IString class.  Fixes #1388.
+   *   @history 2021-03-08 Jesse Mapel, Adam Paquette, and Austin Sanders - Refactored
+   *                           subclasses to use Blob as an intermediate storage object
+   *                           when writing to cubes instead of inheriting from Blob. Added
+   *                           several new methods to more easily pass data in and out of
+   *                           Blob objects.
    *
    * @todo Write class description, history, etc.
    */

--- a/isis/src/base/objs/CSMCamera/CSMCamera.cpp
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.cpp
@@ -57,7 +57,7 @@ namespace Isis {
     PvlObject &blobLabel = state.Label();
     QString pluginName = blobLabel.findKeyword("PluginName")[0];
     QString modelName = blobLabel.findKeyword("ModelName")[0];
-    QString stateString = QString::fromUtf8(state.getBuffer(), state.Size());
+    QString stateString(state.getBuffer());
     init(cube, pluginName, modelName, stateString);
   }
 

--- a/isis/src/base/objs/CubeStretch/CubeStretch.cpp
+++ b/isis/src/base/objs/CubeStretch/CubeStretch.cpp
@@ -60,8 +60,7 @@ namespace Isis {
    * @param blob The Blob to read data from.
    */
   CubeStretch::CubeStretch(Blob blob) : Stretch() {
-    char *buff = blob.getBuffer();
-    std::string stringFromBuffer(buff, blob.Size());
+    std::string stringFromBuffer(blob.getBuffer());
     setName(blob.Label()["Name"][0]);
     setType(blob.Label()["StretchType"][0]);
     Parse(QString::fromStdString(stringFromBuffer));
@@ -88,7 +87,7 @@ namespace Isis {
     blob.Label() += PvlKeyword("StretchType", getType());
     blob.Label() += PvlKeyword("BandNumber", QString::number(getBandNumber()));
     std::string blobString = Text().toStdString();
-    blob.setData(blobString.c_str(), blobString.size());
+    blob.setData(blobString);
     return blob;
   }
 

--- a/isis/src/base/objs/History/History.cpp
+++ b/isis/src/base/objs/History/History.cpp
@@ -77,7 +77,7 @@ namespace Isis {
     if (p_bufferSize > 0) ostr << std::endl;
     ostr << p_history;
     string histStr = ostr.str();
-    int bytes = histStr.size();
+    int bytes = histStr.size() + 1; // Add 1 for the null terminator
 
     int blobBufferSize = p_bufferSize+bytes;
     char *blobBuffer = new char[blobBufferSize];

--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
@@ -64,7 +64,7 @@ namespace Isis {
    *
    */
   ImagePolygon::ImagePolygon(Blob &blob) : ImagePolygon() {
-    p_polyStr = string(blob.getBuffer(), blob.Size());
+    p_polyStr = string(blob.getBuffer());
 
     geos::io::WKTReader *wkt = new geos::io::WKTReader(&(*globalFactory));
     p_polygons = PolygonTools::MakeMultiPolygon(wkt->read(p_polyStr));
@@ -1357,7 +1357,7 @@ namespace Isis {
     delete wkt;
 
     Blob newBlob("Footprint", "Polygon");
-    newBlob.setData(polyStr.c_str(), polyStr.size());
+    newBlob.setData(polyStr);
     return newBlob;
   }
 

--- a/isis/src/base/objs/OriginalLabel/OriginalLabel.cpp
+++ b/isis/src/base/objs/OriginalLabel/OriginalLabel.cpp
@@ -84,7 +84,7 @@ namespace Isis {
     sstream << m_originalLabel;
     string orglblStr = sstream.str();
     Isis::Blob blob("IsisCube", "OriginalLabel");
-    blob.setData(orglblStr.c_str(), orglblStr.size());
+    blob.setData(orglblStr);
     return blob;
   }
 

--- a/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
+++ b/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
@@ -80,7 +80,7 @@ namespace Isis {
     sstream << m_originalLabel.toString();
     string orglblStr = sstream.str();
     Isis::Blob blob("IsisCube", "OriginalXmlLabel");
-    blob.setData((char*)orglblStr.data(), orglblStr.length());
+    blob.setData(orglblStr);
     blob.Label() += Isis::PvlKeyword("ByteOrder", "NULL");
     if (Isis::IsLsb()) {
       blob.Label()["ByteOrder"] = Isis::ByteOrderName(Isis::Lsb);

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -523,7 +523,7 @@ namespace Isis {
   void GalileoSsiCube::SetUp() {
     DefaultCube::SetUp();
 
-    // Change default dims 
+    // Change default dims
     PvlGroup &dim = label.findObject("IsisCube").findObject("Core").findGroup("Dimensions");
     dim.findKeyword("Samples").setValue("800");
     dim.findKeyword("Lines").setValue("800");
@@ -538,7 +538,7 @@ namespace Isis {
     PvlGroup &kernels = testCube->label()->findObject("IsisCube").findGroup("Kernels");
     kernels.findKeyword("NaifFrameCode").setValue("-77001");
     PvlGroup &inst = testCube->label()->findObject("IsisCube").findGroup("Instrument");
-    
+
     std::istringstream iss(R"(
       Group = Instrument
         SpacecraftName            = "Galileo Orbiter"
@@ -596,7 +596,7 @@ namespace Isis {
         INS-77001_BORESIGHT_LINE   = 400.0
       End_Object
     )");
-    
+
     PvlObject newNaifKeywords;
     nk >> newNaifKeywords;
     naifKeywords = newNaifKeywords;
@@ -611,8 +611,8 @@ namespace Isis {
     End_Group
     )");
 
-    PvlGroup &archive = testCube->label()->findObject("IsisCube").findGroup("Archive"); 
-    PvlGroup newArchive; 
+    PvlGroup &archive = testCube->label()->findObject("IsisCube").findGroup("Archive");
+    PvlGroup newArchive;
     ar >> newArchive;
     archive = newArchive;
 
@@ -974,8 +974,8 @@ namespace Isis {
 
     FileName newCube(tempDir.path() + "/testing.cub");
 
-    testCube->fromIsd(newCube, label, isd, "rw");    
-    
+    testCube->fromIsd(newCube, label, isd, "rw");
+
     PvlGroup &kernels = testCube->label()->findObject("IsisCube").findGroup("Kernels");
     kernels.findKeyword("NaifFrameCode").setValue(ikid);
     kernels["ShapeModel"] = "Null";
@@ -1013,8 +1013,8 @@ namespace Isis {
     bandBin = newBandBin;
 
     json nk;
-    nk["BODY2101955_RADII"] =  {2825, 2675, 254}; 
-    nk["INS"+ikid.toStdString()+"_FOCAL_LENGTH"] = 630.0; 
+    nk["BODY2101955_RADII"] =  {2825, 2675, 254};
+    nk["INS"+ikid.toStdString()+"_FOCAL_LENGTH"] = 630.0;
     nk["INS"+ikid.toStdString()+"_PIXEL_SIZE"] = 8.5;
     nk["CLOCK_ET_-64_1/0600694569.00000_COMPUTED"] = "8ed6ae8930f3bd41";
     nk["INS"+ikid.toStdString()+"_TRANSX"] = {0.0, 0.0085, 0.0};
@@ -1023,12 +1023,12 @@ namespace Isis {
     nk["INS"+ikid.toStdString()+"_ITRANSL"] = {0.0, 0.0, -117.64705882353};
     nk["INS"+ikid.toStdString()+"_CCD_CENTER"] = {511.5, 511.5};
     nk["BODY_FRAME_CODE"] = 2101955;
-    
+
     PvlObject &naifKeywords = testCube->label()->findObject("NaifKeywords");
     PvlObject newNaifKeywords("NaifKeywords", nk);
     naifKeywords = newNaifKeywords;
 
-    QString fileName = testCube->fileName();  
+    QString fileName = testCube->fileName();
     delete testCube;
     testCube = new Cube(fileName, "rw");
  }
@@ -1086,7 +1086,7 @@ namespace Isis {
 
     // CSMState BLOB
     Blob csmStateBlob("CSMState", "String");
-    csmStateBlob.setData(mockModelName.c_str(), mockModelName.size());
+    csmStateBlob.setData(mockModelName);
     csmStateBlob.Label() += PvlKeyword("ModelName", QString::fromStdString(mockModelName));
     csmStateBlob.Label() += PvlKeyword("PluginName", QString::fromStdString(loadablePlugin.getPluginName()));
     testCube->write(csmStateBlob);
@@ -1186,7 +1186,7 @@ namespace Isis {
     std::string histStr = ostr.str();
 
     historyBlob = Blob("IsisCube", "History");
-    historyBlob.setData(histStr.c_str(), histStr.size());
+    historyBlob.setData(histStr);
   }
 
 

--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -96,7 +96,7 @@ TEST_F(CSMPluginFixture, CSMInitDefault) {
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
-  std::string modelState(stateString.getBuffer(), stateString.Size());
+  std::string modelState(stateString.getBuffer());
   EXPECT_TRUE(plugin->canModelBeConstructedFromState(modelName, modelState));
 
   // Check blob label ModelName and Plugin Name
@@ -168,7 +168,7 @@ TEST_F(CSMPluginFixture, CSMInitRunTwice) {
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
-  std::string modelState(stateString.getBuffer(), stateString.Size());
+  std::string modelState(stateString.getBuffer());
   EXPECT_TRUE(plugin->canModelBeConstructedFromState(modelName, modelState));
 
   // Make sure there is only one CSMState Blob on the label
@@ -224,7 +224,7 @@ TEST_F(CSMPluginFixture, CSMInitMultiplePossibleModels) {
 
   // Check that the plugin can create a model from the state string
   std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
-  std::string modelState(stateString.getBuffer(), stateString.Size());
+  std::string modelState(stateString.getBuffer());
   EXPECT_TRUE(plugin->canModelBeConstructedFromState(modelName, modelState));
 
   // check blob label ModelName and Plugin Name
@@ -469,7 +469,7 @@ TEST_F(CSMPluginFixture, CSMInitWithState) {
   testCube->close();
 
   // Write the state out to a file
-  std::string stateBefore(state.getBuffer(), state.Size());
+  std::string stateBefore(state.getBuffer());
   QString statePath = tempDir.path() + "/state.json";
   std::ofstream stateFile(statePath.toStdString());
   stateFile << stateBefore;
@@ -490,6 +490,6 @@ TEST_F(CSMPluginFixture, CSMInitWithState) {
 
   Blob stateBlobAfter("CSMState", "String");
   testCube->read(stateBlobAfter);
-  std::string stateAfter(stateBlobAfter.getBuffer(), stateBlobAfter.Size());
+  std::string stateAfter(stateBlobAfter.getBuffer());
   EXPECT_EQ(stateBefore, stateAfter);
 }

--- a/isis/tests/HistoryTests.cpp
+++ b/isis/tests/HistoryTests.cpp
@@ -30,6 +30,40 @@ TEST_F(HistoryBlob, HistoryTestsAddEntry) {
   EXPECT_TRUE(newHistoryPvl.findObject("mroctx2isis").hasGroup("UserParameters"));
 }
 
+TEST_F(HistoryBlob, HistoryTestsAddSecondEntry) {
+  History history(historyBlob);
+
+  std::istringstream hss(R"(
+      Object = ctxcal
+        IsisVersion       = "4.1.0  | 2020-07-01"
+        ProgramVersion    = 2016-06-10
+        ProgramPath       = /Users/acpaquette/repos/ISIS3/build/bin
+        ExecutionDateTime = 2020-07-01T16:48:40
+        HostName          = Unknown
+        UserName          = acpaquette
+        Description       = "Import an MRO CTX image as an Isis cube"
+
+        Group = UserParameters
+          FROM    = /Users/acpaquette/Desktop/J03_045994_1986_XN_18N282W_isis.cub
+          TO      = /Users/acpaquette/Desktop/J03_045994_1986_XN_18N282W_isis.cal.cub
+        End_Group
+      End_Object)");
+
+  PvlObject secondHistoryPvl;
+  hss >> secondHistoryPvl;
+
+  history.AddEntry(secondHistoryPvl);
+
+  Blob blob = history.toBlob();
+
+  History reingestedHistory(blob);
+
+  Pvl newHistoryPvl = reingestedHistory.ReturnHist();
+
+  ASSERT_TRUE(newHistoryPvl.hasObject("ctxcal"));
+  EXPECT_TRUE(newHistoryPvl.findObject("ctxcal").hasGroup("UserParameters"));
+}
+
 TEST_F(HistoryBlob, HistoryTeststoBlob) {
   History history(historyBlob);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Added an extra setData method to Blob to take a string as many different things serialize to a string and then a blob. This way, we only have to enforce the inclusion of the null terminator in one place.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#4082

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

We were having some strange behavior with the strings not being copied and cleaned up correctly in places.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on Ubuntu and added an extra History test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
