### PR TITLE
Add distortion to EIS WAC Frame Camera + add test

### DIFF
--- a/isis/src/clipper/objs/ClipperWacFcCamera/ClipperWacFcCamera.cpp
+++ b/isis/src/clipper/objs/ClipperWacFcCamera/ClipperWacFcCamera.cpp
@@ -47,7 +47,11 @@ namespace Isis {
     // Set up detector map, focal plane map, and distortion map
     new CameraDetectorMap(this);
     new CameraFocalPlaneMap(this, naifIkCode());
+    CameraFocalPlaneMap *focalMap = new CameraFocalPlaneMap(this, naifIkCode());
+    focalMap->SetDetectorOrigin(2092.5, 1112.5);
     new CameraDistortionMap(this);
+    CameraDistortionMap *distMap = new CameraDistortionMap(this);
+    distMap->SetDistortion(naifIkCode());
 
     // Setup the ground and sky map
     new CameraGroundMap(this);

--- a/isis/tests/ClipperWacFcCameraTests.cpp
+++ b/isis/tests/ClipperWacFcCameraTests.cpp
@@ -47,7 +47,7 @@ TEST_F(ClipperWacFcCube, ClipperWacFcCameraUnitTest) {
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameLong(), "Europa Imaging System Framing Wide Angle Camera");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cam->instrumentNameShort(), "EIS-FWAC");
 
-  
+
   // Check SetImage on corners
   int line, samp, nline, nsamp;
   line = 1.0;     samp = 1.0;
@@ -66,4 +66,33 @@ TEST_F(ClipperWacFcCube, ClipperWacFcCameraUnitTest) {
   std::pair<iTime, iTime> startStop;
   startStop = cam->ShutterOpenCloseTimes(etStart.Et(), 0.00005);  // dummy value for exposure duration
   EXPECT_TRUE(startStop.first.Et() < startStop.second.Et());
+
+
+  EXPECT_TRUE(cam->SetImage(145, 161));
+  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 8.5881709286625423);
+  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 253.71621132953456);
+  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
+  EXPECT_NEAR(cam->Sample(), 145, 0.001);
+  EXPECT_NEAR(cam->Line(), 161, 0.001);
+
+  EXPECT_TRUE(cam->SetImage(3655, 157));
+  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 12.445262207724664);
+  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 255.73569853485378);
+  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
+  EXPECT_NEAR(cam->Sample(), 3655, 0.001);
+  EXPECT_NEAR(cam->Line(), 157, 0.001);
+
+  EXPECT_TRUE(cam->SetImage(289, 1767));
+  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 7.7976578051658336);
+  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 255.60927064348147);
+  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
+  EXPECT_NEAR(cam->Sample(), 289, 0.001);
+  EXPECT_NEAR(cam->Line(), 1767, 0.001);
+
+  EXPECT_TRUE(cam->SetImage(3767, 1579));
+  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 11.80993221278302);
+  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 257.50821511090754);
+  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
+  EXPECT_NEAR(cam->Sample(), 3767, 0.001);
+  EXPECT_NEAR(cam->Line(), 1579, 0.001);
 }

--- a/isis/tests/ClipperWacFcCameraTests.cpp
+++ b/isis/tests/ClipperWacFcCameraTests.cpp
@@ -25,6 +25,15 @@ void TestLineSamp(Camera *cam, double samp, double line) {
   }
 }
 
