### PR TITLE
Potential fix for bandnorm test fails

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,6 +95,19 @@ for (lbl in labels) {
                             if (osFailed) {
                                 error "Failed on ${label}"
                             }
+
+                            // TEMPORARY Repeat Bandnorm tests
+                            stageStatus = "Running Bandnorm gtests on ${label}"
+                            try {
+                                loginShell "ctest -R Bandnorm --repeat-until-fail 100"
+                            } catch(e) {
+                                errors.add(stageStatus)
+                                osFailed = true
+                            }
+
+                            if (osFailed) {
+                                error "Failed on ${label}"
+                            }
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,20 +58,6 @@ for (lbl in labels) {
                                 error stageStatus
                             }
 
-
-                            // TEMPORARY Repeat Bandnorm tests
-                            stageStatus = "Running Bandnorm gtests on ${label}"
-                            try {
-                                loginShell "ctest -R Bandnorm --repeat-until-fail 100"
-                            } catch(e) {
-                                errors.add(stageStatus)
-                                osFailed = true
-                            }
-
-                            if (osFailed) {
-                                error "Failed on ${label}"
-                            }
-
                             // Unit tests
                             stageStatus = "Running unit tests on ${label}"
                             try {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,20 @@ for (lbl in labels) {
                                 error stageStatus
                             }
 
+
+                            // TEMPORARY Repeat Bandnorm tests
+                            stageStatus = "Running Bandnorm gtests on ${label}"
+                            try {
+                                loginShell "ctest -R Bandnorm --repeat-until-fail 100"
+                            } catch(e) {
+                                errors.add(stageStatus)
+                                osFailed = true
+                            }
+
+                            if (osFailed) {
+                                error "Failed on ${label}"
+                            }
+
                             // Unit tests
                             stageStatus = "Running unit tests on ${label}"
                             try {
@@ -87,19 +101,6 @@ for (lbl in labels) {
                             stageStatus = "Running gtests on ${label}"
                             try {
                                 loginShell "ctest -R '.' -E '(_app_|_unit_|_module_)' -j${NUM_CORES} -VV"
-                            } catch(e) {
-                                errors.add(stageStatus)
-                                osFailed = true
-                            }
-
-                            if (osFailed) {
-                                error "Failed on ${label}"
-                            }
-
-                            // TEMPORARY Repeat Bandnorm tests
-                            stageStatus = "Running Bandnorm gtests on ${label}"
-                            try {
-                                loginShell "ctest -R Bandnorm --repeat-until-fail 100"
                             } catch(e) {
                                 errors.add(stageStatus)
                                 osFailed = true

--- a/isis/tests/FunctionalTestsBandnorm.cpp
+++ b/isis/tests/FunctionalTestsBandnorm.cpp
@@ -14,7 +14,7 @@ using namespace Isis;
 static QString APP_XML = FileName("$ISISROOT/bin/xml/bandnorm.xml").expanded();
 
 TEST_F(SmallCube, FunctionalTestBandnormDefault) {
-  QString outCubeFileName = tempDir.path()+"/outTEMP.cub";
+  QString outCubeFileName = tempDir.path() + "/outTEMP.cub";
 
   // force all bands to be normalized to 1's
   LineManager line(*testCube);
@@ -49,8 +49,8 @@ TEST_F(SmallCube, FunctionalTestBandnormDefault) {
 
 
 TEST_F(SmallCube, FunctionalTestBandnormPencil) {
-  QString outCubeFileName = tempDir.path()+"/outTEMP.cub";
-  QString pencilPath = "/tmp/pencil.txt";
+  QString outCubeFileName = tempDir.path() + "/outTEMP.cub";
+  QString pencilPath = tempDir.path() + "/pencil.txt";
 
   QVector<QString> args = {"to="+outCubeFileName, "SPECTRUM="+pencilPath, "AVERAGE=PENCIL"};
 
@@ -137,8 +137,8 @@ TEST_F(SmallCube, FunctionalTestBandnormPencil) {
 
 
 TEST_F(SmallCube, FunctionalTestBandnormByNumber) {
-  QString outCubeFileName = tempDir.path()+"/outTEMP.cub";
-  QString pencilPath = "/tmp/pencil.txt";
+  QString outCubeFileName = tempDir.path() + "/outTEMP.cub";
+  QString pencilPath = tempDir.path() + "/pencil.txt";
 
   QVector<QString> args = {"to="+outCubeFileName, "SPECTRUM="+pencilPath, "AVERAGE=PENCIL",
                            "method=number", "number=1"};
@@ -183,8 +183,8 @@ TEST_F(SmallCube, FunctionalTestBandnormByNumber) {
 
 
 TEST_F(SmallCube, FunctionalTestBandnormByBandAvg) {
-  QString outCubeFileName = tempDir.path()+"/outTEMP.cub";
-  QString pencilPath = "/tmp/pencil.txt";
+  QString outCubeFileName = tempDir.path() + "/outTEMP.cub";
+  QString pencilPath = tempDir.path() + "/pencil.txt";
 
   QVector<QString> args = {"to="+outCubeFileName, "AVERAGE=Band"};
 
@@ -213,8 +213,8 @@ TEST_F(SmallCube, FunctionalTestBandnormByBandAvg) {
 
 
 TEST_F(SmallCube, FunctionalTestBandnormByCubeAvg) {
-  QString outCubeFileName = tempDir.path()+"/outTEMP.cub";
-  QString pencilPath = "/tmp/pencil.txt";
+  QString outCubeFileName = tempDir.path() + "/outTEMP.cub";
+  QString pencilPath = tempDir.path() + "/pencil.txt";
 
   QVector<QString> args = {"to="+outCubeFileName, "AVERAGE=Cube"};
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
There have been intermittent test failures on FunctionalTestBandnorm. I replaced some absolute paths to /tmp/pencil.txt which could be causing the problem.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4416

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All bandnorm tests passed. This failure is intermittent, though, so passing once isn't sure-fire.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
