### PR TITLE
PDS4 - topds4 TEMPLATE default option, working TGOCaSSIS.tpl

### DIFF
--- a/isis/appdata/export/TGOCaSSIS.tpl
+++ b/isis/appdata/export/TGOCaSSIS.tpl
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1700.sch" schemetypens="http://purl.oclc.org/dsdl/schematron"?>
+<?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1800.sch" schemetypens="http://purl.oclc.org/dsdl/schematron"?>
+<Product_Observational>
+ <CaSSIS_Header>
+  <IDENTIFICATION_DATA/>
+  <GEOMETRIC_DATA>
+   <PREDICTED_MAXIMUM_EXPOSURE_TIME unit="{{MainLabel.IsisCube.Archive.PredictMaximumExposureTime.Units}}">{{MainLabel.IsisCube.Archive.PredictMaximumExposureTime.Value}}</PREDICTED_MAXIMUM_EXPOSURE_TIME>
+   <CASSIS_OFF_NADIR_ANGLE unit="{{MainLabel.IsisCube.Archive.CassisOffNadirAngle.Units}}">{{MainLabel.IsisCube.Archive.CassisOffNadirAngle.Value}}</CASSIS_OFF_NADIR_ANGLE>
+   <PREDICTED_REQUIRED_REPETITION_FREQUENCY unit="{{MainLabel.IsisCube.Archive.PredictedRepetitionFrequency.Units}}">{{MainLabel.IsisCube.Archive.PredictedRepetitionFrequency.Value}}</PREDICTED_REQUIRED_REPETITION_FREQUENCY>
+   <TGO_GROUND_TRACK_VELOCITY unit="{{MainLabel.IsisCube.Archive.GroundTrackVelocity.Units}}">{{MainLabel.IsisCube.Archive.GroundTrackVelocity.Value}}</TGO_GROUND_TRACK_VELOCITY>
+   <FORWARD_ROTATION_ANGLE_REQUIRED unit="{{MainLabel.IsisCube.Archive.ForwardRotationAngle.Units}}">{{MainLabel.IsisCube.Archive.ForwardRotationAngle.Value}}</FORWARD_ROTATION_ANGLE_REQUIRED>
+   <SPICE_KERNEL_MISALIGNMENT_PREDICT unit="{{MainLabel.IsisCube.Archive.SpiceMisalignment.Units}}">{{MainLabel.IsisCube.Archive.SpiceMisalignment.Value}}</SPICE_KERNEL_MISALIGNMENT_PREDICT>
+  </GEOMETRIC_DATA>
+  <CaSSIS_General>
+   <TELESCOPE_FOCAL_LENGTH unit="{{MainLabel.IsisCube.Archive.FocalLength.Units}}">{{MainLabel.IsisCube.Archive.FocalLength.Value}}</TELESCOPE_FOCAL_LENGTH>
+   <TELESCOPE_F_NUMBER>{{MainLabel.IsisCube.Archive.FNumber.Value}}</TELESCOPE_F_NUMBER>
+  </CaSSIS_General>
+  <IMAGE_COMMAND/>
+  <FSW_HEADER>
+  <PEHK_HEADER>
+  <DERIVED_HEADER_DATA>
+   <PixelsPossiblySaturated>{{MainLabel.IsisCube.Archive.PixelsPossiblySaturated.Value}}</PixelsPossiblySaturated>
+   <Filter>{{MainLabel.IsisCube.BandBin.FilterName.Value}}</Filter>
+  </DERIVED_HEADER_DATA>
+ </CaSSIS_Header>
+ <Identification_Area>
+  <logical_identifier>urn:nasa:pds:TBD:TBD:TBD</logical_identifier>
+  <version_id>1.0</version_id>
+  <title>PDS4 product exported from ISIS3 cube.</title>
+  <information_model_version>1.8.0.0</information_model_version>
+  <product_class>Product_Observational</product_class>
+  <Modification_History>
+   <Modification_Detail>
+  </Modification_History>
+ </Identification_Area>
+ <Observation_Area>
+  <Time_Coordinates>
+   <start_date_time>{{MainLabel.IsisCube.Instrument.StartTime.Value}}</start_date_time>
+   {% if exists("MainLabel.IsisCube.Instrument.StopTime") %}
+   <stop_date_time>{{MainLabel.IsisCube.Instrument.StopTime.Value}}Z</stop_date_time>
+   {% else %}
+   <stop_date_time>{{MainLabel.IsisCube.Instrument.StartTime.Value}}Z</stop_date_time>
+   {% endif %}
+  </Time_Coordinates>
+  <Investigation_Area>
+   <name>{{MainLabel.IsisCube.Instrument.SpacecraftName.Value}}</name>
+   <type>Mission</type>
+   <Internal_Reference>
+    <lid_reference>urn:nasa:pds:TBD</lid_reference>
+    <reference_type>data_to_investigation</reference_type>
+   </Internal_Reference>
+  </Investigation_Area>
+  <Observing_System>
+   <name>{{MainLabel.IsisCube.Instrument.SpacecraftName.Value}} {{MainLabel.IsisCube.Instrument.InstrumentId.Value}}</name>
+   <Observing_System_Component>
+    <name>{{MainLabel.IsisCube.Instrument.SpacecraftName.Value}}</name>
+    <type>Spacecraft</type>
+   </Observing_System_Component>
+   <Observing_System_Component>
+    <name>{{MainLabel.IsisCube.Instrument.InstrumentId.Value}}</name>
+    <type>Instrument</type>
+   </Observing_System_Component>
+  </Observing_System>
+  <Target_Identification>
+   <name>{{MainLabel.IsisCube.Instrument.TargetName.Value}}</name>
+   <type>{{GeneratedJson.targetType}}</type>
+  </Target_Identification>
+  <Discipline_Area>
+   <disp:Display_Settings>
+    <Local_Internal_Reference>
+     <local_identifier_reference>Array_3D_Image</local_identifier_reference>
+     <local_reference_type>display_settings_to_array</local_reference_type>
+    </Local_Internal_Reference>
+    <disp:Display_Direction>
+     <disp:horizontal_display_axis>Sample</disp:horizontal_display_axis>
+     <disp:horizontal_display_direction>Left to Right</disp:horizontal_display_direction>
+     <disp:vertical_display_axis>Line</disp:vertical_display_axis>
+     <disp:vertical_display_direction>Top to Bottom</disp:vertical_display_direction>
+    </disp:Display_Direction>
+   </disp:Display_Settings>
+  </Discipline_Area>
+ </Observation_Area>
+ <File_Area_Observational>
+  <File>
+   <file_name>{{MainLabel.IsisCube.Archive.FileName.Value}}.img</file_name>
+  </File>
+  <Array_3D_Image>
+   <local_identifier>Array_3D_Image</local_identifier>
+   <offset unit="byte">0</offset>
+   <axes>3</axes>
+   <axis_index_order>Last Index Fastest</axis_index_order>
+   <Element_Array>
+    <data_type>{{GeneratedJson.pixelType}}</data_type>
+    <scaling_factor>1.0</scaling_factor>
+    <value_offset>0.0</value_offset>
+   </Element_Array>
+   <Axis_Array>
+    <axis_name>Band</axis_name>
+    <elements>{{MainLabel.IsisCube.Core.Dimensions.Bands.Value}}</elements>
+    <sequence_number>1</sequence_number>
+   </Axis_Array>
+   <Axis_Array>
+    <axis_name>Line</axis_name>
+    <elements>{{MainLabel.IsisCube.Core.Dimensions.Lines.Value}}</elements>
+    <sequence_number>2</sequence_number>
+   </Axis_Array>
+   <Axis_Array>
+    <axis_name>Sample</axis_name>
+    <elements>{{MainLabel.IsisCube.Core.Dimensions.Samples.Value}}</elements>
+    <sequence_number>3</sequence_number>
+   </Axis_Array>
+  </Array_3D_Image>
+ </File_Area_Observational>
+</Product_Observational>
+

