### PR TITLE
Cassis Template Updated BandBin and AlphaCube Groups

### DIFF
--- a/isis/appdata/import/cassis.lbl.tpl
+++ b/isis/appdata/import/cassis.lbl.tpl
@@ -1,3 +1,8 @@
+{% set PO=Product_Observational%}
+{% set CassHeader="Product_Observational.CaSSIS_Header"%}
+{% set IdArea="Product_Observational.Identification_Area"%}
+{% set FileArea="Product_Observational.File_Area_Observational"%}
+
 Object = IsisCube
   Object = Core
     StartByte   = 65537
@@ -6,9 +11,9 @@ Object = IsisCube
     TileLines   = 280
 
     Group = Dimensions
-      Samples = {{Product_Observational.File_Area_Observational.Array_2D_Image.Axis_Array.0.elements}}
-      Lines   = {{Product_Observational.File_Area_Observational.Array_2D_Image.Axis_Array.1.elements}}
-      Bands   = {%if exists("Product_Observational.File_Area_Observational.Array_2D_Image.Axis_Array.2.elements")%}{{Product_Observational.File_Area_Observational.Array_2D_Image.Axis_Array.2.elements}}{%else%}1{%endif%}
+      Samples = {{PO.File_Area_Observational.Array_2D_Image.Axis_Array.0.elements}}
+      Lines   = {{PO.File_Area_Observational.Array_2D_Image.Axis_Array.1.elements}}
+      Bands   = {%if exists(FileArea + ".Array_2D_Image.Axis_Array.2.elements")%}{{PO.File_Area_Observational.Array_2D_Image.Axis_Array.2.elements}}{%else%}1{%endif%}
     End_Group
 
     Group = Pixels
@@ -20,132 +25,323 @@ Object = IsisCube
   End_Object
 
   Group = Instrument
