### PR TITLE
Fixed "About Qview" to point to website documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ release.
 
 - Fixed relative paths not being properly converted to absolute paths in isisVarInit.py [4274](https://github.com/USGS-Astrogeology/ISIS3/issues/4274)
 - Fixed issue where serial numbers for Kaguya TC and MI image could not be generated. [4235](https://github.com/USGS-Astrogeology/ISIS3/issues/4235)
+- Fixed "About Qview" to point to website documentation. [4333](https://github.com/USGS-Astrogeology/ISIS3/issues/4333)
 
 ## [4.4.0] - 2021-02-11
 

--- a/isis/src/base/objs/Gui/Gui.cpp
+++ b/isis/src/base/objs/Gui/Gui.cpp
@@ -883,7 +883,7 @@ namespace Isis {
   void Gui::AboutProgram() {
     Isis::PvlGroup &uig = Isis::Preference::Preferences().findGroup("UserInterface");
     QString command = (QString) uig["GuiHelpBrowser"] +
-                      "http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
+                      " http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
                       Isis::Application::GetUserInterface().ProgramName() + "/" +
                       Isis::Application::GetUserInterface().ProgramName() + ".html";
     ProgramLauncher::RunSystemCommand(command);

--- a/isis/src/base/objs/Gui/Gui.cpp
+++ b/isis/src/base/objs/Gui/Gui.cpp
@@ -882,10 +882,17 @@ namespace Isis {
   // Show help for the current app
   void Gui::AboutProgram() {
     Isis::PvlGroup &uig = Isis::Preference::Preferences().findGroup("UserInterface");
+#if defined(__linux__)
     QString command = (QString) uig["GuiHelpBrowser"] +
                       " http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
                       Isis::Application::GetUserInterface().ProgramName() + "/" +
                       Isis::Application::GetUserInterface().ProgramName() + ".html";
+#elif defined(__APPLE__)
+    QString command = "open -a" + (QString) uig["GuiHelpBrowser"] +
+                      " http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
+                      Isis::Application::GetUserInterface().ProgramName() + "/" +
+                      Isis::Application::GetUserInterface().ProgramName() + ".html";
+#endif
     ProgramLauncher::RunSystemCommand(command);
   }
 

--- a/isis/src/base/objs/Gui/Gui.cpp
+++ b/isis/src/base/objs/Gui/Gui.cpp
@@ -104,21 +104,21 @@ namespace Isis {
       QString style = uiPref["GuiStyle"];
       QApplication::setStyle(style);
     }
-    
-    
+
+
     if (uiPref.hasKeyword("GuiFontName")) {
       QString fontString = uiPref["GuiFontName"];
       QFont font = QFont(fontString);
-      
+
       if (uiPref.hasKeyword("GuiFontSize")) {
         int pointSize = uiPref["GuiFontSize"];
         font.setPointSize(pointSize);
       }
-      
+
       QApplication::setFont(font);
     }
-    
-    
+
+
     // Create the main window
     p_gui = new Gui(ui);
     p_gui->show();
@@ -881,16 +881,11 @@ namespace Isis {
 
   // Show help for the current app
   void Gui::AboutProgram() {
-    Isis::FileName file((QString)
-                        "$ISISROOT/doc/Application/presentation/PrinterFriendly/" +
-                        Isis::Application::GetUserInterface().ProgramName() +
-                        "/" +
-                        Isis::Application::GetUserInterface().ProgramName() +
-                        ".html");
-
     Isis::PvlGroup &uig = Isis::Preference::Preferences().findGroup("UserInterface");
     QString command = (QString) uig["GuiHelpBrowser"] +
-                          (QString)" file:" + file.expanded() + " &";
+                      "http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
+                      Isis::Application::GetUserInterface().ProgramName() + "/" +
+                      Isis::Application::GetUserInterface().ProgramName() + ".html";
     ProgramLauncher::RunSystemCommand(command);
   }
 

--- a/isis/src/base/objs/Gui/Gui.cpp
+++ b/isis/src/base/objs/Gui/Gui.cpp
@@ -874,8 +874,13 @@ namespace Isis {
   // Show help for Isis
   void Gui::AboutIsis() {
     Isis::PvlGroup &uig = Isis::Preference::Preferences().findGroup("UserInterface");
+#if defined(__linux__)
     QString command = (QString) uig["GuiHelpBrowser"] +
                           " http://isis.astrogeology.usgs.gov >> /dev/null &";
+#elif defined(__APPLE__)
+    QString command = "open -a" + (QString) uig["GuiHelpBrowser"] +
+                      " http://isis.astrogeology.usgs.gov >> /dev/null &";
+#endif                  
     ProgramLauncher::RunSystemCommand(command);
   }
 

--- a/isis/src/qisis/apps/qview/qview.xml
+++ b/isis/src/qisis/apps/qview/qview.xml
@@ -7,100 +7,103 @@
 
   <description>
     <p>
-      This program will display cubes and allow for interactive analysis. Although the program 
-      comprises a number of individual tools to perform analysis on your data, only the Spatial 
-      Plot Tool is discussed here until further notice.  
+      This program will display cubes and allow for interactive analysis. Although the program
+      comprises a number of individual tools to perform analysis on your data, only the Spatial
+      Plot Tool is discussed here until further notice.
     </p>
     <h3>Spatial Plot Tool</h3>
     <p>
-      This tool is used for analyzing manually selected pixel DN values. It works with two 
-      different modes: linear and rotated rectangle. It is also capable of handling three different 
-      modes of interpolation: Nearest Neighbor, BiLinear and Cubic Convolution. 
+      This tool is used for analyzing manually selected pixel DN values. It works with two
+      different modes: linear and rotated rectangle. It is also capable of handling three different
+      modes of interpolation: Nearest Neighbor, BiLinear and Cubic Convolution.
     </p>
     <h4>Linear</h4>
     <p>
-      This mode involves drawing a 
-      line across an open cube. The selection is started by clicking and holding the mouse where 
-      you would like to start your calculations, at which point you may drag the mouse in any 
+      This mode involves drawing a
+      line across an open cube. The selection is started by clicking and holding the mouse where
+      you would like to start your calculations, at which point you may drag the mouse in any
       direction and release the click to establish the end of your selection.
     </p>
     <p>
-      The tool calculates the length of the line in pixels, rounding to the nearest full pixel 
-      value. It then divides the actual length of the line by this rounded length to achieve a 
-      step-size. <strong>Please note:</strong> This step size may be slightly bigger or smaller 
-      than a pixel length, but this difference becomes negligible for larger selections. For 
-      example, if the length of the drawn line was 2.91 pixels, the tool would round the length to 
+      The tool calculates the length of the line in pixels, rounding to the nearest full pixel
+      value. It then divides the actual length of the line by this rounded length to achieve a
+      step-size. <strong>Please note:</strong> This step size may be slightly bigger or smaller
+      than a pixel length, but this difference becomes negligible for larger selections. For
+      example, if the length of the drawn line was 2.91 pixels, the tool would round the length to
       3 and the step-size would be 2.91/3 (or 0.97).
     </p>
     <p>
-      A plot window will be generated with the calculated DN values of the pixels. The first value 
-      to be calculated is the value where the original mouse click was made. At each increment, 
-      according to step size, the tool calculates the value along the line until it reaches where the 
-      mouse-click was released. This means that for a line with a rounded length of 3, the plot would show a 
-      total of 4 plotted DN values. <strong>Please note:</strong> For a line with a rounded length of 
+      A plot window will be generated with the calculated DN values of the pixels. The first value
+      to be calculated is the value where the original mouse click was made. At each increment,
+      according to step size, the tool calculates the value along the line until it reaches where the
+      mouse-click was released. This means that for a line with a rounded length of 3, the plot would show a
+      total of 4 plotted DN values. <strong>Please note:</strong> For a line with a rounded length of
       <i>n</i>, the tool will calculate <i>n</i> + 1 values.
     </p>
+    <!--
     <image src="assets/image/LinearSelection.png" height="400" />
     <image src="assets/image/LinearPlot.png" height="400" />
     <p>
-      The images above include an example of the line as drawn in the cube view and the 
-      associated plot window. Marking has been added to delineate where mouse clicks were made and 
-      the DN values were calculated. The mouse was first clicked at dileneation marked "1" on the 
-      cube, and was released at "4". The number from the cube view correlates with the "Pixel 
+      The images above include an example of the line as drawn in the cube view and the
+      associated plot window. Marking has been added to delineate where mouse clicks were made and
+      the DN values were calculated. The mouse was first clicked at dileneation marked "1" on the
+      cube, and was released at "4". The number from the cube view correlates with the "Pixel
       Number" on the plot.
-      
     </p>
+    -->
     <h4>Rotated Rectangle</h4>
     <p>
-      This mode of the Spatial Plot Tool involves drawing a 
-      rectangle across an open cube. The selection starts by clicking and holding the mouse 
-      where you would like to start your calculations, at which point you may drag the mouse in any 
-      direction and release the click to establish one edge of your selection. You may then 
-      drag the mouse away from this original line to expand in the other direction. A single mouse 
-      click establishes your final selection. <strong>Please note:</strong> The tool will lock 
+      This mode of the Spatial Plot Tool involves drawing a
+      rectangle across an open cube. The selection starts by clicking and holding the mouse
+      where you would like to start your calculations, at which point you may drag the mouse in any
+      direction and release the click to establish one edge of your selection. You may then
+      drag the mouse away from this original line to expand in the other direction. A single mouse
+      click establishes your final selection. <strong>Please note:</strong> The tool will lock
       angles to be perpendicular and so your selections will always be a perfect rectangle.
     </p>
 
     <p>
-      Similar to the linear mode of this tool, the lengths of the lines in pixels are rounded to the 
-      nearest full pixel value, and then the lengths are divided by their rounded lengths to establish 
+      Similar to the linear mode of this tool, the lengths of the lines in pixels are rounded to the
+      nearest full pixel value, and then the lengths are divided by their rounded lengths to establish
       a step-size. <strong>Please note:</strong>
-      The step-size along one edge of the selection may differ from the step-size of the 
-      perpendicular edge, this becomes negligible for larger selections. For 
-      example, if the length of the line in one direction was 2.91 pixels, the step-size would be 2.91/3 
-      (or 0.97), whereas if the length of the line in the perpendicular direction was 4.92, the step 
+      The step-size along one edge of the selection may differ from the step-size of the
+      perpendicular edge, this becomes negligible for larger selections. For
+      example, if the length of the line in one direction was 2.91 pixels, the step-size would be 2.91/3
+      (or 0.97), whereas if the length of the line in the perpendicular direction was 4.92, the step
       size would be 4.92/5 (0.98).
     </p>
     <p>
-      A plot window will be generated with the calculated DN values. This is done by calculating the 
-      value where the original mouse click was made, then continuing in the direction of that 
-      first-drawn line, calculating the DN value at each step-sized increment until it reaches where 
-      the original mouse-click was released. The tool will then calculate the average of these 
+      A plot window will be generated with the calculated DN values. This is done by calculating the
+      value where the original mouse click was made, then continuing in the direction of that
+      first-drawn line, calculating the DN value at each step-sized increment until it reaches where
+      the original mouse-click was released. The tool will then calculate the average of these
       values. This average becomes the first value in the plot.
     </p>
     <p>
-      The tool will then shift a step-size along the perpendicular edge, and calculate the average DN 
-      value along a line running parallel to the first-drawn line. This average becomes the second 
-      value in the plot. The tool continues this pattern until it has reached the opposite edge of 
+      The tool will then shift a step-size along the perpendicular edge, and calculate the average DN
+      value along a line running parallel to the first-drawn line. This average becomes the second
+      value in the plot. The tool continues this pattern until it has reached the opposite edge of
       the rectangle as the first-drawn line.
     </p>
+    <!--
     <image src="assets/image/RRSelection.png" height="400" />
     <image src="assets/image/RRSelectionMarked.png" height="400" />
     <image src="assets/image/RRPlot.png" height="400" />
     <p>
-      The first image is the original selection. The second image 
-      is the same view that has been marked for reference purposes. Finally, the last image 
-      is the associated plot window. The original mouse click was made at delineation 
-      "1" within the cube view, the original mouse release was made at "5", and the final 
-      mouse click was made at "15". The Spatial Plot Tool calculates the average of the DN values at 
-      delineations 1-5, and this value is stored as "Pixel Value" 1 in the plot window, while the 
-      averages of 6-10 are stored in 2, and 7-15 are stored in 3. 
+      The first image is the original selection. The second image
+      is the same view that has been marked for reference purposes. Finally, the last image
+      is the associated plot window. The original mouse click was made at delineation
+      "1" within the cube view, the original mouse release was made at "5", and the final
+      mouse click was made at "15". The Spatial Plot Tool calculates the average of the DN values at
+      delineations 1-5, and this value is stored as "Pixel Value" 1 in the plot window, while the
+      averages of 6-10 are stored in 2, and 7-15 are stored in 3.
     </p>
+    -->
     <h4>Interpolations</h4>
     <p>
-      Spatial Plot Tool makes use of Nearest Nieghbor, BiLinear and Cubic Convolution interpolations 
-      when calculating the DN values at particular points. <strong>Do be aware that when the tool is 
-      calculating a DN value at a particular point, it is calculating the interpolated DN value at 
+      Spatial Plot Tool makes use of Nearest Nieghbor, BiLinear and Cubic Convolution interpolations
+      when calculating the DN values at particular points. <strong>Do be aware that when the tool is
+      calculating a DN value at a particular point, it is calculating the interpolated DN value at
       that point.</strong>
     </p>
   </description>

--- a/isis/src/qisis/objs/HelpTool/HelpTool.cpp
+++ b/isis/src/qisis/objs/HelpTool/HelpTool.cpp
@@ -62,10 +62,17 @@ namespace Isis {
    */
   void HelpTool::aboutProgram() {
     PvlGroup &uig = Preference::Preferences().findGroup("UserInterface");
+#if defined(__linux__)
     QString command = (QString) uig["GuiHelpBrowser"] +
                       " http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
                       QApplication::applicationName() + "/" +
                       QApplication::applicationName() + ".html";
+#elif defined(__APPLE__)
+    QString command = "open -a" + (QString) uig["GuiHelpBrowser"] +
+                      " http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
+                      QApplication::applicationName() + "/" +
+                      QApplication::applicationName() + ".html";
+#endif
     ProgramLauncher::RunSystemCommand(command);
   }
 }

--- a/isis/src/qisis/objs/HelpTool/HelpTool.cpp
+++ b/isis/src/qisis/objs/HelpTool/HelpTool.cpp
@@ -11,6 +11,7 @@
 #include "MainWindow.h"
 #include "Workspace.h"
 #include "Preference.h"
+#include "ProgramLauncher.h"
 
 
 namespace Isis {
@@ -60,17 +61,11 @@ namespace Isis {
    * @author  2007-06-12 Tracie Sucharski
    */
   void HelpTool::aboutProgram() {
-    FileName file(
-                  "$ISISROOT/doc/Application/presentation/PrinterFriendly/" +
-                  QApplication::applicationName() + "/" +
-                  QApplication::applicationName() + ".html");
-
     PvlGroup &uig = Preference::Preferences().findGroup("UserInterface");
     QString command = (QString) uig["GuiHelpBrowser"] +
-                      (QString)" file:" + file.expanded() + " &";
-    if(system(command.toLatin1().data()) != 0) {
-      IString msg = "Failed to execute [" + command + "]";
-      throw IException(IException::Programmer, msg, _FILEINFO_);
-    }
+                      " http://isis.astrogeology.usgs.gov/Application/presentation/Tabbed/" +
+                      QApplication::applicationName() + "/" +
+                      QApplication::applicationName() + ".html";
+    ProgramLauncher::RunSystemCommand(command);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated Gui::AboutProgram and HelpTool::AboutProgram to point to ISIS website documentation rather than a local file  documentation that we no longer use. I also found a bug in the command not functioning correctly on Macs. Therefore I updated these functions to accommodate to the user's OS. 

The related issue also mentioned broken images on qview's website documentation. Since these images were not found in historical repositories, I temporary removed the image sources from qview.xml. An additional issue may be needed to further search for these images or to replace them. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4333 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bug that prevents users from accessing the "About" on application's GUI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested through multiple application's GUI on both Mac and Linux machines.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
