### PR TITLE
PDS4 - Fix template search and targetGroup template variable for tgocassis.tpl

### DIFF
--- a/isis/appdata/export/TGOCaSSIS.tpl
+++ b/isis/appdata/export/TGOCaSSIS.tpl
@@ -5,10 +5,10 @@
 <?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational xmlns:psa="http://psa.esa.int/psa/v1" xmlns:cas="http://psa.esa.int/psa/em16/cas/v1" xmlns:img="http://pds.nasa.gov/pds4/img/v1" xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd http://pds.nasa.gov/pds4/disp/v1 http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.xsd http://pds.nasa.gov/pds4/img/v1 http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.xsd http://pds.nasa.gov/pds4/cart/v1 http://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1900.xsd http://psa.esa.int/psa/v1 http://psa.esa.int/psa/v1/PDS4_PSA_1000.xsd http://psa.esa.int/psa/em16/cas/v1 http://psa.esa.int/psa/em16/cas/v1/PDS4_PSA_EM16_CAS_1000.xsd http://pds.nasa.gov/pds4/geom/v1 http://pds.nasa.gov/pds4/geom/v1/PDS4_GEOM_1B00_1610.xsd" xmlns:disp="http://pds.nasa.gov/pds4/disp/v1" xmlns:cart="http://pds.nasa.gov/pds4/cart/v1" xmlns:geom="http://pds.nasa.gov/pds4/geom/v1">
-{% if exists("MainLabel.IsisCube.Mosaic") -%}
-  {% set productId = MainLabel.IsisCube.Mosaic.ObservationId -%}
-{% else if exists("MainLabel.IsisCube.Archive") -%}
-  {% set productId = MainLabel.IsisCube.Archive.ObservationId -%}
+{% if exists("MainLabel.IsisCube.Archive.ObservationId.Value") -%}
+  {% set productId = MainLabel.IsisCube.Mosaic.ObservationId.Value -%}
+{% else if exists("MainLabel.IsisCube.Archive.ObservationId.Value") -%}
+  {% set productId = MainLabel.IsisCube.Archive.ObservationId.Value -%}
 {% endif -%}
  <CaSSIS_Header>
   <IDENTIFICATION_DATA/>
@@ -38,6 +38,7 @@
   <logical_identifier>urn:esa:psa:em16_tgo_cas:
                       {% if exists("MainLabel.IsisCube.Instrument") -%}
                         {% set targetGroup = MainLabel.IsisCube.Instrument -%}
+                        {% set sTargetGroup = "MainLabel.IsisCube.Instrument" -%}
                         {% if exists("MainLabel.IsisCube.Mapping") -%}
                           data_projected:
                         {% else -%}
@@ -45,11 +46,12 @@
                         {% endif -%}
                       {% else if exists("MainLabel.IsisCube.Mosaic") -%}
                         {% set targetGroup = MainLabel.IsisCube.Mosaic -%}
+                        {% set sTargetGroup = "MainLabel.IsisCube.Mosaic" -%}
                         data_derived:
                       {% else -%}
                         TBD:
                       {% endif -%}
-                      {{lower("productId")}}
+                      {% if exists("productId") -%}{{lower("productId")-}}{% endif -%}
   </logical_identifier>
   <version_id>1.0</version_id>
   <title>PDS4 product exported from ISIS3 cube.</title>
@@ -57,7 +59,8 @@
   <product_class>Product_Observational</product_class>
   <Alias_List>
    <Alias>
-    <alternate_id>{{productId}}</alternate_id>
+    <alternate_id>{% if exists("productId") -%}{{productId}}{% endif -%}
+  </logical_identifier></alternate_id>
     <comment>CaSSIS Internal Identifier</comment>
    </Alias>
   </Alias_List>
@@ -73,16 +76,16 @@
  <Observation_Area>
   <Time_Coordinates>
    <start_date_time>{{targetGroup.StartTime.Value}}Z</start_date_time>
-   {% if exists("targetGroup.StopTime") %}
+   {% if exists(sTargetGroup + ".StopTime") %}
    <stop_date_time>{{targetGroup.StopTime.Value}}Z</stop_date_time>
    {% else %}
    <stop_date_time>{{targetGroup.StartTime.Value}}Z</stop_date_time>
    {% endif %}
