### PR TITLE
Spice Server Associated Changes

### DIFF
--- a/isis/src/base/apps/spiceinit/SpiceClient.cpp
+++ b/isis/src/base/apps/spiceinit/SpiceClient.cpp
@@ -17,6 +17,7 @@
 #include "IString.h"
 #include "Pvl.h"
 #include "Table.h"
+#include "TextFile.h"
 
 using namespace std;
 using namespace Isis;
@@ -83,6 +84,25 @@ namespace Isis {
     raw += "</input_label>";
 
     *p_xml = QString(QByteArray(raw.toLatin1()).toHex().constData());
+
+    /*
+     * For Debugging, you may want to run spiceserver locally (without spiceinit).
+     *
+     * Uncomment the following code and run the spiceinit with web=true. An error will be thrown
+     * with the file name of the stored input hex file. You can rsync that file to your work area
+     * and run spiceserver locally.
+     */
+
+    // const char *inmode = "overwrite";
+    // const char *ext  = "dat";
+    // TextFile newInput;
+    // QString serverInputFile("/tmp/input");
+    // newInput.Open(serverInputFile, inmode, ext);
+    // newInput.Rewind();//start at begining
+    // newInput.PutLine(hexCode);
+    // newInput.Close();
+    // QString msg = "Exporting expected server input to: " + serverInputFile;
+    // throw IException(IException::Programmer, msg, _FILEINFO_);
 
     int contentLength = p_xml->length();
     QString contentLengthStr = toString((BigInt)contentLength);

--- a/isis/src/base/apps/spiceinit/SpiceClient.h
+++ b/isis/src/base/apps/spiceinit/SpiceClient.h
@@ -24,6 +24,9 @@ namespace Isis {
    * @author ????-??-?? Steven Lambright
    *
    * @internal
+   *   @history 2021-08-10 Adam Paquette - Moved debugging code for spiceserver
+   *                           into SpiceClient to maintain current debugging
+   *                           practices.
    */
   class SpiceClient : public QThread {
       Q_OBJECT

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -684,7 +684,12 @@ namespace Isis {
       log->addGroup(kernelsGroup);
     }
 
-    icube->label()->addObject(naifKeywords);
+    Pvl *icubeLabel = icube->label();
+
+    if (icubeLabel->hasObject(naifKeywords.name())) {
+      icubeLabel->deleteObject(naifKeywords.name());
+    }
+    icubeLabel->addObject(naifKeywords);
 
     icube->write(*pointingTable);
     icube->write(*positionTable);

--- a/isis/src/base/apps/spiceinit/spiceinit.xml
+++ b/isis/src/base/apps/spiceinit/spiceinit.xml
@@ -306,6 +306,10 @@
       Moved writeHistory() call to main function because a history entry was only being written
       to the cube when using a data area for kernels (not using the web service). Fixes #4040.
     </change>
+    <change name="Adam Paquette" date="2021-08-10">
+      Fixed the NaifKeywords PvlObject not being updated/replaced when spiceinit with web=true was
+      run on a cube that was already spiceinit'd.
+    </change>
   </history>
 
   <oldName>

--- a/isis/src/base/apps/spiceserver/spiceserver.cpp
+++ b/isis/src/base/apps/spiceserver/spiceserver.cpp
@@ -79,25 +79,6 @@ namespace Isis {
       // GetLine returns false if it was the last line... so we can't check for problems really
       inFile.GetLine(hexCode);
 
-      /*
-       * For Debugging, you may want to run spiceserver locally (without spiceinit).
-       *
-       * Uncomment the following code and run the spiceinit with web=true. An error will be thrown
-       * with the file name of the stored input hex file. You can rsync that file to your work area
-       * and run spice server locally.
-       */
-      /*
-       * const char *inmode = "overwrite";
-       * const char *ext  = "dat";
-       * TextFile newInput;
-       * newInput.Open(QString("/tmp/spice_web_service/input"), inmode, ext);
-       * newInput.Rewind();//start at begining
-       * newInput.PutLine(hexCode);
-       * newInput.Close();
-       * QString msg = "In: " + ui.GetFileName("FROM") + "   " + ui.GetFileName("TO");
-       * throw IException(IException::Programmer, msg, _FILEINFO_);
-       */
-
       Pvl label;
       label.clear();
       QString otherVersion;

--- a/isis/src/base/apps/spiceserver/spiceserver.xml
+++ b/isis/src/base/apps/spiceserver/spiceserver.xml
@@ -25,15 +25,15 @@ xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Applica
       Original Version
     </change>
     <change name="Debbie A. Cook" date="2012-07-06">
-       Updated Spice members to be more compliant with Isis coding standards. 
+       Updated Spice members to be more compliant with Isis coding standards.
        References #972.
     </change>
     <change name="Steven Lambright" date="2012-09-05">
       Added parameter CHECKVERSION in order to increase the testability of this program.
     </change>
     <change name="Jeannie Backer" date="2013-02-26">
-      Added ability to load multiple ck database files from the system using a 
-      conf file. Changed methods to lower camel case and added "g_" prefix to 
+      Added ability to load multiple ck database files from the system using a
+      conf file. Changed methods to lower camel case and added "g_" prefix to
       global variables to comply with Isis3 standards. References #924.
     </change>
     <change name="Stuart Sides" date="2013-07-11">
@@ -54,6 +54,9 @@ xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Applica
     <change name="Tyler Wilson" date="2019-02-11">
       Modified the version check.  Now all versions of ISIS3 >= 3.5.*.* will be acceptable
       to the application.
+    </change>
+    <change name="Adam Paquette" date="2021-08-10">
+      Removed commented out debugging code that should be run in SpiceClient/spiceinit.
     </change>
   </history>
 
@@ -88,7 +91,7 @@ xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Applica
         <filter>*.dat</filter>
       </parameter>
     </group>
-    
+
     <group name="Options">
       <parameter name="CHECKVERSION">
         <type>boolean</type>
@@ -114,7 +117,7 @@ xsi:noNamespaceSchemaLocation="http://isis.astrogeology.usgs.gov/Schemas/Applica
         </brief>
         <description>
           This parameter was added for testing purposes only. The spice server has access to the
-          default location but the app tests will use their own output directory as the temp cube 
+          default location but the app tests will use their own output directory as the temp cube
           location.
         </description>
         <filter>*.cub</filter>


### PR DESCRIPTION
Updates a few things regarding debugging the `spiceserver` and fixes a small bug when spiceiniting from the web.

## Description
Moves a commented out section of code from the `spiceserver` app to `SpiceClient` and can be accessed when run with `spiceinit from=... web=true`. This is likely where the code should have been and makes debugging slightly less painful.

This PR also addresses a small bug when running with `web=true`, where the `NaifKeywords` PvlObject would not be replaced when run on a cube that has already been spiceinit'd.

## Related Issue
Closes #4044 

## Motivation and Context
Updates the `spiceserver` to something newer than ISIS 3.5.0 and remains backwards compatible to ISIS 3.7.0 (Checked with MRO CTX image)

## How Has This Been Tested?
This PR does not contain the scope of the ticket as the spiceserver hosted under Astro is not properly versioned. I manually tested all minor versions (ISIS X.X.0) of ISIS from ISIS 3.7.0 - 6.0.0-RC1 with an MRO CTX image, all versions tested worked with the new ISIS 5.0.2 server (The newest stable release)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
