### PR TITLE
ObliqueDetectorResolution uses local emission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ release.
 synchronized with footprintinit default values of the same parameters.
 This corrects inconsistencies of footprint generation failing in caminfo
 but passing in footprintinit. [#4651](https://github.com/USGS-Astrogeology/ISIS3/issues/4651).
+- Changed the internal logic of ObliqueDataResolution() to use LocalEmission angle rather than Emission angle.
+This will cause differences in output; new values will be more accurate because they use DEM rather than
+ellipsoid. The cost to compute the local emissoin will increase by approximately x1.5. [#3600](https://github.com/USGS-Astrogeology/ISIS3/issues/3600)
 
 ### Added
 - Added the USECAMSTATSTBL option to caminfo. This allows caminfo to extract existing
@@ -77,7 +80,6 @@ Keywords when running CAMSTATS.  [#3605](https://github.com/USGS-Astrogeology/IS
 - isisVarInit.py no longer writes a "cat" statement by default to the activate scripts which cause the ISIS version information to be written on conda activate.  This can be included in those scripts via a command line option to isisVarInit.py.  Also, a quiet option is provided to isisVarInit.py to suppress its own writing to standard out, if needed.
 - Changed how the images.csv file is output in jigsaw when there are multiple models. Now each sensor model will have its own images.csv file so that column headers can all be correct. For example, a solution involving LRONAC pairs and Apollo Metric images would generate three images.csv files: LRONAC Left, LRONAC Right, and Apollo Metric. [#4324](https://github.com/USGS-Astrogeology/ISIS3/issues/4324)
 - Changed the API of many Bundle utility classes as part of CSM support in jigsaw. [#4324](https://github.com/USGS-Astrogeology/ISIS3/issues/4324)
-- Changed the internal logic of ObliqueDataResolution() to use LocalEmission angle rather than Emission angle. This will cause differences in output; new values will be more accurate because they use DEM rather than ellipsoid.
 
 ## [5.0.2] - 2021-07-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Keywords when running CAMSTATS.  [#3605](https://github.com/USGS-Astrogeology/IS
 - isisVarInit.py no longer writes a "cat" statement by default to the activate scripts which cause the ISIS version information to be written on conda activate.  This can be included in those scripts via a command line option to isisVarInit.py.  Also, a quiet option is provided to isisVarInit.py to suppress its own writing to standard out, if needed.
 - Changed how the images.csv file is output in jigsaw when there are multiple models. Now each sensor model will have its own images.csv file so that column headers can all be correct. For example, a solution involving LRONAC pairs and Apollo Metric images would generate three images.csv files: LRONAC Left, LRONAC Right, and Apollo Metric. [#4324](https://github.com/USGS-Astrogeology/ISIS3/issues/4324)
 - Changed the API of many Bundle utility classes as part of CSM support in jigsaw. [#4324](https://github.com/USGS-Astrogeology/ISIS3/issues/4324)
+- Changed the internal logic of ObliqueDataResolution() to use LocalEmission angle rather than Emission angle. This will cause differences in output; new values will be more accurate because they use DEM rather than ellipsoid.
 
 ## [5.0.2] - 2021-07-30
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ for (lbl in labels) {
                             // Gtests
                             stageStatus = "Running gtests on ${label}"
                             try {
-                                loginShell "ctest -R '.' -E '(_app_|_unit_|_module_)' -j${NUM_CORES} --output-on-failure"
+                                loginShell "ctest -R '.' -E '(_app_|_unit_|_module_)' -j${NUM_CORES} --output-on-failure --timeout 10000"
                             } catch(e) {
                                 errors.add(stageStatus)
                                 osFailed = true

--- a/isis/src/base/objs/CSMCamera/CSMCamera.cpp
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.cpp
@@ -391,7 +391,7 @@ namespace Isis {
    *
    * @returns @b double The oblique line resolution in meters per pixel
    */
-  double CSMCamera::ObliqueLineResolution() {
+  double CSMCamera::ObliqueLineResolution(bool useLocal) {
     // CSM resolution is always the oblique resolution so just return it
     return LineResolution();
   }
@@ -406,7 +406,7 @@ namespace Isis {
    *
    * @returns @b double The oblique sample resolution in meters per pixel
    */
-  double CSMCamera::ObliqueSampleResolution() {
+  double CSMCamera::ObliqueSampleResolution(bool useLocal) {
     // CSM resolution is always the oblique resolution so just return it
     return SampleResolution();
   }
@@ -421,7 +421,7 @@ namespace Isis {
    *
    * @returns @b double The oblique detector resolution in meters per pixel
    */
-  double CSMCamera::ObliqueDetectorResolution() {
+  double CSMCamera::ObliqueDetectorResolution(bool useLocal) {
     // CSM resolution is always the oblique resolution so just return it
     return DetectorResolution();
   }

--- a/isis/src/base/objs/CSMCamera/CSMCamera.h
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.h
@@ -87,9 +87,9 @@ namespace Isis {
       virtual double LineResolution();
       virtual double SampleResolution();
       virtual double DetectorResolution();
-      virtual double ObliqueLineResolution();
-      virtual double ObliqueSampleResolution();
-      virtual double ObliqueDetectorResolution();
+      virtual double ObliqueLineResolution(bool useLocal = true);
+      virtual double ObliqueSampleResolution(bool useLocal = true);
+      virtual double ObliqueDetectorResolution(bool useLocal = true);
 
       virtual double parentLine() const;
       virtual double parentSample() const;

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -576,7 +576,7 @@ namespace Isis {
    *
    *   <b>Reference 2:</b>  Handwritten notes by Orrin Thomas which can be found in the
    *                 Glossary under the entry for Oblique Detector Resolution.
-   * 
+   *
    * @param useLocal If true, emission is fetched from LocalPhotometricAngles.
    *                 Otherwise, emission is fetched from EmissionAngle().
    *                 This is an optional parameter that defaults to true,
@@ -586,10 +586,8 @@ namespace Isis {
    */
   double Camera::ObliqueDetectorResolution(bool useLocal) {
 
-    std::cout << "checking intersect" << std::endl;
 
     if(!HasSurfaceIntersection()) {
-      std::cout << "no intersect" << std::endl;
       return Isis::Null;
     }
 
@@ -656,8 +654,8 @@ namespace Isis {
    *
    * @return @b double The sample resolution
    */
-  double Camera::ObliqueSampleResolution() {
-    return ObliqueDetectorResolution() * p_detectorMap->SampleScaleFactor();
+  double Camera::ObliqueSampleResolution(bool useLocal) {
+    return ObliqueDetectorResolution(useLocal) * p_detectorMap->SampleScaleFactor();
   }
 
 
@@ -678,8 +676,8 @@ namespace Isis {
    *
    * @return @b double The line resolution
    */
-  double Camera::ObliqueLineResolution() {
-    return ObliqueDetectorResolution() * p_detectorMap->LineScaleFactor();
+  double Camera::ObliqueLineResolution(bool useLocal) {
+    return ObliqueDetectorResolution(useLocal) * p_detectorMap->LineScaleFactor();
   }
 
 
@@ -702,9 +700,9 @@ namespace Isis {
    *
    * @return @b double The pixel resolution
    */
-  double Camera::ObliquePixelResolution() {
-    double lineRes = ObliqueLineResolution();
-    double sampRes = ObliqueSampleResolution();
+  double Camera::ObliquePixelResolution(bool useLocal) {
+    double lineRes = ObliqueLineResolution(useLocal);
+    double sampRes = ObliqueSampleResolution(useLocal);
     if (lineRes < 0.0) return Isis::Null;
     if (sampRes < 0.0) return Isis::Null;
     return (lineRes + sampRes) / 2.0;

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -586,8 +586,10 @@ namespace Isis {
    */
   double Camera::ObliqueDetectorResolution(bool useLocal) {
 
+    std::cout << "checking intersect" << std::endl;
 
     if(!HasSurfaceIntersection()) {
+      std::cout << "no intersect" << std::endl;
       return Isis::Null;
     }
 
@@ -1669,6 +1671,7 @@ namespace Isis {
     SpiceDouble mag;
     unorm_c(normal,normal,&mag);
     if (mag == 0.) {
+      std::cout << "0 mag" << std::endl;
       success = false;
       return;
     }

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -579,23 +579,36 @@ namespace Isis {
    *
    * @return @b double
    */
-  double Camera::ObliqueDetectorResolution(){
+  double Camera::ObliqueDetectorResolution(bool useLocal) {
 
 
-      if(HasSurfaceIntersection()){
+    if(!HasSurfaceIntersection()) {
+      return -1.0;
+    }
 
-          double thetaRad;
-          thetaRad = EmissionAngle()*DEG2RAD;
+    double thetaRad;
+    double emissionDeg;
 
-          if (thetaRad < HALFPI) {
-            return DetectorResolution()/cos(thetaRad);
+    if(useLocal) {
+      Angle phase, emission, incidence;
+      bool success;
 
-          }
-          return Isis::Null;
+      LocalPhotometricAngles(phase, incidence, emission, success);
+      emissionDeg = (success) ? emission.degrees() : EmissionAngle();
+    }
+    else {
+      emissionDeg = EmissionAngle();
+    }
 
-      }
+    thetaRad = emissionDeg*DEG2RAD;
 
-      return Isis::Null;
+    if (thetaRad < HALFPI) {
+      return DetectorResolution()/cos(thetaRad);
+
+    }
+
+    return -1.0;
+
 
   }
 

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -1669,7 +1669,6 @@ namespace Isis {
     SpiceDouble mag;
     unorm_c(normal,normal,&mag);
     if (mag == 0.) {
-      std::cout << "0 mag" << std::endl;
       success = false;
       return;
     }

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -557,7 +557,7 @@ namespace Isis {
   /**
    * @brief This method returns the Oblique Detector Resolution
    * if the Look Vector intersects the target and if the emission angle is greater than or equal
-   * to 0, and less than 90 degrees.   Otherwise, it returns -1.0.  This formula provides an
+   * to 0, and less than 90 degrees.   Otherwise, it returns Isis::Null.  This formula provides an
    * improved estimate to the detector resolution for images near the limb:
    *
    *
@@ -576,6 +576,11 @@ namespace Isis {
    *
    *   <b>Reference 2:</b>  Handwritten notes by Orrin Thomas which can be found in the
    *                 Glossary under the entry for Oblique Detector Resolution.
+   * 
+   * @param useLocal If true, emission is fetched from LocalPhotometricAngles.
+   *                 Otherwise, emission is fetched from EmissionAngle().
+   *                 This is an optional parameter that defaults to true,
+   *                 because local emission will give more accurate results.
    *
    * @return @b double
    */
@@ -583,7 +588,7 @@ namespace Isis {
 
 
     if(!HasSurfaceIntersection()) {
-      return -1.0;
+      return Isis::Null;
     }
 
     double thetaRad;
@@ -594,7 +599,7 @@ namespace Isis {
       bool success;
 
       LocalPhotometricAngles(phase, incidence, emission, success);
-      emissionDeg = (success) ? emission.degrees() : EmissionAngle();
+      emissionDeg = (success) ? emission.degrees() : Isis::Null;
     }
     else {
       emissionDeg = EmissionAngle();
@@ -607,7 +612,7 @@ namespace Isis {
 
     }
 
-    return -1.0;
+    return Isis::Null;
 
 
   }

--- a/isis/src/base/objs/Camera/Camera.h
+++ b/isis/src/base/objs/Camera/Camera.h
@@ -235,7 +235,7 @@ namespace Isis {
 
   class Camera : public Sensor {
     public:
-      // constructors 
+      // constructors
       Camera(Cube &cube);
 
       // destructor
@@ -279,7 +279,7 @@ namespace Isis {
       virtual double SampleResolution();
       virtual double DetectorResolution();
 
-      virtual double ObliqueDetectorResolution(bool useLocal = true);
+      virtual double ObliqueDetectorResolution(bool useLocal = false);
       virtual double ObliqueSampleResolution();
       virtual double ObliqueLineResolution();
       virtual double ObliquePixelResolution();

--- a/isis/src/base/objs/Camera/Camera.h
+++ b/isis/src/base/objs/Camera/Camera.h
@@ -279,7 +279,7 @@ namespace Isis {
       virtual double SampleResolution();
       virtual double DetectorResolution();
 
-      virtual double ObliqueDetectorResolution(bool useLocal = false);
+      virtual double ObliqueDetectorResolution(bool useLocal = true);
       virtual double ObliqueSampleResolution();
       virtual double ObliqueLineResolution();
       virtual double ObliquePixelResolution();

--- a/isis/src/base/objs/Camera/Camera.h
+++ b/isis/src/base/objs/Camera/Camera.h
@@ -279,7 +279,7 @@ namespace Isis {
       virtual double SampleResolution();
       virtual double DetectorResolution();
 
-      virtual double ObliqueDetectorResolution();
+      virtual double ObliqueDetectorResolution(bool useLocal = true);
       virtual double ObliqueSampleResolution();
       virtual double ObliqueLineResolution();
       virtual double ObliquePixelResolution();

--- a/isis/src/base/objs/Camera/Camera.h
+++ b/isis/src/base/objs/Camera/Camera.h
@@ -280,9 +280,9 @@ namespace Isis {
       virtual double DetectorResolution();
 
       virtual double ObliqueDetectorResolution(bool useLocal = true);
-      virtual double ObliqueSampleResolution();
-      virtual double ObliqueLineResolution();
-      virtual double ObliquePixelResolution();
+      virtual double ObliqueSampleResolution(bool useLocal = true);
+      virtual double ObliqueLineResolution(bool useLocal = true);
+      virtual double ObliquePixelResolution(bool useLocal = true);
 
 
       virtual double resolution();

--- a/isis/src/base/objs/Camera/Camera.truth
+++ b/isis/src/base/objs/Camera/Camera.truth
@@ -84,11 +84,11 @@ GroundRange: 0
 IntersectsLongitudeDomain: 0
 PixelResolution: 628
 ExposureDuration: 0.4
-ObliquePixelResolution: 748
+ObliquePixelResolution: 746
 LineResolution: 628
-ObliqueLineResolution: 748
+ObliqueLineResolution: 746
 SampleResolution: 628
-ObliqueSampleResolution: 748
+ObliqueSampleResolution: 746
 DetectorResolution: 157
 ObliqueDetectorResolution: 187
 LowestImageResolution: 2047

--- a/isis/src/base/objs/CameraPointInfo/CameraPointInfo.truth
+++ b/isis/src/base/objs/CameraPointInfo/CameraPointInfo.truth
@@ -15,10 +15,10 @@ Group = GroundPoint
   LocalRadius                = 1742653.345818 <meters>
   SampleResolution           = 186.88473742666 <meters/pixel>
   LineResolution             = 186.88473742666 <meters/pixel>
-  ObliqueDetectorResolution  = 187.44583818806 <meters>
-  ObliquePixelResolution     = 187.44583818806 <meters/pix>
-  ObliqueLineResolution      = 187.44583818806 <meters>
-  ObliqueSampleResolution    = 187.44583818806 <meters>
+  ObliqueDetectorResolution  = 190.4516366997 <meters>
+  ObliquePixelResolution     = 190.4516366997 <meters/pix>
+  ObliqueLineResolution      = 190.4516366997 <meters>
+  ObliqueSampleResolution    = 190.4516366997 <meters>
 
   # Spacecraft Information
   SpacecraftPosition         = (216.77599432924, 54.260221515165,
@@ -78,10 +78,10 @@ Group = GroundPoint
   LocalRadius                = 1738477.7500095 <meters>
   SampleResolution           = 187.58212566559 <meters/pixel>
   LineResolution             = 187.58212566559 <meters/pixel>
-  ObliqueDetectorResolution  = 187.61662252249 <meters>
-  ObliquePixelResolution     = 187.61662252249 <meters/pix>
-  ObliqueLineResolution      = 187.61662252249 <meters>
-  ObliqueSampleResolution    = 187.61662252249 <meters>
+  ObliqueDetectorResolution  = 190.29281394228 <meters>
+  ObliquePixelResolution     = 190.29281394228 <meters/pix>
+  ObliqueLineResolution      = 190.29281394228 <meters>
+  ObliqueSampleResolution    = 190.29281394228 <meters>
 
   # Spacecraft Information
   SpacecraftPosition         = (216.77599432924, 54.260221515165,

--- a/isis/tests/CameraTests.cpp
+++ b/isis/tests/CameraTests.cpp
@@ -1,0 +1,39 @@
+#include <iostream>
+#include <QTemporaryFile>
+
+
+#include "Cube.h"
+#include "CubeAttribute.h"
+#include "IException.h"
+#include "PixelType.h"
+#include "Pvl.h"
+#include "PvlGroup.h"
+#include "PvlKeyword.h"
+#include "TestUtilities.h"
+#include "FileName.h"
+#include "Camera.h"
+#include "Fixtures.h"
+
+using namespace Isis;
+
+TEST_F(DemCube, CameraObliqueResolution) {
+
+    Camera *c = NULL;
+    c = testCube->camera();
+
+    c->SetImage(1, 1);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.2435, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.2435, 1e-4);
+
+    c->SetImage(1, 1055);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.7497, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.7497, 1e-4);
+
+    c->SetImage(1203, 1055);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.8820, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.8820, 1e-4);
+
+    c->SetImage(1203, 1);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.3449, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.3449, 1e-4);
+}

--- a/isis/tests/CameraTests.cpp
+++ b/isis/tests/CameraTests.cpp
@@ -22,18 +22,18 @@ TEST_F(DemCube, CameraObliqueResolution) {
     c = testCube->camera();
 
     c->SetImage(1, 1);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.1806, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.2435, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.1806, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.2435, 1e-4);
 
     c->SetImage(1, 1055);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.4278, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.7497, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.4278, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.7497, 1e-4);
 
     c->SetImage(1203, 1055);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.5252, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.8820, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.5252, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.8820, 1e-4);
 
     c->SetImage(1203, 1);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.2788, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.3449, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.2788, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.3449, 1e-4);
 }

--- a/isis/tests/CameraTests.cpp
+++ b/isis/tests/CameraTests.cpp
@@ -22,18 +22,18 @@ TEST_F(DemCube, CameraObliqueResolution) {
     c = testCube->camera();
 
     c->SetImage(1, 1);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.2435, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.2435, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.1806, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.2435, 1e-4);
 
     c->SetImage(1, 1055);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.7497, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.7497, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.4278, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.7497, 1e-4);
 
     c->SetImage(1203, 1055);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.8820, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.8820, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.5252, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.8820, 1e-4);
 
     c->SetImage(1203, 1);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.3449, 1e-4);
-    EXPECT_NEAR(c->ObliqueDetectorResolution(false), 19.3449, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(), 19.2788, 1e-4);
+    EXPECT_NEAR(c->ObliqueDetectorResolution(true), 19.3449, 1e-4);
 }

--- a/isis/tests/FunctionalTestsCaminfo.cpp
+++ b/isis/tests/FunctionalTestsCaminfo.cpp
@@ -212,18 +212,18 @@ TEST_F(DefaultCube, FunctionalTestCaminfoDefault) {
     EXPECT_NEAR(camstats.findKeyword("ResolutionMaximum"), 18.985953877822, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("ResolutionAverage"), 18.90816559308, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("ResolutionStandardDeviation"), 0.038060007171614, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMinimum"), 19.180671135452, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMaximum"), 19.525658668048, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionAverage"), 19.342626220123, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionStandardDeviation"), 0.078013435023742, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMinimum"), 19.180671135452, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMaximum"), 19.525658668048, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionAverage"), 19.342626220123, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionStandardDeviation"), 0.078013435023742, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMinimum"), 19.180671135452, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMaximum"), 19.525658668048, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionAverage"), 19.342626220123, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionStandardDeviation"), 0.078013435023742, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMinimum"), 18.967781671350998, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMaximum"), 21.179434547755999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionAverage"), 19.550786846366002, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionStandardDeviation"), 0.21126188466418, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMinimum"), 18.967781671350998, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMaximum"), 21.179434547755999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionAverage"), 19.550786846366002, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionStandardDeviation"), 0.21126188466418, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMinimum"), 18.967781671350998, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMaximum"), 21.179434547755999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionAverage"), 19.550786846366002, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionStandardDeviation"), 0.21126188466418, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("AspectRatioMinimum"), 1.0, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("AspectRatioAverage"), 1.0, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("AspectRatioStandardDeviation"), 0.0, 0.001 );
@@ -231,14 +231,14 @@ TEST_F(DefaultCube, FunctionalTestCaminfoDefault) {
     EXPECT_NEAR(camstats.findKeyword("PhaseMaximum"), 81.304900313013, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("PhaseAverage"), 80.529097153288, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("PhaseStandardDeviation"), 0.44420861263609, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionMinimum"), 10.798462835458, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionMaximum"), 13.502630463571, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionAverage"), 12.15148695101, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionStandardDeviation"), 0.56543791358689, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceMinimum"), 69.941096124192, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceMaximum"), 70.311944975377, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceAverage"), 70.127459134075, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceStandardDeviation"), 0.10249039125851, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionMinimum"), 6.5875955784639002, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionMaximum"), 26.933702102375999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionAverage"), 14.577804851994999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionStandardDeviation"), 1.9856896435092, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceMinimum"), 53.332095294516002, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceMaximum"), 73.850710962080996, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceAverage"), 66.178552657137004, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceStandardDeviation"), 1.7434735102028001, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalSolarTimeMinimum"), 7.7698055422189, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalSolarTimeMaximum"), 7.8031735959943, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalSolarTimeAverage"), 7.7863626216564, 0.001 );
@@ -322,10 +322,10 @@ TEST_F(DefaultCube, FunctionalTestCaminfoDefault) {
     EXPECT_EQ(geometry.findKeyword("HasLongitudeBoundary")[0].toStdString(), "FALSE");
     EXPECT_EQ(geometry.findKeyword("HasNorthPole")[0].toStdString(), "FALSE");
     EXPECT_EQ(geometry.findKeyword("HasSouthPole")[0].toStdString(), "FALSE");
-    EXPECT_NEAR(geometry.findKeyword("ObliqueSampleResolution"), 19.336214228383, 0.0001);
-    EXPECT_NEAR(geometry.findKeyword("ObliqueLineResolution"), 19.336214228383, 0.0001);
-    EXPECT_NEAR(geometry.findKeyword("ObliquePixelResolution"), 19.336214228383, 0.0001);
-    EXPECT_NEAR(geometry.findKeyword("ObliqueDetectorResolution"), 19.336214228383, 0.0001);
+    EXPECT_NEAR(geometry.findKeyword("ObliqueSampleResolution"), 19.589652452595999, 0.0001);
+    EXPECT_NEAR(geometry.findKeyword("ObliqueLineResolution"), 19.589652452595999, 0.0001);
+    EXPECT_NEAR(geometry.findKeyword("ObliquePixelResolution"), 19.589652452595999, 0.0001);
+    EXPECT_NEAR(geometry.findKeyword("ObliqueDetectorResolution"), 19.589652452595999, 0.0001);
 }
 
 
@@ -398,10 +398,10 @@ TEST_F(DefaultCube, FunctionalTestCaminfoBoundary) {
     EXPECT_NEAR(camstats.findKeyword("ResolutionMaximum"), 18.985953877821999, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("PhaseMinimum"), 79.756145388578005, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("PhaseMaximum"), 81.304900313013, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionMinimum"), 10.798462835458, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionMaximum"), 13.502630463571, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceMinimum"), 69.941096124192, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceMaximum"), 70.311944975377, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionMinimum"), 7.4919183637178, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionMaximum"), 21.091782435858001, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceMinimum"), 60.113879909235997, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceMaximum"), 72.470329236867997, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalSolarTimeMinimum"), 7.7698055422189, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalSolarTimeMaximum"), 7.8031735959943, 0.001 );
 }
@@ -468,14 +468,14 @@ TEST_F(DefaultCube, FunctionalTestCaminfoCamStatsTable) {
     EXPECT_NEAR(camstats.findKeyword("MaximumResolution"), 18.985953877821999, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("MinimumPhase"), 79.756145388578005, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("MaximumPhase"), 81.304900313013, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("MinimumEmission"), 10.798462835458, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("MaximumEmission"), 13.502630463571, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("MinimumIncidence"), 69.941096124192, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("MaximumIncidence"), 70.311944975377, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("MinimumEmission"), 9.8943199851049997, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("MaximumEmission"), 19.639762075680999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("MinimumIncidence"), 61.658112222808001, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("MaximumIncidence"), 71.417244415552005, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalTimeMinimum"), 7.7698055422189, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalTimeMaximum"), 7.8031735959943, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMinimum"), 19.180671135452, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMaximum"), 19.525658668048, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMinimum"), 19.183652922680999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMaximum"), 20.152531403933999, 0.001 );
 
     EXPECT_NEAR(camstats.findKeyword("LatitudeMinimum"), 9.9286479874788, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LatitudeMaximum"), 10.434709753119, 0.001 );
@@ -502,20 +502,20 @@ TEST_F(DefaultCube, FunctionalTestCaminfoCamStatsTable) {
     EXPECT_NEAR(camstats.findKeyword("ResolutionAverage"), 18.911994840355, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("ResolutionStandardDeviation"), 0.042469580108781, 0.001 );
 
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMinimum"), 19.180671135452, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMaximum"), 19.525658668048, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionAverage"), 19.351980481534, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionStandardDeviation"), 0.087529228348495, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMinimum"), 19.183652922680999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionMaximum"), 20.152531403933999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionAverage"), 19.559780980294999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueSampleResolutionStandardDeviation"), 0.21057982709442, 0.001 );
 
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMinimum"), 19.180671135452, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMaximum"), 19.525658668048, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionAverage"), 19.351980481534, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionStandardDeviation"), 0.087529228348495, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMinimum"), 19.183652922680999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionMaximum"), 20.152531403933999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionAverage"), 19.559780980294999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueLineResolutionStandardDeviation"), 0.21057982709442, 0.001 );
 
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMinimum"), 19.180671135452, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMaximum"), 19.525658668048, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionAverage"), 19.351980481534, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionStandardDeviation"), 0.087529228348495, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMinimum"), 19.183652922680999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionMaximum"), 20.152531403933999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionAverage"), 19.559780980294999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("ObliqueResolutionStandardDeviation"), 0.21057982709442, 0.001 );
 
     EXPECT_NEAR(camstats.findKeyword("AspectRatioMinimum"), 1.0, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("AspectRatioMaximum"), 1.0, 0.001 );
