### PR TITLE
hideal2pds SAMPLE_BITS = 8 for ubyte output

### DIFF
--- a/isis/src/mro/apps/hideal2pds/main.cpp
+++ b/isis/src/mro/apps/hideal2pds/main.cpp
@@ -197,6 +197,11 @@ void IsisMain() {
   image.addKeyword(PvlKeyword("SAMPLE_BIT_MASK", toString((int)pow(2.0, (double)nbits) - 1)),
                    Pvl::Replace);
 
+  // SAMPLE_BITS defaults to 16 but should be 8 when BITS=8
+  if( nbits == 8 ) {
+    image.addKeyword(PvlKeyword("SAMPLE_BITS", toString(nbits)), Pvl::Replace);
+  }
+
   Camera *cam = inputCube->camera();
   updatePdsLabelRootObject(isisCubeLab, pdsLabel, ui, cam);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change SAMPLE_BITS to 8 in the PDS image label if the user entered BITS=8. 

From the app documentation for the BITS parameter:
> The output data type will be automaticity choosen using this value. A value of 8 will create unsigned byte output files. Values from 9 to 16 will create unsigned word output files. Unused bits in the unsigned word output file will be set to zero.

The way I understand this is that there are 16 "sample bits" for BITS=[9, 16] and 8 for BITS=8. I seem to remember talking to @scsides about this back when I made the issue.

Before merging:
I think this should be verified by someone more familiar with this app / hirise / pds images.
Would this require a changeLog entry? IIRC small output differences like this can be time-consuming for products / missions to validate.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4006 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Closes an issue for ISIS support milestone. Fixes unintended output for hideal2pds.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Output from makefile tests verifies that these changes work as intended

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
