### PR TITLE
Fixes failing observation pair tests

### DIFF
--- a/isis/tests/FileListTests.cpp
+++ b/isis/tests/FileListTests.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include "FileList.h"
 #include "IException.h"
+#include "TestUtilities.h"
 
 TEST(FileList, NonExistantFileConstructor)
 {
@@ -11,8 +12,7 @@ TEST(FileList, NonExistantFileConstructor)
   }
   catch(Isis::IException &e)
   {
-    EXPECT_TRUE(e.toString().toLatin1().contains("Unable to open [FakeFile]"))
-      << e.toString().toStdString();
+    EXPECT_THAT(e.what(), testing::HasSubstr("Unable to open [FakeFile]"));
   }
   catch(...)
   {

--- a/isis/tests/FunctionalTestsCkwriter.cpp
+++ b/isis/tests/FunctionalTestsCkwriter.cpp
@@ -152,8 +152,8 @@ TEST_F(ObservationPair, FunctionalTestsCkwriterCantValidate) {
 
   UserInterface options(APP_XML, args);
   try {
-   ckwriter(options, &appLog);
-   FAIL() << "Should not have been able to generate new CK" << std::endl;
+    ckwriter(options, &appLog);
+    FAIL() << "Should not have been able to generate new CK" << std::endl;
   }
   catch (IException &e) {
     EXPECT_THAT(e.what(), HasSubstr("Time overlap conflicts are present in segment (image) list."));

--- a/isis/tests/data/observationPair/observationImageL.pvl
+++ b/isis/tests/data/observationPair/observationImageL.pvl
@@ -92,7 +92,7 @@ Object = IsisCube
                                  $lro/kernels/ck/moc42r_2009181_2009213_v14.bc,
                                  $lro/kernels/fk/lro_frames_2014049_v01.tf)
     Instrument                = $lro/kernels/ik/lro_lroc_v18.ti
-    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2020358_v00.tsc
+    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2021076_v00.tsc
     InstrumentPosition        = (Table,
                                  $lro/kernels/spk/fdf29r_2009182_2009213_v01.b-
                                  sp)

--- a/isis/tests/data/observationPair/observationImageR.pvl
+++ b/isis/tests/data/observationPair/observationImageR.pvl
@@ -92,7 +92,7 @@ Object = IsisCube
                                  $lro/kernels/ck/moc42r_2009181_2009213_v14.bc,
                                  $lro/kernels/fk/lro_frames_2014049_v01.tf)
     Instrument                = $lro/kernels/ik/lro_lroc_v18.ti
-    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2020358_v00.tsc
+    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2021076_v00.tsc
     InstrumentPosition        = (Table,
                                  $lro/kernels/spk/fdf29r_2009182_2009213_v01.b-
                                  sp)


### PR DESCRIPTION
Changes to labels to get the ObservationPair tests working

## Description
Updated both the left and right Observation pair with new kernel path. This also addresses an old test that wasn't using the HasSubStr utility method.

## Related Issue
N/A

## Motivation and Context
Clean up some failing ISIS tests

## How Has This Been Tested?
These are test fixes.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
