### PR TITLE
Implemented Clipper Push Broom Variable Line Rate

### DIFF
--- a/isis/src/clipper/objs/ClipperPushBroomCamera/ClipperPushBroomCamera.h
+++ b/isis/src/clipper/objs/ClipperPushBroomCamera/ClipperPushBroomCamera.h
@@ -10,8 +10,6 @@ find files of those names at the top level of this repository. **/
 
 #include "LineScanCamera.h"
 
-#include <QString>
-
 #include "VariableLineScanCameraDetectorMap.h"
 
 namespace Isis {
@@ -28,6 +26,12 @@ namespace Isis {
       virtual int CkFrameId() const;
       virtual int CkReferenceId() const;
       virtual int SpkReferenceId() const;
+
+    private:
+      void ReadLineRates(QString filename);
+
+      std::vector<LineRateChange> p_lineRates; /**< Vector of the variable line rates for this
+                                                    camera model.*/
   };
 };
 

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -1599,7 +1599,7 @@ namespace Isis {
     )");
     PvlObject newWacNkPvl; newWacNk >> newWacNkPvl;
     realWacNk = newWacNkPvl;
-    
+
     double offset = 10;
     AlphaCube aCube(wacFcCube->sampleCount(), wacFcCube->lineCount(),
                     wacFcCube->sampleCount()-offset, wacFcCube->lineCount() - offset,
@@ -1689,5 +1689,28 @@ namespace Isis {
       QFile::copy("data/clipper/ClipperWacPb.cub", testPath);
       testCube = new Cube(testPath, "rw");
     }
+
+    PvlGroup &inst = testCube->label()->findObject("IsisCube").findGroup("Instrument");
+
+    TableField ephTimeField("MinimumRadius", TableField::Double);
+    TableField expTimeField("MaximumRadius", TableField::Double);
+    TableField lineStartField("LineStart", TableField::Integer);
+
+    TableRecord timesRecord;
+    timesRecord += ephTimeField;
+    timesRecord += expTimeField;
+    timesRecord += lineStartField;
+
+    Table timesTable("LineScanTimes", timesRecord);
+
+    timesRecord[0] = 893716269.18552;
+    timesRecord[1] = (double) inst["LineExposureDuration"] / 1000;
+    timesRecord[2] = 1;
+    timesTable += timesRecord;
+
+    testCube->write(timesTable);
+    QString fileName = testCube->fileName();
+    delete testCube;
+    testCube = new Cube(fileName, "rw");
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Updated push broom camera model to use VariableLineScanCameraDetectorMap. Updated fixture with added LineScanTimes Table. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
EIS Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Previous tests are passing(No changes) with the same exposure rate from using LineScanCameraDetectorMap.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
