### PR TITLE
Implemented Distortion in NAC RS camera model

### DIFF
--- a/isis/appdata/templates/noproj/noprojInstruments.pvl
+++ b/isis/appdata/templates/noproj/noprojInstruments.pvl
@@ -3,14 +3,14 @@ Object = IdealInstrumentsSpecifications
   Created      = 2006-12-14T10:10:49
   LastModified = 2019-06-27
   # 2019-11-05 Modified by ladoramkershner: Added Mariner 10
-  
+
   # Group name and values will change once stabilized
-  Group = "Clipper EIS 2025/EIS-NAC-RS"
+  Group = "Clipper/EIS-NAC-RS"
     DetectorSamples = 4000
     DetectorLines = 2000
   End_Group
 
-  Group = "Clipper EIS 2025/EIS-WAC-FC"
+  Group = "Clipper/EIS-WAC-FC"
     DetectorSamples = 4000
     DetectorLines = 2000
   End_Group
@@ -61,7 +61,7 @@ Object = IdealInstrumentsSpecifications
     TransY = -0.39031635
     ItransS = 55.759479
   End_Group
-  
+
   Group = "MARS RECONNAISSANCE ORBITER/HIRISE"
     DetectorSamples = 20000
 #    Use the average of red ccd's 4 & 5 for the offsets

--- a/isis/src/clipper/objs/ClipperNacRollingShutterCamera/ClipperNacRollingShutterCamera.cpp
+++ b/isis/src/clipper/objs/ClipperNacRollingShutterCamera/ClipperNacRollingShutterCamera.cpp
@@ -86,8 +86,9 @@ namespace Isis {
     // Set up camera detector map with the coefficients and readout times
     new RollingShutterCameraDetectorMap(this, readoutTimes, sampleCoeffs, lineCoeffs);
 
-    // Set up focal plane map
-    new CameraFocalPlaneMap(this, naifIkCode());
+    // Setup focal plane map, and detector origin
+    CameraFocalPlaneMap *focalMap = new CameraFocalPlaneMap(this, naifIkCode()); 
+    focalMap->SetDetectorOrigin(2048.5, 1024.5);
 
     // Set up distortion map (use default for now)
     CameraDistortionMap *distMap = new CameraDistortionMap(this);

--- a/isis/src/clipper/objs/ClipperNacRollingShutterCamera/ClipperNacRollingShutterCamera.cpp
+++ b/isis/src/clipper/objs/ClipperNacRollingShutterCamera/ClipperNacRollingShutterCamera.cpp
@@ -90,7 +90,8 @@ namespace Isis {
     new CameraFocalPlaneMap(this, naifIkCode());
 
     // Set up distortion map (use default for now)
-    new CameraDistortionMap(this);
+    CameraDistortionMap *distMap = new CameraDistortionMap(this);
+    distMap->SetDistortion(naifIkCode());
 
     // Set up the ground and sky map
     new CameraGroundMap(this);

--- a/isis/tests/ClipperNacRollingShutterCameraTests.cpp
+++ b/isis/tests/ClipperNacRollingShutterCameraTests.cpp
@@ -25,29 +25,29 @@ TEST_F(ClipperNacRsCube, ClipperNacRsCameraUnitTest) {
 
 
   EXPECT_TRUE(cam->SetImage(145, 161));
-  EXPECT_NEAR(cam->UniversalLatitude(), 10.248688804675723, 0.0001);
-  EXPECT_NEAR(cam->UniversalLongitude(), 256.15486019464515, 0.0001);
+  EXPECT_NEAR(cam->UniversalLatitude(), 8.6646548238559333, 0.0001);
+  EXPECT_NEAR(cam->UniversalLongitude(), 253.93886964420707, 0.0001);
   EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
   EXPECT_NEAR(cam->Sample(), 145, 0.0001);
   EXPECT_NEAR(cam->Line(), 161, 0.0001);
 
   EXPECT_TRUE(cam->SetImage(3655, 157));
-  EXPECT_NEAR(cam->UniversalLatitude(), 14.250132025597672, 0.0001);
-  EXPECT_NEAR(cam->UniversalLongitude(), 258.44639101206752, 0.0001);
+  EXPECT_NEAR(cam->UniversalLatitude(), 12.365243218956246, 0.0001);
+  EXPECT_NEAR(cam->UniversalLongitude(), 255.86310676733405, 0.0001);
   EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
   EXPECT_NEAR(cam->Sample(), 3655, 0.0001);
   EXPECT_NEAR(cam->Line(), 157, 0.0001);
 
   EXPECT_TRUE(cam->SetImage(289, 1767));
-  EXPECT_NEAR(cam->UniversalLatitude(), 9.4776705775142567, 0.0001);
-  EXPECT_NEAR(cam->UniversalLongitude(), 258.17321108594587, 0.0001);
+  EXPECT_NEAR(cam->UniversalLatitude(), 7.8856314924390674, 0.0001);
+  EXPECT_NEAR(cam->UniversalLongitude(), 255.74387203937229, 0.0001);
   EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
   EXPECT_NEAR(cam->Sample(), 289, 0.0001);
   EXPECT_NEAR(cam->Line(), 1767, 0.001);
 
   EXPECT_TRUE(cam->SetImage(3767, 1579));
-  EXPECT_NEAR(cam->UniversalLatitude(), 13.641265011679993, 0.0001);
-  EXPECT_NEAR(cam->UniversalLongitude(), 260.38986965108342, 0.0001);
+  EXPECT_NEAR(cam->UniversalLatitude(), 11.758392399326441, 0.0001);
+  EXPECT_NEAR(cam->UniversalLongitude(), 257.58926744604787, 0.0001);
   EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
   EXPECT_NEAR(cam->Sample(), 3767, 0.0001);
   EXPECT_NEAR(cam->Line(), 1579, 0.001);

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -1592,6 +1592,7 @@ namespace Isis {
         INS-159011_TRANSY       = (0.0, 0.0, 0.01399535)
         INS-159011_ITRANSS      = (0.0, 71.404849, 0.0)
         INS-159011_ITRANSL      = (0.0, 0.0, 71.4523)
+        INS-159011_OD_K         = (0.0, 0.0, 0.0)
       End_Object
     )");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Implemented distortion in NAC RS camera model. Set focal map to center of image. Update Clipper IAK to include OD_K values for NAC RS. Updated NAC RS cam tests with added OD_K keyword to naif keywords in fixture. Updated test outputs for universal lat/lon due to changes to detector origin. Updated noproj Clipper group name in template.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
EIS Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually calculated radial distortion equation from Randy's EIS Sensor summary spreadsheet alongside cameraDistortionMap's setFocalPlane distortion equation.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