--- a/isis/src/base/apps/topds4/topds4.h
+++ b/isis/src/base/apps/topds4/topds4.h
@@ -10,4 +10,6 @@ namespace Isis {
   extern void topds4(UserInterface &ui, Pvl *log=nullptr);
 }
 
+extern QString PDS4PixelType(Isis::PixelType ipixelType, Isis::ByteOrder ibyteOrder);
+
 #endif

--- a/isis/src/base/apps/topds4/topds4.xml
+++ b/isis/src/base/apps/topds4/topds4.xml
@@ -55,6 +55,7 @@
 
       <parameter name="TEMPLATE">
         <type>filename</type>
+        <internalDefault>None</internalDefault>
         <fileMode>input</fileMode>
         <brief>
           Input template


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The TEMPLATE option can still be user-entered. Otherwise it defaults to $ISISROOT/appdata/export/<SpacecraftID><InstrumentId>.tpl 
An exception is thrown if the template does not exist. I also added a $ISISROOT/appdata/export/TGOCaSSIS.tpl that mimics the functionality of ProcessExportPDS4 for tgo cassis.

I didn't update the info on topds4.xml, but docs should be updated before any of this gets to dev.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use inja templating engine for exporting isis cubes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Taking the cube from `$ISISTESTDATA/isis/src/tgo/apps/tgocassisrdrgen/tsts/default/input/CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub`
Running: `topds4 from= CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub to= output.xml`
gives expected output.

gtests for topds4 all passed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
