### PR TITLE
Move some functions to pure virtual in BundleObservation in csmbundle branch

### DIFF
--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.cpp
@@ -88,8 +88,6 @@ namespace Isis {
     m_observationNumber = src.m_observationNumber;
     m_instrumentId = src.m_instrumentId;
 
-    m_solveSettings = src.m_solveSettings;
-
     m_index = src.m_index;
   }
 
@@ -121,8 +119,8 @@ namespace Isis {
       m_observationNumber = src.m_observationNumber;
       m_instrumentId = src.m_instrumentId;
 
-      m_solveSettings = src.m_solveSettings;
     }
+
     return *this;
   }
 
@@ -214,18 +212,6 @@ namespace Isis {
 
 
   /**
-   * Accesses the solve settings
-   *
-   * @return @b const BundleObservationSolveSettingsQsp Returns a pointer to the solve
-   *                                                    settings for this AbstractBundleObservation
-   */
-  const BundleObservationSolveSettingsQsp AbstractBundleObservation::solveSettings() {
-    // NEEDED for BundleMeasure
-    return m_solveSettings;
-  }
-
-
-  /**
    * Applies the parameter corrections
    *
    * @param corrections Vector of corrections to apply
@@ -241,8 +227,8 @@ namespace Isis {
    * @internal
    *   @todo always returns true?
    */
+// FIXME: can this work at parent level or should be pure virtual?
   bool AbstractBundleObservation::applyParameterCorrections(LinearAlgebra::Vector corrections) {
-    // Will be different for ISIS and CSM
     return false;
   }
 
@@ -250,13 +236,10 @@ namespace Isis {
   /**
    * Returns the number of total parameters there are for solving
    *
-   * The total number of parameters is equal to the number of position parameters and number of
-   * pointing parameters
-   *
    * @return @b int Returns the number of parameters there are
    */
+// FIXME: can this work at parent level or should be pure virtual?
   int AbstractBundleObservation::numberParameters() {
-    // different
     return 0;
   }
 
@@ -278,61 +261,6 @@ namespace Isis {
    */
   int AbstractBundleObservation::index() {
     return m_index;
-  }
-
-  /**
- * @brief Creates and returns a formatted QString representing the bundle coefficients and
- * parameters
- *
- * @depricated The function formatBundleOutputString is depricated as of ISIS 3.9
- * and will be removed in ISIS 4.0
- *
- * @param errorPropagation Boolean indicating whether or not to attach more information
- *     (corrections, sigmas, adjusted sigmas...) to the output QString
- * @param imageCSV Boolean which is set to true if the function is being
- *     called from BundleSolutionInfo::outputImagesCSV().  It is set to false by default
- *     for backwards compatibility.
- *
- * @return @b QString Returns a formatted QString representing the AbstractBundleObservation
- *
- * @internal
- *   @history 2016-10-26 Ian Humphrey - Default values are now provided for parameters that are
- *                           not being solved. Fixes #4464.
- */
-QString AbstractBundleObservation::formatBundleOutputString(bool errorPropagation, bool imageCSV) {
-  // different for both
-  // TODO: either remove or update. 
-  return "Test";
-}
-
-
-  /**
-   * @brief Takes in an open std::ofstream and writes out information which goes into the
-   * bundleout.txt file.
-   *
-   * @param fpOut The open std::ofstream object which is passed in from
-   * BundleSolutionInfo::outputText()
-   * @param errorPropagation Boolean indicating whether or not to attach more information
-   *     (corrections, sigmas, adjusted sigmas...) to the output.
-   */
-  void AbstractBundleObservation::bundleOutputString(std::ostream &fpOut, bool errorPropagation) {
-    // different in both
-  }
-
-  /**
-   * @brief Creates and returns a formatted QString representing the bundle coefficients and
-   * parameters in csv format.
-   *
-   * @param errorPropagation Boolean indicating whether or not to attach more information
-   *     (corrections, sigmas, adjusted sigmas...) to the output QString
-   *
-   * @return @b QString Returns a formatted QString representing the AbstractBundleObservation in
-   * csv format
-   */
-  QString AbstractBundleObservation::bundleOutputCSV(bool errorPropagation) {
-    // different in both
-    // TODO: either remove or update. 
-    return "Test";
   }
 
 

--- a/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/AbstractBundleObservation.h
@@ -31,7 +31,7 @@ namespace Isis {
 
       // constructor
       AbstractBundleObservation(BundleImageQsp image, QString observationNumber, QString instrumentId,
-                        BundleTargetBodyQsp bundleTargetBody); // target body and CSM question
+                        BundleTargetBodyQsp bundleTargetBody);
 
       // copy constructor
       AbstractBundleObservation(const AbstractBundleObservation &src);
@@ -61,15 +61,14 @@ namespace Isis {
       virtual LinearAlgebra::Vector &adjustedSigmas();
 
 
-      // TODO: remove later
-      virtual const BundleObservationSolveSettingsQsp solveSettings();              
+      virtual const BundleObservationSolveSettingsQsp solveSettings() = 0;              
       virtual int numberParameters();
       virtual bool applyParameterCorrections(LinearAlgebra::Vector corrections);
 
-      virtual void bundleOutputString(std::ostream &fpOut,bool errorPropagation);
-      virtual QString bundleOutputCSV(bool errorPropagation);
+      virtual void bundleOutputString(std::ostream &fpOut,bool errorPropagation) = 0;
+      virtual QString bundleOutputCSV(bool errorPropagation) = 0;
 
-      virtual QString formatBundleOutputString(bool errorPropagation, bool imageCSV=false);
+      virtual QString formatBundleOutputString(bool errorPropagation, bool imageCSV=false) = 0;
 
       virtual QStringList parameterList();
       virtual QStringList imageNames();
@@ -96,7 +95,6 @@ namespace Isis {
       LinearAlgebra::Vector m_aprioriSigmas;
       //! A posteriori (adjusted) parameter sigmas.
       LinearAlgebra::Vector m_adjustedSigmas;
-      BundleObservationSolveSettingsQsp m_solveSettings; //!< Solve settings for this observation.
   };
 
   //! Typdef for AbstractBundleObservation QSharedPointer.

--- a/isis/src/control/objs/BundleUtilities/BundleObservation.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservation.h
@@ -138,6 +138,7 @@ namespace Isis {
       bool initParameterWeights();
 
     private:
+      QStringList m_parameterNamesList; //!< List of all cube parameters.
       BundleObservationSolveSettingsQsp m_solveSettings; //!< Solve settings for this observation.
 
       SpiceRotation *m_instrumentRotation;   //!< Instrument spice rotation (in primary image).


### PR DESCRIPTION
## Description
Title and also left out a change to BundleObservation from my last PR?

## Related Issue
#4410 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
