### PR TITLE
Improve lronac2isis error message and update app docs

### DIFF
--- a/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
+++ b/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
@@ -39,7 +39,8 @@ namespace Isis {
   void lronac2isis(UserInterface &ui) {
     // Initialize variables
     ResetGlobals();
-    //Check that the file comes from the right camera
+
+    // Check that the file comes from the right camera
     FileName inFile = ui.GetFileName("FROM");
     QString id;
     try {
@@ -50,10 +51,10 @@ namespace Isis {
         QString msg = "Unable to read [DATA_SET_ID] from input file [" + inFile.expanded() + "]";
         throw IException(IException::Unknown, msg, _FILEINFO_);
       }
-      //Checks if in file is rdr
+      // Checks if in file is RDR
       bool projected = lab.hasObject("IMAGE_MAP_PROJECTION");
       if(projected) {
-        QString msg = "[" + inFile.name() + "] appears to be an rdr file.";
+        QString msg = "[" + inFile.name() + "] appears to be an RDR file.";
         msg += " Use pds2isis.";
         throw IException(IException::User, msg, _FILEINFO_);
       }
@@ -90,7 +91,8 @@ namespace Isis {
     id = id.simplified().trimmed();
     if(id.mid(13, 3) != "EDR") {
       QString msg = "Input file [" + inFile.expanded() + "] does not appear to be "
-                   + "in LROC-NAC EDR format. DATA_SET_ID is [" + id + "]";
+                   + "in LROC-NAC EDR format. DATA_SET_ID is [" + id + "]"
+                   + " Use pds2isis for RDR or CDR.";
       throw IException(IException::Io, msg, _FILEINFO_);
     }
 

--- a/isis/src/lro/apps/lronac2isis/lronac2isis.xml
+++ b/isis/src/lro/apps/lronac2isis/lronac2isis.xml
@@ -7,8 +7,8 @@
     </brief>
 
     <description>
-        This program takes an image from the Lunar Reconnaissance Orbiter Narrow Angle Camera
-        and produces an Isis cube containing the image data.
+        This program takes a raw EDR image from the Lunar Reconnaissance Orbiter Narrow Angle Camera
+        and produces an Isis cube containing the image data. LRO NAC images in the CDR or RDR format should be ingested using pds2isis.
     </description>
 
     <history>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds to the `if(id.mid(13, 3) != "EDR")` exception message to include information about using pds2isis for RDR/CDR. Adds some clarity to the app documentation so that users know lronac2isis is for EDR, and are referred to pds2isis for RDR/CDR.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4055

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Documentation improvement.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing checks for non-EDR formats are working as intended. Tested with EDR, CDR, and RDR files [found here](http://lroc.sese.asu.edu/data). The app correctly ingests for EDR and throws exceptions for CDR/RDR. I don't see how a CDR image could slip through the cracks without causing an exception.

Existing tests for lronac2isis still pass with this PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