-   {% if exists("targetGroup.LocalTime") %}
+   {% if exists(sTargetGroup + ".LocalTime") %}
    <local_true_solar_time>{{targetGroup.LocalTime.Value}}</local_true_solar_time>
    {% endif %}
-   {% if exists("targetGroup.SolarLongitude") %}
-   <solar_longitude unit="{{targetGroup.SolarLongitude.Units}}">{{targetGroup.SolarLongitude.Value}}</solar_longitude>
+   {% if exists(sTargetGroup + ".SolarLongitude") %}
+   <solar_longitude unit="deg">{{targetGroup.SolarLongitude.Value}}</solar_longitude>
    {% endif %}
   </Time_Coordinates>
   <Investigation_Area>
@@ -109,6 +112,8 @@
    <name>{{targetGroup.TargetName.Value}}</name>
    <type>Planet</type>
   </Target_Identification>
+
+  {# TODO - seems like none of these values are consistently included in the Archive group. May require coordination with isisimport 
   {% if exists("MainLabel.IsisCube.Archive") -%}
   <Mission_Area>
    <psa:Mission_Information>
@@ -154,6 +159,8 @@
    </cas:CASSIS_Data>
   </Mission_Area>
   {% endif -%}
+  #}
+  
   <Discipline_Area>
   <disp:Display_Settings>
   <Local_Internal_Reference>
@@ -234,7 +241,8 @@
   <File>
    <file_name>{{MainLabel.IsisCube.Archive.FileName.Value}}.img</file_name>
   </File>
-  <Array_3D_Image> {# TODO - This can be 2D if there are no Bands -#}
+  <Array_3D_Image> {# TODO - Can this be 2D if there are no Bands ?? -#}
+  <Array_3D_Image>
    <local_identifier>Array_3D_Image</local_identifier>
    <offset unit="byte">0</offset>
    <axes>3</axes>

--- a/isis/appdata/export/TGOCaSSIS.tpl
+++ b/isis/appdata/export/TGOCaSSIS.tpl
@@ -5,10 +5,14 @@
 <?xml-model href="http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <?xml-model href="http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.sch" schematypens="http://purl.oclc.org/dsdl/schematron"?>
 <Product_Observational xmlns:psa="http://psa.esa.int/psa/v1" xmlns:cas="http://psa.esa.int/psa/em16/cas/v1" xmlns:img="http://pds.nasa.gov/pds4/img/v1" xmlns="http://pds.nasa.gov/pds4/pds/v1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pds.nasa.gov/pds4/pds/v1 http://pds.nasa.gov/pds4/pds/v1/PDS4_PDS_1B00.xsd http://pds.nasa.gov/pds4/disp/v1 http://pds.nasa.gov/pds4/disp/v1/PDS4_DISP_1B00.xsd http://pds.nasa.gov/pds4/img/v1 http://pds.nasa.gov/pds4/img/v1/PDS4_IMG_1A10_1510.xsd http://pds.nasa.gov/pds4/cart/v1 http://pds.nasa.gov/pds4/cart/v1/PDS4_CART_1900.xsd http://psa.esa.int/psa/v1 http://psa.esa.int/psa/v1/PDS4_PSA_1000.xsd http://psa.esa.int/psa/em16/cas/v1 http://psa.esa.int/psa/em16/cas/v1/PDS4_PSA_EM16_CAS_1000.xsd http://pds.nasa.gov/pds4/geom/v1 http://pds.nasa.gov/pds4/geom/v1/PDS4_GEOM_1B00_1610.xsd" xmlns:disp="http://pds.nasa.gov/pds4/disp/v1" xmlns:cart="http://pds.nasa.gov/pds4/cart/v1" xmlns:geom="http://pds.nasa.gov/pds4/geom/v1">
-{% if exists("MainLabel.IsisCube.Archive.ObservationId.Value") -%}
+{% if exists("MainLabel.IsisCube.Mosaic.ObservationId.Value") -%}
   {% set productId = MainLabel.IsisCube.Mosaic.ObservationId.Value -%}
+  {% set sProductId = "MainLabel.IsisCube.Mosaic.ObservationId.Value" -%}
 {% else if exists("MainLabel.IsisCube.Archive.ObservationId.Value") -%}
   {% set productId = MainLabel.IsisCube.Archive.ObservationId.Value -%}
+  {% set sProductId = "MainLabel.IsisCube.Archive.ObservationId.Value" -%}
+{% else -%}
+  {% set sProductId = "None" -%}
 {% endif -%}
  <CaSSIS_Header>
   <IDENTIFICATION_DATA/>
@@ -35,23 +39,24 @@
   </DERIVED_HEADER_DATA>
  </CaSSIS_Header>
  <Identification_Area>
-  <logical_identifier>urn:esa:psa:em16_tgo_cas:
-                      {% if exists("MainLabel.IsisCube.Instrument") -%}
-                        {% set targetGroup = MainLabel.IsisCube.Instrument -%}
-                        {% set sTargetGroup = "MainLabel.IsisCube.Instrument" -%}
-                        {% if exists("MainLabel.IsisCube.Mapping") -%}
-                          data_projected:
-                        {% else -%}
-                          data_raw:
-                        {% endif -%}
-                      {% else if exists("MainLabel.IsisCube.Mosaic") -%}
-                        {% set targetGroup = MainLabel.IsisCube.Mosaic -%}
-                        {% set sTargetGroup = "MainLabel.IsisCube.Mosaic" -%}
-                        data_derived:
-                      {% else -%}
-                        TBD:
-                      {% endif -%}
-                      {% if exists("productId") -%}{{lower("productId")-}}{% endif -%}
+  <logical_identifier>urn:esa:psa:em16_tgo_cas:{% if exists("MainLabel.IsisCube.Instrument") -%}
+                                                  {% set targetGroup = MainLabel.IsisCube.Instrument -%}
+                                                  {% set sTargetGroup = "MainLabel.IsisCube.Instrument" -%}
+                                                  {% if exists("MainLabel.IsisCube.Mapping") -%}
+                                                    data_projected:
+                                                  {% else -%}
+                                                    data_raw:
+                                                  {% endif -%}
+                                                {% else if exists("MainLabel.IsisCube.Mosaic") -%}
+                                                  {% set targetGroup = MainLabel.IsisCube.Mosaic -%}
+                                                  {% set sTargetGroup = "MainLabel.IsisCube.Mosaic" -%}
+                                                  data_derived:
+                                                {% else -%}
+                                                  {% set sTargetGroup = "None" -%}
+                                                  TBD:
+                                                {% endif -%}
+                                                {% if exists(sProductId) -%}{{lower(productId)-}}{% endif -%}
+                      
   </logical_identifier>
   <version_id>1.0</version_id>
   <title>PDS4 product exported from ISIS3 cube.</title>
@@ -59,7 +64,7 @@
   <product_class>Product_Observational</product_class>
   <Alias_List>
    <Alias>
-    <alternate_id>{% if exists("productId") -%}{{productId}}{% endif -%}
+    <alternate_id>{% if exists(sProductId) -%}{{productId}}{% endif -%}
   </logical_identifier></alternate_id>
     <comment>CaSSIS Internal Identifier</comment>
    </Alias>
@@ -112,7 +117,6 @@
    <name>{{targetGroup.TargetName.Value}}</name>
    <type>Planet</type>
   </Target_Identification>
-
   {# TODO - seems like none of these values are consistently included in the Archive group. May require coordination with isisimport 
   {% if exists("MainLabel.IsisCube.Archive") -%}
   <Mission_Area>
@@ -160,7 +164,6 @@
   </Mission_Area>
   {% endif -%}
   #}
-  
   <Discipline_Area>
   <disp:Display_Settings>
   <Local_Internal_Reference>
@@ -241,7 +244,7 @@
   <File>
    <file_name>{{MainLabel.IsisCube.Archive.FileName.Value}}.img</file_name>
   </File>
-  <Array_3D_Image> {# TODO - Can this be 2D if there are no Bands ?? -#}
+  <Array_3D_Image> {# TODO - Can this be 2D if there are no Bands ?? #}
    <local_identifier>Array_3D_Image</local_identifier>
    <offset unit="byte">0</offset>
    <axes>3</axes>

--- a/isis/appdata/export/TGOCaSSIS.tpl
+++ b/isis/appdata/export/TGOCaSSIS.tpl
@@ -242,7 +242,6 @@
    <file_name>{{MainLabel.IsisCube.Archive.FileName.Value}}.img</file_name>
   </File>
   <Array_3D_Image> {# TODO - Can this be 2D if there are no Bands ?? -#}
-  <Array_3D_Image>
    <local_identifier>Array_3D_Image</local_identifier>
    <offset unit="byte">0</offset>
    <axes>3</axes>

--- a/isis/appdata/export/pvl2template.tpl
+++ b/isis/appdata/export/pvl2template.tpl
@@ -1,0 +1,17 @@
+{% if exists("MainLabel.IsisCube.Instrument.InstrumentId.Value") -%}
+{% set InstrumentId=MainLabel.IsisCube.Instrument.InstrumentId.Value -%}
+{% endif -%}
+
+{% if exists("MainLabel.IsisCube.Instrument.SpacecraftName.Value") -%}
+{% set SpacecraftName=MainLabel.IsisCube.Instrument.SpacecraftName.Value -%}
+{% else if exists("MainLabel.IsisCube.Mosaic.SpacecraftName.Value") -%}
+{% set SpacecraftName=MainLabel.IsisCube.Mosaic.SpacecraftName.Value -%}
+{% endif -%}
+
+{% if SpacecraftName == "TRACE GAS ORBITER" -%}
+{% set SpacecraftId="TGO" -%}
+{% else -%}
+{% set SpacecraftId=SpacecraftName -%}
+{% endif -%}
+
+{% if SpacecraftId -%}$ISISROOT/appdata/export/{{- SpacecraftId -}}{{- InstrumentId -}}.tpl{% endif -%}

--- a/isis/src/base/apps/isisexport/isisexport.cpp
+++ b/isis/src/base/apps/isisexport/isisexport.cpp
@@ -47,6 +47,7 @@ namespace Isis {
 
     // Name for output image
     FileName outputFileName(outputFile);
+    FileName genDefaultTemplate = ("$ISISROOT/appdata/export/pvl2template.tpl");
     QString path(outputFileName.originalPath());
     QString name(outputFileName.baseName());
     QString outputCubePath = path + "/" + name + ".cub";
@@ -55,6 +56,8 @@ namespace Isis {
     cubeatt(icube, outputCubePath, outputAttributes);
 
     json dataSource;
+
+    Environment env;
 
     Pvl &cubeLabel = *icube->label();
 
@@ -68,16 +71,9 @@ namespace Isis {
       templateFn = ui.GetFileName("TEMPLATE");
     }
     else {
-      if(cubeLabel.hasGroup("Instrument")) {
-        PvlGroup &inst = cubeLabel.findGroup("Instrument", Pvl::Traverse);
-        templateFn = FileName( "$ISISROOT/appdata/export/" +
-                                    inst["SpacecraftId"][0] +
-                                    inst["InstrumentId"][0] + ".tpl" );
-      }
-      else {
-        QString msg = "Cannot locate a template because Input Cube label has no Instrument group. Provide a template file to use.";
-        throw IException(IException::User, msg, _FILEINFO_);
-      }
+         std::string templateFnStd = env.render_file(genDefaultTemplate.expanded().toStdString(), dataSource);
+         templateFn = FileName(QString::fromStdString(templateFnStd));
+     
     }
 
     if(!templateFn.fileExists()) {
@@ -177,7 +173,6 @@ namespace Isis {
       }
     }
 
-    Environment env;
     env.set_trim_blocks(true);
     env.set_lstrip_blocks(true);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Includes a template for finding a template in isisexport, modeled after the same for isisimport. Also includes some changes to tgocassis.tpl. The `targetGroup` variable was not working as intended so I set two versions: `targetGroup` as the json object, and `sTargetGroup` as the string to reference that object. This allows for exists() calls using the string and actual referencing using the object.

Important to note: I still don't consider TGOCaSSIS.tpl to be fully complete. There are TODO comments in the template for a few things I have not yet been able to address.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
PDS4 sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`isisexport from= CAS-MCO-2016-11-26T22.32.39.582-BLU-03025-00.cub to=out.xml` gave good output.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
