### PR TITLE
Qview Precision Update

### DIFF
--- a/isis/src/base/objs/SpecialPixel/SpecialPixel.h
+++ b/isis/src/base/objs/SpecialPixel/SpecialPixel.h
@@ -368,7 +368,7 @@ namespace Isis {
    *
    * @return string The name of the pixel type
    */
-  inline QString PixelToString(double d) {
+  inline QString PixelToString(double d, double precision=8) {
     if(Isis::IsSpecial(d)) {
       if(Isis::IsNullPixel(d)) return "Null";
       if(Isis::IsLrsPixel(d)) return "Lrs";
@@ -379,7 +379,7 @@ namespace Isis {
     }
 
     QString result;
-    return result.setNum(d, 'g', 8);
+    return result.setNum(d, 'g', precision);
   }
 
 

--- a/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
+++ b/isis/src/qisis/objs/AdvancedTrackTool/AdvancedTrackTool.cpp
@@ -337,16 +337,14 @@ namespace Isis {
     }
 
     // Otherwise write out col 4 (Pixel value)
+    QString pixel;
     if(cvp->isGray()) {
-      QString grayPixel = PixelToString(cvp->grayPixel(isample, iline));
-      QString p = grayPixel;
-      p_tableWin->table()->item(row, getIndex("Pixel"))->setText(p);
+      pixel = PixelToString(cvp->grayPixel(isample, iline), 12);
     }
     else {
-      QString redPixel = PixelToString(cvp->redPixel(isample, iline));
-      QString p = redPixel;
-      p_tableWin->table()->item(row, getIndex("Pixel"))->setText(p);
+      pixel = PixelToString(cvp->redPixel(isample, iline), 12);
     }
+    p_tableWin->table()->item(row, getIndex("Pixel"))->setText(pixel);
 
     // Do we have a camera model?
     if(cvp->camera() != NULL) {

--- a/isis/src/qisis/objs/TrackTool/TrackTool.cpp
+++ b/isis/src/qisis/objs/TrackTool/TrackTool.cpp
@@ -240,23 +240,11 @@ namespace Isis {
       p_grnLabel->hide();
       p_bluLabel->hide();
 
-      ViewportBuffer *grayBuf = cvp->grayBuffer();
+      ViewportBuffer *buf = cvp->grayBuffer();
 
-      if(grayBuf->working()) {
-        p_grayLabel->setText("BUSY");
-      }
-      else {
-        const QRect rect(grayBuf->bufferXYRect());
+      QString pixelString = updateColorLabel(p, buf, p_grayLabel);
 
-        if(p.x() >= rect.left() && p.x() <= rect.right() &&
-            p.y() >= rect.top() && p.y() <= rect.bottom()) {
-          const int bufX = p.x() - rect.left();
-          const int bufY = p.y() - rect.top();
-          QString pixelString = IString(PixelToString(
-                                                grayBuf->getLine(bufY)[bufX])).ToQt();
-          p_grayLabel->setText(pixelString);
-        }
-      }
+      p_grayLabel->setText(pixelString);
     }
     else {
       p_grayLabel->hide();
@@ -265,60 +253,37 @@ namespace Isis {
       p_bluLabel->show();
 
       ViewportBuffer *redBuf = cvp->redBuffer();
-
-      if(redBuf->working()) {
-        p_grayLabel->setText("BUSY");
-      }
-      else {
-        const QRect rRect = redBuf->bufferXYRect();
-
-        if(p.x() >= rRect.left() && p.x() < rRect.right() &&
-            p.y() >= rRect.top() && p.y() < rRect.bottom()) {
-          const int rBufX = p.x() - rRect.left();
-          const int rBufY = p.y() - rRect.top();
-          QString rLab = "R ";
-          rLab += IString(PixelToString(
-                                  redBuf->getLine(rBufY)[rBufX])).ToQt();
-          p_redLabel->setText(rLab);
-        }
-      }
+      QString pixelString = updateColorLabel(p, redBuf, p_redLabel);
+      QString rLab = "R ";
+      rLab += IString(pixelString).ToQt();
+      p_redLabel->setText(rLab);
 
       ViewportBuffer *greenBuf = cvp->greenBuffer();
-
-      if(greenBuf->working()) {
-        p_grayLabel->setText("BUSY");
-      }
-      else {
-        const QRect gRect = greenBuf->bufferXYRect();
-
-        if(p.x() >= gRect.left() && p.x() < gRect.right() &&
-            p.y() >= gRect.top() && p.y() < gRect.bottom()) {
-          const int gBufX = p.x() - gRect.left();
-          const int gBufY = p.y() - gRect.top();
-          QString gLab = "G ";
-          gLab += IString(PixelToString(
-                                  greenBuf->getLine(gBufY)[gBufX])).ToQt();
-          p_grnLabel->setText(gLab);
-        }
-      }
+      pixelString = updateColorLabel(p, greenBuf, p_grnLabel);
+      QString gLab = "G ";
+      gLab += IString(pixelString).ToQt();
+      p_grnLabel->setText(gLab);
 
       ViewportBuffer *blueBuf = cvp->blueBuffer();
+      pixelString = updateColorLabel(p, blueBuf, p_bluLabel);
+      QString bLab = "B ";
+      bLab += IString(pixelString).ToQt();
+      p_bluLabel->setText(bLab);
+    }
+  }
 
-      if(blueBuf->working()) {
-        p_grayLabel->setText("BUSY");
-      }
-      else {
-        const QRect bRect = blueBuf->bufferXYRect();
+  QString TrackTool::updateColorLabel(QPoint p, ViewportBuffer *buf, QLabel *label) {
+    if(buf->working()) {
+      label->setText("BUSY");
+    }
+    else {
+      const QRect rRect = buf->bufferXYRect();
 
-        if(p.x() >= bRect.left() && p.x() < bRect.right() &&
-            p.y() >= bRect.top() && p.y() < bRect.bottom()) {
-          const int bBufX = p.x() - bRect.left();
-          const int bBufY = p.y() - bRect.top();
-          QString bLab = "B ";
-          bLab += IString(PixelToString(
-                                  blueBuf->getLine(bBufY)[bBufX])).ToQt();
-          p_bluLabel->setText(bLab);
-        }
+      if(p.x() >= rRect.left() && p.x() < rRect.right() &&
+          p.y() >= rRect.top() && p.y() < rRect.bottom()) {
+        const int rBufX = p.x() - rRect.left();
+        const int rBufY = p.y() - rRect.top();
+        return PixelToString(buf->getLine(rBufY)[rBufX], 12);
       }
     }
   }
@@ -383,4 +348,3 @@ namespace Isis {
     return p_sbar;
   }
 }
-

--- a/isis/src/qisis/objs/TrackTool/TrackTool.h
+++ b/isis/src/qisis/objs/TrackTool/TrackTool.h
@@ -11,6 +11,7 @@ class QStatusBar;
 namespace Isis {
   class MdiCubeViewport;
   class WarningWidget;
+  class ViewportBuffer;
 
   /**
    * @brief This tool is part of the Qisis namespace and displays the statusbar of the window.
@@ -61,6 +62,7 @@ namespace Isis {
 
     private:
       void updateLabels(QPoint p);
+      QString updateColorLabel(QPoint p, ViewportBuffer *buf, QLabel *label);
       void clearLabels();
 
       QStatusBar *p_sbar;           //!< Status bar


### PR DESCRIPTION
Adds the ability to adjust precision to q apps that display DNs

## Description
Precision for some high quality elevation maps were not being reported with enough precision. Now double precision values will have 12 digits displayed rather than only 8.

## Related Issue
Closes #4603 

## Motivation and Context
High quality DEMs need to be able to display more than 8 digits from a double precision value in qview and other applications. This PR allows for precision to be addressed on a number per number basis and doesn't alter the current logic that ISIS already operates with.

## How Has This Been Tested?
Tested with existing ISIS tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
