### PR TITLE
Addresses test failures caused by updated data / frame codes

### DIFF
--- a/isis/tests/ClipperWacFcCameraTests.cpp
+++ b/isis/tests/ClipperWacFcCameraTests.cpp
@@ -67,10 +67,10 @@ TEST_F(ClipperWacFcCube, ClipperWacFcCameraUnitTest) {
   // Left
   TestLineSamp(cam, 544, 1024);
 
-  TestImageToGroundToImage(cam, 745, 261, 12.5675574458974923, 97.998866820335223);
-  TestImageToGroundToImage(cam, 3655, 157, -72.978969945309146, 99.874929787292132);
-  TestImageToGroundToImage(cam, 489, 1767, 36.483523069365532, 63.342537568059711);
-  TestImageToGroundToImage(cam, 3767, 1579, -49.080726453081574, 20.804349813352175);
+  TestImageToGroundToImage(cam, 745, 261, 11.208058331735591, 94.210914418320556);
+  TestImageToGroundToImage(cam, 3655, 157, -73.190005076221794, 89.189042140654522);
+  TestImageToGroundToImage(cam, 489, 1767, 35.950887637869364, 60.291146636386621);
+  TestImageToGroundToImage(cam, 3767, 1579, -50.121882340218569, 10.23020799909251);
 
   // Simple test for ClipperWacFcCamera::ShutterOpenCloseTimes
   PvlGroup &inst = wacFcCube->label()->findObject("IsisCube").findGroup("Instrument", Pvl::Traverse);

--- a/isis/tests/FunctionalTestsEis2isis.cpp
+++ b/isis/tests/FunctionalTestsEis2isis.cpp
@@ -63,7 +63,7 @@ TEST(Eis2Isis, Eis2IsisTestNacDefault) {
 
   // Kernels Group
   PvlGroup &kernels = isisLabel->findGroup("Kernels", Pvl::Traverse);
-  ASSERT_EQ(int(kernels["NaifFrameCode"]), -159011 );
+  ASSERT_EQ(int(kernels["NaifFrameCode"]), -159101 );
 
   Histogram *hist = cube.histogram();
 
@@ -129,7 +129,7 @@ TEST(Eis2Isis, Eis2IsisTestNacCheckline)
 
   // Kernels Group
   PvlGroup &kernels = isisLabel->findGroup("Kernels", Pvl::Traverse);
-  ASSERT_EQ(int(kernels["NaifFrameCode"]), -159011 );
+  ASSERT_EQ(int(kernels["NaifFrameCode"]), -159101 );
 
   Histogram *hist = cube.histogram();
 
@@ -137,7 +137,7 @@ TEST(Eis2Isis, Eis2IsisTestNacCheckline)
   ASSERT_NEAR(hist->Sum(), 1.1068e+20, 1e+16);
   ASSERT_EQ(hist->ValidPixels(), 180);
   ASSERT_NEAR(hist->StandardDeviation(),  1.2004e+19, 1e+15);
-  
+
 }
 
 
@@ -208,7 +208,7 @@ TEST(Eis2Isis, Eis2IsisTestWacDefault) {
 
   // Kernels Group
   PvlGroup &kernels = isisLabel->findGroup("Kernels", Pvl::Traverse);
-  ASSERT_EQ(int(kernels["NaifFrameCode"]), -159104 );
+  ASSERT_EQ(int(kernels["NaifFrameCode"]), -159102 );
 
 
   Histogram *hist = cube.histogram();

--- a/isis/tests/FunctionalTestsJitterfit.cpp
+++ b/isis/tests/FunctionalTestsJitterfit.cpp
@@ -123,25 +123,25 @@ TEST_F(TempTestingFiles, FunctionalTestJitterfitDefault){
   EXPECT_DOUBLE_EQ(regLine[0].toDouble(), 471); // Checkline Line
   EXPECT_DOUBLE_EQ(regLine[1].toDouble(), 375); // Checkline Sample
   EXPECT_DOUBLE_EQ(regLine[2].toDouble(), -1); // Checkline Time Taken
-  EXPECT_DOUBLE_EQ(regLine[3].toDouble(), 472.05701420458); // Matched Jittered Image Line
-  EXPECT_DOUBLE_EQ(regLine[4].toDouble(), 376.18491660661); // Matched Jittered Image Sample
-  EXPECT_DOUBLE_EQ(regLine[5].toDouble(), -0.52792617775619); // Matched Jittered image Time Taken
-  EXPECT_DOUBLE_EQ(regLine[6].toDouble(), -1.057014204579); // Delta Line
-  EXPECT_DOUBLE_EQ(regLine[7].toDouble(), -1.1849166066075); // Delta Sample
-  EXPECT_DOUBLE_EQ(regLine[8].toDouble(), 0.98617538549134); // Goodness Of Fit
+  EXPECT_NEAR(regLine[3].toDouble(), 472.05701420458, .00000001); // Matched Jittered Image Line
+  EXPECT_NEAR(regLine[4].toDouble(), 376.18491660661, .00000001); // Matched Jittered Image Sample
+  EXPECT_NEAR(regLine[5].toDouble(), -0.52792617775619, .00000001); // Matched Jittered image Time Taken
+  EXPECT_NEAR(regLine[6].toDouble(), -1.057014204579, .00000001); // Delta Line
+  EXPECT_NEAR(regLine[7].toDouble(), -1.1849166066075, .00000001); // Delta Sample
+  EXPECT_NEAR(regLine[8].toDouble(), 0.98617538549134, .00000001); // Goodness Of Fit
   EXPECT_DOUBLE_EQ(regLine[9].toDouble(), 1); // Registration Success
 
   // middle
   regLine = regCsv.getRow(29);
   EXPECT_DOUBLE_EQ(regLine[0].toDouble(), 1461);
   EXPECT_DOUBLE_EQ(regLine[1].toDouble(), 375);
-  EXPECT_DOUBLE_EQ(regLine[2].toDouble(), -0.016949152542373);
+  EXPECT_NEAR(regLine[2].toDouble(), -0.016949152542373, .00000001);
   EXPECT_DOUBLE_EQ(regLine[3].toDouble(), 1460);
   EXPECT_DOUBLE_EQ(regLine[4].toDouble(), 374);
-  EXPECT_DOUBLE_EQ(regLine[5].toDouble(), 0.46284604176785);
+  EXPECT_NEAR(regLine[5].toDouble(), 0.46284604176785, .00000001);
   EXPECT_DOUBLE_EQ(regLine[6].toDouble(), 1);
   EXPECT_DOUBLE_EQ(regLine[7].toDouble(), 1);
-  EXPECT_DOUBLE_EQ(regLine[8].toDouble(), 0.98756321875905);
+  EXPECT_NEAR(regLine[8].toDouble(), 0.98756321875905, .00000001);
   EXPECT_DOUBLE_EQ(regLine[9].toDouble(), 0);
 
   // Last
@@ -149,12 +149,12 @@ TEST_F(TempTestingFiles, FunctionalTestJitterfitDefault){
   EXPECT_DOUBLE_EQ(regLine[0].toDouble(), 1461);
   EXPECT_DOUBLE_EQ(regLine[1].toDouble(), 375);
   EXPECT_DOUBLE_EQ(regLine[2].toDouble(), 1);
-  EXPECT_DOUBLE_EQ(regLine[3].toDouble(), 1461.1743826668001);
-  EXPECT_DOUBLE_EQ(regLine[4].toDouble(), 374.47660613948);
-  EXPECT_DOUBLE_EQ(regLine[5].toDouble(), 0.46284604176785);
-  EXPECT_DOUBLE_EQ(regLine[6].toDouble(), -0.17438266677323);
-  EXPECT_DOUBLE_EQ(regLine[7].toDouble(), 0.52339386051505998);
-  EXPECT_DOUBLE_EQ(regLine[8].toDouble(), 0.94265790827978002);
+  EXPECT_NEAR(regLine[3].toDouble(), 1461.1743826668001, .00000001);
+  EXPECT_NEAR(regLine[4].toDouble(), 374.47660613948, .00000001);
+  EXPECT_NEAR(regLine[5].toDouble(), 0.46284604176785, .00000001);
+  EXPECT_NEAR(regLine[6].toDouble(), -0.17438266677323, .00000001);
+  EXPECT_NEAR(regLine[7].toDouble(), 0.52339386051505998, .00000001);
+  EXPECT_NEAR(regLine[8].toDouble(), 0.94265790827978002, .00000001);
   EXPECT_DOUBLE_EQ(regLine[9].toDouble(), 1);
 
 


### PR DESCRIPTION
Addresses test failures in clipperwacfc, jitterfit, and eis2isis
## Description
This PR fixes tests that failed due to updated test data.

## Related Issue
EIS sprint

## Motivation and Context
Test failures

## How Has This Been Tested?
ctest

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
