### PR TITLE
GEOS: Remove some deletes, add some comments

### DIFF
--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
@@ -295,6 +295,9 @@ namespace Isis {
     }
 
     std::vector<geos::geom::Geometry *> *polys = new std::vector<geos::geom::Geometry *>;
+
+    // Do we lose ownership of global p_pts here?
+    // Could cause problems
     geos::geom::Polygon *poly = globalFactory->createPolygon(globalFactory->createLinearRing(p_pts), nullptr);
     polys->push_back(poly->clone().release());
     // createMultiPolygon takes ownership of polys argument
@@ -1323,11 +1326,11 @@ namespace Isis {
       std::cout << "F 2==========" << std::endl;
       delete newGeom;
       std::cout << "F 3==========" << std::endl;
-      delete newLonLatPts;
+      // delete newLonLatPts;
       std::cout << "F 4==========" << std::endl;
-      delete pts;
+      // delete pts;
       std::cout << "F 5==========" << std::endl;
-      delete pts2;
+      // delete pts2;
       std::cout << "F 6==========" << std::endl;
     }
     catch(geos::util::IllegalArgumentException *geosIll) {

--- a/isis/src/base/objs/PolygonTools/PolygonTools.cpp
+++ b/isis/src/base/objs/PolygonTools/PolygonTools.cpp
@@ -280,7 +280,7 @@ namespace Isis {
                                                  ugm->Line()));
           } // end num coords in hole loop
           holes->push_back(globalFactory->createLinearRing(slcoords));
-          delete slcoords;
+          // delete slcoords;
           delete llcoords;
         } // end num holes in polygon loop
 
@@ -822,13 +822,14 @@ namespace Isis {
       }
 
       // Test the middle point for a spike
+      // IsSpiked takes ownership of these inputs
       if(IsSpiked(vertices->getAt(testCoords[0]),
                   vertices->getAt(testCoords[1]),
                   vertices->getAt(testCoords[2]))) {
         // It's spiked, delete it
         std::vector<geos::geom::Coordinate> coords;
         vertices->toVector(coords);
-        coords.erase(coords.begin()+testCoords[1]);
+        coords.erase(coords.begin()+testCoords[1]); // testCoords[1] destructor called here without ownership
         vertices->setPoints(coords);
 
         // Back up to the first test that is affected by this change
@@ -894,6 +895,7 @@ namespace Isis {
    */
   bool PolygonTools::TestSpiked(geos::geom::Coordinate first, geos::geom::Coordinate middle,
                                 geos::geom::Coordinate last) {
+    // globalFactory takes ownership of function inputs
     geos::geom::Point *firstPt = Isis::globalFactory->createPoint(first);
     geos::geom::Point *middlePt = Isis::globalFactory->createPoint(middle);
     geos::geom::Point *lastPt = Isis::globalFactory->createPoint(last);
@@ -951,7 +953,7 @@ namespace Isis {
       delete poly;
     }
 
-
+    // TODO are these owned by libgeos now?
     delete firstPt;
     delete middlePt;
     delete lastPt;
@@ -2067,7 +2069,7 @@ namespace Isis {
       geos::geom::Polygon *newPoly = globalFactory->createPolygon
                                      (globalFactory->createLinearRing(newLonLatPts), NULL);
       geos::geom::MultiPolygon *multi_polygon = PolygonTools::MakeMultiPolygon(newPoly);
-      delete newLonLatPts;
+      // delete newLonLatPts;
       return multi_polygon;
     }
 
@@ -2162,9 +2164,9 @@ namespace Isis {
             lon = lon - 360;
           }
           newLonLatPts->add(geos::geom::Coordinate(lon, lat), k);
-
-          delete pts3;
         }
+        delete pts3;
+
         // Add the points to polys
         finalpolys->push_back(globalFactory->createPolygon
                               (globalFactory->createLinearRing(newLonLatPts), NULL));
@@ -2178,11 +2180,11 @@ namespace Isis {
 
       geos::geom::MultiPolygon *multi_polygon = globalFactory->createMultiPolygon(finalpolys);
 
-      delete finalpolys;
+      // delete finalpolys;
       delete newGeom;
-      delete newLonLatPts;
-      delete pts;
-      delete pts2;
+      // delete newLonLatPts;
+      // delete pts;
+      // delete pts2;
       return multi_polygon;
     }
     catch(geos::util::IllegalArgumentException *geosIll) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Address a number of problems that may be causing memory issues.

The main problem addressed: when we give a pointer to globalFactory, we lose ownership. Wherever I found them, I removed the deletion of these pointers in our code.

I left comments in places where I'm unsure about the impact of handing a pointer over to globalFactory.

In my testing, this PR does not solve any failures.


## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
