### PR TITLE
Pds4 Cassini

### DIFF
--- a/isis/appdata/import/CassiniVIMS.tpl
+++ b/isis/appdata/import/CassiniVIMS.tpl
@@ -1,0 +1,151 @@
+Object = IsisCube
+  Object = Core
+    Group = Dimensions
+      Samples = {{ at(QUBE.CORE_ITEMS.Value, 0) }}
+      Lines   = {{ at(QUBE.CORE_ITEMS.Value, 2) }}
+      Bands   = {{ at(QUBE.CORE_ITEMS.Value, 1) }}
+    End_Group
+
+    Group = Pixels
+      {%- set sampbits=QUBE.CORE_ITEM_BYTES.Value -%}
+      {%- if sampbits == "1" -%}
+      {%- set sampbits="8" -%}
+      {%- else if sampbits == "2" -%}
+      {%- set sampbits="16" -%}
+      {%- else if sampbits == "4" -%}
+      {%- set sampbits="32" -%}
+      {%- endif -%}
+
+      {%- set type=QUBE.CORE_ITEM_TYPE.Value -%}
+      {%- if type == "LSB_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "MSB_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "PC_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "MAC_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "SUN_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "VAX_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "UNSIGNED INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "LSB_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "MSB_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "PC_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "MAC_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "SUN_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "VAX_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "FLOAT" -%} {%- set pixType="Real" -%}
+      {%- else if type == "REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "PC_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "IEEE_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "MAC_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "SUN_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "VAX_REAL" -%} {%- set pixType="Real" -%}
+      {%- else -%} {%- set pixType="LSB_INTEGER" -%}
+      {%- endif -%}
+      Type       = {% if pixType == "Real" and sampbits == "64" %} Double
+                   {% else if pixType == "Real" and sampbits == "32" %} Real
+                   {% else if pixType == "Integer" and sampbits == "8" %} UnsignedByte
+                   {% else if pixType == "Integer" and sampbits == "16" %} SignedWord
+                   {% else if pixType == "Integer" and sampbits == "32" %} SignedInteger
+                   {% else if pixType == "Natural" and sampbits == "8" %} UnsignedByte
+                   {% else if pixType == "Natural" and sampbits == "16" %} UnsignedWord
+                   {% else if pixType == "Natural" and sampbits == "32" %} UnsignedInteger
+                   {% endif %}
+      ByteOrder  = {% if type == "LSB_INTEGER" %} LSB
+                   {% else if type == "PC_INTEGER" %} LSB
+                   {% else if type == "VAX_INTEGER" %} LSB
+                   {% else if type == "LSB_UNSIGNED_INTEGER" %} LSB
+                   {% else if type == "PC_UNSIGNED_INTEGER" %} LSB
+                   {% else if type == "VAX_UNSIGNED_INTEGER" %} LSB
+                   {% else if type == "PC_REAL" %} LSB
+                   {% else if type == "VAX_REAL" %} LSB
+                   {% else if type == "MSB_INTEGER" %} MSB
+                   {% else if type == "MAC_INTEGER" %} MSB
+                   {% else if type == "SUN_INTEGER" %} MSB
+                   {% else if type == "UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "UNSIGNED INTEGER" %} MSB
+                   {% else if type == "MSB_UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "MAC_UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "SUN_UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "FLOAT" %} MSB
+                   {% else if type == "REAL" %} MSB
+                   {% else if type == "IEEE_REAL" %} MSB
+                   {% else if type == "MAC_REAL" %} MSB
+                   {% else if type == "SUN_REAL" %} MSB
+                   {% else %} LSB_INTEGER
+                   {% endif %}
+      Base       = {% if exists("QUBE.CORE_BASE.Value") %}
+                   {{ QUBE.CORE_BASE.Value }}
+                   {% else %}
+                   0.0
+                   {% endif %}
+      Multiplier = {% if exists("QUBE.CORE_MULTIPLIER.Value") %}
+                   {{ QUBE.CORE_MULTIPLIER.Value }}
+                   {% else %}
+                   1.0
+                   {% endif %}
+    End_Group
+  End_Object
+
+  Group = Instrument
+    {%- if exists("ROOT.MISSION_NAME.Value") -%}
+    {%- set infoGroup=ROOT -%}
+    {%- else -%}
+    {%- set infoGroup=QUBE -%}
+    {%- endif -%}
+    SpacecraftName       = {{ infoGroup.MISSION_NAME.Value }}
+    InstrumentId         = {{ infoGroup.INSTRUMENT_ID.Value }}
+    TargetName           = {{ infoGroup.TARGET_NAME.Value }}
+    SpacecraftClockStartCount = {{ infoGroup.SPACECRAFT_CLOCK_START_COUNT.Value }}
+    SpacecraftClockStopCount = {{ infoGroup.SPACECRAFT_CLOCK_STOP_COUNT.Value }}
+    StartTime            = {% set startTime=infoGroup.START_TIME.Value %}
+                           {{ RemoveStartTimeZ(startTime) }}
+    StopTime             = {% set stopTime=infoGroup.STOP_TIME.Value %}
+                           {{ RemoveStartTimeZ(stopTime) }}
+    NativeStartTime      = {{ infoGroup.NATIVE_START_TIME.Value }}
+    NativeStopTime       = {{ infoGroup.NATIVE_STOP_TIME.Value }}
+    InterlineDelayDuration = {{ infoGroup.INTERLINE_DELAY_DURATION.Value }}
+    XOffset              = {{ infoGroup.X_OFFSET.Value }}
+    ZOffset              = {{ infoGroup.Z_OFFSET.Value }}
+    SwathWidth           = {{ infoGroup.SWATH_WIDTH.Value }}
+    SwathLength          = {{ infoGroup.SWATH_LENGTH.Value }}
+    Channel              = VIS
+    ExposureDuration     = ({{ QUBE.EXPOSURE_DURATION.Value.0 }} <IR>, {{ QUBE.EXPOSURE_DURATION.Value.1 }} <VIS>)
+    GainMode             = ({{ QUBE.GAIN_MODE_ID.Value.0 }}, {{ QUBE.GAIN_MODE_ID.Value.1 }})
+  End_Group
+
+  Group = Archive
+    MissionPhaseName     = {{ infoGroup.MISSION_PHASE_NAME.Value }}
+    SequenceId           = {{ infoGroup.SEQUENCE_ID.Value }}
+    SequenceTitle        = {{ infoGroup.SEQUENCE_TITLE.Value }}
+    ObservationId        = {{ infoGroup.OBSERVATION_ID.Value }}
+    ProductId            = {{ infoGroup.PRODUCT_ID.Value }}
+    InstrumentModeId     = {{ infoGroup.INSTRUMENT_MODE_ID.Value }}
+    CompressorId         = {{ infoGroup.COMPRESSOR_ID.Value }}
+    PowerStateFlag       = ({{ infoGroup.POWER_STATE_FLAG.Value.0 }}, {{ infoGroup.POWER_STATE_FLAG.Value.1 }})
+    SpectralSummingFlag  = {{ infoGroup.SPECTRAL_SUMMING_FLAG.Value }}
+    SpectralEditingFlag  = {{ infoGroup.SPECTRAL_EDITING_FLAG.Value }}
+    StarTracking         = {{ infoGroup.STAR_TRACKING.Value }}
+    SnapshotMode         = {{ infoGroup.SNAPSHOT_MODE.Value }}
+    SamplingMode         = ({{ QUBE.SAMPLING_MODE_ID.Value.0 }}, {{ QUBE.SAMPLING_MODE_ID.Value.1 }})
+    {% if exists("QUBE.CORE_NULL.Value") %}
+    PdsNULL              = {{ QUBE.CORE_NULL.Value }}
+    {% endif %}
+    {% if exists("QUBE.CORE_NULL.Value") %}
+    PdsNULL              = {{ QUBE.CORE_NULL.Value }}
+    {% endif %}
+    {% if exists("QUBE.CORE_LOW_REPR_SATURATION.Value") %}
+    PdsLRS               = {{ QUBE.CORE_LOW_REPR_SATURATION.Value }}
+    {% endif %}
+    {% if exists("QUBE.CORE_LOW_INSTR_SATURATION.Value") %}
+    PdsLIS               = {{ QUBE.CORE_LOW_INSTR_SATURATION.Value }}
+    {% endif %}
+    {% if exists("QUBE.CORE_HIGH_REPR_SATURATION.Value") %}
+    PdsHRS               = {{ QUBE.CORE_HIGH_REPR_SATURATION.Value }}
+    {% endif %}
+    {% if exists("QUBE.CORE_HIGH_INSTR_SATURATION.Value") %}
+    PdsHIS               = {{ QUBE.CORE_HIGH_INSTR_SATURATION.Value }}
+    {% endif %}
+    OriginalAxisOrder    = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
+  End_Group
+
+End_Object
+End

--- a/isis/appdata/import/CassiniVIMS.tpl
+++ b/isis/appdata/import/CassiniVIMS.tpl
@@ -1,151 +1,27 @@
-Object = IsisCube
-  Object = Core
-    Group = Dimensions
-      Samples = {{ at(QUBE.CORE_ITEMS.Value, 0) }}
-      Lines   = {{ at(QUBE.CORE_ITEMS.Value, 2) }}
-      Bands   = {{ at(QUBE.CORE_ITEMS.Value, 1) }}
-    End_Group
+{% extends "qube_base.tpl" %}
 
-    Group = Pixels
-      {%- set sampbits=QUBE.CORE_ITEM_BYTES.Value -%}
-      {%- if sampbits == "1" -%}
-      {%- set sampbits="8" -%}
-      {%- else if sampbits == "2" -%}
-      {%- set sampbits="16" -%}
-      {%- else if sampbits == "4" -%}
-      {%- set sampbits="32" -%}
-      {%- endif -%}
+{% block instrument %}
+{{ super() }}
+SpacecraftClockStopCount = {{ infoGroup.SPACECRAFT_CLOCK_STOP_COUNT.Value }}
+StopTime             = {% set stopTime=infoGroup.STOP_TIME.Value %}
+                       {{ RemoveStartTimeZ(stopTime) }}
+NativeStartTime      = {{ infoGroup.NATIVE_START_TIME.Value }}
+NativeStopTime       = {{ infoGroup.NATIVE_STOP_TIME.Value }}
+InterlineDelayDuration = {{ infoGroup.INTERLINE_DELAY_DURATION.Value }}
+XOffset              = {{ infoGroup.X_OFFSET.Value }}
+ZOffset              = {{ infoGroup.Z_OFFSET.Value }}
+SwathWidth           = {{ infoGroup.SWATH_WIDTH.Value }}
+SwathLength          = {{ infoGroup.SWATH_LENGTH.Value }}
+Channel              = VIS
+ExposureDuration     = ({{ QUBE.EXPOSURE_DURATION.Value.0 }} <IR>, {{ QUBE.EXPOSURE_DURATION.Value.1 }} <VIS>)
+GainMode             = ({{ QUBE.GAIN_MODE_ID.Value.0 }}, {{ QUBE.GAIN_MODE_ID.Value.1 }})
+{% endblock %}
 
-      {%- set type=QUBE.CORE_ITEM_TYPE.Value -%}
-      {%- if type == "LSB_INTEGER" -%} {%- set pixType="Integer" -%}
-      {%- else if type == "MSB_INTEGER" -%} {%- set pixType="Integer" -%}
-      {%- else if type == "PC_INTEGER" -%} {%- set pixType="Integer" -%}
-      {%- else if type == "MAC_INTEGER" -%} {%- set pixType="Integer" -%}
-      {%- else if type == "SUN_INTEGER" -%} {%- set pixType="Integer" -%}
-      {%- else if type == "VAX_INTEGER" -%} {%- set pixType="Integer" -%}
-      {%- else if type == "UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "UNSIGNED INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "LSB_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "MSB_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "PC_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "MAC_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "SUN_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "VAX_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
-      {%- else if type == "FLOAT" -%} {%- set pixType="Real" -%}
-      {%- else if type == "REAL" -%} {%- set pixType="Real" -%}
-      {%- else if type == "PC_REAL" -%} {%- set pixType="Real" -%}
-      {%- else if type == "IEEE_REAL" -%} {%- set pixType="Real" -%}
-      {%- else if type == "MAC_REAL" -%} {%- set pixType="Real" -%}
-      {%- else if type == "SUN_REAL" -%} {%- set pixType="Real" -%}
-      {%- else if type == "VAX_REAL" -%} {%- set pixType="Real" -%}
-      {%- else -%} {%- set pixType="LSB_INTEGER" -%}
-      {%- endif -%}
-      Type       = {% if pixType == "Real" and sampbits == "64" %} Double
-                   {% else if pixType == "Real" and sampbits == "32" %} Real
-                   {% else if pixType == "Integer" and sampbits == "8" %} UnsignedByte
-                   {% else if pixType == "Integer" and sampbits == "16" %} SignedWord
-                   {% else if pixType == "Integer" and sampbits == "32" %} SignedInteger
-                   {% else if pixType == "Natural" and sampbits == "8" %} UnsignedByte
-                   {% else if pixType == "Natural" and sampbits == "16" %} UnsignedWord
-                   {% else if pixType == "Natural" and sampbits == "32" %} UnsignedInteger
-                   {% endif %}
-      ByteOrder  = {% if type == "LSB_INTEGER" %} LSB
-                   {% else if type == "PC_INTEGER" %} LSB
-                   {% else if type == "VAX_INTEGER" %} LSB
-                   {% else if type == "LSB_UNSIGNED_INTEGER" %} LSB
-                   {% else if type == "PC_UNSIGNED_INTEGER" %} LSB
-                   {% else if type == "VAX_UNSIGNED_INTEGER" %} LSB
-                   {% else if type == "PC_REAL" %} LSB
-                   {% else if type == "VAX_REAL" %} LSB
-                   {% else if type == "MSB_INTEGER" %} MSB
-                   {% else if type == "MAC_INTEGER" %} MSB
-                   {% else if type == "SUN_INTEGER" %} MSB
-                   {% else if type == "UNSIGNED_INTEGER" %} MSB
-                   {% else if type == "UNSIGNED INTEGER" %} MSB
-                   {% else if type == "MSB_UNSIGNED_INTEGER" %} MSB
-                   {% else if type == "MAC_UNSIGNED_INTEGER" %} MSB
-                   {% else if type == "SUN_UNSIGNED_INTEGER" %} MSB
-                   {% else if type == "FLOAT" %} MSB
-                   {% else if type == "REAL" %} MSB
-                   {% else if type == "IEEE_REAL" %} MSB
-                   {% else if type == "MAC_REAL" %} MSB
-                   {% else if type == "SUN_REAL" %} MSB
-                   {% else %} LSB_INTEGER
-                   {% endif %}
-      Base       = {% if exists("QUBE.CORE_BASE.Value") %}
-                   {{ QUBE.CORE_BASE.Value }}
-                   {% else %}
-                   0.0
-                   {% endif %}
-      Multiplier = {% if exists("QUBE.CORE_MULTIPLIER.Value") %}
-                   {{ QUBE.CORE_MULTIPLIER.Value }}
-                   {% else %}
-                   1.0
-                   {% endif %}
-    End_Group
-  End_Object
-
-  Group = Instrument
-    {%- if exists("ROOT.MISSION_NAME.Value") -%}
-    {%- set infoGroup=ROOT -%}
-    {%- else -%}
-    {%- set infoGroup=QUBE -%}
-    {%- endif -%}
-    SpacecraftName       = {{ infoGroup.MISSION_NAME.Value }}
-    InstrumentId         = {{ infoGroup.INSTRUMENT_ID.Value }}
-    TargetName           = {{ infoGroup.TARGET_NAME.Value }}
-    SpacecraftClockStartCount = {{ infoGroup.SPACECRAFT_CLOCK_START_COUNT.Value }}
-    SpacecraftClockStopCount = {{ infoGroup.SPACECRAFT_CLOCK_STOP_COUNT.Value }}
-    StartTime            = {% set startTime=infoGroup.START_TIME.Value %}
-                           {{ RemoveStartTimeZ(startTime) }}
-    StopTime             = {% set stopTime=infoGroup.STOP_TIME.Value %}
-                           {{ RemoveStartTimeZ(stopTime) }}
-    NativeStartTime      = {{ infoGroup.NATIVE_START_TIME.Value }}
-    NativeStopTime       = {{ infoGroup.NATIVE_STOP_TIME.Value }}
-    InterlineDelayDuration = {{ infoGroup.INTERLINE_DELAY_DURATION.Value }}
-    XOffset              = {{ infoGroup.X_OFFSET.Value }}
-    ZOffset              = {{ infoGroup.Z_OFFSET.Value }}
-    SwathWidth           = {{ infoGroup.SWATH_WIDTH.Value }}
-    SwathLength          = {{ infoGroup.SWATH_LENGTH.Value }}
-    Channel              = VIS
-    ExposureDuration     = ({{ QUBE.EXPOSURE_DURATION.Value.0 }} <IR>, {{ QUBE.EXPOSURE_DURATION.Value.1 }} <VIS>)
-    GainMode             = ({{ QUBE.GAIN_MODE_ID.Value.0 }}, {{ QUBE.GAIN_MODE_ID.Value.1 }})
-  End_Group
-
-  Group = Archive
-    MissionPhaseName     = {{ infoGroup.MISSION_PHASE_NAME.Value }}
-    SequenceId           = {{ infoGroup.SEQUENCE_ID.Value }}
-    SequenceTitle        = {{ infoGroup.SEQUENCE_TITLE.Value }}
-    ObservationId        = {{ infoGroup.OBSERVATION_ID.Value }}
-    ProductId            = {{ infoGroup.PRODUCT_ID.Value }}
-    InstrumentModeId     = {{ infoGroup.INSTRUMENT_MODE_ID.Value }}
-    CompressorId         = {{ infoGroup.COMPRESSOR_ID.Value }}
-    PowerStateFlag       = ({{ infoGroup.POWER_STATE_FLAG.Value.0 }}, {{ infoGroup.POWER_STATE_FLAG.Value.1 }})
-    SpectralSummingFlag  = {{ infoGroup.SPECTRAL_SUMMING_FLAG.Value }}
-    SpectralEditingFlag  = {{ infoGroup.SPECTRAL_EDITING_FLAG.Value }}
-    StarTracking         = {{ infoGroup.STAR_TRACKING.Value }}
-    SnapshotMode         = {{ infoGroup.SNAPSHOT_MODE.Value }}
-    SamplingMode         = ({{ QUBE.SAMPLING_MODE_ID.Value.0 }}, {{ QUBE.SAMPLING_MODE_ID.Value.1 }})
-  End_Group
-End_Object
-
-Object = Translation
-  {% if exists("QUBE.CORE_NULL.Value") %}
-  PdsNULL              = {{ QUBE.CORE_NULL.Value }}
-  {% endif %}
-  {% if exists("QUBE.CORE_LOW_REPR_SATURATION.Value") %}
-  PdsLRS               = {{ QUBE.CORE_LOW_REPR_SATURATION.Value }}
-  {% endif %}
-  {% if exists("QUBE.CORE_LOW_INSTR_SATURATION.Value") %}
-  PdsLIS               = {{ QUBE.CORE_LOW_INSTR_SATURATION.Value }}
-  {% endif %}
-  {% if exists("QUBE.CORE_HIGH_REPR_SATURATION.Value") %}
-  PdsHRS               = {{ QUBE.CORE_HIGH_REPR_SATURATION.Value }}
-  {% endif %}
-  {% if exists("QUBE.CORE_HIGH_INSTR_SATURATION.Value") %}
-  PdsHIS               = {{ QUBE.CORE_HIGH_INSTR_SATURATION.Value }}
-  {% endif %}
-  OriginalAxisOrder    = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
-  OriginalImageOffset  = {{ imageOffset }}
-End_Object
-End
+{% block archive %}
+PowerStateFlag       = ({{ infoGroup.POWER_STATE_FLAG.Value.0 }}, {{ infoGroup.POWER_STATE_FLAG.Value.1 }})
+SpectralSummingFlag  = {{ infoGroup.SPECTRAL_SUMMING_FLAG.Value }}
+SpectralEditingFlag  = {{ infoGroup.SPECTRAL_EDITING_FLAG.Value }}
+StarTracking         = {{ infoGroup.STAR_TRACKING.Value }}
+SnapshotMode         = {{ infoGroup.SNAPSHOT_MODE.Value }}
+SamplingMode         = ({{ QUBE.SAMPLING_MODE_ID.Value.0 }}, {{ QUBE.SAMPLING_MODE_ID.Value.1 }})
+{% endblock%}

--- a/isis/appdata/import/CassiniVIMS.tpl
+++ b/isis/appdata/import/CassiniVIMS.tpl
@@ -12,7 +12,7 @@ XOffset              = {{ infoGroup.X_OFFSET.Value }}
 ZOffset              = {{ infoGroup.Z_OFFSET.Value }}
 SwathWidth           = {{ infoGroup.SWATH_WIDTH.Value }}
 SwathLength          = {{ infoGroup.SWATH_LENGTH.Value }}
-Channel              = VIS
+Channel              = (IR, VIS)
 ExposureDuration     = ({{ QUBE.EXPOSURE_DURATION.Value.0 }} <IR>, {{ QUBE.EXPOSURE_DURATION.Value.1 }} <VIS>)
 GainMode             = ({{ QUBE.GAIN_MODE_ID.Value.0 }}, {{ QUBE.GAIN_MODE_ID.Value.1 }})
 {% endblock %}

--- a/isis/appdata/import/CassiniVIMS.tpl
+++ b/isis/appdata/import/CassiniVIMS.tpl
@@ -126,26 +126,26 @@ Object = IsisCube
     StarTracking         = {{ infoGroup.STAR_TRACKING.Value }}
     SnapshotMode         = {{ infoGroup.SNAPSHOT_MODE.Value }}
     SamplingMode         = ({{ QUBE.SAMPLING_MODE_ID.Value.0 }}, {{ QUBE.SAMPLING_MODE_ID.Value.1 }})
-    {% if exists("QUBE.CORE_NULL.Value") %}
-    PdsNULL              = {{ QUBE.CORE_NULL.Value }}
-    {% endif %}
-    {% if exists("QUBE.CORE_NULL.Value") %}
-    PdsNULL              = {{ QUBE.CORE_NULL.Value }}
-    {% endif %}
-    {% if exists("QUBE.CORE_LOW_REPR_SATURATION.Value") %}
-    PdsLRS               = {{ QUBE.CORE_LOW_REPR_SATURATION.Value }}
-    {% endif %}
-    {% if exists("QUBE.CORE_LOW_INSTR_SATURATION.Value") %}
-    PdsLIS               = {{ QUBE.CORE_LOW_INSTR_SATURATION.Value }}
-    {% endif %}
-    {% if exists("QUBE.CORE_HIGH_REPR_SATURATION.Value") %}
-    PdsHRS               = {{ QUBE.CORE_HIGH_REPR_SATURATION.Value }}
-    {% endif %}
-    {% if exists("QUBE.CORE_HIGH_INSTR_SATURATION.Value") %}
-    PdsHIS               = {{ QUBE.CORE_HIGH_INSTR_SATURATION.Value }}
-    {% endif %}
-    OriginalAxisOrder    = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
   End_Group
+End_Object
 
+Object = Translation
+  {% if exists("QUBE.CORE_NULL.Value") %}
+  PdsNULL              = {{ QUBE.CORE_NULL.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_LOW_REPR_SATURATION.Value") %}
+  PdsLRS               = {{ QUBE.CORE_LOW_REPR_SATURATION.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_LOW_INSTR_SATURATION.Value") %}
+  PdsLIS               = {{ QUBE.CORE_LOW_INSTR_SATURATION.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_HIGH_REPR_SATURATION.Value") %}
+  PdsHRS               = {{ QUBE.CORE_HIGH_REPR_SATURATION.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_HIGH_INSTR_SATURATION.Value") %}
+  PdsHIS               = {{ QUBE.CORE_HIGH_INSTR_SATURATION.Value }}
+  {% endif %}
+  OriginalAxisOrder    = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
+  OriginalImageOffset  = {{ imageOffset }}
 End_Object
 End

--- a/isis/appdata/import/fileTemplate.tpl
+++ b/isis/appdata/import/fileTemplate.tpl
@@ -8,6 +8,8 @@
 {%- set SpacecraftName=Product_Observational.Observation_Area.Investigation_Area.Instrument_Host_Name -%}
 {%- else if exists("SPACECRAFT_NAME") -%}
 {%- set SpacecraftName=SPACECRAFT_NAME.Value -%}
+{%- else if exists("QUBE.MISSION_NAME") -%}
+{%- set SpacecraftName=QUBE.MISSION_NAME.Value -%}
 {%- endif -%}
 
 {%- if SpacecraftName == "TRACE GAS ORBITER" -%}
@@ -15,6 +17,9 @@
 {%- else if SpacecraftName == "VIKING_ORBITER_1" or SpacecraftName == "VIKING_ORBITER_2" -%}
 {%- set SpacecraftId="Viking" -%}
 {%- set InstrumentId="VIS" -%}
+{%- else if SpacecraftName == "CASSINI-HUYGENS" -%}
+{%- set SpacecraftId="Cassini" -%}
+{%- set InstrumentId="VIMS" -%}
 {%- endif -%}
 
 {%- if SpacecraftId -%}$ISISROOT/appdata/import/{{- SpacecraftId -}}{{- InstrumentId -}}.tpl{%- endif -%}

--- a/isis/appdata/import/qube_base.tpl
+++ b/isis/appdata/import/qube_base.tpl
@@ -114,9 +114,9 @@ Object = IsisCube
 End_Object
 
 Object = Translation
-  OriginalImageOffset  = {{ imageOffset }}
+  DataFilePointer      = {{ imageOffset }}
   {% if exists("QUBE.AXIS_NAME.Value") %}
-  OriginalAxisOrder    = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
+  CoreAxisNames        = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
   {% endif %}
   {% if exists("BAND_BIN.BAND_BIN_BASE.Value") %}
   BandBinBase          = {{ BAND_BIN.BAND_BIN_BASE.Value }}
@@ -125,19 +125,19 @@ Object = Translation
   BandBinMultiplier    = {{ BAND_BIN.BAND_BIN_MULTIPLIER.Value }}
   {% endif %}
   {% if exists("QUBE.CORE_NULL.Value") %}
-  PdsNULL              = {{ QUBE.CORE_NULL.Value }}
+  CoreNull             = {{ QUBE.CORE_NULL.Value }}
   {% endif %}
   {% if exists("QUBE.CORE_LOW_REPR_SATURATION.Value") %}
-  PdsLRS               = {{ QUBE.CORE_LOW_REPR_SATURATION.Value }}
+  CoreLRS              = {{ QUBE.CORE_LOW_REPR_SATURATION.Value }}
   {% endif %}
   {% if exists("QUBE.CORE_LOW_INSTR_SATURATION.Value") %}
-  PdsLIS               = {{ QUBE.CORE_LOW_INSTR_SATURATION.Value }}
+  CoreLIS              = {{ QUBE.CORE_LOW_INSTR_SATURATION.Value }}
   {% endif %}
   {% if exists("QUBE.CORE_HIGH_REPR_SATURATION.Value") %}
-  PdsHRS               = {{ QUBE.CORE_HIGH_REPR_SATURATION.Value }}
+  CoreHRS              = {{ QUBE.CORE_HIGH_REPR_SATURATION.Value }}
   {% endif %}
   {% if exists("QUBE.CORE_HIGH_INSTR_SATURATION.Value") %}
-  PdsHIS               = {{ QUBE.CORE_HIGH_INSTR_SATURATION.Value }}
+  CoreHIS              = {{ QUBE.CORE_HIGH_INSTR_SATURATION.Value }}
   {% endif %}
   {% if exists("QUBE.SUFFIX_BYTES.Value") %}
   SuffixBytes          = {{ QUBE.SUFFIX_BYTES.Value }}

--- a/isis/appdata/import/qube_base.tpl
+++ b/isis/appdata/import/qube_base.tpl
@@ -1,0 +1,151 @@
+Object = IsisCube
+  Object = Core
+    Group = Dimensions
+      Samples = {{ at(QUBE.CORE_ITEMS.Value, 0) }}
+      Lines   = {{ at(QUBE.CORE_ITEMS.Value, 2) }}
+      Bands   = {{ at(QUBE.CORE_ITEMS.Value, 1) }}
+    End_Group
+
+    Group = Pixels
+      {%- set sampbits=QUBE.CORE_ITEM_BYTES.Value -%}
+      {%- if sampbits == "1" -%}
+      {%- set sampbits="8" -%}
+      {%- else if sampbits == "2" -%}
+      {%- set sampbits="16" -%}
+      {%- else if sampbits == "4" -%}
+      {%- set sampbits="32" -%}
+      {%- endif -%}
+
+      {%- set type=QUBE.CORE_ITEM_TYPE.Value -%}
+      {%- if type == "LSB_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "MSB_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "PC_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "MAC_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "SUN_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "VAX_INTEGER" -%} {%- set pixType="Integer" -%}
+      {%- else if type == "UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "UNSIGNED INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "LSB_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "MSB_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "PC_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "MAC_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "SUN_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "VAX_UNSIGNED_INTEGER" -%} {%- set pixType="Natural" -%}
+      {%- else if type == "FLOAT" -%} {%- set pixType="Real" -%}
+      {%- else if type == "REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "PC_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "IEEE_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "MAC_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "SUN_REAL" -%} {%- set pixType="Real" -%}
+      {%- else if type == "VAX_REAL" -%} {%- set pixType="Real" -%}
+      {%- else -%} {%- set pixType="LSB_INTEGER" -%}
+      {%- endif -%}
+      Type       = {% if pixType == "Real" and sampbits == "64" %} Double
+                   {% else if pixType == "Real" and sampbits == "32" %} Real
+                   {% else if pixType == "Integer" and sampbits == "8" %} UnsignedByte
+                   {% else if pixType == "Integer" and sampbits == "16" %} SignedWord
+                   {% else if pixType == "Integer" and sampbits == "32" %} SignedInteger
+                   {% else if pixType == "Natural" and sampbits == "8" %} UnsignedByte
+                   {% else if pixType == "Natural" and sampbits == "16" %} UnsignedWord
+                   {% else if pixType == "Natural" and sampbits == "32" %} UnsignedInteger
+                   {% endif %}
+      ByteOrder  = {% if type == "LSB_INTEGER" %} LSB
+                   {% else if type == "PC_INTEGER" %} LSB
+                   {% else if type == "VAX_INTEGER" %} LSB
+                   {% else if type == "LSB_UNSIGNED_INTEGER" %} LSB
+                   {% else if type == "PC_UNSIGNED_INTEGER" %} LSB
+                   {% else if type == "VAX_UNSIGNED_INTEGER" %} LSB
+                   {% else if type == "PC_REAL" %} LSB
+                   {% else if type == "VAX_REAL" %} LSB
+                   {% else if type == "MSB_INTEGER" %} MSB
+                   {% else if type == "MAC_INTEGER" %} MSB
+                   {% else if type == "SUN_INTEGER" %} MSB
+                   {% else if type == "UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "UNSIGNED INTEGER" %} MSB
+                   {% else if type == "MSB_UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "MAC_UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "SUN_UNSIGNED_INTEGER" %} MSB
+                   {% else if type == "FLOAT" %} MSB
+                   {% else if type == "REAL" %} MSB
+                   {% else if type == "IEEE_REAL" %} MSB
+                   {% else if type == "MAC_REAL" %} MSB
+                   {% else if type == "SUN_REAL" %} MSB
+                   {% else %} LSB_INTEGER
+                   {% endif %}
+      Base       = {% if exists("QUBE.CORE_BASE.Value") %}
+                   {{ QUBE.CORE_BASE.Value }}
+                   {% else %}
+                   0.0
+                   {% endif %}
+      Multiplier = {% if exists("QUBE.CORE_MULTIPLIER.Value") %}
+                   {{ QUBE.CORE_MULTIPLIER.Value }}
+                   {% else %}
+                   1.0
+                   {% endif %}
+    End_Group
+  End_Object
+
+  Group = Instrument
+    {% block instrument %}
+    {%- if exists("ROOT.MISSION_NAME.Value") -%}
+    {%- set infoGroup=ROOT -%}
+    {%- else -%}
+    {%- set infoGroup=QUBE -%}
+    {%- endif -%}
+    SpacecraftName       = {{ infoGroup.MISSION_NAME.Value }}
+    InstrumentId         = {{ infoGroup.INSTRUMENT_ID.Value }}
+    TargetName           = {{ infoGroup.TARGET_NAME.Value }}
+    SpacecraftClockStartCount = {{ infoGroup.SPACECRAFT_CLOCK_START_COUNT.Value }}
+    StartTime            = {% set startTime=infoGroup.START_TIME.Value %}
+                           {{ RemoveStartTimeZ(startTime) }}
+    {% endblock %}
+  End_Group
+
+  Group = Archive
+    MissionPhaseName     = {{ infoGroup.MISSION_PHASE_NAME.Value }}
+    SequenceId           = {{ infoGroup.SEQUENCE_ID.Value }}
+    SequenceTitle        = {{ infoGroup.SEQUENCE_TITLE.Value }}
+    ObservationId        = {{ infoGroup.OBSERVATION_ID.Value }}
+    ProductId            = {{ infoGroup.PRODUCT_ID.Value }}
+    InstrumentModeId     = {{ infoGroup.INSTRUMENT_MODE_ID.Value }}
+    {% block archive %}
+    {% endblock %}
+  End_Group
+End_Object
+
+Object = Translation
+  OriginalImageOffset  = {{ imageOffset }}
+  {% if exists("QUBE.AXIS_NAME.Value") %}
+  OriginalAxisOrder    = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
+  {% endif %}
+  {% if exists("BAND_BIN.BAND_BIN_BASE.Value") %}
+  BandBinBase          = {{ BAND_BIN.BAND_BIN_BASE.Value }}
+  {% endif %}
+  {% if exists("BAND_BIN.BAND_BIN_MULTIPLIER.Value") %}
+  BandBinMultiplier    = {{ BAND_BIN.BAND_BIN_MULTIPLIER.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_NULL.Value") %}
+  PdsNULL              = {{ QUBE.CORE_NULL.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_LOW_REPR_SATURATION.Value") %}
+  PdsLRS               = {{ QUBE.CORE_LOW_REPR_SATURATION.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_LOW_INSTR_SATURATION.Value") %}
+  PdsLIS               = {{ QUBE.CORE_LOW_INSTR_SATURATION.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_HIGH_REPR_SATURATION.Value") %}
+  PdsHRS               = {{ QUBE.CORE_HIGH_REPR_SATURATION.Value }}
+  {% endif %}
+  {% if exists("QUBE.CORE_HIGH_INSTR_SATURATION.Value") %}
+  PdsHIS               = {{ QUBE.CORE_HIGH_INSTR_SATURATION.Value }}
+  {% endif %}
+  {% if exists("QUBE.SUFFIX_BYTES.Value") %}
+  SuffixBytes          = {{ QUBE.SUFFIX_BYTES.Value }}
+  {% endif %}
+  {% if exists("QUBE.SUFFIX_ITEMS.Value") %}
+  SuffixItems          = ({{ QUBE.SUFFIX_ITEMS.Value.0 }}, {{ QUBE.SUFFIX_ITEMS.Value.1 }}, {{ QUBE.SUFFIX_ITEMS.Value.2 }})
+  {% endif %}
+  {% block translation %}
+  {% endblock %}
+End_Object
+End

--- a/isis/appdata/import/qube_base.tpl
+++ b/isis/appdata/import/qube_base.tpl
@@ -114,7 +114,7 @@ Object = IsisCube
 End_Object
 
 Object = Translation
-  DataFilePointer      = {{ imageOffset }}
+  DataFilePointer      = {{ ptrQUBE.Value }}
   {% if exists("QUBE.AXIS_NAME.Value") %}
   CoreAxisNames        = {{ QUBE.AXIS_NAME.Value.0 }}{{ QUBE.AXIS_NAME.Value.1 }}{{ QUBE.AXIS_NAME.Value.2 }}
   {% endif %}

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -47,8 +47,8 @@ namespace Isis {
         // try to convert pvl to json
         jsonData = pvlToJSON(inputFileName.toString());
         // QString labelOffset = jsonData["^QUBE"]["Value"];
-        if (jsonData.find("^QUBE") != jsonData.end()) {
-          jsonData["imageOffset"] = jsonData["^QUBE"]["Value"];
+        if (jsonData.find("ptrQUBE") != jsonData.end()) {
+          jsonData["imageOffset"] = jsonData["ptrQUBE"]["Value"];
         }
       }
       catch(...) {

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -46,10 +46,6 @@ namespace Isis {
       try {
         // try to convert pvl to json
         jsonData = pvlToJSON(inputFileName.toString());
-        // QString labelOffset = jsonData["^QUBE"]["Value"];
-        if (jsonData.find("ptrQUBE") != jsonData.end()) {
-          jsonData["imageOffset"] = jsonData["ptrQUBE"]["Value"];
-        }
       }
       catch(...) {
         QString msg = "Unable to process import image. Please confirm image is in PDS3 or PDS4 format";

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -10,7 +10,6 @@
 #include "iTime.h"
 #include "OriginalLabel.h"
 #include "OriginalXmlLabel.h"
-#include "OriginalLabel.h"
 #include "XmlToJson.h"
 #include "PvlToJSON.h"
 #include "ProcessImport.h"

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -191,6 +191,22 @@ namespace Isis {
     importer.SetMultiplier(multiplier);
 
     PvlObject translation = newLabel.findObject("Translation");
+
+    // Check translation for potential PDS3 offset
+    if (translation.hasKeyword("DataFilePointer")) {
+      int offset = toInt(translation["DataFilePointer"]);
+
+      if (translation.hasKeyword("DataFileRecordBytes")) {
+        int recSize = toInt(translation["DataFileRecordBytes"]);
+
+        importer.SetFileHeaderBytes((offset - 1) * recSize);
+      }
+    }
+    // Assume PDS4
+    else {
+      importer.SetFileHeaderBytes(0);
+    }
+
     QString originalAxisOrder = QString(translation["OriginalAxisOrder"]);
     if (originalAxisOrder == "SAMPLELINEBAND") {
       importer.SetOrganization(ProcessImport::BSQ);
@@ -211,35 +227,31 @@ namespace Isis {
 
     // Set any special pixel values
     double pdsNull = Isis::NULL8;
-    if (translation.hasKeyword("PdsNULL")) {
-      pdsNull = toDouble(translation["PdsNULL"]);
+    if (translation.hasKeyword("CoreNull")) {
+      pdsNull = toDouble(translation["CoreNull"]);
     }
 
     double pdsLrs = Isis::Lrs;
-    if (translation.hasKeyword("PdsLRS")) {
-      pdsLrs = toDouble(translation["PdsLRS"]);
+    if (translation.hasKeyword("CoreLRS")) {
+      pdsLrs = toDouble(translation["CoreLRS"]);
     }
 
     double pdsLis = Isis::Lis;
-    if (translation.hasKeyword("PdsLIS")) {
-      pdsLis = toDouble(translation["PdsLIS"]);
+    if (translation.hasKeyword("CoreLIS")) {
+      pdsLis = toDouble(translation["CoreLIS"]);
     }
 
     double pdsHrs = Isis::Hrs;
-    if (translation.hasKeyword("PdsHRS")) {
-      pdsHrs = toDouble(translation["PdsHRS"]);
+    if (translation.hasKeyword("CoreHRS")) {
+      pdsHrs = toDouble(translation["CoreHRS"]);
     }
 
     double pdsHis = Isis::His;
-    if (translation.hasKeyword("PdsHIS")) {
-      pdsHis = toDouble(translation["PdsHIS"]);
+    if (translation.hasKeyword("CoreHIS")) {
+      pdsHis = toDouble(translation["CoreHIS"]);
     }
-
     importer.SetSpecialValues(pdsNull, pdsLrs, pdsLis, pdsHrs, pdsHis);
-
-    // TODO: how to handle this?
-    importer.SetFileHeaderBytes(translation["OriginalImageOffset"]);
-
+    
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
     Cube *outputCube = importer.SetOutputCube(ui.GetFileName("TO"), att);
 

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -207,22 +207,24 @@ namespace Isis {
       importer.SetFileHeaderBytes(0);
     }
 
-    QString originalAxisOrder = QString(translation["OriginalAxisOrder"]);
-    if (originalAxisOrder == "SAMPLELINEBAND") {
-      importer.SetOrganization(ProcessImport::BSQ);
-    }
-    else if (originalAxisOrder == "BANDSAMPLELINE") {
-      importer.SetOrganization(ProcessImport::BIP);
-    }
-    else if (originalAxisOrder == "SAMPLEBANDLINE") {
-      importer.SetOrganization(ProcessImport::BIL);
-    }
-    else {
-      stringstream pdsOrgStream;
-      pdsOrgStream << originalAxisOrder;
+    if (translation.hasKeyword("CoreAxisNames")) {
+      QString originalAxisOrder = QString(translation["CoreAxisNames"]);
+      if (originalAxisOrder == "SAMPLELINEBAND") {
+        importer.SetOrganization(ProcessImport::BSQ);
+      }
+      else if (originalAxisOrder == "BANDSAMPLELINE") {
+        importer.SetOrganization(ProcessImport::BIP);
+      }
+      else if (originalAxisOrder == "SAMPLEBANDLINE") {
+        importer.SetOrganization(ProcessImport::BIL);
+      }
+      else {
+        stringstream pdsOrgStream;
+        pdsOrgStream << originalAxisOrder;
 
-      QString msg = "Unsupported axis order [" + QString(originalAxisOrder) + "]";
-      throw IException(IException::Programmer, msg, _FILEINFO_);
+        QString msg = "Unsupported axis order [" + QString(originalAxisOrder) + "]";
+        throw IException(IException::Programmer, msg, _FILEINFO_);
+      }
     }
 
     // Set any special pixel values
@@ -251,7 +253,7 @@ namespace Isis {
       pdsHis = toDouble(translation["CoreHIS"]);
     }
     importer.SetSpecialValues(pdsNull, pdsLrs, pdsLis, pdsHrs, pdsHis);
-    
+
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
     Cube *outputCube = importer.SetOutputCube(ui.GetFileName("TO"), att);
 

--- a/isis/src/cassini/apps/vims2isis/main.cpp
+++ b/isis/src/cassini/apps/vims2isis/main.cpp
@@ -144,7 +144,7 @@ void IsisMain() {
 
   //Clean up
   QString tmp(tempname.expanded());
-  // QFile::remove(tmp);
+  QFile::remove(tmp);
 }
 
 /**

--- a/isis/src/cassini/apps/vims2isis/main.cpp
+++ b/isis/src/cassini/apps/vims2isis/main.cpp
@@ -144,7 +144,7 @@ void IsisMain() {
 
   //Clean up
   QString tmp(tempname.expanded());
-  QFile::remove(tmp);
+  // QFile::remove(tmp);
 }
 
 /**


### PR DESCRIPTION
Adds a basic Cassini VIMS template to the isisimport

## Description
Adds the base Cassini VIMS template to isisimport. 

There are three extenuating circumstances with the template that have not been addressed from the original `vims2isis` application. The issues are as follows:
- The current ingestion does not perfectly match the same phase as `vims2isis`
- There is a custom processing function that is not part of the current functionality in isisimport if there is suffix data on the vims image (see [this](https://github.com/USGS-Astrogeology/ISIS3/blob/d1cbf4dba3a82e7af7db44dc478127f9e2b6c76c/isis/src/cassini/apps/vims2isis/main.cpp#L99))
- There is a post processing step that separates the VIS bands from the IR bands if they exist within the image

## Related Issue
N/A

## Motivation and Context
Generic 2isis application

## How Has This Been Tested?
No tests for specific instruments yet

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
