### PR TITLE
Assert pvl group equal

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -314,6 +314,10 @@
       "name": "Miller-Ribelin, Elizabeth"
     },
     {
+        "affiliation": "United States Geological Survey, Astro Geology Science Center",
+        "name": "Nelson, Gavin"
+    },
+    {
       "name": "Neubauer, Cole"
     },
     {

--- a/isis/src/base/objs/ProcessMapMosaic/ProcessMapMosaic.truth
+++ b/isis/src/base/objs/ProcessMapMosaic/ProcessMapMosaic.truth
@@ -37,8 +37,8 @@ Object = IsisCube
     MaximumLatitude    = -4.0
     MinimumLongitude   = 29.5
     MaximumLongitude   = 31.0
-    UpperLeftCornerX   = -15195.585618718
-    UpperLeftCornerY   = -121074.5047685
+    UpperLeftCornerX   = -15195.585618718 <meters>
+    UpperLeftCornerY   = -121074.5047685 <meters>
     PixelResolution    = 245.09009062449 <meters/pixel>
     Scale              = 123.72328210776 <pixels/degree>
   End_Group
@@ -92,8 +92,8 @@ Object = IsisCube
     MaximumLatitude    = -4.0
     MinimumLongitude   = 29.0
     MaximumLongitude   = 31.0
-    UpperLeftCornerX   = -45586.756856155
-    UpperLeftCornerY   = -121074.5047685
+    UpperLeftCornerX   = -45586.756856155 <meters>
+    UpperLeftCornerY   = -121074.5047685 <meters>
     PixelResolution    = 245.09009062449 <meters/pixel>
     Scale              = 123.72328210776 <pixels/degree>
   End_Group
@@ -607,8 +607,8 @@ Object = IsisCube
     LatitudeType       = Planetocentric
     LongitudeDirection = PositiveEast
     LongitudeDomain    = 360
-    UpperLeftCornerX   = -475029.8023764
-    UpperLeftCornerY   = 2042714.0507253
+    UpperLeftCornerX   = -475029.8023764 <meters>
+    UpperLeftCornerY   = 2042714.0507253 <meters>
     PixelResolution    = 429.50253379421 <meters/pixel>
     Scale              = 138.00779473796 <pixels/degree>
   End_Group

--- a/isis/tests/FunctionalTestsHimos.cpp
+++ b/isis/tests/FunctionalTestsHimos.cpp
@@ -52,9 +52,33 @@ TEST_F(MroHiriseCube, FunctionalTestHimosDefault) {
   PvlGroup outputMappingGroup = outputCubeLabel.findGroup("Mapping");
   EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, inputMappingGroup, outputMappingGroup);
 
-  PvlGroup inputMosaicGroup = inputCubeLabel.findGroup("Mosaic");
+  std::istringstream mosaicStream(R"(
+  Group = Mosaic
+    ProductId                 = TRA_000823_1720_BLUEGREEN
+    SourceProductId           = (TRA_000823_1720_RED4_0, TRA_000823_1720_RED4_1)
+    StartTime                 = 2006-09-29T15:16:33.385
+    SpacecraftClockStartCount = 844010212:12516
+    StopTime                  = 2006-09-29T15:16:35.036
+    SpacecraftClockStopCount  = 844010213:55196
+    IncidenceAngle            = 59.687930340662 <DEG>
+    EmissionAngle             = 0.091672512439956 <DEG>
+    PhaseAngle                = 59.597812369363 <DEG>
+    LocalTime                 = 15.486088288555 <LOCALDAY/24>
+    SolarLongitude            = 113.54746578654 <DEG>
+    SubSolarAzimuth           = 212.41484032558 <DEG>
+    NorthAzimuth              = 270.00024569628 <DEG>
+    cpmmTdiFlag               = (Null, Null, Null, Null, Null, 128, Null, Null,
+                                 Null, Null, Null, Null, Null, Null)
+    cpmmSummingFlag           = (Null, Null, Null, Null, Null, 1, Null, Null,
+                                 Null, Null, Null, Null, Null, Null)
+    SpecialProcessingFlag     = (Null, Null, Null, Null, Null, NOMINAL, Null,
+                                 Null, Null, Null, Null, Null, Null, Null)
+  End_Group
+  )");
+  PvlGroup mosaicGroupTruth;
+  mosaicStream >> mosaicGroupTruth;
   PvlGroup outputMosaicGroup = outputCubeLabel.findGroup("Mosaic");
-  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, inputMosaicGroup, outputMosaicGroup);
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, mosaicGroupTruth, outputMosaicGroup);
 
 }
 