-    SpacecraftName            = {%if exists("Product_Observational.Observation_Area.Investigation_Area.name")%} "{{Product_Observational.Observation_Area.Investigation_Area.name}}"{%else%}"{{Product_Observational.Observation_Area.Investigation_Area.Instrument_Host_Name}}"{%endif%}
-    InstrumentId              = {{Product_Observational.Observation_Area.Observing_System.Observing_System_Component.1.name}}
-    TargetName                = {%if exists("Product_Observational.Observation_Area.Target_Identification.name")%}{{Product_Observational.Observation_Area.Target_Identification.name}}{%else%}{{Product_Observational.CaSSIS_Header.GEOMETRIC_DATA.TARGET}}{%endif%}
-    StartTime                 = {%if exists("Product_Observational.Observation_Area.Time_Coordinates.start_date_time")%}{{Product_Observational.Observation_Area.Time_Coordinates.start_date_time}}{%else%}{{Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.OnboardImageAcquisitionTime._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}SpacecraftClockStartCount = {{Product_Observational.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp}}{%endif%}
-    ExposureDuration          = {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}{{Product_Observational.Observation_Area.Discipline_Area.img_Imaging.img_Imaging_Instrument_Parameters.img_exposure_duration._text}}<seconds>{%else%}{{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time}}<seconds>{%endif%}
-    Filter                    = {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}{{Product_Observational.Observation_Area.Discipline_Area.img_Imaging.img_Image_Product_Information.img_Filter.img_filter_name}}{%else%}{{Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.Filter._text}}{%endif%}
-    Expanded                  = {%if exists("Product_Observational.CaSSIS_Header")%}{{Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.Expanded._text}}{%else%}1{%endif%}
-    SummingMode               = 0
+    SpacecraftName            = {%if exists("Product_Observational.Observation_Area.Investigation_Area.name")%} "{{PO.Observation_Area.Investigation_Area.name}}"{%else%}"{{PO.Observation_Area.Investigation_Area.Instrument_Host_Name}}"{%endif%}
+    InstrumentId              = {{PO.Observation_Area.Observing_System.Observing_System_Component.1.name}}
+    TargetName                = {%if exists("Product_Observational.Observation_Area.Target_Identification.name")%}{{PO.Observation_Area.Target_Identification.name}}{%else%}{{PO.CaSSIS_Header.GEOMETRIC_DATA.TARGET}}{%endif%}
+    StartTime                 = {%if exists("Product_Observational.Observation_Area.Time_Coordinates.start_date_time")%}{{PO.Observation_Area.Time_Coordinates.start_date_time}}{%else%}{{PO.CaSSIS_Header.DERIVED_HEADER_DATA.OnboardImageAcquisitionTime._text}}{%endif%}
+    {%if exists(CassHeader)%}
+    SpacecraftClockStartCount = {{PO.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp}}
+    {%endif%}
+    ExposureDuration          = {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}{{PO.Observation_Area.Discipline_Area.img_Imaging.img_Imaging_Instrument_Parameters.img_exposure_duration._text}}<seconds>{%else%}{{PO.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time}}<seconds>{%endif%}
+    Filter                    = {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}{{PO.Observation_Area.Discipline_Area.img_Imaging.img_Image_Product_Information.img_Filter.img_filter_name}}{%else%}{{PO.CaSSIS_Header.DERIVED_HEADER_DATA.Filter._text}}{%endif%}
+    Expanded                  = {%if exists(CassHeader)%}
+                                {% set expanded=int(PO.CaSSIS_Header.DERIVED_HEADER_DATA.Expanded._text)%}
+                                {{PO.CaSSIS_Header.DERIVED_HEADER_DATA.Expanded._text}}
+                                {%else%}
+                                1
+                                {% set expanded=1%}
+                                {%endif%}
+    SummingMode               = {%if expanded == 1%}
+                                0
+                                {%else%}
+                                Window{{PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter}}Binning
+                                {%endif%}
   End_Group
 
   Group = Archive
-    {%if exists("Product_Observational.Identification_Area.Alias_List")%}ObservationId             = {{Product_Observational.Identification_Area.Alias_List.Alias.alternate_id}}{%endif%}
-    DataSetId                    = {{Product_Observational.Identification_Area.logical_identifier}}
-    {%if exists("Product_Observational.Identification_Area.version_id")%}ProductVersionId             = {{Product_Observational.Identification_Area.version_id}}{%endif%}
-    {%if exists("Product_Observational.Identification_Area.Producer_data")%}ProducerId                   = {{Product_Observational.Identification_Area.Producer_data.Producer_id}}{%endif%}
-    {%if exists("Product_Observational.Identification_Area.Producer_data")%}ProducerName                 = "{{Product_Observational.Identification_Area.Producer_data.Producer_full_name}}"{%endif%}
-    {%if exists("Product_Observational.File_Area_Observational.File.creation_date_time")%}ProductCreationTime          = {{Product_Observational.File_Area_Observational.File.creation_date_time}}{%endif%}
-    FileName                     = {{Product_Observational.File_Area_Observational.File.file_name}}
-    ScalingFactor                = {{Product_Observational.File_Area_Observational.Array_2D_Image.Element_Array.scaling_factor}}
-    {%if exists("Product_Observational.File_Area_Observational.Array_2D_Image.Element_Array.offset")%}Offset                       = {{Product_Observational.File_Area_Observational.Array_2D_Image.Element_Array.offset}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}PredictMaximumExposureTime   = {{Product_Observational.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_MAXIMUM_EXPOSURE_TIME._text}} <ms>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}CassisOffNadirAngle          = {{Product_Observational.CaSSIS_Header.GEOMETRIC_DATA.CASSIS_OFF_NADIR_ANGLE._text}} <deg>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}PredictedRepetitionFrequency = {{Product_Observational.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_REQUIRED_REPETITION_FREQUENCY._text}} <ms>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}GroundTrackVelocity          = {{Product_Observational.CaSSIS_Header.GEOMETRIC_DATA.TGO_GROUND_TRACK_VELOCITY._text}} <km/s>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}ForwardRotationAngle         = {{Product_Observational.CaSSIS_Header.GEOMETRIC_DATA.FORWARD_ROTATION_ANGLE_REQUIRED._text}} <deg>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}SpiceMisalignment            = {{Product_Observational.CaSSIS_Header.GEOMETRIC_DATA.SPICE_KERNEL_MISALIGNMENT_PREDICT._text}} <deg>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}FocalLength                  = {{Product_Observational.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text}} <m>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}FNumber                      = {{Product_Observational.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}ExposureTimeCommand          = {{Product_Observational.CaSSIS_Header.IMAGE_COMMAND.T_exp._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}FrameletNumber               = {{Product_Observational.CaSSIS_Header.FSW_HEADER.attrib_SequenceCounter}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}NumberOfFramelets            = {{Product_Observational.CaSSIS_Header.IMAGE_COMMAND.Num_exp._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}ImageFrequency               = {{Product_Observational.CaSSIS_Header.IMAGE_COMMAND.Step_exp._text}} <ms>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}NumberOfWindows              = {{Product_Observational.CaSSIS_Header.IMAGE_COMMAND.Num_win._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header.hasSymbol")%}UniqueIdentifier             = {{Product_Observational.CaSSIS_Header.IMAGE_COMMAND.Unique_Identifier._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}UID                          = {{Product_Observational.CaSSIS_Header.FSW_HEADER.attrib_UID}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}ExposureTimestamp            = {{Product_Observational.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}ExposureTimePEHK             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time}} <ms>{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}PixelsPossiblySaturated      = {{Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.PixelsPossiblySaturated._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}IFOV                         = {{Product_Observational.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}IFOVUnit                     = {{Product_Observational.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV.attrib_Unit}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}FiltersAvailable             = "{{Product_Observational.CaSSIS_Header.CaSSIS_General.FILTERS_AVAILABLE}}"{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}FocalLength                  = {{Product_Observational.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}FocalLengthUnit              = {{Product_Observational.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH.attrib_Unit}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}TelescopeFNumber              = {{Product_Observational.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}TelescopeType                = "{{Product_Observational.CaSSIS_Header.CaSSIS_General.TELESCOPE_TYPE}}"{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}DetectorDescription          = "{{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_DESC}}"{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}PixelHeight                  = {{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}PixelHeightUnit              = {{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT.attrib_Unit}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}PixelWidth                   = {{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}PixelWidthUnit               = {{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH.attrib_Unit}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}DetectorType                 = "{{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_TYPE}}"{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}ReadNoise                    = {{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}ReadNoiseUnit                = {{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE.attrib_Unit}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}MissionPhase                 = {{Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.MissionPhase._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}SubInstrumentIdentifier      = {{Product_Observational.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}WindowCount                  = {{Product_Observational.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window1Binning               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_1}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window1StartSample           = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window1EndSample             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window1StartLine             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window1EndLine               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window2Binning               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_2}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window2StartSample           = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window2EndSample             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window2StartLine             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window2EndLine               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window3Binning               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_3}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window3StartSample           = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window3EndSample             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window3StartLine             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window3EndLine               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window4Binning               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_4}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window4StartSample           = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window4EndSample             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window4StartLine             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window4EndLine               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window5Binning               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_5}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window5StartSample           = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window5EndSample             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window5StartLine             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window5EndLine               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window6Binning               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_6}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window6StartSample           = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window6EndSample             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Col}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window6StartLine             = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Row}}{%endif%}
-    {%if exists("Product_Observational.CaSSIS_Header")%}Window6EndLine               = {{Product_Observational.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Row}}{%endif%}
+    {%if exists(IdArea + ".Alias_List")%}
+    ObservationId             = {{PO.Identification_Area.Alias_List.Alias.alternate_id}}
+    {%endif%}
+    DataSetId                    = {{PO.Identification_Area.logical_identifier}}
+    {%if exists(IdArea + ".version_id")%}
+    ProductVersionId             = {{PO.Identification_Area.version_id}}
+    {%endif%}
+    {%if exists(IdArea + ".Producer_data")%}
+    ProducerId                   = {{PO.Identification_Area.Producer_data.Producer_id}}
+    {%endif%}
+    {%if exists(IdArea + ".Producer_data")%}
+    ProducerName                 = "{{PO.Identification_Area.Producer_data.Producer_full_name}}"
+    {%endif%}
+    {%if exists(FileArea + ".File.creation_date_time")%}
+    ProductCreationTime          = {{PO.File_Area_Observational.File.creation_date_time}}
+    {%endif%}
+    FileName                     = {{PO.File_Area_Observational.File.file_name}}
+    ScalingFactor                = {{PO.File_Area_Observational.Array_2D_Image.Element_Array.scaling_factor}}
+    {%if exists(FileArea + ".Array_2D_Image.Element_Array.offset")%}
+    Offset                       = {{PO.File_Area_Observational.Array_2D_Image.Element_Array.offset}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    PredictMaximumExposureTime   = {{PO.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_MAXIMUM_EXPOSURE_TIME._text}} <ms>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    CassisOffNadirAngle          = {{PO.CaSSIS_Header.GEOMETRIC_DATA.CASSIS_OFF_NADIR_ANGLE._text}} <deg>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    PredictedRepetitionFrequency = {{PO.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_REQUIRED_REPETITION_FREQUENCY._text}} <ms>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    GroundTrackVelocity          = {{PO.CaSSIS_Header.GEOMETRIC_DATA.TGO_GROUND_TRACK_VELOCITY._text}} <km/s>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    ForwardRotationAngle         = {{PO.CaSSIS_Header.GEOMETRIC_DATA.FORWARD_ROTATION_ANGLE_REQUIRED._text}} <deg>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    SpiceMisalignment            = {{PO.CaSSIS_Header.GEOMETRIC_DATA.SPICE_KERNEL_MISALIGNMENT_PREDICT._text}} <deg>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    FocalLength                  = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text}} <m>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    FNumber                      = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    ExposureTimeCommand          = {{PO.CaSSIS_Header.IMAGE_COMMAND.T_exp._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    FrameletNumber               = {{PO.CaSSIS_Header.FSW_HEADER.attrib_SequenceCounter}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    NumberOfFramelets            = {{PO.CaSSIS_Header.IMAGE_COMMAND.Num_exp._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    ImageFrequency               = {{PO.CaSSIS_Header.IMAGE_COMMAND.Step_exp._text}} <ms>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    NumberOfWindows              = {{PO.CaSSIS_Header.IMAGE_COMMAND.Num_win._text}}
+    {%endif%}
+    {%if exists(CassHeader + ".IMAGE_COMMAND")%}
+    UniqueIdentifier             = {{PO.CaSSIS_Header.IMAGE_COMMAND.Unique_Identifier._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    UID                          = {{PO.CaSSIS_Header.FSW_HEADER.attrib_UID}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    ExposureTimestamp            = {{PO.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    ExposureTimePEHK             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time}} <ms>
+    {%endif%}
+    {%if exists(CassHeader)%}
+    PixelsPossiblySaturated      = {{PO.CaSSIS_Header.DERIVED_HEADER_DATA.PixelsPossiblySaturated._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    IFOV                         = {{PO.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    IFOVUnit                     = {{PO.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV.attrib_Unit}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    FiltersAvailable             = "{{PO.CaSSIS_Header.CaSSIS_General.FILTERS_AVAILABLE}}"
+    {%endif%}
+    {%if exists(CassHeader)%}
+    FocalLength                  = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    FocalLengthUnit              = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH.attrib_Unit}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    TelescopeFNumber              = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    TelescopeType                = "{{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_TYPE}}"
+    {%endif%}
+    {%if exists(CassHeader)%}
+    DetectorDescription          = "{{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_DESC}}"{%endif%}
+    {%if exists(CassHeader)%}
+    PixelHeight                  = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT._text}}{%endif%}
+    {%if exists(CassHeader)%}
+    PixelHeightUnit              = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT.attrib_Unit}}{%endif%}
+    {%if exists(CassHeader)%}
+    PixelWidth                   = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH._text}}{%endif%}
+    {%if exists(CassHeader)%}
+    PixelWidthUnit               = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH.attrib_Unit}}{%endif%}
+    {%if exists(CassHeader)%}
+    DetectorType                 = "{{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_TYPE}}"
+    {%endif%}
+    {%if exists(CassHeader)%}
+    ReadNoise                    = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    ReadNoiseUnit                = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE.attrib_Unit}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    MissionPhase                 = {{PO.CaSSIS_Header.DERIVED_HEADER_DATA.MissionPhase._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    SubInstrumentIdentifier      = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    WindowCount                  = {{PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window1Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_1}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window1StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window1EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window1StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window1EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window2Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_2}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window2StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window2EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window2StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window2EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window3Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_3}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window3StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window3EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window3StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window3EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window4Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_4}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window4StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window4EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window4StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window4EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window5Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_5}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window5StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window5EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window5StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window5EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window6Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_6}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window6StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window6EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Col}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window6StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Row}}
+    {%endif%}
+    {%if exists(CassHeader)%}
+    Window6EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Row}}
+    {%endif%}
   End_Group
 
   Group = BandBin
