### PR TITLE
Automate a cherrypick PR into the latest feature branch

### DIFF
--- a/.github/workflows/autopr_bugfix.yml
+++ b/.github/workflows/autopr_bugfix.yml
@@ -37,13 +37,13 @@ jobs:
       uses: "WyriHaximus/github-action-get-previous-tag@v1"
     - id: get_short_version
       run: |
-	# Get the major / minor version without patch info i.e. 6.0 from 6.0.1
+        # Get the major / minor version without patch info i.e. 6.0 from 6.0.1
         major_minor=$(echo ${{steps.get_latest_tag.outputs.tag}} | cut -d '.' -f 1,2)
         echo "::set-output name=major_minor::$major_minor"
     - name: Create PR to branch
       uses: adamtharani/github-action-cherry-pick@master
       with:
-	# PR to the latest feature release.  Merges are enabled
+        # PR to the latest feature release.  Merges are enabled
         pr_branch: ${{steps.get_short_version.outputs.major_minor}}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/autopr_bugfix.yml
+++ b/.github/workflows/autopr_bugfix.yml
@@ -36,16 +36,16 @@ jobs:
       id: get_latest_tag
       uses: "WyriHaximus/github-action-get-previous-tag@v1"
     - id: get_short_version
+      # Get the major / minor version without patch info i.e. 6.0 from 6.0.1
       run: |
-        # Get the major / minor version without patch info i.e. 6.0 from 6.0.1
         major_minor=$(echo ${{steps.get_latest_tag.outputs.tag}} | cut -d '.' -f 1,2)
         echo "::set-output name=major_minor::$major_minor"
     - name: Create PR to branch
       uses: adamtharani/github-action-cherry-pick@master
+      # PR to the latest feature release.  Merges are enabled
       with:
-        # PR to the latest feature release.  Merges are enabled
         pr_branch: ${{steps.get_short_version.outputs.major_minor}}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DRY_RUN: false
+        DRY_RUN: true
 

--- a/.github/workflows/autopr_bugfix.yml
+++ b/.github/workflows/autopr_bugfix.yml
@@ -1,0 +1,44 @@
+name: Cherrypick bugfixes to release branch
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  check_labels:
+    runs-on: ubuntu-latest
+    name: Check PR labels action step
+    outputs: 
+      result: ${{steps.check_pr_labels.outputs.result}}
+    steps:
+    - id: check_pr_labels
+      uses: 3pointer/check-pr-labels-on-push-action@v1.0.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        labels: '["bug"]'
+    - name: See result
+      run: echo "${{ steps.check_pr_labels.outputs.result }}"
+  release_pull_request:
+    needs: check_labels
+    if: contains(needs.check_labels.outputs.result, 'true')
+    runs-on: ubuntu-latest
+    name: release_pull_request
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2.2.0
+      with:
+        fetch-depth: 0
+    - name: 'Get Previous tag'
+      id: get_latest_tag
+      uses: "WyriHaximus/github-action-get-previous-tag@v1"
+    - id: get_short_version
+      run: |
+        major_minor=$(echo ${{steps.get_latest_tag.outputs.tag}} | cut -d '.' -f 1,2)
+        echo "::set-output name=major_minor::$major_minor"
+    - name: Create PR to branch
+      uses: adamtharani/github-action-cherry-pick@master
+      with:
+        pr_branch: ${{steps.get_short_version.outputs.major_minor}}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        DRY_RUN: false
+

--- a/.github/workflows/autopr_bugfix.yml
+++ b/.github/workflows/autopr_bugfix.yml
@@ -4,9 +4,11 @@ on:
     branches:
       - dev
 jobs:
+  # Check if the PR is a bugfix
   check_labels:
     runs-on: ubuntu-latest
     name: Check PR labels action step
+    # Make the output of this job available to other jobs
     outputs: 
       result: ${{steps.check_pr_labels.outputs.result}}
     steps:
@@ -15,16 +17,19 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         labels: '["bug"]'
+    # Print the result to the log
     - name: See result
       run: echo "${{ steps.check_pr_labels.outputs.result }}"
   release_pull_request:
     needs: check_labels
+    # Only run this step if the code was a bugfix
     if: contains(needs.check_labels.outputs.result, 'true')
     runs-on: ubuntu-latest
     name: release_pull_request
     steps:
     - name: checkout
       uses: actions/checkout@v2.2.0
+      # Fetch all info including branches + tags
       with:
         fetch-depth: 0
     - name: 'Get Previous tag'
@@ -32,11 +37,13 @@ jobs:
       uses: "WyriHaximus/github-action-get-previous-tag@v1"
     - id: get_short_version
       run: |
+	# Get the major / minor version without patch info i.e. 6.0 from 6.0.1
         major_minor=$(echo ${{steps.get_latest_tag.outputs.tag}} | cut -d '.' -f 1,2)
         echo "::set-output name=major_minor::$major_minor"
     - name: Create PR to branch
       uses: adamtharani/github-action-cherry-pick@master
       with:
+	# PR to the latest feature release.  Merges are enabled
         pr_branch: ${{steps.get_short_version.outputs.major_minor}}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Automate a cherrypick PR into the latest feature branch when a bugfix PR is merged.

## Description
This PR creates a github action that will automatically create a PR into the latest feature branch when a bugfix PR is merged into dev.  This relies on the PR being labeled with "bug," but the specific label is configurable via line 19 of the .yml file.

As written, this will target the feature branch based on the major/minor version that is part of the most recent tag, so if we have a tagged version 6.0.1, then this will attempt to PR into a branch called 6.0   .  When we tag a 6.1.0 release, we'll also have to have a 6.1 branch.

## Related Issue
Software management [91](https://github.com/USGS-Astrogeology/softwaremanagement/issues/91)

## Motivation and Context
Manually cherry picking bugfix commits is tedious and error prone.  This should alleviate the process by automating part of the process.

## How Has This Been Tested?
Tested in separate fork under three conditions:

1.  Pushed directly to dev.  This **did not** result in a PR to feature branch, because PRs should only come from other PRs.  This case is uncommon (if no prohibited) in our system.
2. Created a PR labeled "bug."  This resulted in a PR to 6.0.
3. Created a PR not labeled "bug."  This **did not** result in a PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
