### PR TITLE
Updates XmlToJson parsing to be more inja-friendly

### DIFF
--- a/isis/src/base/objs/XmlToJson/XmlToJson.cpp
+++ b/isis/src/base/objs/XmlToJson/XmlToJson.cpp
@@ -78,10 +78,11 @@ namespace Isis {
    * JSON: {tag: value}
    * 
    *  XML: <tag attributeName="attributeValue">textValue</tag>
-   *  JSON: {tag: {@attributeName: "attributeValue, "#text":textValue } }
+   *  JSON: {tag: {attrib_attributeName: "attributeValue,
+   *  "_text":textValue } }
    *
    *  XML: <tag attributeName="attributeValue" />
-   *  JSON: {tag: {@attributeName: "attributeValue"} }
+   *  JSON: {tag: {attrib_attributeName: "attributeValue"} }
    * 
    *  XML: <tag />
    *  JSON: tag: null
@@ -97,24 +98,24 @@ namespace Isis {
       QDomNamedNodeMap attrMap = element.attributes();
       for (int i=0; i < attrMap.size(); i++) {
         QDomAttr attr = attrMap.item(i).toAttr(); 
-        attributeSection["@"+attr.name().toStdString()] = attr.value().toStdString();
+        attributeSection["attrib_"+attr.name().toStdString()] = attr.value().toStdString();
       }
       // If there is no textValue, don't include it
       // <tag attributeName="attributeValue" />
       if (!element.text().isEmpty()) {
-        attributeSection["#text"] = element.text().toStdString(); 
+        attributeSection["_text"] = element.text().toStdString(); 
       }
-      newJson[element.tagName().toStdString()] = attributeSection;
+      newJson[element.tagName().replace(":", "_").toStdString()] = attributeSection;
     }
     else {
       // Just add element and its value
       // <tag>value</tag>
       if (!element.text().isEmpty()) {
-        newJson[element.tagName().toStdString()] = element.text().toStdString();
+        newJson[element.tagName().replace(":", "_").toStdString()] = element.text().toStdString();
       }
       else {
         // <tag /> no value case
-        newJson[element.tagName().toStdString()];
+        newJson[element.tagName().replace(":", "_").toStdString()];
       }
     }
     return newJson;
@@ -157,9 +158,9 @@ namespace Isis {
           if (!output[element.tagName().toStdString()].is_array()) {
             json repeatedArray;
             repeatedArray.push_back(output[element.tagName().toStdString()]);
-            output[element.tagName().toStdString()] = repeatedArray;
+            output[element.tagName().replace(":", "_").toStdString()] = repeatedArray;
           }
-          output[element.tagName().toStdString()].push_back(converted[element.tagName().toStdString()]);
+          output[element.tagName().replace(":", "_").toStdString()].push_back(converted[element.tagName().toStdString()]);
         }
       }
       else {
@@ -175,9 +176,9 @@ namespace Isis {
           if (!output[element.tagName().toStdString()].is_array()) {
             json repeatedArray;
             repeatedArray.push_back(output[element.tagName().toStdString()]);
-            output[element.tagName().toStdString()] = repeatedArray;
+            output[element.tagName().replace(":", "_").toStdString()] = repeatedArray;
           }
-          output[element.tagName().toStdString()].push_back(temporaryJson);
+          output[element.tagName().replace(":", "_").toStdString()].push_back(temporaryJson);
         }
         else {
           if (element.hasAttributes()) {
@@ -185,15 +186,15 @@ namespace Isis {
             QDomNamedNodeMap attrMap = element.attributes();
             for (int j=0; j < attrMap.size(); j++) {
               QDomAttr attr = attrMap.item(j).toAttr(); 
-              tempArea["@"+attr.name().toStdString()] = attr.value().toStdString();
+              tempArea["attrib_"+attr.name().toStdString()] = attr.value().toStdString();
             }
             tempArea.update(
                 convertXmlToJson(next, output[element.tagName().toStdString()]));
-            output[element.tagName().toStdString()] = tempArea;
+            output[element.tagName().replace(":", "_").toStdString()] = tempArea;
           }
           else {
             output[element.tagName().toStdString()] = 
-              convertXmlToJson(next, output[element.tagName().toStdString()]);
+              convertXmlToJson(next, output[element.tagName().replace(":", "_").toStdString()]);
           }
         }
       }

--- a/isis/tests/XmlToJsonTests.cpp
+++ b/isis/tests/XmlToJsonTests.cpp
@@ -22,7 +22,7 @@ TEST(XmlToJson, XmlNoAttributeWithTextValue) {
 }
 
 // XML: <tag attributeName="attributeValue">textValue</tag>
-// JSON: {tag: {@attributeName: "attributeValue, "#text":textValue } }
+// JSON: {tag: {attrib_attributeName: "attributeValue, "_text":textValue } }
 TEST(XmlToJson, XmlAttributeWithTextValue) {
   QString xmlInput = R"(<Tag>
     <TagWithAttribute attribute="attributeValue">textValue</TagWithAttribute>
@@ -32,12 +32,12 @@ TEST(XmlToJson, XmlAttributeWithTextValue) {
   xmlDocument.setContent(xmlInput);
   json result = xmlToJson(xmlDocument);
 
-  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["@attribute"], "attributeValue");
-  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["#text"], "textValue");
+  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["attrib_attribute"], "attributeValue");
+  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["_text"], "textValue");
 }
 
 // XML: <tag attributeName="attributeValue" />
