### PR TITLE
Added time bias to ephemeris times in ckwriter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ release.
 - Fixed issue where serial numbers for Kaguya TC and MI image could not be generated. [4235](https://github.com/USGS-Astrogeology/ISIS3/issues/4235)
 - Fixed hardcoded file naming in the hijitter app dealing with output from pipeline. [#4372](https://github.com/USGS-Astrogeology/ISIS3/pull/4372)
 - Fixed "About Qview" to point to website documentation. [4333](https://github.com/USGS-Astrogeology/ISIS3/issues/4333)
+- Fixed bug where the time bias was not being added to the ephemeris times in ckwriter. [4129](https://github.com/USGS-Astrogeology/ISIS3/issues/4129)
 
 ### Changed
 

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
@@ -216,7 +216,7 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
 
     _quats = getQuaternions(spice);
     _avvs = getAngularVelocities(spice);
-    _times = getTimes(spice);
+    _times = getTimes(spice, camera->instrumentRotation()->TimeBias());
 
     _startTime = _times[0];
     _endTime = _times[size(_times)-1];
@@ -303,13 +303,13 @@ CkSpiceSegment::SMatrix CkSpiceSegment::getAngularVelocities(const SMatrix &spic
 }
 
 
-CkSpiceSegment::SVector CkSpiceSegment::getTimes(const SMatrix &spice) const {
+CkSpiceSegment::SVector CkSpiceSegment::getTimes(const SMatrix &spice, const double timeBias) const {
   int nrecs = size(spice);
   SVector etdp(nrecs);
   int tcol = spice.dim2() - 1;
 
   for ( int i = 0 ; i < nrecs ; i++ ) {
-    etdp[i] = spice[i][tcol];
+    etdp[i] = spice[i][tcol] + timeBias;
   }
   return (etdp);
 }

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.h
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.h
@@ -86,6 +86,8 @@ class PvlObject;
  *
  * @history 2019-12-05 Adam Paquette - Changed how kernels are loaded so CkSpiceSegment
  *                          no longer needs to use the Spice class.
+ *                          
+ * @history 2021-03-23 Kaitlyn Lee - Added time bias to ET times in getTimes(). Fixes #4129
  */
 class CkSpiceSegment {
   public:
@@ -172,7 +174,7 @@ class CkSpiceSegment {
     SMatrix load(Table &cache);
     SMatrix getQuaternions(const SMatrix &spice) const;
     SMatrix getAngularVelocities(const SMatrix &spice) const;
-    SVector getTimes(const SMatrix &spice) const;
+    SVector getTimes(const SMatrix &spice, const double timeBias) const;
 
     bool getTimeDependentFrameIds(Table &table, int &toId, int &fromId) const;
     bool getFrameChains(Table &table, const int &leftBase,

--- a/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
+++ b/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
@@ -307,6 +307,15 @@ namespace Isis {
     return p_et;
   }
 
+  /**
+   * Accessor method to get current time bias.
+   *
+   * @return @b double The current time bias.
+   */
+  double SpiceRotation::TimeBias() const {
+    return p_timeBias;
+  }
+
 
   /**
    * Checks if the cache is empty.

--- a/isis/src/base/objs/SpiceRotation/SpiceRotation.h
+++ b/isis/src/base/objs/SpiceRotation/SpiceRotation.h
@@ -200,6 +200,7 @@ namespace Isis {
    *                           The current example is the comet 67P/CHURYUMOV-GERASIMENKO
    *                           imaged by Rosetta. Some future comet/astroid missions are expected
    *                           to use a CK defined body fixed reference frame. Fixes #5408.
+   * @history 2021-03-23 Kaitlyn Lee - Added getter function for time bias. Fixes #4129.
    *
    *  @todo Downsize using Hermite cubic spline and allow Nadir tables to be downsized again.
    *  @todo Consider making this a base class with child classes based on frame type or
@@ -223,6 +224,7 @@ namespace Isis {
       int Frame();
 
       void SetTimeBias(double timeBias);
+      double TimeBias() const;
 
       /**
        * The rotation can come from one of 3 places for an Isis cube.  The class


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added a time bias getter function to SpiceRotation and then call the getter in CkSpiceSegment to add the time bias to the ephemeris times. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #4129 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes bug where the ephemeris times were off by the time bias in the tables.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ckwriter tests pass and walked through the steps outlined in the issue and the tabledump outputs match.
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