-    FilterName = PAN
-    Center     = 675 <nm>
-    Width      = 250 <nm>
-    NaifIkCode = -143421
+    {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}
+    {%set filterName=Product_Observational.Observation_Area.Discipline_Area.img_Imaging.img_Image_Product_Information.img_Filter.img_filter_name%}
+    {%else%}
+    {%set filterName=Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.Filter._text%}
+    {%endif%}
+    FilterName = {{filterName}}
+    Center     = {%if filterName == "RED"%}835.4 <nm>
+                 {%else if filterName == "PAN"%} 677.4 <nm>
+                 {%else if filterName == "NIR"%} 940.2 <nm>
+                 {%else if filterName == "BLU"%} 497.4 <nm>
+                 {%endif%}
+    Width      = {%if filterName == "RED"%}98.0 <nm>
+                 {%else if filterName == "PAN"%} 231.5 <nm>
+                 {%else if filterName == "NIR"%} 120.6 <nm>
+                 {%else if filterName == "BLU"%} 134.3 <nm>
+                 {%endif%}
+    NaifIkCode = {%if filterName == "RED"%} -143422
+                 {%else if filterName == "PAN"%} -143421
+                 {%else if filterName == "NIR"%} -143423
+                 {%else if filterName == "BLU"%} -143424
+                 {%else%}-143400{%endif%}
   End_Group
 
   Group = Kernels
     NaifFrameCode = -143400
   End_Group
 
+  {%if exists(CassHeader)%}
+    {% set windowNumber=int(PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter) + 1 %}
+    {%if windowNumber == 1%}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Col) + 1%}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Col) + 1%}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Row) + 1%}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Row) + 1%}
+    {%endif%}
+    {%if windowNumber == 2%}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Col) + 1%}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Col) + 1%}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Row) + 1%}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Row) + 1%}
+    {%endif%}
+    {%if windowNumber == 3%}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Col) + 1%}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Col) + 1%}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Row) + 1%}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Row) + 1%}
+    {%endif%}
+    {%if windowNumber == 4%}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Col) + 1%}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Col) + 1%}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Row) + 1%}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Row) + 1%}
+    {%endif%}
+    {%if windowNumber == 5%}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Col) + 1%}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Col) + 1%}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Row) + 1%}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Row) + 1%}
+    {%endif%}
+    {%if windowNumber == 6%}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Col) + 1%}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Col) + 1%}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Row) + 1%}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Row) + 1%}
+    {%endif%}
+
   Group = AlphaCube
     AlphaSamples        = 2048
     AlphaLines          = 2048
