### PR TITLE
Added deprecation notice to edrget + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ release.
 ### Added
 - Added the ability to search filenames in measure's drop down boxes in Qnet Point Editor. [#4581](https://github.com/USGS-Astrogeology/ISIS3/issues/4581)
 - Added slope, local normal, and ellipsoid normal calculations to phocube. [#3635](https://github.com/USGS-Astrogeology/ISIS3/issues/3645)
+- Added additional translation files for TGO CaSSiS in order to support PSA compliant labels. [#4567](https://github.com/USGS-Astrogeology/ISIS3/issues/4567)
+
+### Deprecated
+- Deprecated edrget as discussed in [#3313](https://github.com/USGS-Astrogeology/ISIS3/issues/3313).
 
 ## [6.0.0] - 2021-08-27
 

--- a/isis/src/base/apps/edrget/main.cpp
+++ b/isis/src/base/apps/edrget/main.cpp
@@ -14,6 +14,12 @@ using namespace Isis;
 using namespace std;
 
 void IsisMain() {
+  std::cout << "\n*********************************** WARNING ***********************************\n"
+    " This program is deprecated and will be made unavailable in a future release of\n"
+    " ISIS.  A brief discussion that lead to this decision can be found at          \n"
+    " https://github.com/USGS-Astrogeology/ISIS3/issues/3313.  Users who require    \n"
+    " similar functionality are encouraged to explore wget as a replacement.        \n"
+    "*******************************************************************************\n" << '\n';
 
   // Get the file name from the GUI
   int timeOut = 60000;
@@ -33,7 +39,7 @@ void IsisMain() {
   QUrl qurl(guiURL);
 
   //test if scheme is ftp or http
-  if (qurl.scheme().toLower() == "ftp" || qurl.scheme().toLower() == "http" || 
+  if (qurl.scheme().toLower() == "ftp" || qurl.scheme().toLower() == "http" ||
       qurl.scheme().toLower() == "https") {
 
     if (ui.IsInteractive()) {


### PR DESCRIPTION
Added deprecation notice to edrget + changelog

## Description
Added deprecation notice to edrget + changelog.  In order to close the edrget deprecation issue, we also need to add a section in the release process (in wiki).

Looks like my previous changelog edit also sneaked into this PR.  It should be included in the changelog anyway...

## Related Issue
#3313 

## Motivation and Context
edrget does not provide functionality beyond that of wget

## How Has This Been Tested?
edrget now produces a deprecation warning when it is run

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
