### PR TITLE
Added Kaguya instrument serial number support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,6 @@ release.
 
 ## [Unreleased]
 
-- Fixed issue where serial numbers for Kaguya TC and MI image could not be generated. [4235](https://github.com/USGS-Astrogeology/ISIS3/issues/4235)
-
 
 ### Added
 - The following calibration applications were updated to not require local mission-specific SPICE kernels when working with spiceinited cubes: amicacal, ctxcal, lrowaccal, moccal, mdiscal, hical, hicalbeta, vikcal, and gllssical. This makes it possible to first run spiceinit using the spice server and then run these calibration applications without ever needing to download mission-specific kernels. If spiceinit has not been run on the input cube, these apps will still require the kernels area to run. [#4303](https://github.com/USGS-Astrogeology/ISIS3/issues/4303)
@@ -47,6 +45,7 @@ release.
 ### Fixed
 
 - Fixed relative paths not being properly converted to absolute paths in isisVarInit.py [4274](https://github.com/USGS-Astrogeology/ISIS3/issues/4274)
+- Fixed issue where serial numbers for Kaguya TC and MI image could not be generated. [4235](https://github.com/USGS-Astrogeology/ISIS3/issues/4235)
 
 ## [4.4.0] - 2021-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+- Fixed issue where serial numbers for Kaguya TC and MI image could not be generated. [4235](https://github.com/USGS-Astrogeology/ISIS3/issues/4235)
+
+
 ### Added
 - The following calibration applications were updated to not require local mission-specific SPICE kernels when working with spiceinited cubes: amicacal, ctxcal, lrowaccal, moccal, mdiscal, hical, hicalbeta, vikcal, and gllssical. This makes it possible to first run spiceinit using the spice server and then run these calibration applications without ever needing to download mission-specific kernels. If spiceinit has not been run on the input cube, these apps will still require the kernels area to run. [#4303](https://github.com/USGS-Astrogeology/ISIS3/issues/4303)
 - Added the new csminit application and CSM Library loading to the IsisPreferences file. Together these allow users to get CSM state strings from ISD files. Once CSM camera model support is added, these will be used to setup a Cube to use a CSM camera model.
@@ -52,7 +55,7 @@ release.
 - Added warning to ocams2isis about the model being out of date. [#4200](https://github.com/USGS-Astrogeology/ISIS3/issues/4200)
 - Added documentation to lronaccal and lrowaccal to describe why there are negative DNs in I/F calibrated images. [#3860](https://github.com/USGS-Astrogeology/ISIS3/issues/3860)
 - Update qview MeasureTool to add an option to calculate distances using RA/DEC and update qview to show DEC/RA rather than LAT/LON in lower-right corner [#3371](https://github.com/USGS-Astrogeology/ISIS3/issues/3371)
-- Updated spiceinit so that a user can specify a shape model and use the spice web service without any errors. [#1986](https://github.com/USGS-Astrogeology/ISIS3/issues/1986) 
+- Updated spiceinit so that a user can specify a shape model and use the spice web service without any errors. [#1986](https://github.com/USGS-Astrogeology/ISIS3/issues/1986)
 
 ### Fixed
 
@@ -69,7 +72,7 @@ release.
  - The isis3VarInit script is now just called isisVarInit and allows for more robust paths. [#3945](https://github.com/USGS-Astrogeology/ISIS3/pull/3945)
  - Isis2raw will now output straight to a 32bit file (no stretch) when stretch is set to None and bittype is set to 32bit. [#3878](https://github.com/USGS-Astrogeology/ISIS3/issues/3878)
  - Findimageoverlaps can now have calculations and writes happen at the same time or sequentially. [#4047](https://github.com/USGS-Astrogeology/ISIS3/pull/4047)
- - IsisPreferences has had the default path to Osirisrex updated to point to new kernels released by NAIF [#4060](https://github.com/USGS-Astrogeology/ISIS3/issues/4060) 
+ - IsisPreferences has had the default path to Osirisrex updated to point to new kernels released by NAIF [#4060](https://github.com/USGS-Astrogeology/ISIS3/issues/4060)
 
 ### Fixed
 

--- a/isis/appdata/serialnumbers/KaguyaMiSerialNumber.trn
+++ b/isis/appdata/serialnumbers/KaguyaMiSerialNumber.trn
@@ -1,0 +1,32 @@
+ObservationKeys = 3
+
+Group = Keyword1
+  Auto
+  InputKey       = SpacecraftName
+  InputGroup     = "IsisCube,Instrument"
+  InputPosition  = (IsisCube, Instrument)
+  OutputName     = Keyword1
+  OutputPosition = (Group, SerialNumberKeywords)
+  Translation    = (*, *)
+End_Group
+
+Group = Keyword2
+  Auto
+  InputKey       = InstrumentId
+  InputGroup     = "IsisCube,Instrument"
+  InputPosition  = (IsisCube, Instrument)
+  OutputName     = Keyword2
+  OutputPosition = (Group, SerialNumberKeywords)
+  Translation    = (*, *)
+End_Group
+
+Group = Keyword3
+  Auto
+  InputKey       = StartTime
+  InputGroup     = "IsisCube,Instrument"
+  InputPosition  = (IsisCube, Instrument)
+  OutputName     = Keyword3
+  OutputPosition = (Group, SerialNumberKeywords)
+  Translation    = (*, *)
+End_Group
+End

--- a/isis/appdata/serialnumbers/KaguyaTcSerialNumber.trn
+++ b/isis/appdata/serialnumbers/KaguyaTcSerialNumber.trn
@@ -1,0 +1,32 @@
+ObservationKeys = 3
+
+Group = Keyword1
+  Auto
+  InputKey       = SpacecraftName
+  InputGroup     = "IsisCube,Instrument"
+  InputPosition  = (IsisCube, Instrument)
+  OutputName     = Keyword1
+  OutputPosition = (Group, SerialNumberKeywords)
+  Translation    = (*, *)
+End_Group
+
+Group = Keyword2
+  Auto
+  InputKey       = InstrumentId
+  InputGroup     = "IsisCube,Instrument"
+  InputPosition  = (IsisCube, Instrument)
+  OutputName     = Keyword2
+  OutputPosition = (Group, SerialNumberKeywords)
+  Translation    = (*, *)
+End_Group
+
+Group = Keyword3
+  Auto
+  InputKey       = StartTime
+  InputGroup     = "IsisCube,Instrument"
+  InputPosition  = (IsisCube, Instrument)
+  OutputName     = Keyword3
+  OutputPosition = (Group, SerialNumberKeywords)
+  Translation    = (*, *)
+End_Group
+End

--- a/isis/appdata/serialnumbers/KaguyaTcSerialNumber.trn
+++ b/isis/appdata/serialnumbers/KaguyaTcSerialNumber.trn
@@ -17,6 +17,7 @@ Group = Keyword2
   InputPosition  = (IsisCube, Instrument)
   OutputName     = Keyword2
   OutputPosition = (Group, SerialNumberKeywords)
+  Translation    = (TC1, TC)
   Translation    = (*, *)
 End_Group
 

--- a/isis/appdata/translations/Instruments.trn
+++ b/isis/appdata/translations/Instruments.trn
@@ -8,7 +8,7 @@
 # The Group names can NOT be repeated.
 #
 # InputGroup is a comma delimited list of objects and/or
-# groups in the inut label. Traversing this list will
+# groups in the input label. Traversing this list will
 # lead to the correct level to find the output key.
 #
 # InputKey is the keyword within the group which holds

--- a/isis/appdata/translations/Instruments.trn
+++ b/isis/appdata/translations/Instruments.trn
@@ -8,22 +8,21 @@
 # The Group names can NOT be repeated.
 #
 # InputGroup is a comma delimited list of objects and/or
-# groups in the foreign label. Traversing this list will
-# lead to the correct level to find the foreign keyword.
+# groups in the inut label. Traversing this list will
+# lead to the correct level to find the output key.
 #
 # InputKey is the keyword within the group which holds
 # the information.
 #
 # InputDefault is the value used if there is no value for
-# the keyword
+# the keyword in the label
 #
-# Translation is the native and corresponding foreign values.
+# Translation is the output and corresponding input values.
 # Translation may be repeated as needed.
 #
 # This file is used to translate the InstrumentId from the
 # Isis cube Instrument group to an InstrumentName
 #
-# history Jeannie Backer and Adam Goins - Added Kaguya TC.
 
 Group = InstrumentName
 
@@ -84,10 +83,10 @@ Group = InstrumentName
   Translation   = (JunoCam, JNC)
 
   # Kaguya
-  Translation   = (Kaguya, MI-VIS)
-  Translation   = (Kaguya, MI-NIR)
-  Translation   = (Kaguya, TC1)
-  Translation   = (Kaguya, TC2)
+  Translation   = (Mi, MI-VIS)
+  Translation   = (Mi, MI-NIR)
+  Translation   = (Tc, TC1)
+  Translation   = (Tc, TC2)
 
   # LO
   Translation   = (Hrc, "High Resolution Camera")

--- a/isis/src/kaguya/apps/kaguyami2isis/kaguyami2isis.cpp
+++ b/isis/src/kaguya/apps/kaguyami2isis/kaguyami2isis.cpp
@@ -23,8 +23,6 @@ find files of those names at the top level of this repository. **/
 
 using namespace std;
 
-static double range(double x);
-
 namespace Isis {
 
   void kaguyami2isis(UserInterface &ui) {
@@ -147,21 +145,5 @@ namespace Isis {
     outcube->putGroup(kern);
 
     p.EndProcess();
-  }
-
-  double range(double x) {
-    double a,b,c;
-    b = x / 360;
-    if(b > 0) {
-      c = floor(b);
-    }
-    else {
-      c = ceil(b);
-    }
-    a = 360 * (b - c);
-    if(a < 0) {
-      a = a + 360;
-    }
-    return a;
   }
 }


### PR DESCRIPTION
Added/modified the translations files to support Kaguya TC1/2 and MI instruments

Modified Instruments.trn to translate the Kaguya instruments, and added the MI and TC serial number files. 
 
## Related Issue
#4235

## Motivation and Context
Control requires ISIS serial numbers. Without this change serial numbers could not be created.

## How Has This Been Tested?
This was tested with several TC1, TC2, and MI images. The label contents were verified against generated serial number.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
