### PR TITLE
Add hooks for csm bundle settings to jigsaw

### DIFF
--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -443,6 +443,29 @@ namespace Isis {
                                                               positionVelocityAprioriSigma,
                                                               positionAccelerationAprioriSigma);
 
+      if ((ui.WasEntered("CSMSOLVESET")  && ui.WasEntered("CSMSOLVETYPE")) ||
+          (ui.WasEntered("CSMSOLVESET")  && ui.WasEntered("CSMSOLVELIST")) ||
+          (ui.WasEntered("CSMSOLVETYPE") && ui.WasEntered("CSMSOLVELIST")) ) {
+        QString msg = "Only one of CSMSOLVESET, CSMSOLVETYPE, and CSMSOLVELIST "
+                      "can be specified at a time.";
+        throw IException(IException::User, msg, _FILEINFO_);
+      }
+
+      if (ui.WasEntered("CSMSOLVESET")) {
+        observationSolveSettings.setCSMSolveSet(
+            BundleObservationSolveSettings::stringToCSMSolveSet(ui.GetString("CSMSOLVESET")));
+      }
+      else if (ui.WasEntered("CSMSOLVETYPE")) {
+        observationSolveSettings.setCSMSolveType(
+            BundleObservationSolveSettings::stringToCSMSolveType(ui.GetString("CSMSOLVETYPE")));
+      }
+      else if (ui.WasEntered("CSMSOLVELIST")) {
+        std::vector<QString> csmParamVector;
+        ui.GetString("CSMSOLVELIST", csmParamVector);
+        QStringList csmParamList = QStringList::fromVector(QVector<QString>::fromStdVector(csmParamVector));
+        observationSolveSettings.setCSMSolveParameterList(csmParamList);
+      }
+
       // add all image observation numbers to this BOSS.
       for (int sn = 0; sn < cubeSNs.size(); sn++) {
         observationSolveSettings.addObservationNumber(cubeSNs.observationNumber(sn));
@@ -450,6 +473,7 @@ namespace Isis {
 
       // append the GUI acquired solve parameters to BOSS list.
       observationSolveSettingsList.append(observationSolveSettings);
+
     }
 
 

--- a/isis/src/control/apps/jigsaw/jigsaw.xml
+++ b/isis/src/control/apps/jigsaw/jigsaw.xml
@@ -1020,7 +1020,7 @@
       </parameter>
     </group>
 
-    <group name="Communit Sensor Model Options">
+    <group name="Community Sensor Model Options">
       <parameter name="CSMSOLVESET">
         <type>string</type>
         <brief>Specify a set of a CSM parameters to solve for.</brief>

--- a/isis/src/control/apps/jigsaw/jigsaw.xml
+++ b/isis/src/control/apps/jigsaw/jigsaw.xml
@@ -1018,7 +1018,84 @@
           <item>No</item>
         </default>
       </parameter>
-      </group>
+    </group>
+
+    <group name="Communit Sensor Model Options">
+      <parameter name="CSMSOLVESET">
+        <type>string</type>
+        <brief>Specify a set of a CSM parameters to solve for.</brief>
+        <description>
+          Specify one of the parameter sets from the CSM GeometricModel API to solve for.
+          All parameters belonging to the specified set will be solved for.
+        </description>
+        <exclusions>
+          <item>CSMSOLVETYPE</item>
+          <item>CSMSOLVELIST</item>
+        </exclusions>
+        <list>
+          <option value="VALID">
+            <brief> Solves for CSM parameters that are not NONE.</brief>
+          </option>
+          <option value="ADJUSTABLE">
+            <brief>Solves for real or fictitous CSM parameters.</brief>
+          </option>
+          <option value="NONADJUSTABLE">
+            <brief>Solves for fixed CSM parameters.</brief>
+            <description>
+              Solve for fixed CSM parameters. These parameters are generally not adjusted
+              but do have uncertainty which can help constrain the solutions and improve
+              a posteriori uncertainties for other parameters.
+            </description>
+          </option>
+        </list>
+      </parameter>
+
+      <parameter name="CSMSOLVETYPE">
+        <type>string</type>
+        <brief>Specify a type of a CSM parameters to solve for.</brief>
+        <description>
+          Specify a parameter type from the CSM GeometricModel API to solve for.
+          All parameters of the specified type will be solved for.
+        </description>
+        <exclusions>
+          <item>CSMSOLVESET</item>
+          <item>CSMSOLVELIST</item>
+        </exclusions>
+        <list>
+          <option value="NONE">
+            <brief>Solve for unitialized CSM parameters</brief>
+          </option>
+          <option value="FICTITIOUS">
+            <brief>Solve for CSM parameters calculted by resection</brief>
+          </option>
+          <option value="REAL">
+            <brief>Solve for measured CSM parameters</brief>
+          </option>
+          <option value="FIXED">
+            <brief>Solve for fixed CSM parameters</brief>
+          </option>
+          <description>
+            Solve for fixed CSM parameters. These parameters are generally not adjusted
+            but do have uncertainty which can help constrain the solutions and improve
+            a posteriori uncertainties for other parameters.
+          </description>
+        </list>
+      </parameter>
+
+      <parameter name="CSMSOLVELIST">
+        <type>string</type>
+        <brief>Specify an explicit list of CSM parameters to solve for.</brief>
+        <description>
+          All CSM parameters in this list will be solved for. Trailing and leading whitespace
+          will be stripped off. Use standard ISIS parameter array notation to specify multiple
+          parameters.
+        </description>
+        <exclusions>
+          <item>CSMSOLVESET</item>
+          <item>CSMSOLVETYPE</item>
+        </exclusions>
+      </parameter>
+    </group>
 
     <group name="Target Body">
       <parameter name="SOLVETARGETBODY">

--- a/isis/src/control/objs/BundleSettings/BundleSettings.cpp
+++ b/isis/src/control/objs/BundleSettings/BundleSettings.cpp
@@ -541,9 +541,6 @@ namespace Isis {
       }
     }
     return defaultSolveSettings;
