### PR TITLE
Adds EIS WAC/NAC PB to noproj config

### DIFF
--- a/isis/appdata/templates/noproj/noprojInstruments.pvl
+++ b/isis/appdata/templates/noproj/noprojInstruments.pvl
@@ -6,13 +6,21 @@ Object = IdealInstrumentsSpecifications
 
   # Group name and values will change once stabilized
   Group = "Clipper/EIS-NAC-RS"
-    DetectorSamples = 4000
-    DetectorLines = 2000
+    DetectorSamples = 4096
+    DetectorLines = 2048
   End_Group
 
   Group = "Clipper/EIS-WAC-FC"
-    DetectorSamples = 4000
-    DetectorLines = 2000
+    DetectorSamples = 4096
+    DetectorLines = 2048
+  End_Group
+
+  Group = "Clipper/EIS-WAC-PB"
+    DetectorSamples = 4096
+  End_Group
+
+  Group = "Clipper/EIS-NAC-PB"
+    DetectorSamples = 4096
   End_Group
 
   # Max offset from undistorted to distorted < 1

--- a/isis/src/clipper/objs/ClipperWacFcCamera/ClipperWacFcCamera.cpp
+++ b/isis/src/clipper/objs/ClipperWacFcCamera/ClipperWacFcCamera.cpp
@@ -48,7 +48,7 @@ namespace Isis {
     new CameraDetectorMap(this);
     new CameraFocalPlaneMap(this, naifIkCode());
     CameraFocalPlaneMap *focalMap = new CameraFocalPlaneMap(this, naifIkCode());
-    focalMap->SetDetectorOrigin(2092.5, 1112.5);
+    focalMap->SetDetectorOrigin(2048.5, 1024.5);
     new CameraDistortionMap(this);
     CameraDistortionMap *distMap = new CameraDistortionMap(this);
     distMap->SetDistortion(naifIkCode());


### PR DESCRIPTION
Adds EIS WAC/NAC PB to noproj config

## Description
Adds EIS WAC/NAC PB to noproj config and changes lines/samples for NAC RS / WAC FC

## Related Issue
EIS Sprint

## Motivation and Context
Noproj config was missing cameras / had the wrong number of lines and samples for some cameras
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
