### PR TITLE
Added Table logic to copy label comments

### DIFF
--- a/isis/src/base/objs/Table/Table.cpp
+++ b/isis/src/base/objs/Table/Table.cpp
@@ -442,6 +442,10 @@ namespace Isis {
       }
     }
 
+    for (int i = 0; i < p_label.comments(); i++){
+      blobLabel.addComment(p_label.comment(i));
+    }
+
     for (int g = 0; g < p_label.groups(); g++) {
       blobLabel += p_label.group(g);
     }

--- a/isis/tests/TableTests.cpp
+++ b/isis/tests/TableTests.cpp
@@ -144,6 +144,9 @@ TEST(TableTests, ToFromBlob) {
   rec[3] = -0.55;
   t += rec;
 
+  QString comment = "test comment";
+  t.Label().addComment(comment);
+
   Blob tableBlob = t.toBlob();
 
   Table t2(tableBlob);
@@ -153,6 +156,7 @@ TEST(TableTests, ToFromBlob) {
   EXPECT_EQ(t.IsSampleAssociated(), t2.IsSampleAssociated());
   EXPECT_EQ(t.IsLineAssociated(), t2.IsLineAssociated());
   EXPECT_EQ(t.IsBandAssociated(), t2.IsBandAssociated());
+  EXPECT_EQ(t.Label().comments(), t2.Label().comments());
 
   ASSERT_EQ(t.Records(), t2.Records());
   for (int i = 0; i < t.Records(); i++) {


### PR DESCRIPTION
Adds functionality to copy label comments in Table::toBlob()

## Description
Adds functionality to copy label comments in Table::toBlob()

Locally failing on cubediff_app_test_withTable, but I'm not sure why.  Running diff on the truth/output .txt files results in no differences.

## Related Issue
Closes #4442 

## Motivation and Context
Bug fix.  Comments were dropped from tables as a result of the BLOB refactor.

## How Has This Been Tested?
Ran jigsaw and verified that the output included comments (see screenshot)

## Screenshots (if appropriate):
<img width="482" alt="Screen Shot 2021-05-26 at 3 49 59 PM" src="https://user-images.githubusercontent.com/3751180/119741587-de2ffe80-be3a-11eb-94d6-06414e8a5b81.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
