### PR TITLE
First round of PolygonTools changes

### DIFF
--- a/isis/src/base/objs/PolygonTools/unitTest.cpp
+++ b/isis/src/base/objs/PolygonTools/unitTest.cpp
@@ -32,7 +32,7 @@ int main() {
     cout << "Unit test for PolygonTools" << endl << endl;
 
     // Create coordinate sequence for the first of two polygons
-    geos::geom::CoordinateSequence *pts = new geos::geom::CoordinateArraySequence();
+    geos::geom::CoordinateArraySequence *pts = new geos::geom::CoordinateArraySequence();
     pts->add(geos::geom::Coordinate(0.0, 0.0));
     pts->add(geos::geom::Coordinate(0.0, 1.0));
     pts->add(geos::geom::Coordinate(1.0, 1.0));
@@ -46,7 +46,7 @@ int main() {
                       Isis::globalFactory->createLinearRing(pts), NULL));
 
     // Create coordinate sequence for the second of two polygons
-    geos::geom::CoordinateSequence *pts2 = new geos::geom::CoordinateArraySequence();
+    geos::geom::CoordinateArraySequence *pts2 = new geos::geom::CoordinateArraySequence();
     pts2->add(geos::geom::Coordinate(360.0, 1.0));
     pts2->add(geos::geom::Coordinate(359.0, 1.0));
     pts2->add(geos::geom::Coordinate(359.0, 0.0));
@@ -55,7 +55,7 @@ int main() {
     cout << "Coordinates of polygon 2:" << pts2->toString() << endl << endl;
 
     // Create coordinate sequence for the hole in the second polygon
-    geos::geom::CoordinateSequence *pts3 = new geos::geom::DefaultCoordinateSequence();
+    geos::geom::CoordinateArraySequence *pts3 = new geos::geom::DefaultCoordinateSequence();
     pts3->add(geos::geom::Coordinate(359.75, 0.75));
     pts3->add(geos::geom::Coordinate(359.25, 0.75));
     pts3->add(geos::geom::Coordinate(359.25, 0.25));
@@ -63,7 +63,7 @@ int main() {
     pts3->add(geos::geom::Coordinate(359.75, 0.75));
     cout << "Coordinates of hole for polygon 2:" << pts3->toString() << endl << endl;
 
-    vector<geos::geom::Geometry *> *hole2 = new vector<geos::geom::Geometry *>;
+    vector<geos::geom::LinearRing *> *hole2 = new vector<geos::geom::LinearRing *>;
     hole2->push_back(Isis::globalFactory->createLinearRing(pts3));
 
     // Create the second polygon
@@ -71,7 +71,7 @@ int main() {
                       Isis::globalFactory->createLinearRing(pts2), hole2));
 
     // Create a multipolygon from the two polygons
-    geos::geom::MultiPolygon *mPolygon = Isis::globalFactory->createMultiPolygon(polys);
+    geos::geom::MultiPolygon *mPolygon = Isis::globalFactory->createMultiPolygon(&polys);
 
     // Create a copy of the multipolygon
     geos::geom::MultiPolygon *tmpMp = PolygonTools::CopyMultiPolygon(mPolygon);
@@ -119,7 +119,7 @@ int main() {
     UniversalGroundMap ugm = UniversalGroundMap(cube);
 
     // Create coordinate sequence for the first of two polygons
-    geos::geom::CoordinateSequence *llpts = new geos::geom::CoordinateArraySequence();
+    geos::geom::CoordinateArraySequence *llpts = new geos::geom::CoordinateArraySequence();
     ugm.SetImage(1.0, 1.0);
     llpts->add(geos::geom::Coordinate(
           qRound(ugm.UniversalLongitude()),
@@ -147,7 +147,7 @@ int main() {
     llpolys.push_back(Isis::globalFactory->createPolygon(
                         Isis::globalFactory->createLinearRing(llpts), NULL));
 
-    geos::geom::MultiPolygon *llmPolygon = Isis::globalFactory->createMultiPolygon(llpolys);
+    geos::geom::MultiPolygon *llmPolygon = Isis::globalFactory->createMultiPolygon(&llpolys);
 
     geos::geom::MultiPolygon *slmPolygon = PolygonTools::LatLonToSampleLine(*llmPolygon, &ugm);
     cout << "Coordinates of Sample/Line polygon:" <<
@@ -155,7 +155,7 @@ int main() {
 
     cout << endl << "Testing LatLonToSampleLine() with coords outside of the valid range." << endl;
     // Create coordinate sequence for the first of two polygons
-    geos::geom::CoordinateSequence *llpts2 = new geos::geom::CoordinateArraySequence();
+    geos::geom::CoordinateArraySequence *llpts2 = new geos::geom::CoordinateArraySequence();
     llpts2->add(geos::geom::Coordinate(175, 0));
     llpts2->add(geos::geom::Coordinate(175.6, -28));
     llpts2->add(geos::geom::Coordinate(181.5, -30.6));
@@ -168,7 +168,7 @@ int main() {
     llpolys2.push_back(Isis::globalFactory->createPolygon(
                         Isis::globalFactory->createLinearRing(llpts2), NULL));
 
-    geos::geom::MultiPolygon *llmPolygon2 = Isis::globalFactory->createMultiPolygon(llpolys2);
+    geos::geom::MultiPolygon *llmPolygon2 = Isis::globalFactory->createMultiPolygon(&llpolys2);
 
     geos::geom::MultiPolygon *slmPolygon2 = PolygonTools::LatLonToSampleLine(*llmPolygon2, &ugm);
     cout << "Coordinates of Sample/Line polygon:" <<


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Still getting this error:
```
/Users/kdlee/builds/new_isis/ISIS3/isis/src/base/objs/PolygonTools/PolygonTools.cpp:105:55: error: no matching member function for call to 'createPolygon'
        geos::geom::Polygon *newPoly = globalFactory->createPolygon(
                                       ~~~~~~~~~~~~~~~^~~~~~~~~~~~~
/Users/kdlee/anaconda3/envs/myisis/include/geos/geom/GeometryFactory.h:251:11: note: candidate function not viable: no known conversion from 'vector<geos::geom::LinearRing *> *' to 'std::vector<Geometry *> *' for 2nd argument
        Polygon* createPolygon(LinearRing *shell,
                 ^
/Users/kdlee/anaconda3/envs/myisis/include/geos/geom/GeometryFactory.h:255:11: note: candidate function not viable: no known conversion from 'geos::geom::LinearRing *' to 'const geos::geom::LinearRing' for 1st argument; dereference the argument with *
        Polygon* createPolygon(const LinearRing &shell,
                 ^
/Users/kdlee/anaconda3/envs/myisis/include/geos/geom/GeometryFactory.h:248:11: note: candidate function not viable: requires 0 arguments, but 2 were provided
        Polygon* createPolygon() const;
```
## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
