### PR TITLE
Fixed googletest to use TestPreference file

### DIFF
--- a/isis/tests/BundleObservationSolveSettingsTests.cpp
+++ b/isis/tests/BundleObservationSolveSettingsTests.cpp
@@ -608,7 +608,7 @@ TEST(BundleObservationSolveSettings, GroupConstructorBadOverExisting) {
 
 TEST(BundleObservationSolveSettings, PositionStringToOptionBadValue)
 {
-  QString message = "Unknown bundle instrument position solve option foo";
+  QString message = "Unknown bundle instrument position solve option foo.";
 
   try {
     BundleObservationSolveSettings::stringToInstrumentPositionSolveOption(
@@ -625,7 +625,7 @@ TEST(BundleObservationSolveSettings, PositionStringToOptionBadValue)
 
 TEST(BundleObservationSolveSettings, PointingStringToOptionBadValue)
 {
-  QString message = "Unknown bundle instrument pointing solve option foo";
+  QString message = "Unknown bundle instrument pointing solve option foo.";
 
   try {
     BundleObservationSolveSettings::stringToInstrumentPointingSolveOption(

--- a/isis/tests/ColumnTests.cpp
+++ b/isis/tests/ColumnTests.cpp
@@ -132,7 +132,7 @@ TEST(Column, SetWidthError) {
 //Should throw an error when Alignment is Decimal and
 //SetType is called with String or Integer
 TEST_P(TypeError, SetTypeError) {
-  QString message = "Integer or string type is not sensible if alignment is Decimal";
+  QString message = "Integer or string type is not sensible if alignment is Decimal.";
   Column column;
   column.SetAlignment(Column::Decimal);
   try {
@@ -151,7 +151,7 @@ TEST_P(TypeError, SetTypeError) {
 //Should throw an error when Type is String or Integer and
 //SetAllignment is called with Decimal
 TEST_P(TypeError, SetAlignmentError) {
-  QString message = "Decimal alignment does not make sense for integer or string values";
+  QString message = "Decimal alignment does not make sense for integer or string values.";
   Column column;
   column.SetType(GetParam());
   try {

--- a/isis/tests/FunctionalTestsCampt.cpp
+++ b/isis/tests/FunctionalTestsCampt.cpp
@@ -59,11 +59,11 @@ TEST_F(DefaultCube, FunctionalTestCamptFlatFileError) {
     FAIL() << "Expected an exception to be thrown";
   }
   catch(Isis::IException &e) {
-    EXPECT_TRUE(e.toString().toLatin1().contains("Flat file must have a name"))
+    EXPECT_TRUE(e.toString().toLatin1().contains("Flat file must have a name."))
       << e.toString().toStdString();
   }
   catch(...) {
-    FAIL() << "Expected an IException with message: \"Flat file must have a name\"";
+    FAIL() << "Expected an IException with message: \"Flat file must have a name.\"";
   }
 }
 

--- a/isis/tests/IsisTestMain.cpp
+++ b/isis/tests/IsisTestMain.cpp
@@ -1,6 +1,11 @@
 #include <gtest/gtest.h>
+#include "Preference.h"
+
+using namespace Isis;
 
 int main(int argc, char **argv) {
+   Isis::Preference::Preferences(true);
+
    ::testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Googletest was using IsisPreferences file instead of TestPreferences file. This was causing improper test failures when updating IsisPreferences.

NOTE: Not sure if this PR should include a changelog entry. 


## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4586 
#3817 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support Sprint 8/9/21

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Revert changes from #3820 for testing purposes.

Hand tested by modifying IsisPreferences by setting `FileLine = On` and testing the tests that were originally failing to confirm they are now using the TestPreferences file. 

There are slight variations in the IsisPreferences and TestPreferences files so it would be worth checking Jenkins builds to see if this affects any tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
