### PR TITLE
Update readme to include conda env config vars option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 1.  Download either the Anaconda or Miniconda installation script for your OS platform. Anaconda is a much larger distribtion of packages supporting scientific python, while Miniconda is a minimal installation and not as large: [Anaconda installer](https://www.anaconda.com/download), [Miniconda installer](https://conda.io/miniconda.html)
 2.  If you are running on some variant of Linux, open a terminal window in the directory where you downloaded the script, and run the following commands. In this example, we chose to do a full install of Anaconda, and our OS is Linux-based. Your file name may be different depending on your environment.
 
-        chmod +x Anaconda3-5.2.0-Linux-x86_64.sh
-        ./Anaconda3-5.2.0-Linux-x86_64.sh
+        chmod +x Anaconda3-5.3.0-Linux-x86_64.sh
+        ./Anaconda3-5.3.0-Linux-x86_64.sh
 
 
     This will start the Anaconda installer which will guide you through the installation process.
@@ -91,30 +91,78 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
 7.  Finally, setup the environment variables:
 
-    To use the default values for: `$ISISROOT, $ISISDATA, $ISISTESTDATA`, run the ISIS variable initialization script with default arguments.
+    ISIS requires several environment variables to be set in order to run correctly. 
+    The variables include: ISISROOT, ISISDATA, and ISISTESTDATA. 
 
-    To do this, for versions of ISIS 4.2.0 and earlier, use:
+    More information about the ISISDATA environment variable and the ISIS Data Area can be found [here]("#The-ISIS-Data-Area"). 
 
-        python $CONDA_PREFIX/scripts/isis3VarInit.py
+    There are two methods to configure the environment variables for ISIS:
 
-    For versions of ISIS after 4.2.0, use:
+    7.1 Using the provided isisVarInit.py script:
 
-        python $CONDA_PREFIX/scripts/isisVarInit.py
+      To use the default values for: `$ISISROOT, $ISISDATA, $ISISTESTDATA`, run the ISIS variable initialization script with default arguments.
+  
+      To do this, for versions of ISIS 4.2.0 and earlier, use:
+  
+          python $CONDA_PREFIX/scripts/isis3VarInit.py
+  
+      For versions of ISIS after 4.2.0, use:
+  
+          python $CONDA_PREFIX/scripts/isisVarInit.py
+  
+      Executing this script with no arguments will result in $ISISDATA=$CONDA\_PREFIX/data, and $ISISTESTDATA=$CONDA\_PREFIX/testdata. The user can specify different directories for both of these optional values:
+  
+      For ISIS 4.2.0 and earlier, use:
+  
+          python $CONDA_PREFIX/scripts/isis3VarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data   directory]
+  
+      For versions of ISIS after 4.2.0, use:
+  
+          python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data   directory]
+  
+      Now every time the isis environment is activated, $ISISROOT, $ISISDATA, and $ISISTESTDATA will be set to the values passed to isisVarInit.py. 
+      This does not happen retroactively, so re-activate the isis environment with one of the following commands:
+  
+          for Anaconda 3.4 and up - conda activate isis
+          prior to Anaconda 3.4 - source activate isis
 
-    Executing this script with no arguments will result in $ISISDATA=$CONDA\_PREFIX/data, and $ISISTESTDATA=$CONDA\_PREFIX/testdata. The user can specify different directories for both of these optional values:
+    7.2 Using `conda env config vars`
 
-    For ISIS 4.2.0 and earlier, use:
+      Conda has a built in method for configuring environment variables that are specific to a conda environment since version 4.8.
+      This version number applies only to the conda package, not to the version of miniconda or anaconda that was installed. 
 
-        python $CONDA_PREFIX/scripts/isis3VarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
+      To determine if your version of conda is recent enough run:
 
-    For versions of ISIS after 4.2.0, use:
+          conda --version
 
-        python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data directory]
+      If the version number is less than 4.8, update conda to a newer version by running:
 
-    More information about the ISISDATA environment variable and the ISIS Data Area can be found [here]("#The-ISIS-Data-Area"). Now everytime the isis environment is activated, $ISISROOT, $ISISDATA, and $ISISTESTDATA will be set to the values passed to isisVarInit.py. This does not happen retroactively, so re-activate the isis envionment with one of the following commands:
+          conda update -n base conda 
 
-        for Anaconda 3.4 and up - conda activate isis
-        prior to Anaconda 3.4 - source activate isis
+      The version number should now be greater than 4.8. 
+
+      To use the built in environment variable configuration feature, first activate the environment by first running:
+
+          conda activate isis 
+
+      After activation, the environment variables can be set using the syntax: `conda config vars set KEY=VALUE`.
+      To set all the environment variables ISIS requires, run the following command, updating the paths as needed:
+
+      For ISIS 4.2.0 and earlier, use:
+
+          conda env config vars set ISISROOT=$CONDA_PREFIX ISISDATA=[path to data directory] ISISTESTDATA=[path to test data directory]
+
+      For versions of ISIS after 4.2.0, use:
+
+          conda env config vars set ISIS3ROOT=$CONDA_PREFIX ISIS3DATA=[path to data directory] ISIS3TESTDATA=[path to test data directory]
+      
+      To make these changes take effect, re-activate the isis environment by running:
+
+          conda activate isis
+
+      The environment variables are now set and ISIS is ready for use every time the isis environment is activated.
+
+
 
 ### Installation with Docker
 The ISIS production Dockerfile automates the conda installation process above.

