### PR TITLE
Github action for stale issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,6 +20,6 @@ jobs:
         days-before-close: 180
         stale-issue-message: "Thank you for your contribution!\n\nUnfortunately, this issue hasn't received much attention lately, so it is labeled as 'stale.'\n\nIf no additional action is taken, this issue will be automatically closed in 180 days."
         stale-pr-message: "Thank you for your contribution!\n\nUnfortunately, this pull request hasn't received much attention lately, so it is labeled as 'stale.'\n\nIf no additional action is taken, this pull request will be automatically closed in 180 days."
-        stale-issue-label: 'stale-issue'
-        stale-pr-label: 'stale-pr'
+        stale-issue-label: 'inactive'
+        stale-pr-label: 'inactive'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@ name: Mark stale issues and pull requests
 
 on:
   schedule:
-  - cron: "5 * * * *"
+  - cron: "0 15 * * *"
 
 jobs:
   stale:
@@ -16,8 +16,8 @@ jobs:
     - uses: actions/stale@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        days-before-stale: 0
-        days-before-close: 1
+        days-before-stale: 180
+        days-before-close: 180
         stale-issue-message: "Thank you for your contribution!\n\nUnfortunately, this issue hasn't received much attention lately, so it is labeled as 'stale.'\n\nIf no additional action is taken, this issue will be automatically closed in 180 days."
         stale-pr-message: "Thank you for your contribution!\n\nUnfortunately, this pull request hasn't received much attention lately, so it is labeled as 'stale.'\n\nIf no additional action is taken, this pull request will be automatically closed in 180 days."
         stale-issue-label: 'stale-issue'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "5 * * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        days-before-stale: 0
+        days-before-close: 1
+        stale-issue-message: "Thank you for your contribution!\n\nUnfortunately, this issue hasn't received much attention lately, so it is labeled as 'stale.'\n\nIf no additional action is taken, this issue will be automatically closed in 180 days."
+        stale-pr-message: "Thank you for your contribution!\n\nUnfortunately, this pull request hasn't received much attention lately, so it is labeled as 'stale.'\n\nIf no additional action is taken, this pull request will be automatically closed in 180 days."
+        stale-issue-label: 'stale-issue'
+        stale-pr-label: 'stale-pr'
+


### PR DESCRIPTION
Creates a github action that marks stale issues / PRs

## Description
Marks any issue or PR that has not seen activity for 180 days as "stale-issue" or "stale-pr".  Writes a message on the issue, and closes the issue after 180 more days.

Set to run once per day at 15:00 UTC = 9:00 MST.

## Related Issue
#4487 

## Motivation and Context
Helps maintain issue backlog

## How Has This Been Tested?
Tested on local fork

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
