### PR TITLE
Fixes target specification for Dawn / Vesta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Keywords when running CAMSTATS.  [#3605](https://github.com/USGS-Astrogeology/IS
 ### Deprecated
 - Deprecated edrget as discussed in [#3313](https://github.com/USGS-Astrogeology/ISIS3/issues/3313).
 
+### Fixed
+- Fixed the Vesta target name not being translated properly in dawnfc2isis. [#4638](https://github.com/USGS-Astrogeology/ISIS3/issues/4638)
+
 ## [6.0.0] - 2021-08-27
 
 ### Added

--- a/isis/src/dawn/apps/dawnfc2isis/DawnFcInstrument.trn
+++ b/isis/src/dawn/apps/dawnfc2isis/DawnFcInstrument.trn
@@ -19,7 +19,7 @@
 #
 # Translation is the native and corresponding foreign values.
 # Translation may be repeated as needed.
- 
+
 Group = SpacecraftName
   Auto
   InputKey       = INSTRUMENT_HOST_NAME
@@ -29,7 +29,7 @@ Group = SpacecraftName
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (DAWN, "DAWN")
 End_Group
- 
+
 Group = InstrumentId
   Auto
   InputKey       = INSTRUMENT_ID
@@ -39,8 +39,8 @@ Group = InstrumentId
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (*, *)
 End_Group
- 
- 
+
+
 Group = SpacecraftClockStartCount
   Auto
   InputKey       = SPACECRAFT_CLOCK_START_COUNT
@@ -80,7 +80,7 @@ Group = StopTime
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (*, *)
 End_Group
- 
+
 Group = ExposureDuration
   Auto
   InputKey       = EXPOSURE_DURATION
@@ -90,7 +90,7 @@ Group = ExposureDuration
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (*, *)
 End_Group
- 
+
 Group = PixelAveragingWidth
   Auto
   InputKey       = PIXEL_AVERAGING_WIDTH
@@ -112,7 +112,7 @@ Group = PixelAveragingHeight
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (*, *)
 End_Group
- 
+
 Group = TargetName
   Auto
   InputKey       = TARGET_NAME
@@ -121,6 +121,7 @@ Group = TargetName
   OutputName     = TargetName
   InputDefault   = "N/A"
   OutputPosition = (Object, IsisCube, Group, Instrument)
+  Translation    = ("VESTA", "4 VESTA")
   Translation    = (*, *)
 End_Group
 
@@ -134,8 +135,8 @@ Group = OriginalTargetName
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (*, *)
 End_Group
- 
- 
+
+
 Group = OrbitNumber
   Auto
   InputKey       = ORBIT_NUMBER
@@ -145,7 +146,7 @@ Group = OrbitNumber
   OutputPosition = (Object, IsisCube, Group, Instrument)
   Translation    = (*, *)
 End_Group
- 
+
 Group = FirstLine
   Auto
   InputKey       = FIRST_LINE


### PR DESCRIPTION
Adds target translation from '4 VESTA' to 'VESTA' in dawnfc2isis

## Description
Adds target translation from '4 VESTA' to 'VESTA' in dawnfc2isis

## Related Issue
Closes #4638 

## Motivation and Context
When running dawnfc2isis with target of Vesta, the target was specified as "4 VESTA", but the kerneldb files only had targets for "VESTA". This resulted in a failure to load necessary TSPKs, which prevented users from running spiceinit on the resulting .cub.

## How Has This Been Tested?
```ctest -VV -R "Dawn" . ``` All tests passing

Hand tested with data from issue #4638 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