--- a/isis/tests/FunctionalTestsHimos.cpp
+++ b/isis/tests/FunctionalTestsHimos.cpp
@@ -61,7 +61,7 @@ TEST_F(MroHiriseCube, FunctionalTestHimosDefault) {
     StopTime                  = 2006-09-29T15:16:35.036
     SpacecraftClockStopCount  = 844010213:55196
     IncidenceAngle            = 59.687930340662 <DEG>
-    EmissionAngle             = 0.091672512439956 <DEG>
+    EmissionAngle             = 0.091672512443932 <DEG>
     PhaseAngle                = 59.597812369363 <DEG>
     LocalTime                 = 15.486088288555 <LOCALDAY/24>
     SolarLongitude            = 113.54746578654 <DEG>

--- a/isis/tests/FunctionalTestsHimos.cpp
+++ b/isis/tests/FunctionalTestsHimos.cpp
@@ -34,7 +34,7 @@ TEST_F(MroHiriseCube, FunctionalTestHimosDefault) {
   }
   Cube outputMos(options.GetFileName("TO"));
   PvlObject inputCubeLabel = dejitteredCube.label()->findObject("IsisCube");
-  PvlObject outputCubeLabel = dejitteredCube.label()->findObject("IsisCube");
+  PvlObject outputCubeLabel = outputMos.label()->findObject("IsisCube");
   PvlGroup dimensions = outputCubeLabel.findObject("Core").findGroup("Dimensions");
   PvlGroup pixels = outputCubeLabel.findObject("Core").findGroup("Pixels");
 
@@ -50,21 +50,12 @@ TEST_F(MroHiriseCube, FunctionalTestHimosDefault) {
 
   PvlGroup inputMappingGroup = inputCubeLabel.findGroup("Mapping");
   PvlGroup outputMappingGroup = outputCubeLabel.findGroup("Mapping");
-
-  
-  std::cout<< "input mapping group\n----------"<<std::endl;
-  std::cout << inputMappingGroup << std::endl;
-  std::cout<< "\n output mapping group\n----------"<<std::endl;
-  std::cout << outputMappingGroup << std::endl;
-
-
   EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, inputMappingGroup, outputMappingGroup);
-  // EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, inputCubeLabel.findGroup("Mapping"), outputCubeLabel.findGroup("Mapping"));
 
-  // AssertPvlGroupEqual("InputMapping", "OutputMapping",
-  //                     inputCubeLabel.findGroup("Mapping"), outputCubeLabel.findGroup("Mapping"));
-  // AssertPvlGroupEqual("InputMosaic", "OutputMosaic",
-  //                     inputCubeLabel.findGroup("Mosaic"), outputCubeLabel.findGroup("Mosaic"));
+  PvlGroup inputMosaicGroup = inputCubeLabel.findGroup("Mosaic");
+  PvlGroup outputMosaicGroup = outputCubeLabel.findGroup("Mosaic");
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, inputMosaicGroup, outputMosaicGroup);
+
 }
 
 TEST_F(MroHiriseCube, FunctionalTestHimosError) {

--- a/isis/tests/FunctionalTestsHimos.cpp
+++ b/isis/tests/FunctionalTestsHimos.cpp
@@ -34,7 +34,7 @@ TEST_F(MroHiriseCube, FunctionalTestHimosDefault) {
   }
   Cube outputMos(options.GetFileName("TO"));
   PvlObject inputCubeLabel = dejitteredCube.label()->findObject("IsisCube");
-  PvlObject outputCubeLabel = outputMos.label()->findObject("IsisCube");
+  PvlObject outputCubeLabel = dejitteredCube.label()->findObject("IsisCube");
   PvlGroup dimensions = outputCubeLabel.findObject("Core").findGroup("Dimensions");
   PvlGroup pixels = outputCubeLabel.findObject("Core").findGroup("Pixels");
 
@@ -47,10 +47,24 @@ TEST_F(MroHiriseCube, FunctionalTestHimosDefault) {
   EXPECT_EQ(double(pixels["Base"]), 1.4996565881653);
   EXPECT_EQ(double(pixels["Multiplier"]), 4.57882446313283e-05);
 
-  AssertPvlGroupEqual("InputMapping", "OutputMapping",
-                      inputCubeLabel.findGroup("Mapping"), outputCubeLabel.findGroup("Mapping"));
-  AssertPvlGroupEqual("InputMosaic", "OutputMosaic",
-                      inputCubeLabel.findGroup("Mosaic"), outputCubeLabel.findGroup("Mosaic"));
+
+  PvlGroup inputMappingGroup = inputCubeLabel.findGroup("Mapping");
+  PvlGroup outputMappingGroup = outputCubeLabel.findGroup("Mapping");
+
+  
+  std::cout<< "input mapping group\n----------"<<std::endl;
+  std::cout << inputMappingGroup << std::endl;
+  std::cout<< "\n output mapping group\n----------"<<std::endl;
+  std::cout << outputMappingGroup << std::endl;
+
+
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, inputMappingGroup, outputMappingGroup);
+  // EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, inputCubeLabel.findGroup("Mapping"), outputCubeLabel.findGroup("Mapping"));
+
+  // AssertPvlGroupEqual("InputMapping", "OutputMapping",
+  //                     inputCubeLabel.findGroup("Mapping"), outputCubeLabel.findGroup("Mapping"));
+  // AssertPvlGroupEqual("InputMosaic", "OutputMosaic",
+  //                     inputCubeLabel.findGroup("Mosaic"), outputCubeLabel.findGroup("Mosaic"));
 }
 
 TEST_F(MroHiriseCube, FunctionalTestHimosError) {

--- a/isis/tests/FunctionalTestsKaguyami2isis.cpp
+++ b/isis/tests/FunctionalTestsKaguyami2isis.cpp
@@ -150,10 +150,10 @@ TEST(kaguyatc2isisTest, FunctionalTestKaguyami2isisNir) {
   PvlGroup &bandBin = isisLabel->findGroup("BandBin", Pvl::Traverse);
   std::istringstream bandBinStream(R"(
   Group = BandBin
-    FilterName = (MV1, MV2, MV3, MV4, MV5)
-    Center     = (414.0, 749.0, 901.0, 950.0, 1001.0) <nm>
-    Width      = (20.0, 12.0, 21.0, 30.0, 42.0) <nm>
-    BaseBand   = MV5
+    FilterName = (MN1, MN2, MN3, MN4)
+    Center     = (1000.0, 1049.0, 1248.0, 1548.0) <nm>
+    Width      = (27.0, 28.0, 33.0, 48.0) <nm>
+    BaseBand   = MN1
   End_Group
   )");
   PvlGroup bandBinTruth;

--- a/isis/tests/FunctionalTestsKaguyami2isis.cpp
+++ b/isis/tests/FunctionalTestsKaguyami2isis.cpp
@@ -80,7 +80,7 @@ TEST(kaguyatc2isisTest, FunctionalTestKaguyami2isisVis) {
   )");
   PvlGroup bandBinTruth;
   bandBinStream >> bandBinTruth;
-  AssertPvlGroupEqual("resultingBandBin", "truthBandBin", bandBin, bandBinTruth);
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, bandBin, bandBinTruth);
 
   // Kernels Group
   PvlGroup &kern = isisLabel->findGroup("Kernels", Pvl::Traverse);
@@ -158,7 +158,14 @@ TEST(kaguyatc2isisTest, FunctionalTestKaguyami2isisNir) {
   )");
   PvlGroup bandBinTruth;
   bandBinStream >> bandBinTruth;
-  AssertPvlGroupEqual("resultingBandBin", "truthBandBin", bandBin, bandBinTruth);
+  // AssertPvlGroupEqual("resultingBandBin", "truthBandBin", bandBin, bandBinTruth);
+
+  std::cout<<"\nbandBin Group--------\n"<<std::endl;
+  std::cout<<bandBin<<std::endl;
+  std::cout<<"\nbandBinTruth Group--------\n"<<std::endl;
+  std::cout<<bandBinTruth<<std::endl;
+
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, bandBin, bandBinTruth);
 
   // Kernels Group
   PvlGroup &kern = isisLabel->findGroup("Kernels", Pvl::Traverse);