-    //QString msg = "Unable to find BundleObservationSolveSettings for observation number ["
-    //              + observationNumber + "].";
-   // throw IException(IException::Unknown, msg, _FILEINFO_);
   }
 
 

--- a/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.cpp
@@ -58,7 +58,7 @@ namespace Isis {
   BundleObservationSolveSettings::BundleObservationSolveSettings(const PvlGroup &scParameterGroup) {
     initialize();
 
-      // group name must be instrument id
+    // group name must be instrument id
     m_instrumentId = (QString)scParameterGroup.nameKeyword();
 
     // If CKDEGREE is not specified, then a default of 2 is used
@@ -66,7 +66,7 @@ namespace Isis {
       m_ckDegree = (int)(scParameterGroup.findKeyword("CKDEGREE"));
     }
 
-    // If CKSOLVEDEGREE is not specified, then a default of 2 is used -------jwb----- why ??? why not match camsolve option ???
+    // If CKSOLVEDEGREE is not specified, then a default of 2 is used
     if (scParameterGroup.hasKeyword("CKSOLVEDEGREE")) {
       m_ckSolveDegree = (int) (scParameterGroup.findKeyword("CKSOLVEDEGREE"));
     }
@@ -443,7 +443,7 @@ namespace Isis {
   // =============================================================================================//
 
 
-  BundleObservationSolveSettings::CSMSolveOption 
+  BundleObservationSolveSettings::CSMSolveOption
       BundleObservationSolveSettings::stringToCSMSolveOption(QString option) {
     if (option.compare("NoCSMParameters", Qt::CaseInsensitive) == 0) {
       return BundleObservationSolveSettings::NoCSMParameters;
@@ -481,6 +481,84 @@ namespace Isis {
     else {
       throw IException(IException::Programmer,
                        "Unknown CSM solve option enum [" + toString(option) + "].",
+                       _FILEINFO_);
+    }
+  }
+
+
+
+  csm::param::Set BundleObservationSolveSettings::stringToCSMSolveSet(QString set) {
+    if (set.compare("VALID", Qt::CaseInsensitive) == 0) {
+      return csm::param::VALID;
+    }
+    else if (set.compare("ADJUSTABLE", Qt::CaseInsensitive) == 0) {
+      return csm::param::ADJUSTABLE;
+    }
+    else if (set.compare("NON_ADJUSTABLE", Qt::CaseInsensitive) == 0) {
+      return csm::param::NON_ADJUSTABLE;
+    }
+    else {
+      throw IException(IException::Unknown,
+                       "Unknown bundle CSM parameter set " + set + ".",
+                       _FILEINFO_);
+    }
+  }
+
+  QString BundleObservationSolveSettings::csmSolveSetToString(csm::param::Set set) {
+    if (set == csm::param::VALID) {
+      return "VALID";
+    }
+    else if (set == csm::param::ADJUSTABLE)  {
+      return "ADJUSTABLE";
+    }
+    else if (set == csm::param::NON_ADJUSTABLE) {
+      return "NON_ADJUSTABLE";
+    }
+    else {
+      throw IException(IException::Programmer,
+                       "Unknown CSM parameter set enum [" + toString(set) + "].",
+                       _FILEINFO_);
+    }
+  }
+
+
+  csm::param::Type BundleObservationSolveSettings::stringToCSMSolveType(QString type) {
+    if (type.compare("NONE", Qt::CaseInsensitive) == 0) {
+      return csm::param::NONE;
+    }
+    else if (type.compare("FICTITIOUS", Qt::CaseInsensitive) == 0) {
+      return csm::param::FICTITIOUS;
+    }
+    else if (type.compare("REAL", Qt::CaseInsensitive) == 0) {
+      return csm::param::REAL;
+    }
+    else if (type.compare("FIXED", Qt::CaseInsensitive) == 0) {
+      return csm::param::FIXED;
+    }
+    else {
+      throw IException(IException::Unknown,
+                       "Unknown bundle CSM parameter type " + type + ".",
+                       _FILEINFO_);
+    }
+  }
+
+
+  QString BundleObservationSolveSettings::csmSolveTypeToString(csm::param::Type type) {
+    if (type == csm::param::NONE) {
+      return "NONE";
+    }
+    else if (type == csm::param::FICTITIOUS)  {
+      return "FICTITIOUS";
+    }
+    else if (type == csm::param::REAL) {
+      return "REAL";
+    }
+    else if (type == csm::param::FIXED) {
+      return "FIXED";
+    }
+    else {
+      throw IException(IException::Programmer,
+                       "Unknown CSM parameter type enum [" + toString(type) + "].",
                        _FILEINFO_);
     }
   }

--- a/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.cpp
@@ -237,6 +237,22 @@ namespace Isis {
         }
       }
     }
+
+    // CSM settings
+    if (scParameterGroup.hasKeyword("CSMSOLVESET")) {
+      setCSMSolveSet(stringToCSMSolveSet(scParameterGroup.findKeyword("CSMSOLVESET")));
+    }
+    else if (scParameterGroup.hasKeyword("CSMSOLVETYPE")) {
+      setCSMSolveType(stringToCSMSolveType(scParameterGroup.findKeyword("CSMSOLVETYPE")));
+    }
+    else if (scParameterGroup.hasKeyword("CSMSOLVELIST")) {
+      PvlKeyword csmSolveListKey = scParameterGroup.findKeyword("CSMSOLVELIST");
+      QStringList csmSolveList;
+      for (int i = 0; i < csmSolveListKey.size(); i++) {
+        csmSolveList.append(csmSolveListKey[i]);
+      }
+      setCSMSolveParameterList(csmSolveList);
+    }
   }
 
 

--- a/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationSolveSettings.h
@@ -110,6 +110,10 @@ class BundleObservationSolveSettings {
 
       static CSMSolveOption stringToCSMSolveOption(QString option);
       static QString csmSolveOptionToString(CSMSolveOption option);
+      static csm::param::Set stringToCSMSolveSet(QString set);
+      static QString csmSolveSetToString(csm::param::Set set);
+      static csm::param::Type stringToCSMSolveType(QString type);
+      static QString csmSolveTypeToString(csm::param::Type type);
       void setCSMSolveSet(csm::param::Set set);
       void setCSMSolveType(csm::param::Type type);
       void setCSMSolveParameterList(QStringList list);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds jigsaw parameters for solving for CSM parameters in images. This should be supported for command line and scconfig setups.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#4410 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This threads the hooks from #4419 to jigsaw so that users can actually set them.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally with debugger and all values set as expected. Also, added automated tests for the BOSS changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
