### PR TITLE
Added FileHeaderBytes and OriginalLabel for PDS3 images in isisimport.

### DIFF
--- a/isis/appdata/import/VikingVIS.tpl
+++ b/isis/appdata/import/VikingVIS.tpl
@@ -273,4 +273,13 @@ Object = IsisCube
     Status   = Nominal
   End_Group
 End_Object
+
+Object = Translation
+  {% if exists("ptrIMAGE.Value") %}
+  DataFilePointer             = {{ ptrIMAGE.Value }}
+  {% endif %}
+  {% if exists("RECORD_BYTES") %}
+  DataFileRecordBytes         = {{ RECORD_BYTES.Value }}
+  {% endif %}
+End_Object
 End

--- a/isis/appdata/import/fileTemplate.tpl
+++ b/isis/appdata/import/fileTemplate.tpl
@@ -12,7 +12,7 @@
 
 {%- if SpacecraftName == "TRACE GAS ORBITER" -%}
 {%- set SpacecraftId="TGO" -%}
-{%- else if SpacecraftName == "VIKING_ORBITER_2" -%}
+{%- else if SpacecraftName == "VIKING_ORBITER_1" or SpacecraftName == "VIKING_ORBITER_2" -%}
 {%- set SpacecraftId="Viking" -%}
 {%- set InstrumentId="VIS" -%}
 {%- endif -%}

--- a/isis/src/base/objs/PvlToJSON/PvlToJSON.cpp
+++ b/isis/src/base/objs/PvlToJSON/PvlToJSON.cpp
@@ -147,7 +147,14 @@ namespace Isis {
         jsonContainer[keywordIt->name().toStdString()].push_back(pvlKeywordToJSON(*keywordIt));
       }
       else {
-        jsonContainer[keywordIt->name().toStdString()] = pvlKeywordToJSON(*keywordIt);
+        // Check if keyword has a '^', if so replace with 'ptr'.
+        // This removal is due to inja handling '^' as a mathematical operator.
+        if(keywordIt->name().toStdString()[0] == '^') {
+          jsonContainer[keywordIt->name().replace("^", "ptr").toStdString()] = pvlKeywordToJSON(*keywordIt);
+        }
+        else {
+          jsonContainer[keywordIt->name().toStdString()] = pvlKeywordToJSON(*keywordIt);
+        }
       }
     }
 
@@ -369,7 +376,7 @@ namespace Isis {
       QString msg = QString("Failed to open file for PVL Input: [%1]").arg(pvlFile);
       throw IException(e, IException::User, msg, _FILEINFO_);
     }
-    
+
     return pvlToJSON(pvl);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
After comparing output of a viking image from isisimport and vik2isis, I found two differences: Not handling the file header and not adding in the OriginalLabel. This PR adds these in.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran cubediff and pvldiff on isisimport output against vik2isis output.


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