@@ -527,15 +527,15 @@ TEST_F(DefaultCube, FunctionalTestCaminfoCamStatsTable) {
     EXPECT_NEAR(camstats.findKeyword("PhaseAngleAverage"), 80.556249549336, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("PhaseAngleStandardDeviation"), 0.496128069014, 0.001 );
 
-    EXPECT_NEAR(camstats.findKeyword("EmissionAngleMinimum"), 10.798462835458, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionAngleMaximum"), 13.502630463571, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionAngleAverage"), 12.222241624466, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("EmissionAngleStandardDeviation"), 0.63393199155819, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionAngleMinimum"), 9.8943199851049997, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionAngleMaximum"), 19.639762075680999, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionAngleAverage"), 14.638344628861001, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("EmissionAngleStandardDeviation"), 1.9665305080041, 0.001 );
 
-    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleMinimum"), 69.941096124192, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleMaximum"), 70.311944975377, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleAverage"), 70.121640864056, 0.001 );
-    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleStandardDeviation"), 0.1144744474437, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleMinimum"), 61.658112222808001, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleMaximum"), 71.417244415552005, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleAverage"), 66.194841491336007, 0.001 );
+    EXPECT_NEAR(camstats.findKeyword("IncidenceAngleStandardDeviation"), 1.7313642198304, 0.001 );
 
     EXPECT_NEAR(camstats.findKeyword("LocalSolarTimeMinimum"), 7.7698055422189, 0.001 );
     EXPECT_NEAR(camstats.findKeyword("LocalSolarTimeMaximum"), 7.8031735959943, 0.001 );