-    AlphaStartingSample = 0.5
-    AlphaStartingLine   = 354.5
-    AlphaEndingSample   = 2048.5
-    AlphaEndingLine     = 634.5
-    BetaSamples         = 2048
-    BetaLines           = 280
+    AlphaStartingSample = {{frameletStartSample - 0.5}}
+    AlphaStartingLine   = {{frameletStartLine - 0.5}}
+    AlphaEndingSample   = {{frameletEndSample + 0.5}}
+    AlphaEndingLine     = {{frameletEndLine + 0.5}}
+    BetaSamples         = {{frameletEndSample - frameletStartSample + 1}}
+    BetaLines           = {{frameletEndLine - frameletStartLine + 1}}
   End_Group
-End_Object
-
-Object = Label
-  Bytes = 65536
-End_Object
-
-Object = History
-  Name      = IsisCube
-  StartByte = 2359297
-  Bytes     = 572
-End_Object
-
-Object = OriginalXmlLabel
-  Name      = IsisCube
-  StartByte = 2359869
-  Bytes     = 13408
-  ByteOrder = Lsb
+  {%endif%}
 End_Object
 End

--- a/isis/appdata/import/cassis.lbl.tpl
+++ b/isis/appdata/import/cassis.lbl.tpl
@@ -5,7 +5,6 @@
 {% set threeDArray="Product_Observational.File_Area_Observational.Array_3D_Image" %}
 
 Object = IsisCube
-  Object = Core
 
     {% if exists(threeDArray) %}
     Group = Dimensions
@@ -77,7 +76,6 @@ Object = IsisCube
       Multiplier = {{ PO.File_Area_Observational.Array_2D_Image.Element_Array.scaling_factor }}
     End_Group
     {% endif %}
-  End_Object
 
   Group = Instrument
     SpacecraftName            = {% if exists("Product_Observational.Observation_Area.Investigation_Area.name") %}

--- a/isis/appdata/import/cassis.lbl.tpl
+++ b/isis/appdata/import/cassis.lbl.tpl
@@ -2,14 +2,47 @@
 {% set CassHeader="Product_Observational.CaSSIS_Header" %}
 {% set IdArea="Product_Observational.Identification_Area" %}
 {% set FileArea="Product_Observational.File_Area_Observational" %}
+{% set threeDArray="Product_Observational.File_Area_Observational.Array_3D_Image" %}
 
 Object = IsisCube
   Object = Core
-    StartByte   = 65537
-    Format      = Tile
-    TileSamples = 512
-    TileLines   = 280
 
+    {% if exists(threeDArray) %}
+    Group = Dimensions
+      Samples = {{ PO.File_Area_Observational.Array_3D_Image.Axis_Array.0.elements }}
+      Lines   = {{ PO.File_Area_Observational.Array_3D_Image.Axis_Array.1.elements }}
+      Bands   = {% if exists(FileArea + ".Array_3D_Image.Axis_Array.2.elements") %}
+                {{ PO.File_Area_Observational.Array_3D_Image.Axis_Array.2.elements }}
+                {% else %}
+                1
+                {% endif %}
+    End_Group
+
+    Group = Pixels
+      {% if exists("Product_Observational.File_Area_Observational.Array_3D_Image.Element_Array.idl_data_type") %}
+      {% set type=PO.File_Area_Observational.Array_3D_Image.Element_Array.idl_data_type %}
+      Type       = {% if type == "1" %} UnsignedByte
+                   {% else if type == "2" %} SignedWord
+                   {% else if type == "3" %} SignedInteger
+                   {% else if type == "4" or type == "5" %} Real
+                   {% else if type == "12" %} UnsignedWord
+                   {% else if type == "13" %} UnsignedInteger
+                   {% else if type == "14" %} SignedInteger
+                   {% else if type == "14" %} UnsignedInteger
+                   {% endif %}
+      {% else %}
+      Type       = Real
+      {% endif %}
+      ByteOrder  = Lsb
+                   {% if exists("Product_Observational.File_Area_Observational.Array_3D_Image.Element_Array.offset") %}
+      Base       = {{ PO.File_Area_Observational.Array_3D_Image.Element_Array.offset }}
+                   {% else %}
+                   {{ PO.File_Area_Observational.Array_3D_Image.Element_Array.value_offset }}
+                   {% endif %}
+      Multiplier = {{ PO.File_Area_Observational.Array_3D_Image.Element_Array.scaling_factor }}
+    End_Group
+
+    {% else %}
     Group = Dimensions
       Samples = {{ PO.File_Area_Observational.Array_2D_Image.Axis_Array.0.elements }}
       Lines   = {{ PO.File_Area_Observational.Array_2D_Image.Axis_Array.1.elements }}
@@ -21,11 +54,29 @@ Object = IsisCube
     End_Group
 
     Group = Pixels
+      {% if exists("Product_Observational.File_Area_Observational.Array_2D_Image.Element_Array.idl_data_type") %}
+      {% set type=PO.File_Area_Observational.Array_2D_Image.Element_Array.idl_data_type %}
+      Type       = {% if type == "1" %} UnsignedByte
+                   {% else if type == "2" %} SignedWord
+                   {% else if type == "3" %} SignedInteger
+                   {% else if type == "4" or type == "5" %} Real
+                   {% else if type == "12" %} UnsignedWord
+                   {% else if type == "13" %} UnsignedInteger
+                   {% else if type == "14" %} SignedInteger
+                   {% else if type == "14" %} UnsignedInteger
+                   {% endif %}
+      {% else %}
       Type       = Real
+      {% endif %}
       ByteOrder  = Lsb
-      Base       = 0.0
-      Multiplier = 1.0
+                   {% if exists("Product_Observational.File_Area_Observational.Array_2D_Image.Element_Array.offset") %}
+      Base       = {{ PO.File_Area_Observational.Array_2D_Image.Element_Array.offset }}
+                   {% else %}
+                   {{ PO.File_Area_Observational.Array_2D_Image.Element_Array.value_offset }}
+                   {% endif %}
+      Multiplier = {{ PO.File_Area_Observational.Array_2D_Image.Element_Array.scaling_factor }}
     End_Group
+    {% endif %}
   End_Object
 
   Group = Instrument

--- a/isis/appdata/import/cassis.lbl.tpl
+++ b/isis/appdata/import/cassis.lbl.tpl
@@ -1,7 +1,7 @@
-{% set PO=Product_Observational%}
-{% set CassHeader="Product_Observational.CaSSIS_Header"%}
-{% set IdArea="Product_Observational.Identification_Area"%}
-{% set FileArea="Product_Observational.File_Area_Observational"%}
+{% set PO=Product_Observational %}
+{% set CassHeader="Product_Observational.CaSSIS_Header" %}
+{% set IdArea="Product_Observational.Identification_Area" %}
+{% set FileArea="Product_Observational.File_Area_Observational" %}
 
 Object = IsisCube
   Object = Core
