### PR TITLE
Fix caminfo uselabel SegFault

### DIFF
--- a/isis/src/base/apps/caminfo/CamTools.cpp
+++ b/isis/src/base/apps/caminfo/CamTools.cpp
@@ -335,7 +335,6 @@ namespace Isis {
       if (getFootBlob && band == 0) {
         // Read the footprint from the image labels
         ImagePolygon poly = cube.readFootprint();
-        cube.close();
         geos::geom::MultiPolygon *multiP = poly.Polys();
         _polys.push_back(multiP->clone());
         _combined = multiP->clone();

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -421,13 +421,6 @@ namespace Isis{
           }
 
           bandGeom->collect(*cam, *incube, doGeometry, doPolygon, getFootBlob, precision);
-         
-          // When getFootBlob is true, incube is closed in the above function call
-          // incube must be reopened before GeneratePVLOutput/GenerateCSVOutput
-          if( getFootBlob )
-          {
-            incube->open(ui.GetFileName("FROM"), "r");
-          }
           
           // Check if the user requires valid image center geometry
           if(ui.GetBoolean("VCAMERA") && (!bandGeom->hasCenterGeometry())) {
@@ -440,6 +433,8 @@ namespace Isis{
           GeneratePVLOutput(incube, general, camstats, statistics, bandGeom, ui);
         else
           GenerateCSVOutput(incube, general, camstats, statistics, bandGeom, ui);
+
+        incube->close();
 
         // Clean the data
         delete general;

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -421,7 +421,14 @@ namespace Isis{
           }
 
           bandGeom->collect(*cam, *incube, doGeometry, doPolygon, getFootBlob, precision);
-
+         
+          // When getFootBlob is true, incube is closed in the above function call
+          // incube must be reopened before GeneratePVLOutput/GenerateCSVOutput
+          if( getFootBlob )
+          {
+            incube->open(ui.GetFileName("FROM"), "r");
+          }
+          
           // Check if the user requires valid image center geometry
           if(ui.GetBoolean("VCAMERA") && (!bandGeom->hasCenterGeometry())) {
             QString msg = "Image center does not project in camera model";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
In caminfo there is a call to BandGeometry::collect that closes the input cube object if uselabel=yes. The cube needs to remain open for a few other tasks, so this was causing a segmentation fault. To fix this, I added a few lines after the BandGeometry::collect call that open the cube back up if uselabel=yes.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4401 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This bug was found in the release candidate due at end of month.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All caminfo gtests are passing. Both sample caminfo calls given in #4401 run correctly.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
