### PR TITLE
Fix #631 Map2Map creating null images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ release.
 - Fixed history entry not being added to a cube when running spiceinit with web=true. [4040](https://github.com/USGS-Astrogeology/ISIS3/issues/4040)
 - Updated wavelength and bandbin values in translation files for the TGO CaSSIS BandBin group. [4147](https://github.com/USGS-Astrogeology/ISIS3/issues/4147)
 - Fixed the JunoCam serialNumber translation using an old keyword. [4341](https://github.com/USGS-Astrogeology/ISIS3/issues/4341)
+- Fixed map2map bug where small images would return all null image [#632](https://github.com/USGS-Astrogeology/ISIS3/issues/631)
 
 ## [4.3.0] - 2020-10-02
 

--- a/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
+++ b/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
@@ -174,8 +174,8 @@ namespace Isis {
         bool useLastTileMap = false;
         for (int band = 1; band <= OutputCubes[0]->bandCount(); band++) {
           otile.SetTile(tile, band);
-
-          if (p_startQuadSize <= 2) {
+          
+          if (p_startQuadSize <= 2 || OutputCubes[0]->lineCount() <= p_startQuadSize) {
             SlowGeom(otile, iportal, trans, interp);
           }
           else {

--- a/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
+++ b/isis/src/base/objs/ProcessRubberSheet/ProcessRubberSheet.cpp
@@ -6,6 +6,7 @@ find files of those names at the top level of this repository. **/
 /* SPDX-License-Identifier: CC0-1.0 */
 #include <iostream>
 #include <iomanip>
+#include <algorithm>
 
 #include <QVector>
 
@@ -174,8 +175,9 @@ namespace Isis {
         bool useLastTileMap = false;
         for (int band = 1; band <= OutputCubes[0]->bandCount(); band++) {
           otile.SetTile(tile, band);
-          
-          if (p_startQuadSize <= 2 || OutputCubes[0]->lineCount() <= p_startQuadSize) {
+
+          // If either image or quad sizes are small, skip to SlowGeom. 
+          if (p_startQuadSize <= 2 || min(OutputCubes[0]->lineCount(), OutputCubes[0]->sampleCount()) <= p_startQuadSize) {
             SlowGeom(otile, iportal, trans, interp);
           }
           else {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

If the output image for map2map which are too small to split into quads, the entire image is transformed instead (e.g. if inputting an extremely high spatial resolution). 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

fixes #631 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test case mentioned in the issue was manually tested. 

## Screenshots (if appropriate):


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