@@ -11,9 +11,13 @@ Object = IsisCube
     TileLines   = 280
 
     Group = Dimensions
-      Samples = {{PO.File_Area_Observational.Array_2D_Image.Axis_Array.0.elements}}
-      Lines   = {{PO.File_Area_Observational.Array_2D_Image.Axis_Array.1.elements}}
-      Bands   = {%if exists(FileArea + ".Array_2D_Image.Axis_Array.2.elements")%}{{PO.File_Area_Observational.Array_2D_Image.Axis_Array.2.elements}}{%else%}1{%endif%}
+      Samples = {{ PO.File_Area_Observational.Array_2D_Image.Axis_Array.0.elements }}
+      Lines   = {{ PO.File_Area_Observational.Array_2D_Image.Axis_Array.1.elements }}
+      Bands   = {% if exists(FileArea + ".Array_2D_Image.Axis_Array.2.elements") %}
+                {{ PO.File_Area_Observational.Array_2D_Image.Axis_Array.2.elements }}
+                {% else %}
+                1
+                {% endif %}
     End_Group
 
     Group = Pixels
@@ -25,323 +29,342 @@ Object = IsisCube
   End_Object
 
   Group = Instrument
-    SpacecraftName            = {%if exists("Product_Observational.Observation_Area.Investigation_Area.name")%} "{{PO.Observation_Area.Investigation_Area.name}}"{%else%}"{{PO.Observation_Area.Investigation_Area.Instrument_Host_Name}}"{%endif%}
-    InstrumentId              = {{PO.Observation_Area.Observing_System.Observing_System_Component.1.name}}
-    TargetName                = {%if exists("Product_Observational.Observation_Area.Target_Identification.name")%}{{PO.Observation_Area.Target_Identification.name}}{%else%}{{PO.CaSSIS_Header.GEOMETRIC_DATA.TARGET}}{%endif%}
-    StartTime                 = {%if exists("Product_Observational.Observation_Area.Time_Coordinates.start_date_time")%}{{PO.Observation_Area.Time_Coordinates.start_date_time}}{%else%}{{PO.CaSSIS_Header.DERIVED_HEADER_DATA.OnboardImageAcquisitionTime._text}}{%endif%}
-    {%if exists(CassHeader)%}
-    SpacecraftClockStartCount = {{PO.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp}}
-    {%endif%}
-    ExposureDuration          = {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}{{PO.Observation_Area.Discipline_Area.img_Imaging.img_Imaging_Instrument_Parameters.img_exposure_duration._text}}<seconds>{%else%}{{PO.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time}}<seconds>{%endif%}
-    Filter                    = {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}{{PO.Observation_Area.Discipline_Area.img_Imaging.img_Image_Product_Information.img_Filter.img_filter_name}}{%else%}{{PO.CaSSIS_Header.DERIVED_HEADER_DATA.Filter._text}}{%endif%}
-    Expanded                  = {%if exists(CassHeader)%}
-                                {% set expanded=int(PO.CaSSIS_Header.DERIVED_HEADER_DATA.Expanded._text)%}
-                                {{PO.CaSSIS_Header.DERIVED_HEADER_DATA.Expanded._text}}
-                                {%else%}
+    SpacecraftName            = {% if exists("Product_Observational.Observation_Area.Investigation_Area.name") %}
+                                "{{ PO.Observation_Area.Investigation_Area.name }}"
+                                {% else %}
+                                "{{ PO.Observation_Area.Investigation_Area.Instrument_Host_Name }}"
+                                {% endif %}
+    InstrumentId              = {{ PO.Observation_Area.Observing_System.Observing_System_Component.1.name }}
+    TargetName                = {% if exists("Product_Observational.Observation_Area.Target_Identification.name") %}
+                                {{ PO.Observation_Area.Target_Identification.name }}
+                                {% else %}
+                                {{ PO.CaSSIS_Header.GEOMETRIC_DATA.TARGET }}
+                                {% endif %}
+    StartTime                 = {% if exists("Product_Observational.Observation_Area.Time_Coordinates.start_date_time") %}
+                                {{ PO.Observation_Area.Time_Coordinates.start_date_time }}
+                                {% else %}
+                                {{ PO.CaSSIS_Header.DERIVED_HEADER_DATA.OnboardImageAcquisitionTime._text }}
+                                {% endif %}
+                                {% if exists(CassHeader) %}
+    SpacecraftClockStartCount = {{ PO.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp }}
+                                {% endif %}
+    ExposureDuration          = {% if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging") %}
+                                {{ PO.Observation_Area.Discipline_Area.img_Imaging.img_Imaging_Instrument_Parameters.img_exposure_duration._text }}<seconds>
+                                {% else %}
+                                {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time }}<seconds>
+                                {% endif %}
+    Filter                    = {% if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging") %}
+                                {{ PO.Observation_Area.Discipline_Area.img_Imaging.img_Image_Product_Information.img_Filter.img_filter_name }}
+                                {% else %} {{ PO.CaSSIS_Header.DERIVED_HEADER_DATA.Filter._text }}
+                                {% endif %}
+    Expanded                  = {% if exists(CassHeader) %}
+                                {% set expanded=int(PO.CaSSIS_Header.DERIVED_HEADER_DATA.Expanded._text) %}
+                                {{ PO.CaSSIS_Header.DERIVED_HEADER_DATA.Expanded._text }}
+                                {% else %}
                                 1
-                                {% set expanded=1%}
-                                {%endif%}
-    SummingMode               = {%if expanded == 1%}
+                                {% set expanded=1 %}
+                                {% endif %}
+    SummingMode               = {% if expanded == 1 %}
                                 0
-                                {%else%}
-                                Window{{PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter}}Binning
-                                {%endif%}
+                                {% else %}
+                                Window{{ PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter }}Binning
+                                {% endif %}
   End_Group
 
   Group = Archive
-    {%if exists(IdArea + ".Alias_List")%}
-    ObservationId             = {{PO.Identification_Area.Alias_List.Alias.alternate_id}}
-    {%endif%}
-    DataSetId                    = {{PO.Identification_Area.logical_identifier}}
-    {%if exists(IdArea + ".version_id")%}
-    ProductVersionId             = {{PO.Identification_Area.version_id}}
-    {%endif%}
-    {%if exists(IdArea + ".Producer_data")%}
-    ProducerId                   = {{PO.Identification_Area.Producer_data.Producer_id}}
-    {%endif%}
-    {%if exists(IdArea + ".Producer_data")%}
-    ProducerName                 = "{{PO.Identification_Area.Producer_data.Producer_full_name}}"
-    {%endif%}
-    {%if exists(FileArea + ".File.creation_date_time")%}
-    ProductCreationTime          = {{PO.File_Area_Observational.File.creation_date_time}}
-    {%endif%}
-    FileName                     = {{PO.File_Area_Observational.File.file_name}}
-    ScalingFactor                = {{PO.File_Area_Observational.Array_2D_Image.Element_Array.scaling_factor}}
-    {%if exists(FileArea + ".Array_2D_Image.Element_Array.offset")%}
-    Offset                       = {{PO.File_Area_Observational.Array_2D_Image.Element_Array.offset}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    PredictMaximumExposureTime   = {{PO.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_MAXIMUM_EXPOSURE_TIME._text}} <ms>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    CassisOffNadirAngle          = {{PO.CaSSIS_Header.GEOMETRIC_DATA.CASSIS_OFF_NADIR_ANGLE._text}} <deg>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    PredictedRepetitionFrequency = {{PO.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_REQUIRED_REPETITION_FREQUENCY._text}} <ms>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    GroundTrackVelocity          = {{PO.CaSSIS_Header.GEOMETRIC_DATA.TGO_GROUND_TRACK_VELOCITY._text}} <km/s>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    ForwardRotationAngle         = {{PO.CaSSIS_Header.GEOMETRIC_DATA.FORWARD_ROTATION_ANGLE_REQUIRED._text}} <deg>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    SpiceMisalignment            = {{PO.CaSSIS_Header.GEOMETRIC_DATA.SPICE_KERNEL_MISALIGNMENT_PREDICT._text}} <deg>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    FocalLength                  = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text}} <m>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    FNumber                      = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    ExposureTimeCommand          = {{PO.CaSSIS_Header.IMAGE_COMMAND.T_exp._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    FrameletNumber               = {{PO.CaSSIS_Header.FSW_HEADER.attrib_SequenceCounter}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    NumberOfFramelets            = {{PO.CaSSIS_Header.IMAGE_COMMAND.Num_exp._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    ImageFrequency               = {{PO.CaSSIS_Header.IMAGE_COMMAND.Step_exp._text}} <ms>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    NumberOfWindows              = {{PO.CaSSIS_Header.IMAGE_COMMAND.Num_win._text}}
-    {%endif%}
-    {%if exists(CassHeader + ".IMAGE_COMMAND")%}
-    UniqueIdentifier             = {{PO.CaSSIS_Header.IMAGE_COMMAND.Unique_Identifier._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    UID                          = {{PO.CaSSIS_Header.FSW_HEADER.attrib_UID}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    ExposureTimestamp            = {{PO.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    ExposureTimePEHK             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time}} <ms>
-    {%endif%}
-    {%if exists(CassHeader)%}
-    PixelsPossiblySaturated      = {{PO.CaSSIS_Header.DERIVED_HEADER_DATA.PixelsPossiblySaturated._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    IFOV                         = {{PO.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    IFOVUnit                     = {{PO.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV.attrib_Unit}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    FiltersAvailable             = "{{PO.CaSSIS_Header.CaSSIS_General.FILTERS_AVAILABLE}}"
-    {%endif%}
-    {%if exists(CassHeader)%}
-    FocalLength                  = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    FocalLengthUnit              = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH.attrib_Unit}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    TelescopeFNumber              = {{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    TelescopeType                = "{{PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_TYPE}}"
-    {%endif%}
-    {%if exists(CassHeader)%}
-    DetectorDescription          = "{{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_DESC}}"{%endif%}
-    {%if exists(CassHeader)%}
-    PixelHeight                  = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT._text}}{%endif%}
-    {%if exists(CassHeader)%}
-    PixelHeightUnit              = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT.attrib_Unit}}{%endif%}
-    {%if exists(CassHeader)%}
-    PixelWidth                   = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH._text}}{%endif%}
-    {%if exists(CassHeader)%}
-    PixelWidthUnit               = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH.attrib_Unit}}{%endif%}
-    {%if exists(CassHeader)%}
-    DetectorType                 = "{{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_TYPE}}"
-    {%endif%}
-    {%if exists(CassHeader)%}
-    ReadNoise                    = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    ReadNoiseUnit                = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE.attrib_Unit}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    MissionPhase                 = {{PO.CaSSIS_Header.DERIVED_HEADER_DATA.MissionPhase._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    SubInstrumentIdentifier      = {{PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    WindowCount                  = {{PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window1Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_1}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window1StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window1EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window1StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window1EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window2Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_2}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window2StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window2EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window2StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window2EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window3Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_3}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window3StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window3EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window3StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window3EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window4Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_4}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window4StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window4EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window4StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window4EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window5Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_5}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window5StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window5EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window5StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window5EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window6Binning               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_6}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window6StartSample           = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window6EndSample             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Col}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window6StartLine             = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Row}}
-    {%endif%}
-    {%if exists(CassHeader)%}
-    Window6EndLine               = {{PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Row}}
-    {%endif%}
+    {%  if exists(IdArea + ".Alias_List") %}
+    ObservationId             = {{ PO.Identification_Area.Alias_List.Alias.alternate_id }}
+    {% endif %}
+    DataSetId                    = {{ PO.Identification_Area.logical_identifier }}
+    {%  if exists(IdArea + ".version_id") %}
+    ProductVersionId             = {{ PO.Identification_Area.version_id }}
+    {% endif %}
+    {%  if exists(IdArea + ".Producer_data") %}
+    ProducerId                   = {{ PO.Identification_Area.Producer_data.Producer_id }}
+    {% endif %}
+    {%  if exists(IdArea + ".Producer_data") %}
+    ProducerName                 = "{{ PO.Identification_Area.Producer_data.Producer_full_name }}"
+    {% endif %}
+    {%  if exists(FileArea + ".File.creation_date_time") %}
+    ProductCreationTime          = {{ PO.File_Area_Observational.File.creation_date_time }}
+    {% endif %}
+    FileName                     = {{ PO.File_Area_Observational.File.file_name }}
+    ScalingFactor                = {{ PO.File_Area_Observational.Array_2D_Image.Element_Array.scaling_factor }}
+    {%  if exists(FileArea + ".Array_2D_Image.Element_Array.offset") %}
+    Offset                       = {{ PO.File_Area_Observational.Array_2D_Image.Element_Array.offset }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    PredictMaximumExposureTime   = {{ PO.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_MAXIMUM_EXPOSURE_TIME._text }} <ms>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    CassisOffNadirAngle          = {{ PO.CaSSIS_Header.GEOMETRIC_DATA.CASSIS_OFF_NADIR_ANGLE._text }} <deg>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    PredictedRepetitionFrequency = {{ PO.CaSSIS_Header.GEOMETRIC_DATA.PREDICTED_REQUIRED_REPETITION_FREQUENCY._text }} <ms>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    GroundTrackVelocity          = {{ PO.CaSSIS_Header.GEOMETRIC_DATA.TGO_GROUND_TRACK_VELOCITY._text }} <km/s>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    ForwardRotationAngle         = {{ PO.CaSSIS_Header.GEOMETRIC_DATA.FORWARD_ROTATION_ANGLE_REQUIRED._text }} <deg>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    SpiceMisalignment            = {{ PO.CaSSIS_Header.GEOMETRIC_DATA.SPICE_KERNEL_MISALIGNMENT_PREDICT._text }} <deg>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    FocalLength                  = {{ PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text }} <m>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    FNumber                      = {{ PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    ExposureTimeCommand          = {{ PO.CaSSIS_Header.IMAGE_COMMAND.T_exp._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    FrameletNumber               = {{ PO.CaSSIS_Header.FSW_HEADER.attrib_SequenceCounter }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    NumberOfFramelets            = {{ PO.CaSSIS_Header.IMAGE_COMMAND.Num_exp._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    ImageFrequency               = {{ PO.CaSSIS_Header.IMAGE_COMMAND.Step_exp._text }} <ms>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    NumberOfWindows              = {{ PO.CaSSIS_Header.IMAGE_COMMAND.Num_win._text }}
+    {% endif %}
+    {%  if exists(CassHeader + ".IMAGE_COMMAND") %}
+    UniqueIdentifier             = {{ PO.CaSSIS_Header.IMAGE_COMMAND.Unique_Identifier._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    UID                          = {{ PO.CaSSIS_Header.FSW_HEADER.attrib_UID }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    ExposureTimestamp            = {{ PO.CaSSIS_Header.FSW_HEADER.attrib_ExposureTimestamp }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    ExposureTimePEHK             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Exposure_Time }} <ms>
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    PixelsPossiblySaturated      = {{ PO.CaSSIS_Header.DERIVED_HEADER_DATA.PixelsPossiblySaturated._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    IFOV                         = {{ PO.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    IFOVUnit                     = {{ PO.CaSSIS_Header.CaSSIS_General.INSTRUMENT_IFOV.attrib_Unit }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    FiltersAvailable             = "{{ PO.CaSSIS_Header.CaSSIS_General.FILTERS_AVAILABLE }}"
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    FocalLength                  = {{ PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    FocalLengthUnit              = {{ PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_FOCAL_LENGTH.attrib_Unit }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    TelescopeFNumber              = {{ PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_F_NUMBER }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    TelescopeType                = "{{ PO.CaSSIS_Header.CaSSIS_General.TELESCOPE_TYPE }}"
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    DetectorDescription          = "{{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_DESC }}"{% endif %}
+    {%  if exists(CassHeader) %}
+    PixelHeight                  = {{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT._text }}{% endif %}
+    {%  if exists(CassHeader) %}
+    PixelHeightUnit              = {{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_HEIGHT.attrib_Unit }}{% endif %}
+    {%  if exists(CassHeader) %}
+    PixelWidth                   = {{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH._text }}{% endif %}
+    {%  if exists(CassHeader) %}
+    PixelWidthUnit               = {{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_PIXEL_WIDTH.attrib_Unit }}{% endif %}
+    {%  if exists(CassHeader) %}
+    DetectorType                 = "{{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_TYPE }}"
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    ReadNoise                    = {{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    ReadNoiseUnit                = {{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE.attrib_Unit }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    MissionPhase                 = {{ PO.CaSSIS_Header.DERIVED_HEADER_DATA.MissionPhase._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    SubInstrumentIdentifier      = {{ PO.CaSSIS_Header.CaSSIS_General.DETECTOR_READ_NOISE._text }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    WindowCount                  = {{ PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter }}
+    {% endif %}
+    {%  if exists(CassHeader) %}
+    Window1Binning               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_1 }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window1StartSample           = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window1EndSample             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window1StartLine             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window1EndLine               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window2Binning               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_2 }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window2StartSample           = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window2EndSample             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window2StartLine             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window2EndLine               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window3Binning               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_3 }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window3StartSample           = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window3EndSample             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window3StartLine             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window3EndLine               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window4Binning               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_4 }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window4StartSample           = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window4EndSample             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window4StartLine             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window4EndLine               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window5Binning               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_5 }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window5StartSample           = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window5EndSample             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window5StartLine             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window5EndLine               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window6Binning               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Binning_window_6 }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window6StartSample           = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window6EndSample             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Col }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window6StartLine             = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Row }}
+    {% endif %}
+    {% if exists(CassHeader) %}
+    Window6EndLine               = {{ PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Row }}
+    {% endif %}
   End_Group
 
   Group = BandBin
-    {%if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging")%}
-    {%set filterName=Product_Observational.Observation_Area.Discipline_Area.img_Imaging.img_Image_Product_Information.img_Filter.img_filter_name%}
-    {%else%}
-    {%set filterName=Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.Filter._text%}
-    {%endif%}
-    FilterName = {{filterName}}
-    Center     = {%if filterName == "RED"%}835.4 <nm>
-                 {%else if filterName == "PAN"%} 677.4 <nm>
-                 {%else if filterName == "NIR"%} 940.2 <nm>
-                 {%else if filterName == "BLU"%} 497.4 <nm>
-                 {%endif%}
-    Width      = {%if filterName == "RED"%}98.0 <nm>
-                 {%else if filterName == "PAN"%} 231.5 <nm>
-                 {%else if filterName == "NIR"%} 120.6 <nm>
-                 {%else if filterName == "BLU"%} 134.3 <nm>
-                 {%endif%}
-    NaifIkCode = {%if filterName == "RED"%} -143422
-                 {%else if filterName == "PAN"%} -143421
-                 {%else if filterName == "NIR"%} -143423
-                 {%else if filterName == "BLU"%} -143424
-                 {%else%}-143400{%endif%}
+    {% if exists("Product_Observational.Observation_Area.Discipline_Area.img_Imaging") %}
+    {% set filterName=Product_Observational.Observation_Area.Discipline_Area.img_Imaging.img_Image_Product_Information.img_Filter.img_filter_name %}
+    {% else %}
+    {% set filterName=Product_Observational.CaSSIS_Header.DERIVED_HEADER_DATA.Filter._text %}
+    {% endif %}
+    FilterName = {{ filterName }}
+    Center     = {% if filterName == "RED" %} 835.4 <nm>
+                 {% else if filterName == "PAN" %}  677.4 <nm>
+                 {% else if filterName == "NIR" %}  940.2 <nm>
+                 {% else if filterName == "BLU" %}  497.4 <nm>
+                 {% endif %}
+    Width      = {% if filterName == "RED" %} 98.0 <nm>
+                 {% else if filterName == "PAN" %}  231.5 <nm>
+                 {% else if filterName == "NIR" %}  120.6 <nm>
+                 {% else if filterName == "BLU" %}  134.3 <nm>
+                 {% endif %}
+    NaifIkCode = {% if filterName == "RED" %}  -143422
+                 {% else if filterName == "PAN" %}  -143421
+                 {% else if filterName == "NIR" %}  -143423
+                 {% else if filterName == "BLU" %}  -143424
+                 {% else %} -143400{% endif %}
   End_Group
 
   Group = Kernels
     NaifFrameCode = -143400
   End_Group
 
-  {%if exists(CassHeader)%}
-    {% set windowNumber=int(PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter) + 1 %}
-    {%if windowNumber == 1%}
-        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Col) + 1%}
-        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Col) + 1%}
-        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Row) + 1%}
-        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Row) + 1%}
-    {%endif%}
-    {%if windowNumber == 2%}
-        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Col) + 1%}
-        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Col) + 1%}
-        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Row) + 1%}
-        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Row) + 1%}
-    {%endif%}
-    {%if windowNumber == 3%}
-        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Col) + 1%}
-        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Col) + 1%}
-        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Row) + 1%}
-        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Row) + 1%}
-    {%endif%}
-    {%if windowNumber == 4%}
-        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Col) + 1%}
-        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Col) + 1%}
-        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Row) + 1%}
-        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Row) + 1%}
-    {%endif%}
-    {%if windowNumber == 5%}
-        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Col) + 1%}
-        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Col) + 1%}
-        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Row) + 1%}
-        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Row) + 1%}
-    {%endif%}
-    {%if windowNumber == 6%}
-        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Col) + 1%}
-        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Col) + 1%}
-        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Row) + 1%}
-        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Row) + 1%}
-    {%endif%}
+  {% if exists(CassHeader) %}
+    {% set windowNumber=int(PO.CaSSIS_Header.FSW_HEADER.attrib_WindowCounter) + 1  %}
+    {% if windowNumber == 1 %}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Col) + 1 %}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Col) + 1 %}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_Start_Row) + 1 %}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window1_End_Row) + 1 %}
+    {% endif %}
+    {% if windowNumber == 2 %}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Col) + 1 %}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Col) + 1 %}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_Start_Row) + 1 %}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window2_End_Row) + 1 %}
+    {% endif %}
+    {% if windowNumber == 3 %}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Col) + 1 %}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Col) + 1 %}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_Start_Row) + 1 %}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window3_End_Row) + 1 %}
+    {% endif %}
+    {% if windowNumber == 4 %}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Col) + 1 %}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Col) + 1 %}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_Start_Row) + 1 %}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window4_End_Row) + 1 %}
+    {% endif %}
+    {% if windowNumber == 5 %}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Col) + 1 %}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Col) + 1 %}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_Start_Row) + 1 %}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window5_End_Row) + 1 %}
+    {% endif %}
+    {% if windowNumber == 6 %}
+        {% set frameletStartSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Col) + 1 %}
+        {% set frameletEndSample = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Col) + 1 %}
+        {% set frameletStartLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_Start_Row) + 1 %}
+        {% set frameletEndLine = int(PO.CaSSIS_Header.PEHK_HEADER.attrib_Window6_End_Row) + 1 %}
+    {% endif %}
 
   Group = AlphaCube
     AlphaSamples        = 2048
     AlphaLines          = 2048
