### PR TITLE
Update to Stats Best[Max|Min]imum functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release.
 - Fixed logging in FindFeatures where we were trying to get a non-existent Pvl group from the Pvl log. [#4375](https://github.com/USGS-Astrogeology/ISIS3/issues/4375)
 - Fixed an arccos evaluating a double close to either 1, -1 when calculating the ground azimuth in camera.cpp. [#4393](https://github.com/USGS-Astrogeology/ISIS3/issues/4393)
 - Fixed hist outputs to N/A when all DNs are special pixels. [#3709](https://github.com/USGS-Astrogeology/ISIS3/issues/3709)
+- Fixed an Minimum|Maximum calculation error when comparing all equal data in the qview statstics tool. [#4433](https://github.com/USGS-Astrogeology/ISIS3/issues/4414)
 
 ## [5.0.0] - 2021-04-01
 

--- a/isis/src/base/objs/Statistics/Statistics.cpp
+++ b/isis/src/base/objs/Statistics/Statistics.cpp
@@ -597,6 +597,10 @@ namespace Isis {
    */
   double Statistics::BestMinimum(const double percent) const {
     if (m_validPixels < 1) return Isis::NULL8;
+    // ChebyshevMinimum can return erroneous values when the data is all a
+    // single value
+    // In this case, we just want to return the minimum
+    if (Minimum() == Maximum()) return Minimum();
     double min = ChebyshevMinimum(percent);
     if (Minimum() > min) min = Minimum();
     return min;
@@ -620,6 +624,10 @@ namespace Isis {
    */
   double Statistics::BestMaximum(const double percent) const {
     if (m_validPixels < 1) return Isis::NULL8;
+    // ChebyshevMaximum can return erroneous values when the data is all a
+    // single value
+    // In this case, we just want to return the maximum
+    if (Minimum() == Maximum()) return Maximum();
     double max = ChebyshevMaximum(percent);
     if (Maximum() < max) max = Maximum();
     return max;


### PR DESCRIPTION
Forced stats `Best[Max|Min]imum` to return the `Minimum` and `Maximum` if all values within a `Statistics` object are all the same.

## Description
Fixes what likely is a floating point calculation error within `Chebyshev[Max|Min]imum` resulting in the Min being greater than the Max. 

This error was replicated through the process detailed on issue #4414 with one small change. Rather than doing the seemingly random clicking process a precise spot within the image was found. The pixel located at Sample 1938, Line 3817.

## Related Issue
Closes #4414 

## Motivation and Context
General ISIS Fix

## How Has This Been Tested?
Tested manually following the same steps to produce the error.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