--- a/isis/tests/FunctionalTestsKaguyami2isis.cpp
+++ b/isis/tests/FunctionalTestsKaguyami2isis.cpp
@@ -158,13 +158,6 @@ TEST(kaguyatc2isisTest, FunctionalTestKaguyami2isisNir) {
   )");
   PvlGroup bandBinTruth;
   bandBinStream >> bandBinTruth;
-  // AssertPvlGroupEqual("resultingBandBin", "truthBandBin", bandBin, bandBinTruth);
-
-  std::cout<<"\nbandBin Group--------\n"<<std::endl;
-  std::cout<<bandBin<<std::endl;
-  std::cout<<"\nbandBinTruth Group--------\n"<<std::endl;
-  std::cout<<bandBinTruth<<std::endl;
-
   EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, bandBin, bandBinTruth);
 
   // Kernels Group

--- a/isis/tests/PvlObjectTests.cpp
+++ b/isis/tests/PvlObjectTests.cpp
@@ -201,6 +201,7 @@ TEST(PvlObject, PvlGroupEqualTest){
   PvlKeyword pvlTmplKwrdOne("some_message", "true");
   PvlKeyword pvlTmplKwrdTwo("foo", "true");
   PvlKeyword pvlTmplKwrdThree("bar", "false");
+  PvlKeyword pvlTmplKwrdFour("fooie", "true");
   pvlTmplGrp += pvlTmplKwrd;
 
   PvlGroup copy = PvlGroup(pvlTmplGrp);
@@ -210,19 +211,21 @@ TEST(PvlObject, PvlGroupEqualTest){
 
   copy.addKeyword(pvlTmplKwrdOne);
 
-  // EXPECT_NO_FATAL_FAILURE(EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy)); // should fail
+  EXPECT_FALSE(AssertPvlGroupEqual("Point_ErrorMagnitude", "Point_ErrorMagnitude", copy, pvlTmplGrp)); // should fail
 
   pvlTmplGrp.addKeyword(pvlTmplKwrdOne);
   EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy); // should pass
 
   copy.addKeyword(pvlTmplKwrdTwo);
   pvlTmplGrp.addKeyword(pvlTmplKwrdThree);
-  // EXPECT_NO_FATAL_FAILURE(EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy)); // should fail
+
+  EXPECT_FALSE(AssertPvlGroupEqual("Point_ErrorMagnitude", "Point_ErrorMagnitude", copy, pvlTmplGrp)); // should fail
 
   copy.addKeyword(pvlTmplKwrdThree);
   pvlTmplGrp.addKeyword(pvlTmplKwrdTwo);
   EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy); // should pass
 
