### PR TITLE
Fix extra comma in cnetstats output

### DIFF
--- a/isis/src/control/objs/ControlNetFilter/ControlNetFilter.cpp
+++ b/isis/src/control/objs/ControlNetFilter/ControlNetFilter.cpp
@@ -168,7 +168,7 @@ namespace Isis {
    * @author Sharmila Prasad (8/31/2010)
    */
   void ControlNetFilter::CubeStatsHeader(void) {
-    mOstm << "FileName, SerialNumber, ImageTotalPoints, ImagePointsIgnored, ImagePointsEditLocked, ImagePointsFixed, ImagePointsConstrained, ImagePointsFree, ImageConvexHullRatio,";
+    mOstm << "FileName, SerialNumber, ImageTotalPoints, ImagePointsIgnored, ImagePointsEditLocked, ImagePointsFixed, ImagePointsConstrained, ImagePointsFree, ImageConvexHullRatio";
   }
 
   /**
@@ -198,7 +198,7 @@ namespace Isis {
     }
 
     if (pbLastFilter) {
-      mOstm << "PointID, PointType, PointIgnored, PointEditLocked, FileName, SerialNumber, PixelShift, MeasureType, MeasureIgnored, MeasureEditLocked, Reference, ";
+      mOstm << "PointID, PointType, PointIgnored, PointEditLocked, FileName, SerialNumber, PixelShift, MeasureType, MeasureIgnored, MeasureEditLocked, Reference";
       mOstm << endl;
     }
 
@@ -386,7 +386,7 @@ namespace Isis {
     }
 
     if (pbLastFilter) {
-      mOstm << "PointID, PointType, PointIgnored, PointEditLocked, FileName, SerialNumber, ResidualMagnitude, MeasureType, MeasureIgnored, MeasureEditLocked, Reference, ";
+      mOstm << "PointID, PointType, PointIgnored, PointEditLocked, FileName, SerialNumber, ResidualMagnitude, MeasureType, MeasureIgnored, MeasureEditLocked, Reference";
       mOstm << endl;
     }
 
@@ -1037,7 +1037,7 @@ namespace Isis {
     if (pbLastFilter) {
       PointStatsHeader();
       CubeStatsHeader();
-      mOstm << "ImageMeasureIgnored, ImageMeasureEditLocked, ";
+      mOstm << ", ImageMeasureIgnored, ImageMeasureEditLocked";
       mOstm << endl;
     }
 
@@ -1314,7 +1314,7 @@ namespace Isis {
 
     if (pbLastFilter) {
       CubeStatsHeader();
-      mOstm << "Distance_PointIDs >>, " << endl;
+      mOstm << ", Distance_PointIDs >>, " << endl;
     }
 
     int iNumCubes = mSerialNumFilter.size();

--- a/isis/src/control/objs/ControlNetStatistics/ControlNetStatistics.cpp
+++ b/isis/src/control/objs/ControlNetStatistics/ControlNetStatistics.cpp
@@ -402,7 +402,7 @@ namespace Isis {
       throw IException(IException::Io, msg, _FILEINFO_);
     }
 
-    ostm << " PointId, PointType, PointIgnore, PointEditLock, TotalMeasures, MeasuresValid, MeasuresIgnore, MeasuresEditLock," << endl;
+    ostm << " PointId, PointType, PointIgnore, PointEditLock, TotalMeasures, MeasuresValid, MeasuresIgnore, MeasuresEditLock" << endl;
 
     int iNumPoints = mCNet->GetNumPoints();
 

--- a/isis/tests/FunctionalTestsCnetstats.cpp
+++ b/isis/tests/FunctionalTestsCnetstats.cpp
@@ -109,9 +109,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsPointStats) {
     QStringList values = line.split(",");
 
     if(lineNumber == 0) {
-      // The output adds a comma at the end of the first line, increasing the size by 1.
-      // This is a bug in ControlNetStatistics. Once that is fixed, this test wil fail.
-      ASSERT_DOUBLE_EQ(values.size() - 1, 8);
+      ASSERT_DOUBLE_EQ(values.size() - 1, 7);
     }
     else {
       ASSERT_DOUBLE_EQ(values.size(), 8);
@@ -151,9 +149,7 @@ TEST_F(ThreeImageNetwork, FunctionalTestCnetstatsCubeFilter) {
     QStringList values = line.split(",");
 
     if(lineNumber == 0) {
-      // The output adds a comma at the end of the first line, increasing the size by 1.
-      // This is a bug in ControlNetFilter. Once that is fixed, this test wil fail.
-      ASSERT_DOUBLE_EQ(values.size() - 1, 9);
+      ASSERT_DOUBLE_EQ(values.size() - 1, 8);
     }
     else {
       ASSERT_DOUBLE_EQ(values.size(), 9);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There were a few places in ControlNetFilter and ControlNetStatistics responsible for an extra comma being produced in the flat file output. Most changes are straightforward.
Removing the comma in ControlNetFilter::CubeStatsHeader required that I prepend a comma to a few strings in places where CubeStatsHeader is called.
I also updated the tests so everything should be passing. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3700

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran cnetstats on some test input before and after my changes to validate that the extra comma is no longer produced.
All cnetstats gtests passed on linux.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
