### PR TITLE
Add latitudinal partials for CSM

### DIFF
--- a/isis/src/control/objs/CsmBundleObservation/CsmBundleObservation.cpp
+++ b/isis/src/control/objs/CsmBundleObservation/CsmBundleObservation.cpp
@@ -771,7 +771,7 @@ QString CsmBundleObservation::formatBundleOutputString(bool errorPropagation, bo
 
       // Line w.r.t (lat, lon, radius)
       coeffPoint3D(1,0) = 1000 * (groundPartials[0]*latDerivative[0] + groundPartials[1]*latDerivative[1] + groundPartials[2]*latDerivative[2]);
-      coeffPoint3D(1,1) = 1000 * (groundPartials[0]*lonDerivative[0] + groundPartials[1]*lonDerivative[1] + groundpartials[2]*lonDerivative[2]);
+      coeffPoint3D(1,1) = 1000 * (groundPartials[0]*lonDerivative[0] + groundPartials[1]*lonDerivative[1] + groundPartials[2]*lonDerivative[2]);
       coeffPoint3D(1,2) = 1000 * (groundPartials[0]*radDerivative[0] + groundPartials[1]*radDerivative[1] + groundPartials[2]*radDerivative[2]);
 
       // Sample w.r.t (lat, lon, radius)

--- a/isis/src/control/objs/CsmBundleObservation/CsmBundleObservation.cpp
+++ b/isis/src/control/objs/CsmBundleObservation/CsmBundleObservation.cpp
@@ -748,21 +748,41 @@ QString CsmBundleObservation::formatBundleOutputString(bool errorPropagation, bo
     SurfacePoint groundPoint = measure.parentControlPoint()->adjustedSurfacePoint();
     vector<double> groundPartials = measureCamera->GroundPartials(groundPoint);
 
-    // groundPartials is:
-    // line WRT x
-    // line WRT y
-    // line WRT z
-    // sample WRT x
-    // sample WRT y
-    // sample WRT z
-    // Scale from WRT m to WRT Km
-    coeffPoint3D(1,0) = groundPartials[0] * 1000;
-    coeffPoint3D(1,1) = groundPartials[1] * 1000;
-    coeffPoint3D(1,2) = groundPartials[2] * 1000;
-    coeffPoint3D(0,0) = groundPartials[3] * 1000;
-    coeffPoint3D(0,1) = groundPartials[4] * 1000;
-    coeffPoint3D(0,2) = groundPartials[5] * 1000;
+    if (coordType == SurfacePoint::Rectangular) {
+      // groundPartials is:
+      // line WRT x
+      // line WRT y
+      // line WRT z
+      // sample WRT x
+      // sample WRT y
+      // sample WRT z
+      // Scale from WRT m to WRT Km
+      coeffPoint3D(1,0) = groundPartials[0] * 1000;
+      coeffPoint3D(1,1) = groundPartials[1] * 1000;
+      coeffPoint3D(1,2) = groundPartials[2] * 1000;
+      coeffPoint3D(0,0) = groundPartials[3] * 1000;
+      coeffPoint3D(0,1) = groundPartials[4] * 1000;
+      coeffPoint3D(0,2) = groundPartials[5] * 1000;
+    }
+    else if (coordType == SurfacePoint::Latitudinal) {
+      std::vector<double> latDerivative = groundPoint.LatitudinalDerivative(SurfacePoint::One);
+      std::vector<double> lonDerivative = groundPoint.LatitudinalDerivative(SurfacePoint::Two);
+      std::vector<double> radDerivative = groundPoint.LatitudinalDerivative(SurfacePoint::Three);
 
+      // Line w.r.t (lat, lon, radius)
+      coeffPoint3D(1,0) = 1000 * (groundPartials[0]*latDerivative[0] + groundPartials[1]*latDerivative[1] + groundPartials[2]*latDerivative[2]);
+      coeffPoint3D(1,1) = 1000 * (groundPartials[0]*lonDerivative[0] + groundPartials[1]*lonDerivative[1] + groundpartials[2]*lonDerivative[2]);
+      coeffPoint3D(1,2) = 1000 * (groundPartials[0]*radDerivative[0] + groundPartials[1]*radDerivative[1] + groundPartials[2]*radDerivative[2]);
+
+      // Sample w.r.t (lat, lon, radius)
+      coeffPoint3D(0,0) = 1000 * (groundPartials[3]*latDerivative[0] + groundPartials[4]*latDerivative[1] + groundPartials[5]*latDerivative[2]);
+      coeffPoint3D(0,1) = 1000 * (groundPartials[3]*lonDerivative[0] + groundPartials[4]*lonDerivative[1] + groundPartials[5]*lonDerivative[2]);
+      coeffPoint3D(0,2) = 1000 * (groundPartials[3]*radDerivative[0] + groundPartials[4]*radDerivative[1] + groundPartials[5]*radDerivative[2]);
+    }
+    else {
+      IString msg ="Unknown surface point coordinate type enum [" + toString(coordType) + "]." ;
+      throw IException(IException::Programmer, msg, _FILEINFO_);
+    }
     return true;
   }
 


### PR DESCRIPTION
## Description
Adds ground partials with respect to lat, lon, radius to the CSM Observation.

## Related Issue
#4410 

## Motivation and Context
#4410

## How Has This Been Tested?
ctest -R Bundle && ctest -R Jigsaw passes, but doing the same jigsaw run with latitudinal vs. rectangular coordinates has very different output. I'm not seeing what is going wrong. @jessemapel  any ideas? 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
