### PR TITLE
Fix functional tests to work with updated TestCsmModel

### DIFF
--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -36,9 +36,13 @@ class CSMPluginFixture : public TempTestingFiles {
 
       // Create and populate test ISDs
       json isd;
-      isd["test_param_one"] = 1.0;
-      isd["test_param_two"] = 2.0;
-
+      isd["reference_time"] = 0;
+      isd["center_latitude"] = 3.03125;
+      isd["center_longitude"] = -2.9375;
+      isd["scale"] = 240;
+      isd["center_longitude_sigma"] = 0.0645181963189456;
+      isd["center_latitude_sigma"] = 0.0645181963189456;
+      isd["scale_sigma"] = 8.25832912882503;
       isdPath = tempDir.path() + "/default.json";
       std::ofstream file(isdPath.toStdString());
       file << isd;
@@ -118,16 +122,16 @@ TEST_F(CSMPluginFixture, CSMInitDefault) {
   ASSERT_TRUE(infoGroup.hasKeyword("ReferenceTime"));
   EXPECT_EQ(infoGroup["ReferenceTime"][0].toStdString(), model.getReferenceDateAndTime());
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterNames"));
-  ASSERT_EQ(infoGroup["ModelParameterNames"].size(), 2);
+  ASSERT_EQ(infoGroup["ModelParameterNames"].size(), 3);
   EXPECT_EQ(infoGroup["ModelParameterNames"][0].toStdString(), TestCsmModel::PARAM_NAMES[0]);
   EXPECT_EQ(infoGroup["ModelParameterNames"][1].toStdString(), TestCsmModel::PARAM_NAMES[1]);
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterUnits"));
-  ASSERT_EQ(infoGroup["ModelParameterUnits"].size(), 2);
+  ASSERT_EQ(infoGroup["ModelParameterUnits"].size(), 3);
   EXPECT_EQ(infoGroup["ModelParameterUnits"][0].toStdString(), TestCsmModel::PARAM_UNITS[0]);
   EXPECT_EQ(infoGroup["ModelParameterUnits"][1].toStdString(), TestCsmModel::PARAM_UNITS[1]);
   ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterTypes"));
-  ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 2);
-  EXPECT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "FICTITIOUS");
+  ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 3);
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "REAL");
   EXPECT_EQ(infoGroup["ModelParameterTypes"][1].toStdString(), "REAL");
 
   // Check the Kernels group
@@ -291,9 +295,13 @@ TEST_F(CSMPluginFixture, CSMInitFails) {
 TEST_F(DefaultCube, CSMInitSpiceCleanup) {
   // Create an ISD
   json isd;
-  isd["test_param_one"] = 1.0;
-  isd["test_param_two"] = 2.0;
-
+  isd["reference_time"] = 0;
+  isd["center_latitude"] = 3.03125;
+  isd["center_longitude"] = -2.9375;
+  isd["scale"] = 240;
+  isd["center_longitude_sigma"] = 0.0645181963189456;
+  isd["center_latitude_sigma"] = 0.0645181963189456;
+  isd["scale_sigma"] = 8.25832912882503;
   QString isdPath = tempDir.path() + "/default.json";
   std::ofstream file(isdPath.toStdString());
   file << isd;

--- a/isis/tests/FunctionalTestsSpiceinit.cpp
+++ b/isis/tests/FunctionalTestsSpiceinit.cpp
@@ -668,9 +668,13 @@ TEST_F(SmallCube, FunctionalTestSpiceinitCsminitRestorationOnFail) {
 
   // Create an ISD
   json isd;
-  isd["test_param_one"] = 1.0;
-  isd["test_param_two"] = 2.0;
-
+  isd["reference_time"] = 0;
+  isd["center_latitude"] = 3.03125;
+  isd["center_longitude"] = -2.9375;
+  isd["scale"] = 240;
+  isd["center_longitude_sigma"] = 0.0645181963189456;
+  isd["center_latitude_sigma"] = 0.0645181963189456;
+  isd["scale_sigma"] = 8.25832912882503;
   QString isdPath = tempDir.path() + "/default.json";
   std::ofstream file(isdPath.toStdString());
   file << isd;


### PR DESCRIPTION
## Description
Updates functional tests that began failing after updating the `TestCsmModel`. The tests needed to be updated to accommodate the changes made to the model to support actual image-to-ground, ground-to-image, etc, calculations so that automated tests could be written to test jigsaw with csm sensor models. 

## Related Issue
#4410

## Motivation and Context
Needed to accommodate changes made to the `TestCsmModel`. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