-  EXPECT_EQ(copy.keywords(),pvlTmplGrp.keywords()); // should pass
+  copy.addKeyword(pvlTmplKwrdFour);
+  EXPECT_FALSE(AssertPvlGroupEqual("Point_ErrorMagnitude", "Point_ErrorMagnitude", copy, pvlTmplGrp)); // should fail
 }
 

--- a/isis/tests/PvlObjectTests.cpp
+++ b/isis/tests/PvlObjectTests.cpp
@@ -205,21 +205,23 @@ TEST(PvlObject, PvlGroupEqualTest){
 
   PvlGroup copy = PvlGroup(pvlTmplGrp);
 
-  EXPECT_EQ(copy, pvlTmplGrp); // should pass
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy); // should pass
+
 
   copy.addKeyword(pvlTmplKwrdOne);
-  EXPECT_NO_FATAL_FAILURE(ASSERT_EQ(copy, pvlTmplGrp)); // should fail
+
+  // EXPECT_NO_FATAL_FAILURE(EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy)); // should fail
 
   pvlTmplGrp.addKeyword(pvlTmplKwrdOne);
-  ASSERT_EQ(copy, pvlTmplGrp); // should pass
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy); // should pass
 
   copy.addKeyword(pvlTmplKwrdTwo);
   pvlTmplGrp.addKeyword(pvlTmplKwrdThree);
-  EXPECT_NO_FATAL_FAILURE(ASSERT_EQ(copy, pvlTmplGrp)); // should fail
+  // EXPECT_NO_FATAL_FAILURE(EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy)); // should fail
 
   copy.addKeyword(pvlTmplKwrdThree);
   pvlTmplGrp.addKeyword(pvlTmplKwrdTwo);
-  AssertPvlGroupEqual("Point_ErrorMagnitude", "Point_ErrorMagnitude", copy, pvlTmplGrp); // should pass
+  EXPECT_PRED_FORMAT2(AssertPvlGroupEqual, pvlTmplGrp, copy); // should pass
 
   EXPECT_EQ(copy.keywords(),pvlTmplGrp.keywords()); // should pass
 }

--- a/isis/tests/PvlObjectTests.cpp
+++ b/isis/tests/PvlObjectTests.cpp
@@ -1,6 +1,8 @@
 #include "PvlObject.h"
 #include "IException.h"
 
