### PR TITLE
isisVarInit.py: made writing to STDOUT optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Changed
+- isisVarInit.py no longer writes a "cat" statement by default to the activate scripts which cause the ISIS version information to be written on conda activate.  This can be included in those scripts via a command line option to isisVarInit.py.  Also, a quiet option is provided to isisVarInit.py to suppress its own writing to standard out, if needed.
+
 ### Fixed
 - Fixed logging in FindFeatures where we were trying to get a non-existent Pvl group from the Pvl log. [#4375](https://github.com/USGS-Astrogeology/ISIS3/issues/4375)
 - Fixed an arccos evaluating a double close to either 1, -1 when calculating the ground azimuth in camera.cpp. [#4393](https://github.com/USGS-Astrogeology/ISIS3/issues/4393)

--- a/isis/scripts/isisVarInit.py
+++ b/isis/scripts/isisVarInit.py
@@ -5,10 +5,11 @@ variables that are sourced during conda environment activation and
 removed at deactivation.
 
 If the directories don't exist, they are created.  If their path is
-not specified, they are placed in $ISISROOT.
+not specified, they are placed in $CONDA_PREFIX (which is $ISISROOT).
 """
 
 import argparse
+import logging
 import os
 from pathlib import Path
 
@@ -51,7 +52,7 @@ def mkdir(p: Path) -> str:
         return f"Created {p}"
 
 
-def activate_text(shell: dict, env_vars: dict) -> str:
+def activate_text(shell: dict, env_vars: dict, cat=False) -> str:
     """Returns the formatted text to write to the activation script
     based on the passed dictionaries."""
 
@@ -62,7 +63,8 @@ def activate_text(shell: dict, env_vars: dict) -> str:
     if shell["activate_extra"] != "":
         lines.append(shell["activate_extra"])
 
-    lines.append("cat $ISISROOT/version")
+    if cat:
+        lines.append("cat $ISISROOT/version")
 
     return "\n".join(lines)
 
@@ -106,21 +108,37 @@ parser.add_argument(
     action=ResolveAction,
     help="ISIS Ale Data Directory, default: %(default)s",
 )
+parser.add_argument(
+    "-c", "--cat",
+    action="store_true",
+    help="If given, the activation script will include a 'cat' action that "
+         "will print the ISIS version information to STDOUT every time the "
+         "ISIS environment is activated."
+)
+parser.add_argument(
+    "-q", "--quiet",
+    action="store_true",
+    help="If given, will suppress all regular text output."
+)
 args = parser.parse_args()
 
-print("-- ISIS Data Directories --")
-# Create the data directories:
-print(mkdir(args.data_dir))
-print(mkdir(args.test_dir))
-print(mkdir(args.ale_dir))
+log_lvl = {False: "INFO", True: "ERROR"}
 
-print("-- Conda activation and deactivation scripts --")
+logging.basicConfig(format="%(message)s", level=log_lvl[args.quiet])
+
+logging.info("-- ISIS Data Directories --")
+# Create the data directories:
+logging.info(mkdir(args.data_dir))
+logging.info(mkdir(args.test_dir))
+logging.info(mkdir(args.ale_dir))
+
+logging.info("-- Conda activation and deactivation scripts --")
 # Create the conda activation and deactivation directories:
 activate_dir = Path(os.environ["CONDA_PREFIX"]) / "etc/conda/activate.d"
 deactivate_dir = Path(os.environ["CONDA_PREFIX"]) / "etc/conda/deactivate.d"
 
-print(mkdir(activate_dir))
-print(mkdir(deactivate_dir))
+logging.info(mkdir(activate_dir))
+logging.info(mkdir(deactivate_dir))
 
 # Set the environment variables to manage
 env_vars = dict(
@@ -161,9 +179,9 @@ fish = dict(
 # each:
 for shell in (sh, csh, fish):
     a_path = activate_dir / ("isis-activate" + shell["extension"])
-    a_path.write_text(activate_text(shell, env_vars))
-    print(f"Wrote {a_path}")
+    a_path.write_text(activate_text(shell, env_vars, cat=args.cat))
+    logging.info(f"Wrote {a_path}")
 
     d_path = deactivate_dir / ("isis-deactivate" + shell["extension"])
     d_path.write_text(deactivate_text(shell, env_vars))
-    print(f"Wrote {d_path}")
+    logging.info(f"Wrote {d_path}")


### PR DESCRIPTION
## Description
`isisVarInit.py` no longer writes a "cat" statement by default to the activate scripts which cause the ISIS version information to be written on conda activate.  This can be included in those scripts via a command line option to `isisVarInit.py`.  Also, a quiet option is provided to `isisVarInit.py` to suppress its own writing to standard out, if needed.

## Related Issue
This would close #4434 

## How Has This Been Tested?
Tested locally.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
