### PR TITLE
Updated Unit Test for OSIRIS-REx SamCam

### DIFF
--- a/isis/tests/OsirisRexOCamsCameraTests.cpp
+++ b/isis/tests/OsirisRexOCamsCameraTests.cpp
@@ -7,23 +7,23 @@
 #include <gtest/gtest.h>
 
 using namespace Isis;
-using namespace std; 
+using namespace std;
 
 TEST_F(OsirisRexCube, PolyMath) {
   setInstrument("-64360", "PolyCam");
 
   OsirisRexOcamsCamera *cam = (OsirisRexOcamsCamera *)testCube->camera();
-    
+
   EXPECT_EQ(cam->instrumentRotation()->Frame(), -27002);
 
   // Test kernel IDs
   EXPECT_EQ(cam->CkFrameId(), -64000);
-  EXPECT_EQ(cam->CkReferenceId(), 1);  
-  EXPECT_EQ(cam->SpkTargetId(), -64); 
+  EXPECT_EQ(cam->CkReferenceId(), 1);
+  EXPECT_EQ(cam->SpkTargetId(), -64);
   EXPECT_EQ(cam->SpkReferenceId(), 1);
-  
+
   // Test name methods
-  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameLong(), "OSIRIS-REx"); 
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameLong(), "OSIRIS-REx");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameShort(), "OSIRIS-REx");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameLong(), "PolyMath Camera");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameShort(), "PolyCam");
@@ -42,34 +42,57 @@ TEST_F(OsirisRexCube, PolyMath) {
   EXPECT_NEAR(cam->UniversalLatitude(), 9.26486, 0.0001);
   EXPECT_NEAR(cam->UniversalLongitude(), 276.167, 0.0001);
 
-  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude())); 
+  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
   EXPECT_NEAR(cam->Line(), 5, 0.01);
   EXPECT_NEAR(cam->Sample(), 5, 0.01);
 }
 
 
 TEST_F(OsirisRexCube, MappingCam) {
-  setInstrument("-64361", "PolyCam");
+  setInstrument("-64361", "MapCam");
 
-  OsirisRexOcamsCamera *cam = (OsirisRexOcamsCamera *)testCube->camera();;
-  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameLong(), "OSIRIS-REx"); 
+  OsirisRexOcamsCamera *cam = (OsirisRexOcamsCamera *)testCube->camera();
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameLong(), "OSIRIS-REx");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameShort(), "OSIRIS-REx");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameLong(), "Mapping Camera");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameShort(), "MapCam");
-  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentId(), "PolyCam");
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentId(), "MapCam");
 }
 
 
 TEST_F(OsirisRexCube, SamplingCam) {
-  setInstrument("-64362", "PolyCam");
+  setInstrument("-64362", "SamCam");
 
-  OsirisRexOcamsCamera *cam = (OsirisRexOcamsCamera *)testCube->camera();;
-  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameLong(), "OSIRIS-REx"); 
+  OsirisRexOcamsCamera *cam = (OsirisRexOcamsCamera *)testCube->camera();
+
+  EXPECT_EQ(cam->instrumentRotation()->Frame(), -27002);
+
+  // Test kernel IDs
+  EXPECT_EQ(cam->CkFrameId(), -64000);
+  EXPECT_EQ(cam->CkReferenceId(), 1);
+  EXPECT_EQ(cam->SpkTargetId(), -64);
+  EXPECT_EQ(cam->SpkReferenceId(), 1);
+
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameLong(), "OSIRIS-REx");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->spacecraftNameShort(), "OSIRIS-REx");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameLong(), "Sampling Camera");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameShort(), "SamCam");
-  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentId(), "PolyCam");
-   
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentId(), "SamCam");
 
+  const PvlGroup &inst = testCube->label()->findGroup("Instrument", Pvl::Traverse);
+  double exposureDuration = ((double) inst["ExposureDuration"])/1000;
+  QString stime = inst["StartTime"];
+  double et; // StartTime keyword is the center exposure time
+  str2et_c(stime.toLatin1().data(), &et);
+  pair <iTime, iTime> shuttertimes = cam->ShutterOpenCloseTimes(et, exposureDuration);
+  EXPECT_NEAR(shuttertimes.first.Et(), 600694634.18428946, 6E-14);
+  EXPECT_NEAR(shuttertimes.second.Et(), 600694634.28428948, 6E-14);
+
+  EXPECT_TRUE(cam->SetImage(5, 5));
+  EXPECT_NEAR(cam->UniversalLatitude(), 9.26486, 0.0001);
+  EXPECT_NEAR(cam->UniversalLongitude(), 276.167, 0.0001);
+
+  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
+  EXPECT_NEAR(cam->Line(), 5, 0.01);
+  EXPECT_NEAR(cam->Sample(), 5, 0.01);
 }
-

--- a/isis/tests/OsirisRexOCamsCameraTests.cpp
+++ b/isis/tests/OsirisRexOCamsCameraTests.cpp
@@ -81,12 +81,11 @@ TEST_F(OsirisRexCube, SamplingCam) {
 
   const PvlGroup &inst = testCube->label()->findGroup("Instrument", Pvl::Traverse);
   double exposureDuration = ((double) inst["ExposureDuration"])/1000;
-  QString stime = inst["StartTime"];
-  double et; // StartTime keyword is the center exposure time
-  str2et_c(stime.toLatin1().data(), &et);
+  cam->SetImage (0.5, 0.5);
+  double et = cam->time().Et();
   pair <iTime, iTime> shuttertimes = cam->ShutterOpenCloseTimes(et, exposureDuration);
-  EXPECT_NEAR(shuttertimes.first.Et(), 600694634.18428946, 6E-14);
-  EXPECT_NEAR(shuttertimes.second.Et(), 600694634.28428948, 6E-14);
+  EXPECT_NEAR(shuttertimes.first.Et(), 502476937.73296136, 1e-14);
+  EXPECT_NEAR(shuttertimes.second.Et(), 502476937.83296138, 1e-14);
 
   EXPECT_TRUE(cam->SetImage(5, 5));
   EXPECT_NEAR(cam->UniversalLatitude(), 9.26486, 0.0001);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated existing SamCam unit test that was recently converted to a gtest. Updated SamCam gtest to reflect the PolyCam unit gtest. 

I did not include the provided test image due to the fact that these gtests were working with a fixture and therefore avoiding having to introduce more test data. 

I did not update the existing fixture functions due to not finding any camera specific changes needed for SamCam other than updating the instrument id. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4280 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Provides better testing coverage for OSIRIS-REx camera models.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the updated SamCam gtest.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