-//  JSON: {tag: {@attributeName: "attributeValue"} }
+//  JSON: {tag: {attrib_attributeName: "attributeValue"} }
 TEST(XmlToJson, XmlAttributeButNoText) {
   QString xmlInput = R"(<Tag>
     <TagWithAttribute attribute="attributeValue" />>
@@ -47,8 +47,8 @@ TEST(XmlToJson, XmlAttributeButNoText) {
   xmlDocument.setContent(xmlInput);
   json result = xmlToJson(xmlDocument);
 
-  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["@attribute"], "attributeValue");
-  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["#text"], nullptr);
+  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["attrib_attribute"], "attributeValue");
+  EXPECT_EQ(result["Tag"]["TagWithAttribute"]["_text"], nullptr);
 }
 
 //  XML: <tag />
@@ -111,9 +111,9 @@ TEST(XmlToJson, TestRepeatedTagNoChildren){
 
   EXPECT_EQ(result["Tag"]["A"][0], "A1");
   EXPECT_EQ(result["Tag"]["A"][1], "A2");
-  EXPECT_EQ(result["Tag"]["A"][2]["@attribute"], "value");
-  EXPECT_EQ(result["Tag"]["A"][3]["@otherAttribute"], "otherValue");
-  EXPECT_EQ(result["Tag"]["A"][3]["#text"], "textValue");
+  EXPECT_EQ(result["Tag"]["A"][2]["attrib_attribute"], "value");
+  EXPECT_EQ(result["Tag"]["A"][3]["attrib_otherAttribute"], "otherValue");
+  EXPECT_EQ(result["Tag"]["A"][3]["_text"], "textValue");
   EXPECT_EQ(result["Tag"]["A"][4]["B"][0], "b1");
   EXPECT_EQ(result["Tag"]["A"][4]["B"][1], "b2");
   EXPECT_EQ(result["Tag"]["A"][4]["C"], "c1");
@@ -204,12 +204,12 @@ TEST(XmlToJson, TestXMLEverythingTogether) {
   EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2C"]["TagLevel3"]["TagLevel4C"]["TagLevel4D"]["TagLevel4E"], "DeepValue");
 
   // Test attributes (uncomplicated)
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2D"]["@attributeTag2D"], "Attribute value");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2D"]["#text"], "TagLevel2DValue");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2D"]["attrib_attributeTag2D"], "Attribute value");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2D"]["_text"], "TagLevel2DValue");
 
   // Test no-text value cases <tag /> and <tag attributeName="attributeValue" /> 
   EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2ExtraExtra"], nullptr);
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2Extra"]["@attr"], "justAnAttribute");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1A"]["TagLevel2Extra"]["attrib_attr"], "justAnAttribute");
 
   // Test list creation for repeated tags at the same level
   
@@ -223,9 +223,9 @@ TEST(XmlToJson, TestXMLEverythingTogether) {
   // including lots of possible combinations
   EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][0], "A1");
   EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][1], "A2");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][2]["@attribute"], "value");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][3]["@attr"], "val");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][3]["#text"], "zoom");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][2]["attrib_attribute"], "value");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][3]["attrib_attr"], "val");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][3]["_text"], "zoom");
   EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][5], "A3");
   EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["A"][6], nullptr);
 
@@ -237,21 +237,21 @@ TEST(XmlToJson, TestXMLEverythingTogether) {
   EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["First"][0]["ten"][1], "TEN");
 
   // Test many attributes at one level
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["@attributeA"], "A");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["@attributeB"], "B");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["@attributeC"], "C");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["#text"], "ElementValue");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["attrib_attributeA"], "A");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["attrib_attributeB"], "B");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["attrib_attributeC"], "C");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Second"]["A"]["_text"], "ElementValue");
 
   // Test multiple attributes at multiple levels
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["@otherattr"], "firstLetter");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["@attr"], "alphabet");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Alpha"]["@attr2"], "attr2");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Alpha"]["@attr1"], "attr1");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Alpha"]["#text"], "AlphaValue");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Beta"]["#text"], "BetaValue");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Beta"]["@attrbeta2"], "beta2");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["AnotherLevel"]["Gamma"]["@attrgamma"], "gamma");
-  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["AnotherLevel"]["Gamma"]["#text"], "GammaValue");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["attrib_otherattr"], "firstLetter");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["attrib_attr"], "alphabet");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Alpha"]["attrib_attr2"], "attr2");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Alpha"]["attrib_attr1"], "attr1");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Alpha"]["_text"], "AlphaValue");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Beta"]["_text"], "BetaValue");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["Beta"]["attrib_attrbeta2"], "beta2");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["AnotherLevel"]["Gamma"]["attrib_attrgamma"], "gamma");
+  EXPECT_EQ(result["TagLevel0"]["TagLevel1B"]["Third"]["Greek"]["AnotherLevel"]["Gamma"]["_text"], "GammaValue");
 }
 
 


### PR DESCRIPTION
## Description
Updates `XmlToJson` to represent XML attributes by pre-pending them with `attrib_` (instead of `@`) and text values for tags with attributes by `_text` (instead of `#text`.) `inja` was unable to handle keywords with `@` or `#` in the name.

Also updates keyword values which include xml namespaces (ex. <cart:longitude> ) to use a `_` instead of a `:` to delimit the namespace.

## Related Issue
PDS4 work.

## Motivation and Context
Get inja able to parse the json created from the XML input label. 

## How Has This Been Tested?
Tested by-hand to make sure that the values are updated as appropriate, and updated gtest for `XmlToJson`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
