### PR TITLE
Update BundleObservationVector to removed unneeded NULL checks

### DIFF
--- a/isis/src/control/objs/BundleResults/unitTest.cpp
+++ b/isis/src/control/objs/BundleResults/unitTest.cpp
@@ -254,7 +254,14 @@ int main(int argc, char *argv[]) {
     QVector<BundleControlPointQsp> bundleControlPointVector;
     bundleControlPointVector.append(freeBundleControlPoint);
     bundleControlPointVector.append(fixedBundleControlPoint);
+
+    // Need to create a camera
+    QString inputFile = "$ISISTESTDATA/isis/src/mgs/unitTestData/ab102401.lev2.cub";
+    Cube cube;
+    cube.open(inputFile);
     Camera *camera = NULL;
+    camera = cube.camera();
+
     BundleImage bundleImage(camera,
                             "TestImageSerialNumber",
                             "TestImageFileName");

--- a/isis/src/control/objs/BundleSolutionInfo/unitTest.cpp
+++ b/isis/src/control/objs/BundleSolutionInfo/unitTest.cpp
@@ -139,7 +139,14 @@ int main(int argc, char *argv[]) {
     QVector<BundleControlPointQsp> bundleControlPointVector;
     bundleControlPointVector.append(freeBundleControlPoint);
     bundleControlPointVector.append(fixedBundleControlPoint);
+
+    // Need to create a camera
+    QString inputFile = "$ISISTESTDATA/isis/src/mgs/unitTestData/ab102401.lev2.cub";
+    Cube cube;
+    cube.open(inputFile);
     Camera *camera = NULL;
+    camera = cube.camera();
+
     BundleImage bundleImage(camera,
                             "Ignored",
                             "TestImageFileName");

--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
@@ -128,10 +128,7 @@ namespace Isis {
 
       bool isIsisObservation = true;
 
-      // This NULL check is needed solely for the unit test
-      if (bundleImage->camera() != NULL) {
-        isIsisObservation = bundleImage->camera()->GetCameraType() != Camera::Csm;
-      }
+      isIsisObservation = bundleImage->camera()->GetCameraType() != Camera::Csm;
 
       AbstractBundleObservation *observation = NULL;
 
@@ -177,12 +174,9 @@ namespace Isis {
 
       if (isIsisObservation) {
         QSharedPointer<BundleObservation> isisObs = qSharedPointerDynamicCast<BundleObservation>(bundleObservation);
-        // This check is needed for the current unit test
-        if (bundleImage->camera() != NULL) {
-          isisObs->initializeExteriorOrientation();
-          if (bundleSettings->solveTargetBody()) {
-            isisObs->initializeBodyRotation();
-          }
+        isisObs->initializeExteriorOrientation();
+        if (bundleSettings->solveTargetBody()) {
+          isisObs->initializeBodyRotation();
         }
       }
 


### PR DESCRIPTION
## Description
I removed changes I made to `BundleObservationVector` to fix a test failure, when I really should have just updated the tests.
Tests have now been updated and the changes have been removed from `BundleObservationVector`

## Related Issue
#4410 

## Motivation and Context
See #4410 

## How Has This Been Tested?
ctest -R Bundle && ctest -R Jigsaw passes

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
