### PR TITLE
Fixed jigsaw residual reporting in bundleout.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug where the measure residuals reported in the bundleout.txt file were incorrect. [#4655](https://github.com/USGS-Astrogeology/ISIS3/issues/4655)
+
 ### Added
 - Added the ability to search filenames in measure's drop down boxes in Qnet Point Editor. [#4581](https://github.com/USGS-Astrogeology/ISIS3/issues/4581)
 - Added slope, local normal, and ellipsoid normal calculations to phocube. [#3635](https://github.com/USGS-Astrogeology/ISIS3/issues/3645)

--- a/isis/src/control/apps/jigsaw/jigsaw.xml
+++ b/isis/src/control/apps/jigsaw/jigsaw.xml
@@ -319,6 +319,17 @@
       rand notebook that jigsaw was based on. Also added a section in the documentation
       describing the target body radii solve issue.
     </change>
+    <change name="Jesse Mapel and Kristin Berry" date="2021-06-29">
+      Added the ability to bundle adjust images that use a CSM based model. New parameters
+      CSMSOLVESET, CSMSOLVELIST, and CSMSOLVEYPE were added to specify which parameters to
+      solve for. These parameters can also be used as keys in the SCCONFIG file.
+
+      Modified images CSV file to generate a separate CSV for each sensor being adjusted.
+    </change>
+    <change name="Jesse Mapel" date="2021-11-09">
+      Fixed measure residual reporting in bundleout.txt file to match the residuals
+      reported in the residuals CSV file.
+    </change>
   </history>
 
   <groups>

--- a/isis/src/control/objs/BundleUtilities/IsisBundleObservation.cpp
+++ b/isis/src/control/objs/BundleUtilities/IsisBundleObservation.cpp
@@ -1359,7 +1359,7 @@ QStringList IsisBundleObservation::parameterList() {
    * Converts the observed value from a focal plane coordinate to
    * an image sample or line.
    *
-   * @param measure measure The measure that the partials are
+   * @param measure The measure that the partials are
    *                being computed for.
    * @param deltaVal The difference between the measured and
    *                 calculated focal plane coordinate
@@ -1368,8 +1368,7 @@ QStringList IsisBundleObservation::parameterList() {
    *                calculated (line, sample) coordinate
    */
   double IsisBundleObservation::computeObservationValue(BundleMeasure &measure, double deltaVal) {
-    Camera *measureCamera = measure.camera();
-    return deltaVal / measureCamera->PixelPitch();
+    return deltaVal * 1.4;
   }
 }
 

--- a/isis/tests/FunctionalTestsJigsaw.cpp
+++ b/isis/tests/FunctionalTestsJigsaw.cpp
@@ -978,7 +978,14 @@ End)");
   EXPECT_THAT(lines[75].toStdString(), HasSubstr("RADII: MEAN"));
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, lines[76].trimmed(), "");
 
-  QStringList columns = lines[159].split(QRegExp("\\s+"), QString::SkipEmptyParts);
+  QStringList columns = lines[132].split(QRegExp("\\s+"), QString::SkipEmptyParts);
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, columns[0], "minimum:");
+  EXPECT_NEAR(columns[1].toDouble(), -178.8718, 0.001);
+  columns = lines[136].split(QRegExp("\\s+"), QString::SkipEmptyParts);
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, columns[0], "maximum:");
+  EXPECT_NEAR(columns[1].toDouble(), 175.7307, 0.001);
+
+  columns = lines[159].split(QRegExp("\\s+"), QString::SkipEmptyParts);
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, columns[0], "POLE");
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, columns[1], "RA");
   EXPECT_NEAR(columns[2].toDouble(), 269.9949, 0.0001);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixed how residuals are re-scaled when reporting to the bundelout.txt file.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #4655 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This gets the bundleout.txt file in line with the residuals csv.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on an example network I have and added an automated check in a jigsaw gtest.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
