### PR TITLE
Improve grid extend test case

### DIFF
--- a/isis/tests/FunctionalTestsGrid.cpp
+++ b/isis/tests/FunctionalTestsGrid.cpp
@@ -263,7 +263,15 @@ TEST_F(NewHorizonsCube, FunctionalTestGridBandDependent) {
 TEST_F(DefaultCube, FunctionalTestGridExtend) {
   QVector<QString> args = {"to=" + tempDir.path() + "/output.cub", "extendgrid=true"};
   UserInterface options(APP_XML, args);
-  grid(testCube, options);
+
+  // change mapping group of cube to one that extends past longitude domain
+  Pvl newMap;
+  newMap.read("data/defaultImage/extendProj.map");
+  PvlGroup &newMapGrp = newMap.findGroup("Mapping", Pvl::Traverse);
+
+  projTestCube->putGroup(newMapGrp);
+
+  grid(projTestCube, options);
 
   Cube outputCube;
   try {
@@ -275,13 +283,13 @@ TEST_F(DefaultCube, FunctionalTestGridExtend) {
 
   // Check beginning and end of gridline
   LineManager line(outputCube);
-  line.SetLine(579);
+  line.SetLine(1);
   outputCube.read(line);
   EXPECT_EQ(line[0], Isis::Hrs);
 
-  line.SetLine(1056);
+  line.SetLine(1);
   outputCube.read(line);
-  EXPECT_EQ(line[247], Isis::Hrs);
+  EXPECT_EQ(line[2], Isis::Hrs);
 
   outputCube.close();
 }

--- a/isis/tests/data/defaultImage/extendProj.map
+++ b/isis/tests/data/defaultImage/extendProj.map
@@ -1,0 +1,18 @@
+Group = Mapping
+  ProjectionName     = Sinusoidal
+  CenterLongitude    = 370.0 <degrees>
+  TargetName         = MARS
+  EquatorialRadius   = 3396190.0 <meters>
+  PolarRadius        = 3376200.0 <meters>
+  LatitudeType       = Planetocentric
+  LongitudeDirection = PositiveEast
+  LongitudeDomain    = 360 <degrees>
+  MinimumLatitude    = 0 <degrees>
+  MaximumLatitude    = 10 <degrees>
+  MinimumLongitude   = 361 <degrees>
+  MaximumLongitude   = 380 <degrees>
+  UpperLeftCornerX   = 0.0 <meters>
+  UpperLeftCornerY   = 600000.0 <meters>
+  PixelResolution    = 100000.0 <meters/pixel>
+  Scale              = 0.59274697523306 <pixels/degree>
+End_Group


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use projTestCube with a custom Mapping group to place the image area outside of the longitude domain. With extendgrid=false (default), no grid will be written to the output. So the test checks that a grid was written.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4084 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