+void TestImageToGroundToImage(Camera *cam, double samp, double line, double lat, double lon){
+  ASSERT_TRUE(cam->SetImage(samp, line));
+  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), lat);
+  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), lon);
+  ASSERT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
+  EXPECT_NEAR(cam->Sample(), samp, 0.001);
+  EXPECT_NEAR(cam->Line(), line, 0.001);
+}
+
 
 TEST_F(ClipperWacFcCube, ClipperWacFcCameraUnitTest) {
   ClipperWacFcCamera *cam;
@@ -57,6 +66,10 @@ TEST_F(ClipperWacFcCube, ClipperWacFcCameraUnitTest) {
   TestLineSamp(cam, nline, nsamp);
   TestLineSamp(cam, nline, samp);
 
+  TestImageToGroundToImage(cam, 145, 161, 8.5881709286625423, 253.71621132953456);
+  TestImageToGroundToImage(cam, 3655, 157, 12.445262207724664, 255.73569853485378);
+  TestImageToGroundToImage(cam, 289, 1767, 7.7976578051658336, 255.60927064348147);
+  TestImageToGroundToImage(cam, 3767, 1579, 11.80993221278302, 257.50821511090754);
 
   // Simple test for ClipperWacFcCamera::ShutterOpenCloseTimes
   PvlGroup &inst = label.findGroup("Instrument", Pvl::Traverse);
@@ -66,33 +79,4 @@ TEST_F(ClipperWacFcCube, ClipperWacFcCameraUnitTest) {
   std::pair<iTime, iTime> startStop;
   startStop = cam->ShutterOpenCloseTimes(etStart.Et(), 0.00005);  // dummy value for exposure duration
   EXPECT_TRUE(startStop.first.Et() < startStop.second.Et());
-
-
-  EXPECT_TRUE(cam->SetImage(145, 161));
-  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 8.5881709286625423);
-  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 253.71621132953456);
-  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
-  EXPECT_NEAR(cam->Sample(), 145, 0.001);
-  EXPECT_NEAR(cam->Line(), 161, 0.001);
-
-  EXPECT_TRUE(cam->SetImage(3655, 157));
-  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 12.445262207724664);
-  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 255.73569853485378);
-  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
-  EXPECT_NEAR(cam->Sample(), 3655, 0.001);
-  EXPECT_NEAR(cam->Line(), 157, 0.001);
-
-  EXPECT_TRUE(cam->SetImage(289, 1767));
-  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 7.7976578051658336);
-  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 255.60927064348147);
-  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
-  EXPECT_NEAR(cam->Sample(), 289, 0.001);
-  EXPECT_NEAR(cam->Line(), 1767, 0.001);
-
-  EXPECT_TRUE(cam->SetImage(3767, 1579));
-  EXPECT_DOUBLE_EQ(cam->UniversalLatitude(), 11.80993221278302);
-  EXPECT_DOUBLE_EQ(cam->UniversalLongitude(), 257.50821511090754);
-  EXPECT_TRUE(cam->SetUniversalGround(cam->UniversalLatitude(), cam->UniversalLongitude()));
-  EXPECT_NEAR(cam->Sample(), 3767, 0.001);
-  EXPECT_NEAR(cam->Line(), 1579, 0.001);
 }

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -1559,7 +1559,7 @@ namespace Isis {
     std::ifstream cubeLabel("data/defaultImage/defaultCube.pvl");
     isdFile >> isd;
     cubeLabel >> label;
-    
+
     // Define WAC cube
     wacFcCube = new Cube();
     FileName wacFn(tempDir.path() + "/ClipperWAC.cub");
@@ -1584,12 +1584,17 @@ namespace Isis {
       // NaifKeywords Group
     PvlObject &realWacNk = wacFcCube->label()->findObject("NaifKeywords");
     std::istringstream newWacNk(R"(
+      Object = NaifKeywords
+        BODY_CODE               = 502
+        BODY502_RADII           = (1562.6, 1560.3, 1559.5)
+        BODY_FRAME_CODE         = 10024
         INS-159104_FOCAL_LENGTH = 150.40199
         INS-159104_PIXEL_PITCH  = 0.014
         INS-159104_TRANSX       = (0.0, 0.014004651, 0.0)
         INS-159104_TRANSY       = (0.0, 0.0, 0.01399535)
         INS-159104_ITRANSS      = (0.0, 71.404849, 0.0)
         INS-159104_ITRANSL      = (0.0, 0.0, 71.4523)
+        INS-159104_OD_K         = (0.0, -0.0000538628307258204, -4.57142010849732E-09)
       End_Object
     )");
     PvlObject newWacNkPvl; newWacNk >> newWacNkPvl;


### PR DESCRIPTION
Add distortion to EIS WAC Frame Camera + add test
## Description
Modifies the EIS WAC Frame Camera model to add distortion model
## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
EIS Sprint

## How Has This Been Tested?
Added image -> ground -> image test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
