### PR TITLE
passing orex mapcam tests 

### DIFF
--- a/isis/src/osirisrex/tsts/mapcam/Makefile
+++ b/isis/src/osirisrex/tsts/mapcam/Makefile
@@ -18,18 +18,12 @@ commands:
 	ocams2isis $(TSTARGS)                                                                        \
 	           from=$(INPUT)/20190303T100344S990_map_iofL2pan_V001.fits                          \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                  \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# spiceinit first image
 	spiceinit $(TSTARGS)                                                                         \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
-	           ckpredict=t                                                                       \
-	           spkpredict=t                                                                      \
-	           ckrecon=f 																		 \
-			   spkrecon=f                                                                        \
-	           SCLK='$$osirisrex/kernels/sclk/SCLK.tsc'                                          \
-			   extra='$$osirisrex/kernels/pck/bennu_v10.tpc'                                     \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# phocube first image
 	# create 7 band backplane with from the following values:
@@ -42,13 +36,13 @@ commands:
 	           emission=t                                                                        \
 	           incidence=t                                                                       \
 	           pixelres=t                                                                        \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# explode first image's backplane into 5 cubes
 	explode $(TSTARGS)                                                                           \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-bp.cub                       \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-bp-explode                     \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# reunite exploded cubes. output should be identical to phocube bp output above
 	$(LS) $(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-bp-explode*                            \
@@ -56,7 +50,7 @@ commands:
 	cubeit $(TSTARGS)                                                                            \
 	           from=$(OUTPUT)/phocubeBandList.txt                                                \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-bp.cub                         \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# for each pixel in first image, multiply by 2 then add 1 
 	algebra $(TSTARGS)                                                                           \
@@ -65,20 +59,20 @@ commands:
 	           operator=unary                                                                    \
 	           a=2                                                                               \
 	           a=1                                                                               \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# (SKIP) get camera information for first image
     # caminfo fails for this image using the testIsis code provided by team
-	caminfo $(TSTARGS)                                                                           \
+	#caminfo $(TSTARGS)                                                                           \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-caminfo.pvl                    \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# get camera statistics for first image
 	camstats $(TSTARGS)                                                                          \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-camstats.pvl                   \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# get DN statistics for first image
 	stats $(TSTARGS)                                                                             \
@@ -92,7 +86,7 @@ commands:
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-photrim.cub                    \
 	           minphase=100                                                                      \
 	           maxphase=101                                                                      \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# photomet first image
 	photomet $(TSTARGS)                                                                          \
@@ -107,13 +101,13 @@ commands:
 	           albedo=1.0                                                                        \
 	           maxemission=80                                                                    \
 	           maxincidenc=85                                                                    \
-	           >& /dev/null;
+	           > /dev/null;
 
 	# (SKIP) footprint first image
     # footprintinit fails for this image using the testIsis code provided by team
 	footprintinit $(TSTARGS)                                                                     \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
-	           >& /dev/null;
+	           > /dev/null;
 
 
 	# campt 4 corners and center of first image
@@ -124,35 +118,35 @@ commands:
 	           SAMPLE=350                                                                        \
 	           LINE=1                                                                            \
 	           ALLOWOUTSIDE=no                                                                   \
-	           >& /dev/null;											                         
+	           > /dev/null;											                         
 	campt $(TSTARGS)                                                                             \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001_campt_upperright.pvl           \
 	           SAMPLE=1024                                                                       \
 	           LINE=1                                                                            \
 	           ALLOWOUTSIDE=no                                                                   \
-	           >& /dev/null;											                         
+	           > /dev/null;											                         
 	campt $(TSTARGS)                                                                             \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001_campt_lowerright.pvl           \
-	           SAMPLE=1024                                                                       \
-	           LINE=1024                                                                         \
+	           SAMPLE=890                                                                        \
+	           LINE=615                                                                          \
 	           ALLOWOUTSIDE=no                                                                   \
-	           >& /dev/null;											                         
+	           > /dev/null;											                         
 	campt $(TSTARGS)                                                                             \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001_campt_lowerleft.pvl            \
-	           SAMPLE=350                                                                        \
-	           LINE=1024                                                                         \
+	           SAMPLE=256                                                                        \
+	           LINE=750                                                                          \
 	           ALLOWOUTSIDE=no                                                                   \
-	           >& /dev/null;											                         
+	           > /dev/null;											                         
 	campt $(TSTARGS)                                                                             \
 	           from=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-spiceinit.cub                \
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001_campt_imagecenter.pvl          \
 	           SAMPLE=512                                                                        \
 	           LINE=512                                                                          \
 	           ALLOWOUTSIDE=no                                                                   \
-	           >& /dev/null;											                         
+	           > /dev/null;											                         
 
 	# get mapping group containing Equirectangular mosaic range values for the two images
 	$(LS) $(OUTPUT)/*spiceinit.cub > $(OUTPUT)/unprojectedSpiceinitCubeList.txt;
@@ -161,7 +155,7 @@ commands:
 	            to=$(OUTPUT)/MCAM_equi.map                                                       \
 	            precision=6                                                                      \
 	            projection=Equirectangular                                                       \
-	           >& /dev/null;											                         
+	           > /dev/null;											                         
 																		                         
 	# project the two images using the map from mosrange				                         
 	cam2map $(TSTARGS)                                                                           \
@@ -169,7 +163,7 @@ commands:
 	           to=$(OUTPUT)/20190303T100344S990_map_iofL2pan_V001-cam2map_equi.cub               \
 	           map=$(OUTPUT)/MCAM_equi.map                                                       \
 	           pixres=map                                                                        \
-	           >& /dev/null;											                         
+	           > /dev/null;											                         
 																		                         
 	# getsn from each image 											                         
 	echo -e "\nOutput of getsn..." > $(OUTPUT)/MCAM_getsn.txt;  		                         


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The original mapcam test was failing after removing the predicted kernels as it used an old image that cannot be spiceinited with reconstructed kernels. The new image has the same name so this mostly removes the kernel parameters fot spiceinit forcing older kernels and changes campt calls to line/samples  with actual target intersections. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #4475

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All tests are passing locally. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
