### PR TITLE
Csm - Documentation additions to csminit and jigsaw

### DIFF
--- a/isis/src/base/apps/csminit/csminit.xml
+++ b/isis/src/base/apps/csminit/csminit.xml
@@ -18,8 +18,32 @@
     </p>
     <p>
       Information about the CSM model will also be added to the CsmInfo group on
-      the cube label. These are just for users to reference and are not used
+      the cube label. The group includes names, units, and types for model
+      parameter. These are just for users to reference and are not used
       programmatically.
+    </p>
+    <pre>
+Group = CsmInfo
+CSMPlatformID       = Mars_Reconnaissance_Orbiter
+CSMInstrumentId     = "CONTEXT CAMERA"
+ReferenceTime       = 2014-05-21T15:48:56Z
+ModelParameterNames = ("IT Pos. Bias   ", "CT Pos. Bias   ",
+                        "Rad Pos. Bias  ", "IT Vel. Bias   ",
+                        "CT Vel. Bias   ", "Rad Vel. Bias  ",
+                        "Omega Bias     ", "Phi Bias       ",
+                        "Kappa Bias     ", "Omega Rate     ",
+                        "Phi Rate       ", "Kappa Rate     ",
+                        "Omega Accl     ", "Phi Accl       ",
+                        "Kappa Accl     ", "Focal Bias     ")
+ModelParameterUnits = (m, m, m, m, m, m, m, m, m, m, m, m, m, m, m, m)
+ModelParameterTypes = (REAL, REAL, REAL, REAL, REAL, REAL, REAL, REAL,
+                        REAL, REAL, REAL, REAL, REAL, REAL, REAL, REAL)
+End_Group
+    </pre>
+    <p>
+      The ModelParameter keywords contain information that can be used
+      when running jigsaw. This information is unique for each model. For
+      more detail, see the CSMSOLVELIST parameter in the jigsaw documentation.
     </p>
     <p>
       This program can be run on any Cube file, but if the Cube has spice data
@@ -148,4 +172,17 @@
       </parameter>
     </group>
   </groups>
+  <example>
+  <brief>Simple csminit Example</brief>
+  <description>
+    This example uses a calibrated MRO CTX image and an isd generated using ALE or Abstraction Layer for Ephemerides.
+  </description>
+  <terminalInterface>
+    <commandLine> csminit from= F02_036648_2021_XN_22N022W.cal.csm.cub isd= F02_036648_2021_XN_22N022W.cal.csm.json
+    </commandLine>
+    <description>
+      Simple csminit example
+    </description>
+  </terminalInterface>
+</example>
 </application>

--- a/isis/src/control/apps/jigsaw/jigsaw.xml
+++ b/isis/src/control/apps/jigsaw/jigsaw.xml
@@ -1420,6 +1420,21 @@
       </group>
 
     </groups>
+    <example>
+      <brief>Solve with CSM parameters</brief>
+      <description>
+        This is an example where the cubes in the network have been run through csminit.
+        When specified in CSMSOLVELIST, parameters described in the CsmInfo group can
+        be adjusted during the bundle.
+      </description>
+      <terminalInterface>
+        <commandLine> jigsaw fromlis=cubes.lis cnet=input.net onet=output.net radius=yes csmsolvelist="(Omega Bias, Phi Bias, Kappa Bias)" control_point_coordinate_type_bundle=rectangular control_point_coordinate_type_reports=rectangular point_x_sigma=50 point_y_sigma=50 point_z_sigma=50
+        </commandLine>
+        <description>
+         jigsaw CSM example
+        </description>
+      </terminalInterface>
+    </example>
 
     <liens>
       <item>Add items to glossary, example(s) and tips on how to analyze the


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
csminit -
Adds an example of running csminit. Adds an example CsmInfo Pvl Group. Mentions what's in the group. Specifies that the information can be used when solving in jigsaw, and points to the jigsaw CSMSOLVELIST docs for more detail. 

jigsaw -
Adds an example for running jigsaw on a network with csminitted cubes.

IMO it doesn't seem right for the sole "Example" in the jigsaw app docs to be this one use case. I think it may be good to have a more general jigsaw use case for "Example 1" and then this example for "Example 2". But I'm not sure if that general jigsaw doc change is in the scope of this PR. Thoughts?

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#4410 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
