### PR TITLE
Updated LRO SCLK for testing

### DIFF
--- a/isis/tests/data/observationPair/observationImageL.pvl
+++ b/isis/tests/data/observationPair/observationImageL.pvl
@@ -92,7 +92,7 @@ Object = IsisCube
                                  $lro/kernels/ck/moc42r_2009181_2009213_v14.bc,
                                  $lro/kernels/fk/lro_frames_2014049_v01.tf)
     Instrument                = $lro/kernels/ik/lro_lroc_v18.ti
-    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2021076_v00.tsc
+    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2021159_v00.tsc
     InstrumentPosition        = (Table,
                                  $lro/kernels/spk/fdf29r_2009182_2009213_v01.b-
                                  sp)

--- a/isis/tests/data/observationPair/observationImageR.pvl
+++ b/isis/tests/data/observationPair/observationImageR.pvl
@@ -92,7 +92,7 @@ Object = IsisCube
                                  $lro/kernels/ck/moc42r_2009181_2009213_v14.bc,
                                  $lro/kernels/fk/lro_frames_2014049_v01.tf)
     Instrument                = $lro/kernels/ik/lro_lroc_v18.ti
-    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2021076_v00.tsc
+    SpacecraftClock           = $lro/kernels/sclk/lro_clkcor_2021159_v00.tsc
     InstrumentPosition        = (Table,
                                  $lro/kernels/spk/fdf29r_2009182_2009213_v01.b-
                                  sp)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The old LRO SCLK that we used for jigsaw observation pair isn't around any more so this updates to a new one.

I tried a more programmatic approach to getting the newest SCLK, but the cube from ISD+label method instantiates the camera. So, you have to have the correct value already in the PVL file.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No issue, fixing CI test failures

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

All of the tests that use the ObservationPair fixture are failing because of this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested all ObservationPair tests on Ubuntu and they passed

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