-    AlphaStartingSample = {{frameletStartSample - 0.5}}
-    AlphaStartingLine   = {{frameletStartLine - 0.5}}
-    AlphaEndingSample   = {{frameletEndSample + 0.5}}
-    AlphaEndingLine     = {{frameletEndLine + 0.5}}
-    BetaSamples         = {{frameletEndSample - frameletStartSample + 1}}
-    BetaLines           = {{frameletEndLine - frameletStartLine + 1}}
+    AlphaStartingSample = {{ frameletStartSample - 0.5 }}
+    AlphaStartingLine   = {{ frameletStartLine - 0.5 }}
+    AlphaEndingSample   = {{ frameletEndSample + 0.5 }}
+    AlphaEndingLine     = {{ frameletEndLine + 0.5 }}
+    BetaSamples         = {{ frameletEndSample - frameletStartSample + 1 }}
+    BetaLines           = {{ frameletEndLine - frameletStartLine + 1 }}
   End_Group
-  {%endif%}
+  {% endif %}
 End_Object
 End


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
BandBin group uses TgoCassisMosaicBandBin.trn/TgoCassisBanBin.trn information. AlphaCube uses logic from line 449-463 from tgocassis2isis main.cpp. Also cleaned up the template by including variables.

I am unsure if I found a bug in tgocassis2isis but the BandBin is outputting different than the translation file values in TgoCassisMosaicBandBin.trn.

