### PR TITLE
Reverted alphabetization from PR #4595

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,15 @@ release.
 
 ## [Unreleased]
 
+### Added
+- Added the ability to search filenames in measure's drop down boxes in Qnet Point Editor. [#4581](https://github.com/USGS-Astrogeology/ISIS3/issues/4581)
+
 ## [6.0.0] - 2021-08-27
 
 ### Added
 - Added a new application, isisimport. The application is designed to be a replacement for many of the mission/instrument specific import applications. It does not contain the templates for those applications at this time. It uses a templateing engine instead of the translation files.
 - Added a new dark current correction to hical that works with the higher temperatures recent images are captured at. Use the new config file, $ISISDATA/mro/calibration/hical.0023_darkrate.conf, to enable the new dark current correction over the old dark current correction. Runs of hical without the new dark current correction will also produce an extra line in the output log indicating that the ZeroDarkRate module is disabled. [#4324](https://github.com/USGS-Astrogeology/ISIS3/issues/4324)
 - Added the ability to bundle adjust CSM models in jigsaw. Use the new CSMSOLVESET, CSMSOLVETYPE, and CSMSOLVELIST arguments to specify what you solve for. [#4537](https://github.com/USGS-Astrogeology/ISIS3/pull/4537)
-- Added the ability to search filenames in measure's drop down boxes in Qnet Point Editor. [#4581](https://github.com/USGS-Astrogeology/ISIS3/issues/4581)
 
 ### Changed
 - Added the ability to export footprint information from a CaSSIS ISIS Cube label to the generated output PDS4 label in tgocassisrdrgen. [#4473](https://github.com/USGS-Astrogeology/ISIS3/issues/4473)

--- a/isis/src/qisis/objs/QnetTools/QnetTool.cpp
+++ b/isis/src/qisis/objs/QnetTools/QnetTool.cpp
@@ -2310,21 +2310,6 @@ namespace Isis {
           m_rightCombo->setItemData(i,QFont("DejaVu Sans", 12, QFont::Bold), Qt::FontRole);
       }
     }
-    // sort left and right combo boxes alphabetically
-    QSortFilterProxyModel* leftProxy = new QSortFilterProxyModel(m_leftCombo);
-    QSortFilterProxyModel* rightProxy = new QSortFilterProxyModel(m_rightCombo);
-
-    leftProxy->setSourceModel(m_leftCombo->model());
-    rightProxy->setSourceModel(m_rightCombo->model());
-
-    m_leftCombo->model()->setParent(leftProxy);
-    m_rightCombo->model()->setParent(rightProxy);
-
-    m_leftCombo->setModel(leftProxy);
-    m_rightCombo->setModel(rightProxy);
-
-    m_leftCombo->model()->sort(0);
-    m_rightCombo->model()->sort(0);
 
 
     //  TODO:  WHAT HAPPENS IF THERE IS ONLY ONE MEASURE IN THIS CONTROLPOINT??

--- a/isis/src/qisis/objs/QnetTools/QnetTool.h
+++ b/isis/src/qisis/objs/QnetTools/QnetTool.h
@@ -252,9 +252,9 @@ namespace Isis {
    *                           SurfacePoint::SetRadii. Fixes #5457.
    *   @history 2018-07-06 Jesse Mapel - Removed calls to ControlNet::GetTargetRadii because it is
    *                           both no longer needed and no longer available. Fixes #5457.
-   *   @history 2021-08-12 Amy Stamile - Added the ability to search filenames in measure's drop 
+   *   @history 2021-08-12 Amy Stamile - Added the ability to search filenames in measure's drop
                                down boxes by setting m_leftCombo and m_rightCombo to be editable.
-                               Added alphabetization to these combo boxes. Fixes #4581.
+                               Fixes #4581.
    */
   class QnetTool : public Tool {
     Q_OBJECT


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Automatic alphabetization was added to PR #4595 for Qnet's measure drop down boxes. We discussed in the original issue that this is probably not beneficial in the circumstances of adding a measure to a point. Originally, added measures were placed at the bottom of the list of the drop down box which made it easy to find. The auto alphabetization re-sorted these added measures and were no longer found at the bottom of the list.

There was agreement to instead add another issue regarding the possibility of adding this alphabetizing sort as an option rather than doing it automatically. Therefore, these changes are being reverted. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4581 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
