### PR TITLE
Fixes arccos evaluating double close to -1 or 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ release.
 - Fixed "About Qview" to point to website documentation. [4333](https://github.com/USGS-Astrogeology/ISIS3/issues/4333)
 - Fixed bug where the time bias was not being added to the ephemeris times in ckwriter. [4129](https://github.com/USGS-Astrogeology/ISIS3/issues/4129)
 - Fixed logging in FindFeatures where we were trying to get a non-existent Pvl group from the Pvl log. [#4375](https://github.com/USGS-Astrogeology/ISIS3/issues/4375)
+- Fixed an arccos evaluating a double close to either 1, -1 when calculating the ground azimuth in camera.cpp. [#4393](https://github.com/USGS-Astrogeology/ISIS3/issues/4393)
 
 ### Changed
 

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -2303,14 +2303,14 @@ namespace Isis {
     if (sin(b) == 0.0 || sin(c) == 0.0) {
       return azimuth;
     }
-    double intermitent = (cos(a) - cos(b)*cos(c))/(sin(b)*sin(c));
-    if (intermitent < -1.0) {
-      intermitent = -1.0;
+    double intermediate = (cos(a) - cos(b)*cos(c))/(sin(b)*sin(c));
+    if (intermediate < -1.0) {
+      intermediate = -1.0;
     }
-    else if (intermitent > 1.0) {
-      intermitent = 1.0;
+    else if (intermediate > 1.0) {
+      intermediate = 1.0;
     }
-    double A = acos(intermitent) * 180.0 / PI;
+    double A = acos(intermediate) * 180.0 / PI;
     //double B = acos((cos(b) - cos(c)*cos(a))/(sin(c)*sin(a))) * 180.0 / PI;
     if (glat >= 0.0) {
       if (quad == 1 || quad == 4) {

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -2303,7 +2303,14 @@ namespace Isis {
     if (sin(b) == 0.0 || sin(c) == 0.0) {
       return azimuth;
     }
-    double A = acos((cos(a) - cos(b)*cos(c))/(sin(b)*sin(c))) * 180.0 / PI;
+    double intermitent = (cos(a) - cos(b)*cos(c))/(sin(b)*sin(c));
+    if (intermitent < -1.0) {
+      intermitent = -1.0;
+    }
+    else if (intermitent > 1.0) {
+      intermitent = 1.0;
+    }
+    double A = acos(intermitent) * 180.0 / PI;
     //double B = acos((cos(b) - cos(c)*cos(a))/(sin(c)*sin(a))) * 180.0 / PI;
     if (glat >= 0.0) {
       if (quad == 1 || quad == 4) {
@@ -3078,5 +3085,3 @@ namespace Isis {
 
 // end namespace isis
 }
-
-


### PR DESCRIPTION
Fixed issue where the acos of -1.0000000001 was resulting in a nan

## Description
Fixes an issue in caminfo where we apply arccos to another trigonometric expression that results in a double. Sometimes the result should be -1 or 1 but due to double precision accuracy it results in something extremely close to those values eg. `acos(-1.000000000001)`. This is an inelegant solution but solves the problem in caminfo.

## Related Issue
Closes #4393

## Motivation and Context
ISIS 5.0.1 Support Sprint

## How Has This Been Tested?
Tested manually through caminfo/campt

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
