### PR TITLE
Gui Parameters now top aligned

### DIFF
--- a/isis/src/base/objs/Gui/GuiParameter.cpp
+++ b/isis/src/base/objs/Gui/GuiParameter.cpp
@@ -36,7 +36,7 @@ namespace Isis {
     p_label = new QLabel(p_name);
     p_label->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
     p_label->setToolTip(p_ui->ParamBrief(group, param));
-    grid->addWidget(p_label, param, 0, Qt::AlignCenter);
+    grid->addWidget(p_label, param, 0, Qt::AlignTop);
 
     QString whatsThis;
     whatsThis  = (QString)("<b>Parameter:</b> " + p_ui->ParamName(group, param));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This changes the alignment for GUI parameters to be top aligned, which makes it easier to know what options belong to which parameter. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#3710 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This should make the GUIs for some apps less ambiguous. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The app from the app (isis2pds) was run locally and definitely less ambiguous compared to original. 

## Screenshots (if appropriate):

The isis2pds example from the issue. 

![Screen Shot 2021-06-03 at 1 05 58 PM](https://user-images.githubusercontent.com/13245976/120723240-393ea280-c486-11eb-9f8b-fd23c9d85196.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
