### PR TITLE
Initial data snooping test

### DIFF
--- a/isis/src/control/apps/jigsaw/jigsaw.xml
+++ b/isis/src/control/apps/jigsaw/jigsaw.xml
@@ -521,6 +521,42 @@
        </inclusions>
       </parameter>
 
+    <parameter name="GROSS_OUTLIER_REJECTION">
+      <brief> Auto-rejection of outliers gross outliers</brief>
+      <description>
+        Select this option to perform automatic gross outlier detection and rejection.
+        This option uses a statistical test to determine if each measure has a gross
+        error present during each iteration. Any measures that are found to have a gross
+        error are rejected and removed from the solution. Additionally, previously rejected
+        measures are re-checked to see if they still contain a gross error.
+      </description>
+      <type>boolean</type>
+      <default>
+        <item>No</item>
+      </default>
+      <inclusions>
+        <item>GROSS_CONFIDENCE</item>
+     </inclusions>
+    </parameter>
+
+    <parameter name="GROSS_CONFIDENCE">
+      <brief>Confidence level for gross outlier rejection</brief>
+      <description>
+        The statistical confidence level between 0 and 1 used to determine if a
+        measure contains a gross error. This value is converted into critical value
+        via the F distribution that the measure test statistics are compared against.
+      </description>
+      <type>double</type>
+      <default>
+        <item>0.95</item>
+      </default>
+      <inclusions>
+        <item>GROSS_OUTLIER_REJECTION</item>
+      </inclusions>
+      <minimum>0</minimum>
+      <maximum>1</maximum>
+    </parameter>
+
     <parameter name="ERRORPROPAGATION">
       <brief> Compute variance-covariance matrix</brief>
       <description>

--- a/isis/tests/FunctionalTestsJigsaw.cpp
+++ b/isis/tests/FunctionalTestsJigsaw.cpp
@@ -1694,3 +1694,77 @@ TEST_F(CSMNetwork, FunctionalTestJigsawCSM) {
   EXPECT_NEAR(camJ->getParameterValue(1), 0.0, 0.00000001);
   EXPECT_NEAR(camJ->getParameterValue(2), 128.0, 0.00000001);
 }
+
+
+TEST_F(CSMNetwork, FunctionalTestJigsawGrossOutlier) {
+
+  // Add error to a point with many measures
+  QString errorPointId = "csm_test_019";
+  QString errorSerial = "TestCsmModel_PlatformIdentifier/TestCsmModelSensorIdentifier/20000101T120000.000000Z";
+  ControlNet errorNet("data/CSMNetwork/test.net");
+  ControlPoint *errorPoint = errorNet.GetPoint(errorPointId);
+  ControlMeasure *errorMeasure = errorPoint->GetMeasure(errorSerial);
+  // Original sample = 896.5
+  // Original line = 128.5
+  // Simulate removing hundreds from line; new line = 28.5
+  errorMeasure->SetCoordinate(errorMeasure->GetSample(), 28.5);
+  QString errorCnetFileName = tempDir.path() + "/errorTemp.net";
+  errorNet.Write(errorCnetFileName);
+
+  QString outCnetFileName = tempDir.path() + "/outTemp.net";
+
+  // Run the bundle
+  QVector<QString> args1 = {"fromlist="+cubeListFile,
+                            "cnet="+errorCnetFileName,
+                            "onet="+outCnetFileName,
+                            "maxits=10",
+                            "bundleout_txt=no",
+                            "IMAGESCSV=no",
+                            "OUTPUT_CSV=no",
+                            "RESIDUALS_CSV=no",
+                            "csmsolveset=adjustable",
+                            "POINT_LATITUDE_SIGMA=1125",
+                            "POINT_LONGITUDE_SIGMA=1125",
+                            "GROSS_OUTLIER_REJECTION=yes",
+                            "GROSS_CONFIDENCE=0.99",
+                            "file_prefix="+tempDir.path()+"/"
+                           };
+
+  UserInterface options1(APP_XML, args1);
+  try {
+   jigsaw(options1);
+
+  }
+  catch (IException &e) {
+   FAIL() << "Failed to bundle: " << e.what() << std::endl;
+  }
+
+  // Check that the measures in the output network
+  ControlNet jiggedNet(outCnetFileName);
+  for (int i = 0; i < jiggedNet.GetNumPoints(); i++) {
+    ControlPoint *jiggedPoint = jiggedNet.GetPoint(i);
+    QString currentPointId = jiggedPoint->GetId();
+    for (int j = 0; j < jiggedPoint->GetNumMeasures(); j++) {
+      ControlMeasure *jiggedMeasure = jiggedPoint->GetMeasure(j);
+      QString currentSerial = jiggedMeasure->GetCubeSerialNumber();
+
+      if (currentPointId == errorPointId && currentSerial == errorSerial) {
+        EXPECT_TRUE(jiggedMeasure->IsRejected()) << "Expected point [" << currentPointId.toStdString()
+                                                 << "], measure [" << currentSerial.toStdString()
+                                                 << "] to be rejected but wasn't.";
+      }
+      else {
+        EXPECT_FALSE(jiggedMeasure->IsRejected()) << "Expected point [" << currentPointId.toStdString()
+                                                  << "], measure [" << currentSerial.toStdString()
+                                                  << "] to not be rejected but was.";
+      }
+    }
+  }
+
+  // Check that the measure's image solution was unaffected
+  Cube testA(tempDir.path() + "/Test_A.cub");
+  CSMCamera *camB = dynamic_cast<CSMCamera*>(testA.camera());
+  EXPECT_NEAR(camB->getParameterValue(0), 3.0, 0.00000001);
+  EXPECT_NEAR(camB->getParameterValue(1), -3.0, 0.00000001);
+  EXPECT_NEAR(camB->getParameterValue(2), 256.0, 0.00000001);
+}


### PR DESCRIPTION
Just checks that data snooping as able to detection and reject a very large error in a "perfect" set of measurements. More tests will be needed to verify that the confidence level is working properly.

Part of #4559 