### PR TITLE
Fixed caching 0 degree polynomials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ release.
 - Fixed Thm2isis to properly use output attributes [#4213](https://github.com/USGS-Astrogeology/ISIS3/issues/4213)
 - Fixed caminfo uselabel SegFault. [#4401](https://github.com/USGS-Astrogeology/ISIS3/issues/4401)
 - Fixed ISIS docs for incorrect path and -WEBHELP issues [#4510](https://github.com/USGS-Astrogeology/ISIS3/issues/4510)
+- Fixed a bug where writing out updated positions for framing cameras in jigsaw caused an error. [#4545](https://github.com/USGS-Astrogeology/ISIS3/issues/4545)
 
 ## [5.0.0] - 2021-04-01
 

--- a/isis/src/base/objs/SpicePosition/SpicePosition.cpp
+++ b/isis/src/base/objs/SpicePosition/SpicePosition.cpp
@@ -762,7 +762,7 @@ namespace Isis {
       p_et = p_cacheTime[0];
       SetEphemerisTime(p_et);
       std::vector<ale::State> stateCache;
-      stateCache.push_back(p_coordinate);
+      stateCache.push_back(ale::Vec3d(p_coordinate));
       std::vector<double> timeCache;
       timeCache.push_back(p_cacheTime[0]);
       if (m_state != NULL) {

--- a/isis/src/base/objs/SpicePosition/SpicePosition.truth
+++ b/isis/src/base/objs/SpicePosition/SpicePosition.truth
@@ -384,3 +384,8 @@ Velocity (J) = 1 1 1
 Test loading cache from an ALE ISD with non-SPICE SpicePosition
 **PROGRAMMER ERROR** SpicePosition::LoadCache(json) only supports Spice source.
 
+Test loading cache from 0th degree polynomial
+Source = 1
+Has velocity? No
+Time           = 1
+Spacecraft (J) = 1 2 3

--- a/isis/src/base/objs/SpicePosition/unitTest.cpp
+++ b/isis/src/base/objs/SpicePosition/unitTest.cpp
@@ -354,4 +354,27 @@ int main(int argc, char *argv[]) {
   }
 
   cout <<endl;
+
+  // Test loading cache from 0th degree polynomial
+  cout << "Test loading cache from 0th degree polynomial" << endl;
+  json zeroDegreeIsd = {{"spk_table_start_time"    , 1.0},
+                        {"spk_table_end_time"      , 1.0},
+                        {"spk_table_original_size" , 1},
+                        {"ephemeris_times"       , {1.0}},
+                        {"positions"            , {{1.0, 2.0, 3.0}}}};
+  SpicePosition zeroDegreePoly(-94, 499);
+  zeroDegreePoly.LoadCache(zeroDegreeIsd);
+  zeroDegreePoly.ComputeBaseTime();
+  zeroDegreePoly.SetPolynomialDegree(0);
+  zeroDegreePoly.SetPolynomial();
+  Table zeroDegreeTable = zeroDegreePoly.Cache("TestZeroDegree");
+  SpicePosition singlePosition(-94, 499);
+  singlePosition.LoadCache(zeroDegreeTable);
+  cout << "Source = " << singlePosition.GetSource() << endl;
+  cout << "Has velocity? " << (singlePosition.HasVelocity() ? "Yes" : "No") << endl;
+  singlePosition.SetEphemerisTime(1.0);
+  vector<double> singlePos = singlePosition.Coordinate();
+  cout << "Time           = " << 1.0 << endl;
+  cout << "Spacecraft (J) = " << singlePos[0] << " " << singlePos[1] << " " << singlePos[2] << endl;
+
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed a call in SpicePosition when caching a 0th degree polynomial. Instead of passing an ale::Vec3D to the ale::State constructor it passed the direct position vector which caused an error.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #4545 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This was causing an exception when writing updated positions to frame cameras in jigsaw.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested by re-running example set from astrodiscuss, see #4545, and enabling "update=True" on Apollo jigsaw test. I also added a new test to the SpicePosition unitTest for this case.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
