### PR TITLE
Tweaks to improve CSM Camera functionality

### DIFF
--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -1657,8 +1657,8 @@ namespace Isis {
 
     // get a normalized surface spacecraft vector
     SpiceDouble surfSpaceVect[3], unitizedSurfSpaceVect[3], dist;
-    std::vector<double> sB = bodyRotation()->ReferenceVector(
-        instrumentPosition()->Coordinate());
+    std::vector<double> sB(3, Isis::Null);
+    instrumentBodyFixedPosition(&sB[0]);
 
     SpiceDouble pB[3];
     SurfacePoint surfacePoint = GetSurfacePoint();

--- a/isis/tests/CSMCameraTests.cpp
+++ b/isis/tests/CSMCameraTests.cpp
@@ -44,6 +44,18 @@ TEST_F(CSMCameraFixture, SetImage) {
 }
 
 
+TEST_F(CSMCameraFixture, SetImageNoIntersect) {
+  csm::Ellipsoid wgs84;
+  EXPECT_CALL(mockModel, imageToRemoteImagingLocus(MatchImageCoord(csm::ImageCoord(4.5, 4.5)), ::testing::_, ::testing::_, ::testing::_))
+      .Times(1)
+      // looking straight down X-Axis
+      .WillOnce(::testing::Return(csm::EcefLocus(wgs84.getSemiMajorRadius() + 50000, 0, 0, 0, 1, 0)));
+
+  EXPECT_FALSE(testCam->SetImage(5, 5));
+  EXPECT_THAT(testCam->lookDirectionBodyFixed(), ::testing::ElementsAre(0.0, 1.0, 0.0));
+}
+
+
 TEST_F(CSMCameraDemFixture, SetImage) {
   EXPECT_CALL(mockModel, imageToRemoteImagingLocus(MatchImageCoord(csm::ImageCoord(4.5, 4.5)), ::testing::_, ::testing::_, ::testing::_))
       .Times(1)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changed CSMCamera to save off the look vector in setImage when it doesn't intersect the body. This matches the ISIS camera model functionality and will be important for oblique observations with CSM models.

Also changed Camera::LocalPhotometricAngles to use the Camera API to get the body-fixed sensor location instead of directly accessing the body rotation. This allows for the computation of local photometric angles with CSM camera models.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#4410 and general CSM support

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This improves CSM support and will help for potential grounded observations in the future.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested the local photometric angles in phocube and they worked as expected. The CSMCamera saving the look vector fix is tested by a new unit test.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
