### PR TITLE
Get jigsaw tests passing on csmbundle branch

### DIFF
--- a/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
+++ b/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
@@ -425,6 +425,7 @@ namespace Isis {
           throw IException(IException::Programmer, msg, _FILEINFO_);
         }
 
+        // TODO ISIS vs. CSM (addNewIsisObservation?)
         AbstractBundleObservationQsp observation =
             m_bundleObservations.addNew(image, observationNumber, instrumentId, m_bundleSettings);
 
@@ -436,10 +437,13 @@ namespace Isis {
       }
 
       // initialize exterior orientation (spice) for all BundleImages in all BundleObservations
+      // 
       // TODO!!! - should these initializations just be done when we add the new observation above?
       m_bundleObservations.initializeExteriorOrientation();
 
+      // TODO
       if (m_bundleSettings->solveTargetBody()) {
+        std::cout << "in Target body" << std::endl;
         m_bundleObservations.initializeBodyRotation();
       }
 
@@ -501,6 +505,7 @@ namespace Isis {
     // m_rank will be the sum of observation, target, and self-cal parameters
     // TODO
     m_rank = m_bundleObservations.numberParameters();
+    std::cout << "Num parameters: " << m_rank << std::endl;
 
     if (m_bundleSettings->solveTargetBody()) {
       m_rank += m_bundleSettings->numberTargetBodyParameters();
@@ -641,6 +646,7 @@ namespace Isis {
   bool BundleAdjust::initializeNormalEquationsMatrix() {
 
     int nBlockColumns = m_bundleObservations.size();
+    std::cout << "blocks: " << nBlockColumns << std::endl; 
 
     if (m_bundleSettings->solveTargetBody())
       nBlockColumns += 1;
@@ -665,6 +671,7 @@ namespace Isis {
       for (int i = 0; i < nBlockColumns; i++) {
         m_sparseNormals.at(i)->setStartColumn(nParameters);
         nParameters += m_bundleObservations.at(i)->numberParameters();
+        std::cout << "numparms: " << nParameters << std::endl; 
       }
     }
 
@@ -2164,8 +2171,10 @@ namespace Isis {
       observation->applyParameterCorrections(subrange(m_imageSolution,t,t+numParameters));
 
       if (m_bundleSettings->solveTargetBody()) {
-        // TODO: needs to be updated for ISIS vs. CSM CSM has no updateBodyRotation
-//        observation->updateBodyRotation();
+        // TODO: needs to be updated for ISIS vs. CSM CSM has no updateBodyRotation]
+        // TODO: this is no good. 
+        QSharedPointer<BundleObservation> isisObservation = qSharedPointerDynamicCast<BundleObservation>(observation);  
+        isisObservation->updateBodyRotation();
       }
 
       t += numParameters;

--- a/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
+++ b/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
@@ -443,7 +443,6 @@ namespace Isis {
 
       // TODO
       if (m_bundleSettings->solveTargetBody()) {
-        std::cout << "in Target body" << std::endl;
         m_bundleObservations.initializeBodyRotation();
       }
 
@@ -505,7 +504,6 @@ namespace Isis {
     // m_rank will be the sum of observation, target, and self-cal parameters
     // TODO
     m_rank = m_bundleObservations.numberParameters();
-    std::cout << "Num parameters: " << m_rank << std::endl;
 
     if (m_bundleSettings->solveTargetBody()) {
       m_rank += m_bundleSettings->numberTargetBodyParameters();
@@ -646,7 +644,6 @@ namespace Isis {
   bool BundleAdjust::initializeNormalEquationsMatrix() {
 
     int nBlockColumns = m_bundleObservations.size();
-    std::cout << "blocks: " << nBlockColumns << std::endl; 
 
     if (m_bundleSettings->solveTargetBody())
       nBlockColumns += 1;
@@ -671,7 +668,6 @@ namespace Isis {
       for (int i = 0; i < nBlockColumns; i++) {
         m_sparseNormals.at(i)->setStartColumn(nParameters);
         nParameters += m_bundleObservations.at(i)->numberParameters();
-        std::cout << "numparms: " << nParameters << std::endl; 
       }
     }
 

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
@@ -163,24 +163,6 @@ namespace Isis {
   }
 
 
-  // Need something that provides this functionality in child classes, but not here -- function signatures will be different.
-  /**
-   * Set solve parameters
-   *
-   * @param solveSettings The solve settings to use
-   *
-   * @return @b bool Returns true if settings were successfully set
-   *
-   * @internal
-   *   @todo initParameterWeights() doesn't return false, so this methods always
-   *         returns true.
-   */
-  bool AbstractBundleObservation::setSolveSettings(BundleObservationSolveSettings solveSettings) {
-    // different for both
-    return false;
-  }
-
-
   /**
    * Accesses the instrument id
    *

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
@@ -220,6 +220,7 @@ namespace Isis {
    *                                                    settings for this AbstractBundleObservation
    */
   const BundleObservationSolveSettingsQsp AbstractBundleObservation::solveSettings() {
+    // NEEDED for BundleMeasure
     return m_solveSettings;
   }
 

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
@@ -175,9 +175,10 @@ namespace Isis {
    *   @todo initParameterWeights() doesn't return false, so this methods always
    *         returns true.
    */
-//  bool AbstractBundleObservation::setSolveSettings(BundleObservationSolveSettings solveSettings) {
+  bool AbstractBundleObservation::setSolveSettings(BundleObservationSolveSettings solveSettings) {
     // different for both
-//  }
+    return false;
+  }
 
 
   /**
@@ -317,6 +318,8 @@ namespace Isis {
  */
 QString AbstractBundleObservation::formatBundleOutputString(bool errorPropagation, bool imageCSV) {
   // different for both
+  // TODO: either remove or update. 
+  return "Test";
 }
 
 
@@ -345,6 +348,8 @@ QString AbstractBundleObservation::formatBundleOutputString(bool errorPropagatio
    */
   QString AbstractBundleObservation::bundleOutputCSV(bool errorPropagation) {
     // different in both
+    // TODO: either remove or update. 
+    return "Test";
   }
 
 

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
@@ -43,13 +43,14 @@ namespace Isis {
       virtual AbstractBundleObservation &operator=(const AbstractBundleObservation &src);
 
       // copy method
-      virtual void copy(const AbstractBundleObservation &src);
+      // not implementedn in BundleObservation either??? 
+//      virtual void copy(const AbstractBundleObservation &src);
 
-      void append(const BundleImageQsp &value);
+      virtual void append(const BundleImageQsp &value);
 
       BundleImageQsp imageByCubeSerialNumber(QString cubeSerialNumber);
 
-      bool setSolveSettings(BundleObservationSolveSettings solveSettings);
+      virtual bool setSolveSettings(BundleObservationSolveSettings solveSettings);
 
       void setIndex(int n);
       int index();
@@ -61,19 +62,19 @@ namespace Isis {
       LinearAlgebra::Vector &aprioriSigmas();
       LinearAlgebra::Vector &adjustedSigmas();
 
-      const BundleObservationSolveSettingsQsp solveSettings();
+      virtual const BundleObservationSolveSettingsQsp solveSettings();
       int numberParameters();
-      bool applyParameterCorrections(LinearAlgebra::Vector corrections);
+      virtual bool applyParameterCorrections(LinearAlgebra::Vector corrections);
 
 
-      void bundleOutputString(std::ostream &fpOut,bool errorPropagation);
-      QString bundleOutputCSV(bool errorPropagation);
+      virtual void bundleOutputString(std::ostream &fpOut,bool errorPropagation);
+      virtual QString bundleOutputCSV(bool errorPropagation);
 
-      QString formatBundleOutputString(bool errorPropagation, bool imageCSV=false);
+      virtual QString formatBundleOutputString(bool errorPropagation, bool imageCSV=false);
 
       // CAN we have this for both?
-      QStringList parameterList();
-      QStringList imageNames();
+      virtual QStringList parameterList();
+      virtual QStringList imageNames();
 
     private:
       QString m_observationNumber; /**< This is typically equivalent to serial number
@@ -103,7 +104,7 @@ namespace Isis {
   };
 
   //! Typdef for AbstractBundleObservation QSharedPointer.
-  typedef QSharedPointer<AbstractBundleObservation> AbstractBundleObservationQsp; // change name or no?
+  typedef QSharedPointer<AbstractBundleObservation> AbstractBundleObservationQsp;
 }
 
 #endif // AbstractBundleObservation_h

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
@@ -50,8 +50,6 @@ namespace Isis {
 
       BundleImageQsp imageByCubeSerialNumber(QString cubeSerialNumber);
 
-      virtual bool setSolveSettings(BundleObservationSolveSettings solveSettings);
-
       void setIndex(int n);
       int index();
 
@@ -72,7 +70,6 @@ namespace Isis {
 
       virtual QString formatBundleOutputString(bool errorPropagation, bool imageCSV=false);
 
-      // CAN we have this for both?
       virtual QStringList parameterList();
       virtual QStringList imageNames();
 

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
@@ -55,13 +55,14 @@ namespace Isis {
 
       QString instrumentId();
 
-      LinearAlgebra::Vector &parameterWeights();
-      LinearAlgebra::Vector &parameterCorrections();
-      LinearAlgebra::Vector &aprioriSigmas();
-      LinearAlgebra::Vector &adjustedSigmas();
+      virtual LinearAlgebra::Vector &parameterWeights();
+      virtual LinearAlgebra::Vector &parameterCorrections();
+      virtual LinearAlgebra::Vector &aprioriSigmas();
+      virtual LinearAlgebra::Vector &adjustedSigmas();
 
-      virtual const BundleObservationSolveSettingsQsp solveSettings();
-      int numberParameters();
+      // TODO: remove later
+      virtual const BundleObservationSolveSettingsQsp solveSettings();              
+      virtual int numberParameters();
       virtual bool applyParameterCorrections(LinearAlgebra::Vector corrections);
 
 

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
@@ -88,8 +88,6 @@ namespace Isis {
       QStringList m_imageNames;         //!< List of all cube names.
       QString m_instrumentId;      //!< Spacecraft instrument id.
 
-      BundleObservationSolveSettingsQsp m_solveSettings; //!< Solve settings for this observation.
-
       // TODO??? change these to LinearAlgebra vectors...
       LinearAlgebra::Vector m_weights;     //!< Parameter weights.
       //! Cumulative parameter correction vector.
@@ -99,6 +97,7 @@ namespace Isis {
       LinearAlgebra::Vector m_aprioriSigmas;
       //! A posteriori (adjusted) parameter sigmas.
       LinearAlgebra::Vector m_adjustedSigmas;
+      BundleObservationSolveSettingsQsp m_solveSettings; //!< Solve settings for this observation.
   };
 
   //! Typdef for AbstractBundleObservation QSharedPointer.

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
@@ -92,7 +92,6 @@ namespace Isis {
       LinearAlgebra::Vector m_weights;     //!< Parameter weights.
       //! Cumulative parameter correction vector.
       LinearAlgebra::Vector m_corrections;
-      //LinearAlgebra::Vector m_solution;  //!< parameter solution vector.
       //! A posteriori (adjusted) parameter sigmas.
       LinearAlgebra::Vector m_aprioriSigmas;
       //! A posteriori (adjusted) parameter sigmas.

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
@@ -66,7 +66,6 @@ namespace Isis {
       virtual int numberParameters();
       virtual bool applyParameterCorrections(LinearAlgebra::Vector corrections);
 
-
       virtual void bundleOutputString(std::ostream &fpOut,bool errorPropagation);
       virtual QString bundleOutputCSV(bool errorPropagation);
 

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
@@ -29,16 +29,16 @@ namespace Isis {
    * Constructs a BundleObservation initialized to a default state.
    */
   BundleObservation::BundleObservation() {
-//    m_serialNumbers.clear();
-    m_imageNames.clear();
-    m_parameterNamesList.clear();
-    m_observationNumber = "";
-    m_instrumentRotation = NULL;
-    m_instrumentPosition = NULL;
     m_weights.clear();
     m_corrections.clear();
     m_aprioriSigmas.clear();
     m_adjustedSigmas.clear();
+
+    m_parameterNamesList.clear();
+    m_instrumentPosition = NULL;
+    m_instrumentRotation = NULL;
+    // m_solveSettings?
+    // m_bundleTargetBody ? 
   }
 
 
@@ -52,26 +52,18 @@ namespace Isis {
    * @param bundleTargetBody QSharedPointer to the target body of the observation
    */
   BundleObservation::BundleObservation(BundleImageQsp image, QString observationNumber,
-                                       QString instrumentId, BundleTargetBodyQsp bundleTargetBody) {
-//    m_serialNumbers.clear();
-    m_imageNames.clear();
-    m_parameterNamesList.clear();
-    m_observationNumber = "";
-    m_instrumentRotation = NULL;
-    m_instrumentPosition = NULL;
+                                       QString instrumentId, BundleTargetBodyQsp bundleTargetBody) : AbstractBundleObservation(image, observationNumber, instrumentId, bundleTargetBody) {
     m_weights.clear();
     m_corrections.clear();
     m_aprioriSigmas.clear();
     m_adjustedSigmas.clear();
 
-    m_observationNumber = observationNumber;
+    m_parameterNamesList.clear();
     m_bundleTargetBody = bundleTargetBody;
+    m_instrumentRotation = NULL;
+    m_instrumentPosition = NULL;
 
     if (image) {
-      append(image);
-//      m_serialNumbers.append(image->serialNumber());
-//      m_imageNames.append(image->fileName());
-
       // set the observations spice position and rotation objects from the primary image in the
       // observation (this is, by design at the moment, the first image added to the observation)
       // if the image, camera, or instrument position/orientation is null, then set to null
@@ -87,10 +79,6 @@ namespace Isis {
       // set the observations target body spice rotation object from the primary image in the
       // observation (this is, by design at the moment, the first image added to the observation)
       // if the image, camera, or instrument position/orientation is null, then set to null
-      m_bodyRotation = (image->camera() ?
-                           (image->camera()->bodyRotation() ?
-                             image->camera()->bodyRotation() : NULL)
-                           : NULL);
     }
   }
 
@@ -100,12 +88,11 @@ namespace Isis {
    *
    * @param src Reference to the BundleObservation to copy
    */
-  BundleObservation::BundleObservation(const BundleObservation &src) {
-//    m_serialNumbers = src.m_serialNumbers;
-    m_observationNumber = src.m_observationNumber;
+  BundleObservation::BundleObservation(const BundleObservation &src) : AbstractBundleObservation(src) {
     m_instrumentPosition = src.m_instrumentPosition;
     m_instrumentRotation = src.m_instrumentRotation;
     m_solveSettings = src.m_solveSettings;
+    // why not m_targetBody?
   }
 
 
@@ -130,11 +117,11 @@ namespace Isis {
    */
   BundleObservation &BundleObservation::operator=(const BundleObservation &src) {
     if (&src != this) {
-//      m_serialNumbers = src.m_serialNumbers;
-      m_observationNumber = src.m_observationNumber;
+      AbstractBundleObservation::operator=(src);
       m_instrumentPosition = src.m_instrumentPosition;
       m_instrumentRotation = src.m_instrumentRotation;
       m_solveSettings = src.m_solveSettings;
+    // why not m_targetBody?
     }
     return *this;
   }
@@ -168,8 +155,6 @@ namespace Isis {
     m_weights.clear();
     m_corrections.resize(nParameters);
     m_corrections.clear();
-//    m_solution.resize(nParameters);
-//    m_solution.clear();
     m_adjustedSigmas.resize(nParameters);
     m_adjustedSigmas.clear();
     m_aprioriSigmas.resize(nParameters);
@@ -474,9 +459,6 @@ namespace Isis {
         m_weights[nCamPosCoeffsSolved + i] = angAccWeight;
       }
     }
-
-//    for ( int i = 0; i < (int)m_weights.size(); i++ )
-//      std::cout << m_weights[i] << std::endl;
 
     return true;
   }

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
@@ -647,25 +647,6 @@ namespace Isis {
 
 
   /**
-   * Sets the index for the observation
-   *
-   * @param n Value to set the index of the observation to
-   */
-//  void BundleObservation::setIndex(int n) {
-//    m_index = n;
-//  }
-
-
-  /**
-   * Accesses the observation's index
-   *
-   * @return @b int Returns the observation's index
-   */
-//  int BundleObservation::index() {
-//    return m_index;
-//  }
-
-  /**
  * @brief Creates and returns a formatted QString representing the bundle coefficients and
  * parameters
  *

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
@@ -29,7 +29,7 @@ namespace Isis {
    * Constructs a BundleObservation initialized to a default state.
    */
   BundleObservation::BundleObservation() {
-    m_serialNumbers.clear();
+//    m_serialNumbers.clear();
     m_imageNames.clear();
     m_parameterNamesList.clear();
     m_observationNumber = "";
@@ -53,7 +53,7 @@ namespace Isis {
    */
   BundleObservation::BundleObservation(BundleImageQsp image, QString observationNumber,
                                        QString instrumentId, BundleTargetBodyQsp bundleTargetBody) {
-    m_serialNumbers.clear();
+//    m_serialNumbers.clear();
     m_imageNames.clear();
     m_parameterNamesList.clear();
     m_observationNumber = "";
@@ -69,8 +69,8 @@ namespace Isis {
 
     if (image) {
       append(image);
-      m_serialNumbers.append(image->serialNumber());
-      m_imageNames.append(image->fileName());
+//      m_serialNumbers.append(image->serialNumber());
+//      m_imageNames.append(image->fileName());
 
       // set the observations spice position and rotation objects from the primary image in the
       // observation (this is, by design at the moment, the first image added to the observation)
@@ -87,10 +87,10 @@ namespace Isis {
       // set the observations target body spice rotation object from the primary image in the
       // observation (this is, by design at the moment, the first image added to the observation)
       // if the image, camera, or instrument position/orientation is null, then set to null
-//      m_bodyRotation = (image->camera() ?
-//                           (image->camera()->bodyRotation() ?
-//                             image->camera()->bodyRotation() : NULL)
-//                           : NULL);
+      m_bodyRotation = (image->camera() ?
+                           (image->camera()->bodyRotation() ?
+                             image->camera()->bodyRotation() : NULL)
+                           : NULL);
     }
   }
 
@@ -101,7 +101,7 @@ namespace Isis {
    * @param src Reference to the BundleObservation to copy
    */
   BundleObservation::BundleObservation(const BundleObservation &src) {
-    m_serialNumbers = src.m_serialNumbers;
+//    m_serialNumbers = src.m_serialNumbers;
     m_observationNumber = src.m_observationNumber;
     m_instrumentPosition = src.m_instrumentPosition;
     m_instrumentRotation = src.m_instrumentRotation;
@@ -130,7 +130,7 @@ namespace Isis {
    */
   BundleObservation &BundleObservation::operator=(const BundleObservation &src) {
     if (&src != this) {
-      m_serialNumbers = src.m_serialNumbers;
+//      m_serialNumbers = src.m_serialNumbers;
       m_observationNumber = src.m_observationNumber;
       m_instrumentPosition = src.m_instrumentPosition;
       m_instrumentRotation = src.m_instrumentRotation;

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.cpp
@@ -33,13 +33,10 @@ namespace Isis {
     m_imageNames.clear();
     m_parameterNamesList.clear();
     m_observationNumber = "";
-    m_instrumentId = "";
     m_instrumentRotation = NULL;
     m_instrumentPosition = NULL;
-    m_index = 0;
     m_weights.clear();
     m_corrections.clear();
-//    m_solution.clear();
     m_aprioriSigmas.clear();
     m_adjustedSigmas.clear();
   }
@@ -60,26 +57,20 @@ namespace Isis {
     m_imageNames.clear();
     m_parameterNamesList.clear();
     m_observationNumber = "";
-    m_instrumentId = "";
     m_instrumentRotation = NULL;
     m_instrumentPosition = NULL;
-    m_index = 0;
     m_weights.clear();
     m_corrections.clear();
-//    m_solution.clear();
     m_aprioriSigmas.clear();
     m_adjustedSigmas.clear();
 
     m_observationNumber = observationNumber;
-    m_instrumentId = instrumentId;
-
     m_bundleTargetBody = bundleTargetBody;
 
     if (image) {
       append(image);
       m_serialNumbers.append(image->serialNumber());
       m_imageNames.append(image->fileName());
-      m_cubeSerialNumberToBundleImageMap.insert(image->serialNumber(), image);
 
       // set the observations spice position and rotation objects from the primary image in the
       // observation (this is, by design at the moment, the first image added to the observation)
@@ -111,17 +102,10 @@ namespace Isis {
    */
   BundleObservation::BundleObservation(const BundleObservation &src) {
     m_serialNumbers = src.m_serialNumbers;
-    m_cubeSerialNumberToBundleImageMap = src.m_cubeSerialNumberToBundleImageMap;
-
     m_observationNumber = src.m_observationNumber;
-    m_instrumentId = src.m_instrumentId;
-
     m_instrumentPosition = src.m_instrumentPosition;
     m_instrumentRotation = src.m_instrumentRotation;
-
     m_solveSettings = src.m_solveSettings;
-
-    m_index = src.m_index;
   }
 
 
@@ -147,53 +131,12 @@ namespace Isis {
   BundleObservation &BundleObservation::operator=(const BundleObservation &src) {
     if (&src != this) {
       m_serialNumbers = src.m_serialNumbers;
-      m_cubeSerialNumberToBundleImageMap = src.m_cubeSerialNumberToBundleImageMap;
-
       m_observationNumber = src.m_observationNumber;
-      m_instrumentId = src.m_instrumentId;
-
       m_instrumentPosition = src.m_instrumentPosition;
       m_instrumentRotation = src.m_instrumentRotation;
-
       m_solveSettings = src.m_solveSettings;
     }
     return *this;
-  }
-
-
-  /**
-   * Appends a BundleImage shared pointer to the BundleObservation.
-   * If the pointer is valid, then the BundleImage and its serial number will be inserted into
-   * the serial number to BundleImage map.
-   *
-   * @param value The BundleImage to be appended.
-   *
-   * @see QVector::append()
-   */
-  void BundleObservation::append(const BundleImageQsp &value) {
-    if (value) {
-      m_cubeSerialNumberToBundleImageMap.insert(value->serialNumber(), value);
-    }
-    QVector<BundleImageQsp>::append(value);
-  }
-
-
-  /**
-   * Returns the BundleImage shared pointer associated with the given serial number.
-   * If no BundleImage with that serial number is contained a NULL pointer is returned.
-   *
-   * @param cubeSerialNumber The serial number of the cube to be returned.
-   *
-   * @return @b BundleImageQsp A shared pointer to the BundleImage (NULL if not found).
-   */
-  BundleImageQsp BundleObservation::imageByCubeSerialNumber(QString cubeSerialNumber) {
-    BundleImageQsp bundleImage;
-
-    if (m_cubeSerialNumberToBundleImageMap.contains(cubeSerialNumber)) {
-      bundleImage = m_cubeSerialNumberToBundleImageMap.value(cubeSerialNumber);
-    }
-
-    return bundleImage;
   }
 
 
@@ -244,16 +187,6 @@ namespace Isis {
 
 
   /**
-   * Accesses the instrument id
-   *
-   * @return @b QString Returns the instrument id of the observation
-   */
-  QString BundleObservation::instrumentId() {
-    return m_instrumentId;
-  }
-
-
-  /**
    * Accesses the instrument's spice rotation
    *
    * @return @b SpiceRotation* Returns the SpiceRotation for this observation
@@ -291,15 +224,6 @@ namespace Isis {
   LinearAlgebra::Vector &BundleObservation::parameterCorrections() {
     return m_corrections;
   }
-
-
-  /**
-   * @internal
-   *   @todo
-   */
-//  LinearAlgebra::Vector &BundleObservation::parameterSolution() {
-//    return m_solution;
-//  }
 
 
   /**
@@ -342,81 +266,79 @@ namespace Isis {
    *   @todo Should this always return true?
    */
   bool BundleObservation::initializeExteriorOrientation() {
-    std::cout << "do something with states instead" << std::endl;
-//    if (m_solveSettings->instrumentPositionSolveOption() !=
-//        BundleObservationSolveSettings::NoPositionFactors) {
-//
-//      double positionBaseTime = 0.0;
-//      double positiontimeScale = 0.0;
-//      std::vector<double> posPoly1, posPoly2, posPoly3;
-//
-//      for (int i = 0; i < size(); i++) {
-//        BundleImageQsp image = at(i);
-//        SpicePosition *spicePosition = image->camera()->instrumentPosition();
-//
-//        if (i > 0) {
-//          spicePosition->SetPolynomialDegree(m_solveSettings->spkSolveDegree());
-//          spicePosition->SetOverrideBaseTime(positionBaseTime, positiontimeScale);
-//          spicePosition->SetPolynomial(posPoly1, posPoly2, posPoly3,
-//                                       m_solveSettings->positionInterpolationType());
-//        }
-//        else {
-//          // first, set the degree of the spk polynomial to be fit for a priori values
-//          spicePosition->SetPolynomialDegree(m_solveSettings->spkDegree());
-//
-//          // now, set what kind of interpolation to use (SPICE, memcache, hermitecache, polynomial
-//          // function, or polynomial function over constant hermite spline)
-//          // TODO: verify - I think this actually performs the a priori fit
-//          spicePosition->SetPolynomial(m_solveSettings->positionInterpolationType());
-//
-//          // finally, set the degree of the spk polynomial actually used in the bundle adjustment
-//          spicePosition->SetPolynomialDegree(m_solveSettings->spkSolveDegree());
-//
-//          if (m_instrumentPosition) { // ??? TODO: why is this different from rotation code below???
-//            positionBaseTime = m_instrumentPosition->GetBaseTime();
-//            positiontimeScale = m_instrumentPosition->GetTimeScale();
-//            m_instrumentPosition->GetPolynomial(posPoly1, posPoly2, posPoly3);
-//          }
-//        }
-//      }
-//    }
-//
-//    if (m_solveSettings->instrumentPointingSolveOption() !=
-//        BundleObservationSolveSettings::NoPointingFactors) {
-//
-//      double rotationBaseTime = 0.0;
-//      double rotationtimeScale = 0.0;
-//      std::vector<double> anglePoly1, anglePoly2, anglePoly3;
-//
-//      for (int i = 0; i < size(); i++) {
-//        BundleImageQsp image = at(i);
-//        SpiceRotation *spicerotation = image->camera()->instrumentRotation();
-//
-//        if (i > 0) {
-//          spicerotation->SetPolynomialDegree(m_solveSettings->ckSolveDegree());
-//          spicerotation->SetOverrideBaseTime(rotationBaseTime, rotationtimeScale);
-//          spicerotation->SetPolynomial(anglePoly1, anglePoly2, anglePoly3,
-//                                       m_solveSettings->pointingInterpolationType());
-//        }
-//        else {
-//          // first, set the degree of the spk polynomial to be fit for a priori values
-//          spicerotation->SetPolynomialDegree(m_solveSettings->ckDegree());
-//
-//          // now, set what kind of interpolation to use (SPICE, memcache, hermitecache, polynomial
-//          // function, or polynomial function over constant hermite spline)
-//          // TODO: verify - I think this actually performs the a priori fit
-//          spicerotation->SetPolynomial(m_solveSettings->pointingInterpolationType());
-//
-//          // finally, set the degree of the spk polynomial actually used in the bundle adjustment
-//          spicerotation->SetPolynomialDegree(m_solveSettings->ckSolveDegree());
-//
-//          rotationBaseTime = spicerotation->GetBaseTime();
-//          rotationtimeScale = spicerotation->GetTimeScale();
-//          spicerotation->GetPolynomial(anglePoly1, anglePoly2, anglePoly3);
-//        }
-//      }
-//    }
-//
+    if (m_solveSettings->instrumentPositionSolveOption() !=
+        BundleObservationSolveSettings::NoPositionFactors) {
+
+      double positionBaseTime = 0.0;
+      double positiontimeScale = 0.0;
+      std::vector<double> posPoly1, posPoly2, posPoly3;
+
+      for (int i = 0; i < size(); i++) {
+        BundleImageQsp image = at(i);
+        SpicePosition *spicePosition = image->camera()->instrumentPosition();
+
+        if (i > 0) {
+          spicePosition->SetPolynomialDegree(m_solveSettings->spkSolveDegree());
+          spicePosition->SetOverrideBaseTime(positionBaseTime, positiontimeScale);
+          spicePosition->SetPolynomial(posPoly1, posPoly2, posPoly3,
+                                       m_solveSettings->positionInterpolationType());
+        }
+        else {
+          // first, set the degree of the spk polynomial to be fit for a priori values
+          spicePosition->SetPolynomialDegree(m_solveSettings->spkDegree());
+
+          // now, set what kind of interpolation to use (SPICE, memcache, hermitecache, polynomial
+          // function, or polynomial function over constant hermite spline)
+          // TODO: verify - I think this actually performs the a priori fit
+          spicePosition->SetPolynomial(m_solveSettings->positionInterpolationType());
+
+          // finally, set the degree of the spk polynomial actually used in the bundle adjustment
+          spicePosition->SetPolynomialDegree(m_solveSettings->spkSolveDegree());
+
+          if (m_instrumentPosition) { // ??? TODO: why is this different from rotation code below???
+            positionBaseTime = m_instrumentPosition->GetBaseTime();
+            positiontimeScale = m_instrumentPosition->GetTimeScale();
+            m_instrumentPosition->GetPolynomial(posPoly1, posPoly2, posPoly3);
+          }
+        }
+      }
+    }
+
+    if (m_solveSettings->instrumentPointingSolveOption() !=
+        BundleObservationSolveSettings::NoPointingFactors) {
+
+      double rotationBaseTime = 0.0;
+      double rotationtimeScale = 0.0;
+      std::vector<double> anglePoly1, anglePoly2, anglePoly3;
+
+      for (int i = 0; i < size(); i++) {
+        BundleImageQsp image = at(i);
+        SpiceRotation *spicerotation = image->camera()->instrumentRotation();
+
+        if (i > 0) {
+          spicerotation->SetPolynomialDegree(m_solveSettings->ckSolveDegree());
+          spicerotation->SetOverrideBaseTime(rotationBaseTime, rotationtimeScale);
+          spicerotation->SetPolynomial(anglePoly1, anglePoly2, anglePoly3,
+                                       m_solveSettings->pointingInterpolationType());
+        }
+        else {
+          // first, set the degree of the spk polynomial to be fit for a priori values
+          spicerotation->SetPolynomialDegree(m_solveSettings->ckDegree());
+
+          // now, set what kind of interpolation to use (SPICE, memcache, hermitecache, polynomial
+          // function, or polynomial function over constant hermite spline)
+          // TODO: verify - I think this actually performs the a priori fit
+          spicerotation->SetPolynomial(m_solveSettings->pointingInterpolationType());
+
+          // finally, set the degree of the spk polynomial actually used in the bundle adjustment
+          spicerotation->SetPolynomialDegree(m_solveSettings->ckSolveDegree());
+
+          rotationBaseTime = spicerotation->GetBaseTime();
+          rotationtimeScale = spicerotation->GetTimeScale();
+          spicerotation->GetPolynomial(anglePoly1, anglePoly2, anglePoly3);
+        }
+      }
+    }
     return true;
   }
 
@@ -454,54 +376,6 @@ namespace Isis {
       image->camera()->bodyRotation()->setPckPolynomial(raCoefs, decCoefs, pmCoefs);
     }
   }
-
-
-/*
-  bool BundleObservation::initializeExteriorOrientation() {
-
-    if (m_solveSettings->instrumentPositionSolveOption() !=
-        BundleObservationSolveSettings::NoPositionFactors) {
-
-      for (int i = 0; i < size(); i++) {
-        BundleImageQsp image = at(i);
-        SpicePosition *spiceposition = image->camera()->instrumentPosition();
-
-        // first, set the degree of the spk polynomial to be fit for a priori values
-        spiceposition->SetPolynomialDegree(m_solveSettings->spkDegree());
-
-        // now, set what kind of interpolation to use (SPICE, memcache, hermitecache, polynomial
-        // function, or polynomial function over constant hermite spline)
-        // TODO: verify - I think this actually performs the a priori fit
-        spiceposition->SetPolynomial(m_solveSettings->positionInterpolationType());
-
-        // finally, set the degree of the spk polynomial actually used in the bundle adjustment
-        spiceposition->SetPolynomialDegree(m_solveSettings->spkSolveDegree());
-      }
-    }
-
-    if (m_solveSettings->instrumentPointingSolveOption() !=
-        BundleObservationSolveSettings::NoPointingFactors) {
-
-      for (int i = 0; i < size(); i++) {
-        BundleImageQsp image = at(i);
-        SpiceRotation *spicerotation = image->camera()->instrumentRotation();
-
-        // first, set the degree of the spk polynomial to be fit for a priori values
-        spicerotation->SetPolynomialDegree(m_solveSettings->ckDegree());
-
-        // now, set what kind of interpolation to use (SPICE, memcache, hermitecache, polynomial
-        // function, or polynomial function over constant hermite spline)
-        // TODO: verify - I think this actually performs the a priori fit
-        spicerotation->SetPolynomial(m_solveSettings->pointingInterpolationType());
-
-        // finally, set the degree of the spk polynomial actually used in the bundle adjustment
-        spicerotation->SetPolynomialDegree(m_solveSettings->ckSolveDegree());
-      }
-    }
-
-    return true;
-  }
-*/
 
 
   /**
@@ -777,9 +651,9 @@ namespace Isis {
    *
    * @param n Value to set the index of the observation to
    */
-  void BundleObservation::setIndex(int n) {
-    m_index = n;
-  }
+//  void BundleObservation::setIndex(int n) {
+//    m_index = n;
+//  }
 
 
   /**
@@ -787,9 +661,9 @@ namespace Isis {
    *
    * @return @b int Returns the observation's index
    */
-  int BundleObservation::index() {
-    return m_index;
-  }
+//  int BundleObservation::index() {
+//    return m_index;
+//  }
 
   /**
  * @brief Creates and returns a formatted QString representing the bundle coefficients and
@@ -1573,25 +1447,5 @@ QString BundleObservation::formatBundleOutputString(bool errorPropagation, bool 
     }
 
     return finalqStr;
-  }
-
-
-  /**
-   * Access to parameters for CorrelationMatrix to use.
-   *
-   * @return @b QStringList Returns a QStringList of the names of the parameters
-   */
-  QStringList BundleObservation::parameterList() {
-    return m_parameterNamesList;
-  }
-
-
-  /**
-   * Access to image names for CorrelationMatrix to use.
-   *
-   * @return @b QStringList Returns a QStringList of the image names
-   */
-  QStringList BundleObservation::imageNames() {
-    return m_imageNames;
   }
 }

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.h
@@ -152,7 +152,6 @@ namespace Isis {
 
       SpiceRotation *m_instrumentRotation;   //!< Instrument spice rotation (in primary image).
       SpicePosition *m_instrumentPosition;   //!< Instrument spice position (in primary image).
-      SpiceRotation *m_bodyRotation;         //!< Instrument body rotation (in primary image).
 
       BundleTargetBodyQsp m_bundleTargetBody;       //!< QShared pointer to BundleTargetBody.
 

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.h
@@ -138,16 +138,6 @@ namespace Isis {
       bool initParameterWeights();
 
     private:
-      QString m_observationNumber; /**< This is typically equivalent to serial number
-                                        except in the case of "observation mode" (e.g.
-                                        Lunar Orbiter) where for each image in the
-                                        observation, the observation number is the serial number
-                                        augmented with an additional integer. **/
-
-      QStringList m_serialNumbers;      //!< List of all cube serial numbers in observation.
-      QStringList m_parameterNamesList; //!< List of all cube parameters.
-      QStringList m_imageNames;         //!< List of all cube names.
-
       BundleObservationSolveSettingsQsp m_solveSettings; //!< Solve settings for this observation.
 
       SpiceRotation *m_instrumentRotation;   //!< Instrument spice rotation (in primary image).

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.h
@@ -104,20 +104,11 @@ namespace Isis {
       // copy method
       void copy(const BundleObservation &src);
 
-      void append(const BundleImageQsp &value);
-
-      BundleImageQsp imageByCubeSerialNumber(QString cubeSerialNumber);
-
       bool setSolveSettings(BundleObservationSolveSettings solveSettings);
-
-      void setIndex(int n);
-      int index();
 
       int numberPositionParameters();
       int numberPointingParameters();
       int numberParameters();
-
-      QString instrumentId();
 
       SpiceRotation *spiceRotation();
       SpicePosition *spicePosition();
@@ -142,10 +133,8 @@ namespace Isis {
       QString bundleOutputCSV(bool errorPropagation);
 
       QString formatBundleOutputString(bool errorPropagation, bool imageCSV=false);
-      QStringList parameterList();
-      QStringList imageNames();
 
-    private:
+   private:
       bool initParameterWeights();
 
     private:
@@ -155,16 +144,9 @@ namespace Isis {
                                         observation, the observation number is the serial number
                                         augmented with an additional integer. **/
 
-      int m_index; //!< Index of this observation.
-
-      //! Map between cube serial number and BundleImage pointers.
-      QMap<QString, BundleImageQsp> m_cubeSerialNumberToBundleImageMap;
-
       QStringList m_serialNumbers;      //!< List of all cube serial numbers in observation.
       QStringList m_parameterNamesList; //!< List of all cube parameters.
       QStringList m_imageNames;         //!< List of all cube names.
-
-      QString m_instrumentId;      //!< Spacecraft instrument id.
 
       BundleObservationSolveSettingsQsp m_solveSettings; //!< Solve settings for this observation.
 
@@ -178,7 +160,6 @@ namespace Isis {
       LinearAlgebra::Vector m_weights;     //!< Parameter weights.
       //! Cumulative parameter correction vector.
       LinearAlgebra::Vector m_corrections;
-      //LinearAlgebra::Vector m_solution;  //!< parameter solution vector.
       //! A posteriori (adjusted) parameter sigmas.
       LinearAlgebra::Vector m_aprioriSigmas;
       //! A posteriori (adjusted) parameter sigmas.

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.h
@@ -152,7 +152,7 @@ namespace Isis {
 
       SpiceRotation *m_instrumentRotation;   //!< Instrument spice rotation (in primary image).
       SpicePosition *m_instrumentPosition;   //!< Instrument spice position (in primary image).
-//    SpiceRotation *m_bodyRotation;         //!< Instrument body rotation (in primary image).
+      SpiceRotation *m_bodyRotation;         //!< Instrument body rotation (in primary image).
 
       BundleTargetBodyQsp m_bundleTargetBody;       //!< QShared pointer to BundleTargetBody.
 

--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
@@ -160,51 +160,129 @@ namespace Isis {
       // update image serial number to observation ptr map
       m_imageSerialToObservationMap.insertMulti(bundleImage->serialNumber(), bundleObservation);
     }
-
     return bundleObservation;
   }
+
+  // Does this make sense
+/*  BundleObservationQsp BundleObservationVector::addNewIsis(BundleImageQsp bundleImage,
+                                                           QString observationNumber,
+                                                           QString instrumentId,
+                                                           BundleSettingsQsp bundleSettings) {
+
+      BundleObservationQsp bundleObservation;
+      bool addToExisting = false;
+
+      // TODO it looks like this can just become 1 if statement
+      if (bundleSettings->solveObservationMode() &&
+          m_observationNumberToObservationMap.contains(observationNumber)) {
+        bundleObservation = m_observationNumberToObservationMap.value(observationNumber);
+
+        addToExisting = true;
+      }
+
+      if (addToExisting) {
+        // if we have already added a BundleObservation with this number, we have to add the new
+        // BundleImage to this observation
+        bundleObservation->append(bundleImage);
+
+        bundleImage->setParentObservation(bundleObservation);
+
+        // update observation number to observation ptr map
+        m_observationNumberToObservationMap.insertMulti(observationNumber,bundleObservation);
+
+        // update image serial number to observation ptr map
+        m_imageSerialToObservationMap.insertMulti(bundleImage->serialNumber(), bundleObservation);
+      }
+      else {
+        // create new BundleObservation and append to this vector
+        BundleObservation *isisObservation = new BundleObservation(bundleImage,
+                                                                   observationNumber,
+                                                                   instrumentId,
+                                                                   bundleSettings->bundleTargetBody());
+
+
+        if (!isisObservation) {
+          QString message = "Unable to allocate new BundleObservation ";
+          message += "for " + bundleImage->fileName();
+          throw IException(IException::Programmer, message, _FILEINFO_);
+        }
+
+        // Find the bundle observation solve settings for this new observation
+        BundleObservationSolveSettings solveSettings;
+        // When there is only one bundle observation solve setting, use it for all observations
+        if ( bundleSettings->numberSolveSettings() == 1) {
+          solveSettings = bundleSettings->observationSolveSettings(0);
+        }
+        // Otherwise, we want to grab the bundle observation solve settings that is associated with
+        // the observation number for this new observation
+        else {
+          solveSettings = bundleSettings->observationSolveSettings(observationNumber);
+        }
+
+        isisObservation->setSolveSettings(solveSettings);
+
+        bundleObservation.reset(isisObservation);
+
+        bundleObservation->setIndex(size());
+
+        bundleImage->setParentObservation(bundleObservation);
+
+        append(bundleObservation);
+
+        // update observation number to observation ptr map
+        m_observationNumberToObservationMap.insertMulti(observationNumber, bundleObservation);
+
+        // update image serial number to observation ptr map
+        m_imageSerialToObservationMap.insertMulti(bundleImage->serialNumber(), bundleObservation);
+      }
+      return bundleObservation;
+    }*/
 
 
   // getCsmObservations()
   // getIsisObservations()
 
-  // FIXME: needs to go
+  // TODO: if we break API anyway just remove this
   /**
-   * Accesses the number of position parameters for the contained BundleObservations.
+   * Accesses the number of ISIS position parameters for the
+   * contained BundleObservations.
    *
    * @return @b int Returns the total number of position parameters for the BundleObservations
    */
   int BundleObservationVector::numberPositionParameters() {
     int positionParameters = 0;
 
+    // loop over isis observations 
     for (int i = 0; i < size(); i++) {
-      AbstractBundleObservationQsp observation = at(i);
-     // positionParameters += observation->numberPositionParameters();
+      QSharedPointer<BundleObservation> observation = qSharedPointerDynamicCast<BundleObservation>( at(i) );
+      positionParameters += observation->numberPositionParameters();
     }
 
     return positionParameters;
+    // return 0 only CSM observations
   }
 
 
-  // FIXME: needs to go
+  // TODO: if we break API anyway just remove this
   /**
-   * Accesses the number of pointing parameters for the contained BundleObservations.
+   * Accesses the number of ISIS pointing parameters for the
+   * contained BundleObservations.
    *
    * @return @b int Returns the total number of pointing parameters for the BundleObservations
    */
   int BundleObservationVector::numberPointingParameters() {
     int pointingParameters = 0;
 
+    // loop over just isis observations
     for (int i = 0; i < size(); i++) {
-      AbstractBundleObservationQsp observation = at(i);
-//      pointingParameters += observation->numberPointingParameters();
+      QSharedPointer<BundleObservation> observation = qSharedPointerDynamicCast<BundleObservation>( at(i) );
+      pointingParameters += observation->numberPointingParameters();
     }
-
     return pointingParameters;
+    // return 0 only CSM observations
   }
 
 
-  // FIXME: update so it makes sense
   /**
    * Returns the sum of the position parameters and pointing parameters for the contained
    * BundleObservations.
@@ -212,6 +290,7 @@ namespace Isis {
    * @return @b int Returns the total number of parameters for the contained BundleObservations
    */
   int BundleObservationVector::numberParameters() {
+    //TODO: change this to include CSM parameters
     return numberPositionParameters() + numberPointingParameters();
   }
 
@@ -237,18 +316,23 @@ namespace Isis {
   }
 
 
-
-  // TODO: has to go
   /**
-   * Initializes the exterior orientations for the contained BundleObservations.
+   * Initializes the exterior orientations for the contained ISIS
+   * BundleObservations.
    *
    * @return @b bool Returns true upon successful initialization
    */
   bool BundleObservationVector::initializeExteriorOrientation() {
+    // get isis observations
+    // get csm observations 
+
     int nObservations = size();
+    // just do it for ISIS observations
     for (int i = 0; i < nObservations; i++) {
-//      BundleObservationQsp observation = at(i);
-//      observation->initializeExteriorOrientation();
+      QSharedPointer<BundleObservation> observation = qSharedPointerDynamicCast<BundleObservation>( at(i) );
+//      AbstractBundleObservationQsp observation = at(i);
+      // TODO: how to only do this if ISIS observations
+      observation->initializeExteriorOrientation();
     }
     return true;
   }
@@ -262,6 +346,7 @@ namespace Isis {
    */
   bool BundleObservationVector::initializeBodyRotation() {
     int nObservations = size();
+    // just do it for ISIS observations
     for (int i = 0; i < nObservations; i++) {
 //      BundleObservationQsp observation = at(i);
 //      observation->initializeBodyRotation();

--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
@@ -112,7 +112,7 @@ namespace Isis {
 
       bundleImage->setParentObservation(bundleObservation);
 
-      // update observation number to observation ptr map
+      // updateo observation number to observation ptr map
       m_observationNumberToObservationMap.insertMulti(observationNumber,bundleObservation);
 
       // update image serial number to observation ptr map
@@ -163,82 +163,7 @@ namespace Isis {
     return bundleObservation;
   }
 
-  // Does this make sense
-/*  BundleObservationQsp BundleObservationVector::addNewIsis(BundleImageQsp bundleImage,
-                                                           QString observationNumber,
-                                                           QString instrumentId,
-                                                           BundleSettingsQsp bundleSettings) {
-
-      BundleObservationQsp bundleObservation;
-      bool addToExisting = false;
-
-      // TODO it looks like this can just become 1 if statement
-      if (bundleSettings->solveObservationMode() &&
-          m_observationNumberToObservationMap.contains(observationNumber)) {
-        bundleObservation = m_observationNumberToObservationMap.value(observationNumber);
-
-        addToExisting = true;
-      }
-
-      if (addToExisting) {
-        // if we have already added a BundleObservation with this number, we have to add the new
-        // BundleImage to this observation
-        bundleObservation->append(bundleImage);
-
-        bundleImage->setParentObservation(bundleObservation);
-
-        // update observation number to observation ptr map
-        m_observationNumberToObservationMap.insertMulti(observationNumber,bundleObservation);
-
-        // update image serial number to observation ptr map
-        m_imageSerialToObservationMap.insertMulti(bundleImage->serialNumber(), bundleObservation);
-      }
-      else {
-        // create new BundleObservation and append to this vector
-        BundleObservation *isisObservation = new BundleObservation(bundleImage,
-                                                                   observationNumber,
-                                                                   instrumentId,
-                                                                   bundleSettings->bundleTargetBody());
-
-
-        if (!isisObservation) {
-          QString message = "Unable to allocate new BundleObservation ";
-          message += "for " + bundleImage->fileName();
-          throw IException(IException::Programmer, message, _FILEINFO_);
-        }
-
-        // Find the bundle observation solve settings for this new observation
-        BundleObservationSolveSettings solveSettings;
-        // When there is only one bundle observation solve setting, use it for all observations
-        if ( bundleSettings->numberSolveSettings() == 1) {
-          solveSettings = bundleSettings->observationSolveSettings(0);
-        }
-        // Otherwise, we want to grab the bundle observation solve settings that is associated with
-        // the observation number for this new observation
-        else {
-          solveSettings = bundleSettings->observationSolveSettings(observationNumber);
-        }
-
-        isisObservation->setSolveSettings(solveSettings);
-
-        bundleObservation.reset(isisObservation);
-
-        bundleObservation->setIndex(size());
-
-        bundleImage->setParentObservation(bundleObservation);
-
-        append(bundleObservation);
-
-        // update observation number to observation ptr map
-        m_observationNumberToObservationMap.insertMulti(observationNumber, bundleObservation);
-
-        // update image serial number to observation ptr map
-        m_imageSerialToObservationMap.insertMulti(bundleImage->serialNumber(), bundleObservation);
-      }
-      return bundleObservation;
-    }*/
-
-
+  // addnewIsis vs. CSM?
   // getCsmObservations()
   // getIsisObservations()
 
@@ -325,20 +250,17 @@ namespace Isis {
   bool BundleObservationVector::initializeExteriorOrientation() {
     // get isis observations
     // get csm observations 
-
     int nObservations = size();
     // just do it for ISIS observations
     for (int i = 0; i < nObservations; i++) {
-      QSharedPointer<BundleObservation> observation = qSharedPointerDynamicCast<BundleObservation>( at(i) );
-//      AbstractBundleObservationQsp observation = at(i);
       // TODO: how to only do this if ISIS observations
+      QSharedPointer<BundleObservation> observation = qSharedPointerDynamicCast<BundleObservation>( at(i) );
       observation->initializeExteriorOrientation();
     }
     return true;
   }
 
 
-  // TODO: has to go
   /**
    * Initializes the body rotations for the contained BundleObservations.
    *
@@ -346,10 +268,10 @@ namespace Isis {
    */
   bool BundleObservationVector::initializeBodyRotation() {
     int nObservations = size();
-    // just do it for ISIS observations
+    //TODO: just do it for ISIS observations
     for (int i = 0; i < nObservations; i++) {
-//      BundleObservationQsp observation = at(i);
-//      observation->initializeBodyRotation();
+    QSharedPointer<BundleObservation> observation = qSharedPointerDynamicCast<BundleObservation>( at(i) );
+      observation->initializeBodyRotation();
     }
 
     return true;

--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.h
@@ -16,6 +16,7 @@ find files of those names at the top level of this repository. **/
 
 #include "BundleImage.h"
 #include "AbstractBundleObservation.h"
+#include "BundleObservation.h"
 #include "BundleSettings.h"
 
 namespace Isis {
@@ -60,6 +61,10 @@ namespace Isis {
                                           QString observationNumber,
                                           QString instrumentId,
                                           BundleSettingsQsp bundleSettings);
+//      BundleObservation addNewIsis(BundleImageQsp image,
+//                                   QString observationNumber,
+//                                   QString instrumentId,
+//                                   BundleSettingsQsp bundleSettings);
 
       int numberPositionParameters();
       int numberPointingParameters();

--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.h
@@ -61,10 +61,6 @@ namespace Isis {
                                           QString observationNumber,
                                           QString instrumentId,
                                           BundleSettingsQsp bundleSettings);
-//      BundleObservation addNewIsis(BundleImageQsp image,
-//                                   QString observationNumber,
-//                                   QString instrumentId,
-//                                   BundleSettingsQsp bundleSettings);
 
       int numberPositionParameters();
       int numberPointingParameters();
@@ -78,6 +74,7 @@ namespace Isis {
       // To add: 
       // getCsmObservations()
       // getIsisObservations()
+      // addNewIsis()?
 
   private:
       //! Map between observation number and pointer to observation.


### PR DESCRIPTION
## Description
With this update all old-format jigsaw app tests pass and also the new-format jigsaw tests pass. 
One Bundle-class unit test is still failing:
* isis_unit_test_BundleSolutionInfo (Failed)

Notes:
* I left the corrections, weights, adjustedsigmas, and apriorisigmas in `BundleObservation` for now. I think eventually they can probably come out and remain only in the parent class, but I didn't get around to getting this working.
* I removed all the large blocks of code that were already commented out in the Bundle classes I updated. My feeling was that if we we want to ultimately keep these sections of commented-out code, we can add them back in when the re-designed code is a bit more mature.
* Needed to keep SolveSettings in `AbstractBundleObservation` for `BundleMeasure` to compile, but I ultimately think it only belongs in the child classes. 
* I left comments in `BundleObservationVector` about things that need to be changed for ISIS vs. CSM observations, but these changes are not implemented.

## Related Issue
#4410 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