--- a/README.md
+++ b/README.md
@@ -95,28 +95,19 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
     The variables include: ISISROOT, ISISDATA, and ISISTESTDATA. 
 
     More information about the ISISDATA environment variable and the ISIS Data Area can be found [here]("#The-ISIS-Data-Area"). 
+    
+    The following steps are only valid for versions of ISIS after 4.2.0.   
+    For older versions of ISIS follow the instructions in [this readme file.](https://github.com/USGS-Astrogeology/ISIS3/blob/adf52de0a04b087411d53f3fe1c9218b06dff92e/README.md)
 
     There are two methods to configure the environment variables for ISIS:
 
     7.1 Using the provided isisVarInit.py script:
 
-      To use the default values for: `$ISISROOT, $ISISDATA, $ISISTESTDATA`, run the ISIS variable initialization script with default arguments.
-  
-      To do this, for versions of ISIS 4.2.0 and earlier, use:
-  
-          python $CONDA_PREFIX/scripts/isis3VarInit.py
-  
-      For versions of ISIS after 4.2.0, use:
+      To use the default values for: `$ISISROOT, $ISISDATA, $ISISTESTDATA`, run the ISIS variable initialization script with default arguments:
   
           python $CONDA_PREFIX/scripts/isisVarInit.py
   
       Executing this script with no arguments will result in $ISISDATA=$CONDA\_PREFIX/data, and $ISISTESTDATA=$CONDA\_PREFIX/testdata. The user can specify different directories for both of these optional values:
-  
-      For ISIS 4.2.0 and earlier, use:
-  
-          python $CONDA_PREFIX/scripts/isis3VarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data   directory]
-  
-      For versions of ISIS after 4.2.0, use:
   
           python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data   directory]
   
@@ -148,13 +139,7 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
       After activation, the environment variables can be set using the syntax: `conda config vars set KEY=VALUE`.
       To set all the environment variables ISIS requires, run the following command, updating the paths as needed:
 
-      For ISIS 4.2.0 and earlier, use:
-
           conda env config vars set ISISROOT=$CONDA_PREFIX ISISDATA=[path to data directory] ISISTESTDATA=[path to test data directory]
-
-      For versions of ISIS after 4.2.0, use:
-
-          conda env config vars set ISIS3ROOT=$CONDA_PREFIX ISIS3DATA=[path to data directory] ISIS3TESTDATA=[path to test data directory]
       
       To make these changes take effect, re-activate the isis environment by running:
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 7.  Finally, setup the environment variables:
 
     ISIS requires several environment variables to be set in order to run correctly. 
-    The variables include: ISISROOT, ISISDATA, and ISISTESTDATA. 
+    The variables include: ISISROOT and ISISDATA. 
 
     More information about the ISISDATA environment variable and the ISIS Data Area can be found [here]("#The-ISIS-Data-Area"). 
     
@@ -103,15 +103,15 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
     7.1 Using the provided isisVarInit.py script:
 
-      To use the default values for: `$ISISROOT, $ISISDATA, $ISISTESTDATA`, run the ISIS variable initialization script with default arguments:
+      To use the default values for: `$ISISROOT` and `$ISISDATA`, run the ISIS variable initialization script with default arguments:
   
           python $CONDA_PREFIX/scripts/isisVarInit.py
   
-      Executing this script with no arguments will result in $ISISDATA=$CONDA\_PREFIX/data, and $ISISTESTDATA=$CONDA\_PREFIX/testdata. The user can specify different directories for both of these optional values:
+      Executing this script with no arguments will result in $ISISROOT=$CONDA\_PREFIX and $ISISDATA=$CONDA\_PREFIX/data. The user can specify different directories for `$ISISDATA` using the optional value:
   
-          python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  --test-dir=[path to test data   directory]
+          python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]  
   
-      Now every time the isis environment is activated, $ISISROOT, $ISISDATA, and $ISISTESTDATA will be set to the values passed to isisVarInit.py. 
+      Now every time the isis environment is activated, $ISISROOT and $ISISDATA will be set to the values passed to isisVarInit.py. 
       This does not happen retroactively, so re-activate the isis environment with one of the following commands:
   
           for Anaconda 3.4 and up - conda activate isis
@@ -137,9 +137,9 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
           conda activate isis 
 
       After activation, the environment variables can be set using the syntax: `conda config vars set KEY=VALUE`.
-      To set all the environment variables ISIS requires, run the following command, updating the paths as needed:
+      To set all the environment variables ISIS requires, run the following command, updating the path to `ISISDATA` as needed:
 
-          conda env config vars set ISISROOT=$CONDA_PREFIX ISISDATA=[path to data directory] ISISTESTDATA=[path to test data directory]
+          conda env config vars set ISISROOT=$CONDA_PREFIX ISISDATA=[path to data directory] 
       
       To make these changes take effect, re-activate the isis environment by running:
 


### PR DESCRIPTION
Updates readme step 7 of install to include steps for using `conda env
config vars` to set environment variables as option 2.

## Description
This is the first PR to address the feature discussed in issue #4499, currently this is a work in progress as there are possibly other documentation areas to update.
 
There are also a few questions I have that need answered and may require more changes to this pr:

1. ~~Is ISISTESTDATA actually required?~~
2. ~~What about ALEDATA?~~
3. Update miniconda/anaconda version mentioned to a more recent release
4. ~~Can I remove mentions of isis version < 4.2.0, as older readmes contain
   install directions.~~
5. Verify I got the update command correct.
6. See why the markdown doesn't indent for options 1 and 2.

## Related Issue
Issue #4499 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
method tested locally by myself, and in CI jobs for asap-stereo.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
