### PR TITLE
Added alpha cube to Clipper EIS WAC FC and updated tests

### DIFF
--- a/isis/tests/ClipperWacFcCameraTests.cpp
+++ b/isis/tests/ClipperWacFcCameraTests.cpp
@@ -66,11 +66,11 @@ TEST_F(ClipperWacFcCube, ClipperWacFcCameraUnitTest) {
   TestLineSamp(cam, nline, nsamp);
   TestLineSamp(cam, nline, samp);
 
-  TestImageToGroundToImage(cam, 145, 161, 8.5881709286625423, 253.71621132953456);
-  TestImageToGroundToImage(cam, 3655, 157, 12.445262207724664, 255.73569853485378);
-  TestImageToGroundToImage(cam, 289, 1767, 7.7976578051658336, 255.60927064348147);
-  TestImageToGroundToImage(cam, 3767, 1579, 11.80993221278302, 257.50821511090754);
-
+  TestImageToGroundToImage(cam, 145, 161, 8.5839718675128971, 253.72747262733904);
+  TestImageToGroundToImage(cam, 3655, 157, 12.477189586257952, 255.76543090545474);
+  TestImageToGroundToImage(cam, 289, 1767, 7.7936575791457452, 255.62130722292261);
+  TestImageToGroundToImage(cam, 3767, 1579, 11.843295382436571, 257.54360381024532);
+  
   // Simple test for ClipperWacFcCamera::ShutterOpenCloseTimes
   PvlGroup &inst = label.findGroup("Instrument", Pvl::Traverse);
   QString startTime = inst["StartTime"];

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -1599,6 +1599,13 @@ namespace Isis {
     )");
     PvlObject newWacNkPvl; newWacNk >> newWacNkPvl;
     realWacNk = newWacNkPvl;
+    
+    double offset = 10;
+    AlphaCube aCube(wacFcCube->sampleCount(), wacFcCube->lineCount(),
+                    wacFcCube->sampleCount()-offset, wacFcCube->lineCount() - offset,
+                    0, offset, wacFcCube->sampleCount(), wacFcCube->lineCount());
+
+    aCube.UpdateGroup(*wacFcCube);
 
     wacFcCube->reopen("rw");
   }


### PR DESCRIPTION
Adds alphacube information to the label and updates the WAC FC test.
## Description
Adds alphacube information to the label.  Assumes 10 lines of "linescan lines" at the top of the image. Edits the lat/lon portion of the test, but the rest was unchanged.

## Related Issue
EIS sprint

## Motivation and Context
A portion of the WAC frame camera is reserved for linescan.  This "crops" those lines out so that only the portion used for the frame camera is present.

## How Has This Been Tested?
Passes existing tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