--- a/isis/tests/FunctionalTestsCampt.cpp
+++ b/isis/tests/FunctionalTestsCampt.cpp
@@ -94,10 +94,10 @@ TEST_F(DefaultCube, FunctionalTestCamptDefaultParameters) {
   EXPECT_NEAR( (double) groundPoint.findKeyword("LocalRadius"), 3412288.6569795, 1e-8);
   EXPECT_NEAR( (double) groundPoint.findKeyword("SampleResolution"), 18.904248467739, 1e-8);
   EXPECT_NEAR( (double) groundPoint.findKeyword("LineResolution"), 18.904248467739, 1e-8);
-  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliqueDetectorResolution"), 19.336214219327, 1e-8);
-  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliquePixelResolution"), 19.336214219327, 1e-8);
-  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliqueLineResolution"), 19.336214219327, 1e-8);
-  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliqueSampleResolution"), 19.336214219327, 1e-8);
+  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliqueDetectorResolution"), 19.589652452595999, 1e-8);
+  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliquePixelResolution"), 19.589652452595999, 1e-8);
+  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliqueLineResolution"), 19.589652452595999, 1e-8);
+  EXPECT_NEAR( (double) groundPoint.findKeyword("ObliqueSampleResolution"), 19.589652452595999, 1e-8);
 
   EXPECT_NEAR( toDouble(groundPoint.findKeyword("SpacecraftPosition")[0]), -1152.8979327717, 1e-8);
   EXPECT_NEAR( toDouble(groundPoint.findKeyword("SpacecraftPosition")[1]), -3930.9421518203, 1e-8);

--- a/isis/tests/FunctionalTestsCamstats.cpp
+++ b/isis/tests/FunctionalTestsCamstats.cpp
@@ -55,22 +55,22 @@ TEST_F(DefaultCube, FunctionalTestCamstatsDefaultParameters) {
   EXPECT_NEAR( (double) group.findKeyword("ResolutionStandardDeviation"), 0.038060007, 1e-8);
 
   group = appLog.findGroup("ObliqueSampleResolution");
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionMinimum"), 19.180671135, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionMaximum"), 19.525658668, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionAverage"), 19.342626220, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionStandardDeviation"), 0.078013435, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionMinimum"), 18.967781671350998, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionMaximum"), 21.179434547755999, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionAverage"), 19.550786846366002, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueSampleResolutionStandardDeviation"), 0.21126188466418, 1e-8);
 
   group = appLog.findGroup("ObliqueLineResolution");
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionMinimum"), 19.180671135, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionMaximum"), 19.525658668, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionAverage"), 19.342626220, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionStandardDeviation"), 0.078013435, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionMinimum"), 18.967781671350998, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionMaximum"), 21.179434547755999, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionAverage"), 19.550786846366002, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueLineResolutionStandardDeviation"), 0.21126188466418, 1e-8);
 
   group = appLog.findGroup("ObliqueResolution");
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionMinimum"), 19.180671135, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionMaximum"), 19.525658668, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionAverage"), 19.342626220, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionStandardDeviation"), 0.078013435, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionMinimum"), 18.967781671350998, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionMaximum"), 21.179434547755999, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionAverage"), 19.550786846366002, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("ObliqueResolutionStandardDeviation"), 0.21126188466418, 1e-8);
 
   group = appLog.findGroup("AspectRatio");
   EXPECT_DOUBLE_EQ( (double) group.findKeyword("AspectRatioMinimum"), 1.0);