+#include "TestUtilities.h"
+
 #include <QString>
 
 #include <iostream>
@@ -67,7 +69,6 @@ TEST(PvlObject, invalidStream) {
   PvlObject o;
   stringstream os;
   os << "Object = Hello\nKey=Value\nEndGroup\n";
-
   try {  
     os >> o;
   }
@@ -194,4 +195,32 @@ TEST(PvlObject, constructFromPvl) {
   EXPECT_EQ(p.findKeyword("numkey"), numkey);
 }
 
+TEST(PvlObject, PvlGroupEqualTest){
+  PvlGroup pvlTmplGrp("Point_ErrorMagnitude");
+  PvlKeyword pvlTmplKwrd("Point_ErrorMagnitude__Required", "true");
+  PvlKeyword pvlTmplKwrdOne("some_message", "true");
+  PvlKeyword pvlTmplKwrdTwo("foo", "true");
+  PvlKeyword pvlTmplKwrdThree("bar", "false");
+  pvlTmplGrp += pvlTmplKwrd;
+
+  PvlGroup copy = PvlGroup(pvlTmplGrp);
+
+  EXPECT_EQ(copy, pvlTmplGrp); // should pass
+
+  copy.addKeyword(pvlTmplKwrdOne);
+  EXPECT_NO_FATAL_FAILURE(ASSERT_EQ(copy, pvlTmplGrp)); // should fail
+
+  pvlTmplGrp.addKeyword(pvlTmplKwrdOne);
+  ASSERT_EQ(copy, pvlTmplGrp); // should pass
+
+  copy.addKeyword(pvlTmplKwrdTwo);
+  pvlTmplGrp.addKeyword(pvlTmplKwrdThree);
+  EXPECT_NO_FATAL_FAILURE(ASSERT_EQ(copy, pvlTmplGrp)); // should fail
+
+  copy.addKeyword(pvlTmplKwrdThree);
+  pvlTmplGrp.addKeyword(pvlTmplKwrdTwo);
+  AssertPvlGroupEqual("Point_ErrorMagnitude", "Point_ErrorMagnitude", copy, pvlTmplGrp); // should pass
+
+  EXPECT_EQ(copy.keywords(),pvlTmplGrp.keywords()); // should pass
+}
 

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -65,7 +65,6 @@ namespace Isis {
       PvlGroup group1,
       PvlGroup group2) {
     if (group1.name() != group2.name()) {
-      ADD_FAILURE();
       return ::testing::AssertionFailure() << "PvlGroup " << group1_expr
           << " has name (" << group1.name().toStdString() << ") and PvlGroup "
           << group2_expr << " has name (" << group2.name().toStdString() << ").";
@@ -73,28 +72,24 @@ namespace Isis {
 
     for (auto grp1KeyIt = group1.begin(); grp1KeyIt != group1.end(); grp1KeyIt++) {
       if (!group2.hasKeyword(grp1KeyIt->name())) {
-        ADD_FAILURE();
         return ::testing::AssertionFailure() << "PvlGroup " << group1_expr
             << " contains keyword " << grp1KeyIt->name().toStdString()
             << " that is not in PvlGroup " << group2_expr;
       }
       const PvlKeyword &group2Key = group2.findKeyword(grp1KeyIt->name());
       if (grp1KeyIt->size() != group2Key.size()) {
-        ADD_FAILURE();
         return ::testing::AssertionFailure() << "Keyword (" << grp1KeyIt->name().toStdString()
             << ") has size (" << grp1KeyIt->size() << ") in PvlGroup " << group1_expr
             << " and size (" << group2Key.size() << ") in PvlGroup " << group2_expr;
       }
       for (int i = 0; i < grp1KeyIt->size(); i++) {
         if (!grp1KeyIt->isEquivalent(group2Key[i], i)) {
-          ADD_FAILURE();
           return ::testing::AssertionFailure() << "Keyword (" << grp1KeyIt->name().toStdString()
               << ") has value (" << (*grp1KeyIt)[i].toStdString() << ") in PvlGroup "
               << group1_expr << " and value (" << group2Key[i].toStdString()
               << ") in PvlGroup " << group2_expr << " at index " << i;
         }
         if (grp1KeyIt->unit(i) != group2Key.unit(i)) {
-          ADD_FAILURE();
           return ::testing::AssertionFailure() << "Keyword (" << grp1KeyIt->name().toStdString()
               << ") has units (" << grp1KeyIt->unit(i).toStdString() << ") in PvlGroup "
               << group1_expr << " and units (" << group2Key.unit(i).toStdString()
@@ -106,7 +101,6 @@ namespace Isis {
     // The second time through you only have to check that the keys in group 2 exist in group 1
     for (auto grp2KeyIt = group2.begin(); grp2KeyIt != group2.end(); grp2KeyIt++) {
       if (!group1.hasKeyword(grp2KeyIt->name())) {
-        ADD_FAILURE();
         return ::testing::AssertionFailure() << "PvlGroup " << group2_expr
             << " contains keyword " << grp2KeyIt->name().toStdString()
             << " that is not in PvlGroup " << group1_expr;

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -65,6 +65,7 @@ namespace Isis {
       PvlGroup group1,
       PvlGroup group2) {
     if (group1.name() != group2.name()) {
+      ADD_FAILURE();
       return ::testing::AssertionFailure() << "PvlGroup " << group1_expr
           << " has name (" << group1.name().toStdString() << ") and PvlGroup "
           << group2_expr << " has name (" << group2.name().toStdString() << ").";
@@ -72,24 +73,28 @@ namespace Isis {
 
     for (auto grp1KeyIt = group1.begin(); grp1KeyIt != group1.end(); grp1KeyIt++) {
       if (!group2.hasKeyword(grp1KeyIt->name())) {
+        ADD_FAILURE();
         return ::testing::AssertionFailure() << "PvlGroup " << group1_expr
             << " contains keyword " << grp1KeyIt->name().toStdString()
             << " that is not in PvlGroup " << group2_expr;
       }
       const PvlKeyword &group2Key = group2.findKeyword(grp1KeyIt->name());
       if (grp1KeyIt->size() != group2Key.size()) {
+        ADD_FAILURE();
         return ::testing::AssertionFailure() << "Keyword (" << grp1KeyIt->name().toStdString()
             << ") has size (" << grp1KeyIt->size() << ") in PvlGroup " << group1_expr
             << " and size (" << group2Key.size() << ") in PvlGroup " << group2_expr;
       }
       for (int i = 0; i < grp1KeyIt->size(); i++) {
         if (!grp1KeyIt->isEquivalent(group2Key[i], i)) {
+          ADD_FAILURE();
           return ::testing::AssertionFailure() << "Keyword (" << grp1KeyIt->name().toStdString()
               << ") has value (" << (*grp1KeyIt)[i].toStdString() << ") in PvlGroup "
               << group1_expr << " and value (" << group2Key[i].toStdString()
               << ") in PvlGroup " << group2_expr << " at index " << i;
         }
         if (grp1KeyIt->unit(i) != group2Key.unit(i)) {
+          ADD_FAILURE();
           return ::testing::AssertionFailure() << "Keyword (" << grp1KeyIt->name().toStdString()
               << ") has units (" << grp1KeyIt->unit(i).toStdString() << ") in PvlGroup "
               << group1_expr << " and units (" << group2Key.unit(i).toStdString()
@@ -101,12 +106,12 @@ namespace Isis {
     // The second time through you only have to check that the keys in group 2 exist in group 1
     for (auto grp2KeyIt = group2.begin(); grp2KeyIt != group2.end(); grp2KeyIt++) {
       if (!group1.hasKeyword(grp2KeyIt->name())) {
+        ADD_FAILURE();
         return ::testing::AssertionFailure() << "PvlGroup " << group2_expr
             << " contains keyword " << grp2KeyIt->name().toStdString()
             << " that is not in PvlGroup " << group1_expr;
       }
     }
-
     return ::testing::AssertionSuccess();
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The test's for checking if AssertPvlGroupEqual were not showing a failure, the problem was that when a failure was detected no failure was being added. To fix this I added the failures after each check to see if a failure had occurred.  

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
https://github.com/USGS-Astrogeology/ISIS3/issues/4203
AssertPvlGroupEqual comparison not failing when groups are not equal #4203

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The problem was that the test's that compare PvlGroups would always pass even if the group's had different content's. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Test's have been written in the PvlObjectTest.ccp file, to test my changes I created a new PvlGroup  and various keywords. I then made a copy of the PvlGroup and compared the two with out altering either one. Then I altered the copy and compared them again to see if the changes were caught and that I got a test failure. 

Note: I also added an import for "TestUtilities.h" to be able to call AssertPvlGroupEqual from this file. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
