### PR TITLE
Fixes Maptrim failure when mode=both

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ release.
 ### Deprecated
 - Deprecated edrget as discussed in [#3313](https://github.com/USGS-Astrogeology/ISIS3/issues/3313).
 
+### Fixed
+- Fixed Maptrim failures when mode=both for PositiveWest longitude direction. [#4646](https://github.com/USGS-Astrogeology/ISIS3/issues/4646)
+
 ## [6.0.0] - 2021-08-27
 
 ### Added

--- a/isis/src/base/objs/SubArea/SubArea.cpp
+++ b/isis/src/base/objs/SubArea/SubArea.cpp
@@ -191,7 +191,7 @@ namespace Isis {
               }
             }
             else {
-              if (proj->Has180Domain()) {
+              if (proj->Has360Domain()) {
                 minlon = proj->ToPositiveWest(proj->Longitude(), 360);
               }
               else {

--- a/isis/src/base/objs/SubArea/SubArea.cpp
+++ b/isis/src/base/objs/SubArea/SubArea.cpp
@@ -181,37 +181,42 @@ namespace Isis {
           proj->SetWorld(p_ss-.5, p_sl-.5);
           if (proj->IsGood()) {
             maxlat = proj->UniversalLatitude();
-            if (proj->IsPlanetographic()) {
-              maxlat = proj->ToPlanetographic(maxlat);
-            }
+
             if (proj->IsPositiveEast()) {
-              minlon = proj->UniversalLongitude();
-              if (proj->Has180Domain()) {
-                minlon = proj->To180Domain(minlon);
+              if (proj->Has360Domain()) {
+                minlon = proj->ToPositiveEast(proj->Longitude(), 360);
+              }
+              else {
+                minlon = proj->ToPositiveEast(proj->Longitude(), 180);
               }
             }
             else {
-              minlon = proj->ToPositiveWest(proj->UniversalLongitude(), 360);
               if (proj->Has180Domain()) {
-                minlon = proj->To180Domain(proj->ToPositiveWest(proj->UniversalLongitude(), 360));
+                minlon = proj->ToPositiveWest(proj->Longitude(), 360);
+              }
+              else {
+                minlon = proj->ToPositiveWest(proj->Longitude(), 180);
               }
             }
             proj->SetWorld(p_es+.5, p_el+.5);
             if (proj->IsGood()) {
               minlat = proj->UniversalLatitude();
-              if (proj->IsPlanetographic()) {
-                minlat = proj->ToPlanetographic(minlat);
-              }
+
               if (proj->IsPositiveEast()) {
-                maxlon = proj->UniversalLongitude();
-                if (proj->Has180Domain()) {
-                  maxlon = proj->To180Domain(maxlon);
+                if (proj->Has360Domain()) {
+                  maxlon = proj->ToPositiveEast(proj->Longitude(), 360);
+                }
+                else {
+                  maxlon = proj->ToPositiveEast(proj->Longitude(), 180);
                 }
               }
+
               else {
-                maxlon = proj->ToPositiveWest(proj->UniversalLongitude(), 360);
-                if (proj->Has180Domain()) {
-                  maxlon = proj->To180Domain(proj->ToPositiveWest(proj->UniversalLongitude(), 360));
+                if (proj->Has360Domain()) {
+                  maxlon = proj->ToPositiveWest(proj->Longitude(), 360);
+                }
+                else {
+                  maxlon = proj->ToPositiveWest(proj->Longitude(), 180);
                 }
               }
               mapgroup.addKeyword(PvlKeyword("MinimumLatitude",toString(minlat)),Pvl::Replace);

--- a/isis/src/base/objs/SubArea/SubArea.cpp
+++ b/isis/src/base/objs/SubArea/SubArea.cpp
@@ -185,11 +185,9 @@ namespace Isis {
               maxlat = proj->ToPlanetographic(maxlat);
             }
             if (proj->IsPositiveEast()) {
-              if (proj->Has360Domain()) {
-                minlon = proj->ToPositiveEast(proj->Longitude(), 360);
-              }
-              else {
-                minlon = proj->ToPositiveEast(proj->Longitude(), 180);
+              minlon = proj->UniversalLongitude();
+              if (proj->Has180Domain()) {
+                minlon = proj->To180Domain(minlon);
               }
             }
             else {
@@ -207,14 +205,11 @@ namespace Isis {
                 minlat = proj->ToPlanetographic(minlat);
               }
               if (proj->IsPositiveEast()) {
-                if (proj->Has360Domain()) {
-                  maxlon = proj->ToPositiveEast(proj->Longitude(), 360);
-                }
-                else {
-                  maxlon = proj->ToPositiveEast(proj->Longitude(), 180);
+                maxlon = proj->UniversalLongitude();
+                if (proj->Has180Domain()) {
+                  maxlon = proj->To180Domain(maxlon);
                 }
               }
-
               else {
                 if (proj->Has360Domain()) {
                   maxlon = proj->ToPositiveWest(proj->Longitude(), 360);

--- a/isis/src/base/objs/SubArea/SubArea.cpp
+++ b/isis/src/base/objs/SubArea/SubArea.cpp
@@ -181,7 +181,9 @@ namespace Isis {
           proj->SetWorld(p_ss-.5, p_sl-.5);
           if (proj->IsGood()) {
             maxlat = proj->UniversalLatitude();
-
+            if (proj->IsPlanetographic()) {
+              maxlat = proj->ToPlanetographic(maxlat);
+            }
             if (proj->IsPositiveEast()) {
               if (proj->Has360Domain()) {
                 minlon = proj->ToPositiveEast(proj->Longitude(), 360);
@@ -201,7 +203,9 @@ namespace Isis {
             proj->SetWorld(p_es+.5, p_el+.5);
             if (proj->IsGood()) {
               minlat = proj->UniversalLatitude();
-
+              if (proj->IsPlanetographic()) {
+                minlat = proj->ToPlanetographic(minlat);
+              }
               if (proj->IsPositiveEast()) {
                 if (proj->Has360Domain()) {
                   maxlon = proj->ToPositiveEast(proj->Longitude(), 360);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Maptrim fails when image has a PositiveWest longitude direction. I found out that the error was happening when maptrim runs Crop. At the end of the Crop application, it reevaluates the label information based on the newly cropped image using updateLabel. Since the calculation error was within the Mapping Group of the pvl, this was not caught in the crop application. It was rather caught in Maptrim because the app makes a new proj based on the updated mapping information from crop. This fails due to longitude minimum of 360 being larger than max longitude of 0.

Within the Subarea::updateLabel function that updates the mapping area, the issue lies in the fact that Universal Longitude is being called in order to convert the longitude back to PositiveWest. The problem is, Universal Longitude checks if the longitude is PositiveWest and then converts the longitude as if the longitude is already set in PositiveWest. This happens before we actually set the longitude to PositiveWest. Therefore we are converting twice.

For instance, 

- minimum longitude is found at 360 and maximum is found at 0.

- Running Universal Longitude, checks that longitude is PositiveWest, converts minimum to 0 and max to 360.
- Then runs toPositiveWest using the universal longitude range of 0 and 360. This converts the longitude range back to minimum 360 and maximum 0.

To avoid this issue, simply calling the toPositiveEast and toPositiveWest with original found Longitudes will avoid accidentally converting twice. This is easily be done on accident since the conversion between the two is the same (make negative and set domain)


## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #4646 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
ISIS Support Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed that crop tests and maptrim test were not affected. These tests were only testing PositiveEast scenarios.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
