### PR TITLE
Added ability to identify arrays in the csv and place those into table arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@ release.
 
 - Fixed hi2isis MRO:ADC_TIMING_SETTINGS label conversion issue [4290](https://github.com/USGS-Astrogeology/ISIS3/issues/4290)
 
+- Changed csv2table to identify headers with arrays and create table fields as arrays instead of single fields for each element [3676](https://github.com/USGS-Astrogeology/ISIS3/issues/3676)
+
 ## [4.4.0] - 2021-02-11
 
 ### Added

--- a/isis/src/base/apps/csv2table/csv2table.xml
+++ b/isis/src/base/apps/csv2table/csv2table.xml
@@ -26,6 +26,10 @@
     <change name="Jesse Mapel" date="2018-09-04">
       Original version
     </change>
+    <change name="Stuart Sides" date="2021-03-20">
+      Added ability to convert CSV files with indexs into table field arrays
+      instead of individual table fields.
+    </change>
   </history>
 
   <groups>

--- a/isis/src/base/apps/csv2table/csv2table.xml
+++ b/isis/src/base/apps/csv2table/csv2table.xml
@@ -36,7 +36,7 @@
       Original version
     </change>
     <change name="Stuart Sides" date="2021-03-20">
-      Added ability to convert CSV files with indexs into table field arrays
+      Added ability to convert CSV files with indicies into table field arrays
       instead of individual table fields.
     </change>
   </history>

--- a/isis/src/base/apps/csv2table/csv2table.xml
+++ b/isis/src/base/apps/csv2table/csv2table.xml
@@ -6,10 +6,19 @@
   </brief>
 
   <description>
-    This application converts a CSV file to a table and attaches it to a cube
+    <p>
+    This application converts a CSV file to a table and attaches it to a cube.
     The first row of the CSV will be used as the fieldnames for the table.
     The contents of the CSV file will be converted to floating point numbers
     before they are inserted into the table.
+    </p>
+    <p>
+    A single table field with multiple values will be created for consecutive CSV columns
+    with the same column name followed by an index inside parentheses.
+    The index must start at zero and increase from left to right.
+    For example a CSV header line like: "A, B(0), B(1), B(2), C", will create three
+    table fields, A with size=1, B with size=3, and C with size=1.
+    </p>
   </description>
 
   <category>

--- a/isis/src/base/apps/csv2table/main.cpp
+++ b/isis/src/base/apps/csv2table/main.cpp
@@ -64,7 +64,7 @@ void IsisMain() {
 
   // Construct an empty table with the CSV header as field names
   // Collect identical field names together, including those with (###) at the end, so a single
-  // table field with multipal values can be created.
+  // table field with multiple values can be created.
   TableRecord tableRow;
   QRegularExpression rex(R"((?<name>\w+)(\((?<index>[0-9]*)\)|))");
   for (int columnIndex = 0; columnIndex < numColumns; columnIndex++) {

--- a/isis/src/base/apps/csv2table/main.cpp
+++ b/isis/src/base/apps/csv2table/main.cpp
@@ -22,6 +22,9 @@
 
 #include "Isis.h"
 
+#include <vector>
+
+#include <QRegularExpression>
 #include <QString>
 
 #include "Cube.h"
@@ -60,24 +63,48 @@ void IsisMain() {
   CSVReader::CSVAxis header = reader.getHeader();
 
   // Construct an empty table with the CSV header as field names
+  // Collect identical field names together, including those with (###) at the end, so a single
+  // table field with multipal values can be created.
   TableRecord tableRow;
+  QRegularExpression rex(R"((?<name>\w+)(\((?<index>[0-9]*)\)|))");
   for (int columnIndex = 0; columnIndex < numColumns; columnIndex++) {
-    TableField columnField(QString(header[columnIndex]), TableField::Double);
-    tableRow += columnField;
+    QRegularExpressionMatch match = rex.match(header[columnIndex]);
+    if (match.hasMatch()) {
+      QString name = match.captured("name");
+      QString index = match.captured("index");
+
+      // If the next column header is different, create a field for this one
+      QRegularExpressionMatch nextMatch = (columnIndex<numColumns-1)?rex.match(header[columnIndex+1]):QRegularExpressionMatch();
+      if ((columnIndex == numColumns-1) || (nextMatch.hasMatch() && (name != nextMatch.captured("name")))) {
+        TableField columnField(name, TableField::Double, (index.length()>0)?(index.toInt()+1):1);
+        tableRow += columnField;
+      }
+    }
   }
+
   QString tableName = ui.GetString("tablename");
   Table table(tableName, tableRow);
 
-  // Fill the table
+  // Fill the table from the csv
   for (int rowIndex = 0; rowIndex < numRows; rowIndex++) {
     CSVReader::CSVAxis csvRow = reader.getRow(rowIndex);
-    for (int columnIndex = 0; columnIndex < numColumns; columnIndex++) {
-      tableRow[columnIndex] = toDouble(csvRow[columnIndex]);
+    for (int columnIndex = 0, fieldIndex = 0; columnIndex < numColumns; ) {
+      if (tableRow[fieldIndex].size() == 1) {
+        tableRow[fieldIndex] = toDouble(csvRow[columnIndex++]);
+      }
+      else {
+        std::vector<double> dblVector;
+        for (int arrayLen = 0; arrayLen < tableRow[fieldIndex].size(); arrayLen++) {
+          dblVector.push_back(toDouble(csvRow[columnIndex++]));
+        }
+        tableRow[fieldIndex] = dblVector;
+      }
+      fieldIndex++;
     }
     table += tableRow;
   }
 
-  // If a set of label keywords was passed add them to the table
+  // If a set of additional label keywords was given then add them to the table's pvl description
   if (ui.WasEntered("label")) {
     QString labelPvlFilename = ui.GetFileName("label");
     Pvl labelPvl;
@@ -116,5 +143,4 @@ void IsisMain() {
   }
 
   outCube.close();
-
 }

--- a/isis/src/base/apps/csv2table/tsts/NewTable/Makefile
+++ b/isis/src/base/apps/csv2table/tsts/NewTable/Makefile
@@ -10,4 +10,10 @@ commands:
 	tabledump from=$(OUTPUT)/isisTruth.cub \
 	to=$(OUTPUT)/output.csv \
 	NAME="TestTable" > /dev/null;
+	$(APPNAME) csv=$(INPUT)/test_arrays.csv \
+	tablename="TestTableArrays" \
+	to=$(OUTPUT)/isisTruth.cub > /dev/null;
+	tabledump from=$(OUTPUT)/isisTruth.cub \
+	to=$(OUTPUT)/output_arrays.csv \
+	NAME="TestTableArrays" > /dev/null;
 	rm $(OUTPUT)/isisTruth.cub;


### PR DESCRIPTION
Added ability to identify arrays in the CSV header and write those to table field arrays.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
#3676
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
An existing test was expanded to write a table with arrays
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