@@ -86,16 +86,16 @@ TEST_F(DefaultCube, FunctionalTestCamstatsDefaultParameters) {
   EXPECT_NEAR( (double) group.findKeyword("PhaseStandardDeviation"), 0.444208612, 1e-8);
 
   group = appLog.findGroup("EmissionAngle");
-  EXPECT_NEAR( (double) group.findKeyword("EmissionMinimum"), 10.798462835, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("EmissionMaximum"), 13.502630463, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("EmissionAverage"), 12.15148695101, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("EmissionStandardDeviation"), 0.565437913, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("EmissionMinimum"), 6.5875955784639002, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("EmissionMaximum"), 26.933702102375999, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("EmissionAverage"), 14.577804851994999, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("EmissionStandardDeviation"), 1.9856896435092, 1e-8);
 
   group = appLog.findGroup("IncidenceAngle");
-  EXPECT_NEAR( (double) group.findKeyword("IncidenceMinimum"), 69.941096124, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("IncidenceMaximum"), 70.311944975, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("IncidenceAverage"), 70.127459134, 1e-8);
-  EXPECT_NEAR( (double) group.findKeyword("IncidenceStandardDeviation"), 0.102490391, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("IncidenceMinimum"), 53.332095294516002, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("IncidenceMaximum"), 73.850710962080996, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("IncidenceAverage"), 66.178552657137004, 1e-8);
+  EXPECT_NEAR( (double) group.findKeyword("IncidenceStandardDeviation"), 1.7434735102028001, 1e-8);
 
   group = appLog.findGroup("LocalSolarTime");
   EXPECT_NEAR( (double) group.findKeyword("LocalSolarTimeMinimum"), 7.7698055422, 1e-8);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I believe these are the basic changes described by the issue. If I'm not mistaken, this should cause a number of tests to fail, so truth data will need to be updated. This PR could also use a test for the "new" ObliqueDetectorResolution vs the old.
Work in Progress.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3600 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