Example of truth data output
````
  Group = BandBin
    FilterName = BLU
    Center     = 485 <nm>
    Width      = 165 <nm>
    NaifIkCode = -143424
  End_Group
````
Versus using the translated outputs with new template
````
 Group = BandBin
    FilterName = BLU
    Center     = 497.4 <nm>
    Width      = 134.3 <nm>
    NaifIkCode = -143424
  End_Group
````
This is what the TgoCassisMosaicBandBin.trn file has 
````
Group = Center
  Auto
  InputPosition  = (Observation_Area, Discipline_Area, img:Imaging, img:Image_Product_Information, img:Filter)
  InputKey       = img:filter_name
  OutputName     = Center
  OutputPosition = (Object, IsisCube, Group, BandBin)
  Translation    = (677.4, PAN)
  Translation    = (497.4, BLU)
  Translation    = (835.4, RED)
  Translation    = (940.2, NIR)

Group = Width
  Auto
  InputPosition  = (Observation_Area, Discipline_Area, img:Imaging, img:Image_Product_Information, img:Filter)
  InputKey       = img:filter_name
  OutputName     = Width
  OutputPosition = (Object, IsisCube, Group, BandBin)
  Translation    = (231.5, PAN)
  Translation    = (134.3, BLU)
  Translation    = (98.0, RED)
  Translation    = (120.6, NIR)
````




## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
PDS4 Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.