### PR TITLE
Updated FindFeatures Logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ release.
 - Fixed hardcoded file naming in the hijitter app dealing with output from pipeline. [#4372](https://github.com/USGS-Astrogeology/ISIS3/pull/4372)
 - Fixed "About Qview" to point to website documentation. [4333](https://github.com/USGS-Astrogeology/ISIS3/issues/4333)
 - Fixed bug where the time bias was not being added to the ephemeris times in ckwriter. [4129](https://github.com/USGS-Astrogeology/ISIS3/issues/4129)
+- Fixed logging in FindFeatures where we were trying to get a non-existent Pvl group from the Pvl log. [#4375](https://github.com/USGS-Astrogeology/ISIS3/issues/4375)
 
 ### Changed
 

--- a/isis/src/control/apps/findfeatures/findfeatures.cpp
+++ b/isis/src/control/apps/findfeatures/findfeatures.cpp
@@ -81,8 +81,7 @@ namespace Isis{
         }
         else {
           if (log){
-            PvlGroup results = data.findGroup("Results");
-            log->addGroup(results);
+            log->addObject(data);
           }
         }
       }

--- a/isis/src/control/apps/findfeatures/main.cpp
+++ b/isis/src/control/apps/findfeatures/main.cpp
@@ -34,8 +34,8 @@ void IsisMain() {
   }
 
   Pvl results;
-  results.addObject(appLog.findObject("FeatureAlgorithms"));
-  if( ui.WasEntered("TO") && ui.IsInteractive() ) {
+  if( (ui.GetBoolean("LISTALL") || ui.GetBoolean("LISTSPEC")) && ui.IsInteractive() ) {
+    results.addObject(appLog.findObject("FeatureAlgorithms"));
     Application::GuiLog(results);
   }
 }

--- a/isis/src/control/apps/findfeatures/main.cpp
+++ b/isis/src/control/apps/findfeatures/main.cpp
@@ -33,10 +33,9 @@ void IsisMain() {
     Application::Log(*grpIt);
   }
 
-  PvlGroup results = appLog.findGroup("Results");
+  Pvl results;
+  results.addObject(appLog.findObject("FeatureAlgorithms"));
   if( ui.WasEntered("TO") && ui.IsInteractive() ) {
     Application::GuiLog(results);
   }
-
-  SessionLog::TheLog().AddResults(results);
 }


### PR DESCRIPTION
Fixes the GUI output from `findfeatures`

## Description
Addresses trying to get a `Results` group from the output of a `findfeatures` run. This has been replaced with the output that was originally given from `findfeatures` as of the app conversion.

## Related Issue
Fixes #4375 

## Motivation and Context
For support sprint of 4/12/21

## How Has This Been Tested?
Tested through the findfeatures tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
