### PR TITLE
Switch to single quotes in 'Environment and Preference Setup' error

### DIFF
--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -457,7 +457,7 @@ namespace Isis {
                "wish to create this cube, the maximum value can be changed in your personal "
                "preference file located in [~/.Isis/IsisPreferences] within the group "
                "CubeCustomization, keyword MaximumSize. If you do not have an ISISPreference file, "
-               "please refer to the documentation \"Environment and Preference Setup\". Error ";
+               "please refer to the documentation 'Environment and Preference Setup'. Error ";
         throw IException(IException::User, msg, _FILEINFO_);
       }
     }

--- a/isis/src/base/objs/Cube/Cube.h
+++ b/isis/src/base/objs/Cube/Cube.h
@@ -163,6 +163,7 @@ namespace Isis {
    *   @history 2018-11-16 Jesse Mapel - Made several methods virtual for mocking.
    *   @history 2019-06-15 Kristin Berry - Added latLonRange method to return the valid lat/lon rage of the cube. The values in the mapping group are not sufficiently accurate for some purposes.
    *   @history 2021-02-17 Jesse Mapel - Added hasBlob method to check for any type of BLOB.
+   *   @history 2021-10-18 Evin Dunn - Switch to single quotes for 'Environment and Preferences' in Cube::create() exception
    */
   class Cube {
     public:

--- a/isis/src/base/objs/Cube/Cube.truth
+++ b/isis/src/base/objs/Cube/Cube.truth
@@ -271,7 +271,7 @@ Testing errors ...
 **PROGRAMMER ERROR** Tried to write to a cube before opening/creating it.
 **PROGRAMMER ERROR** Number of samples [0], lines [0], or bands [0] cannot be less than 1.
 **I/O ERROR** Label space is full in [IsisCube_04.cub] unable to write labels.
-**USER ERROR** The cube you are attempting to create [IsisCube_05] is [33527GB]. This is larger than the current allowed size of [12GB]. The cube dimensions were (S,L,B) [1000000, 1000000, 9] with [4] bytes per pixel. If you still wish to create this cube, the maximum value can be changed in your personal preference file located in [~/.Isis/IsisPreferences] within the group CubeCustomization, keyword MaximumSize. If you do not have an ISISPreference file, please refer to the documentation "Environment and Preference Setup". Error.
+**USER ERROR** The cube you are attempting to create [IsisCube_05] is [33527GB]. This is larger than the current allowed size of [12GB]. The cube dimensions were (S,L,B) [1000000, 1000000, 9] with [4] bytes per pixel. If you still wish to create this cube, the maximum value can be changed in your personal preference file located in [~/.Isis/IsisPreferences] within the group CubeCustomization, keyword MaximumSize. If you do not have an ISISPreference file, please refer to the documentation 'Environment and Preference Setup'. Error.
 **PROGRAMMER ERROR** Unknown value for access [a]. Expected 'r'  or 'rw'.
 **PROGRAMMER ERROR** SetDimensions:  Invalid number of sample, lines or bands.
 **PROGRAMMER ERROR** SetDimensions:  Invalid number of sample, lines or bands.


### PR DESCRIPTION
Use single quotes for Cube::create() error message

## Description
Use single quotes surrounding 'Environment and Preferences' in Cube::create() error message

## Related Issue
#4652

## Motivation and Context
`errors` program fails to parse out print.prt because of extraneous quotes

## How Has This Been Tested?
Will wait for Jenkins, couldn't rsync test data from isisdist

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
