### PR TITLE
Re-enabled ObservationPair tests

### DIFF
--- a/isis/tests/FunctionalTestsCkwriter.cpp
+++ b/isis/tests/FunctionalTestsCkwriter.cpp
@@ -145,7 +145,7 @@ TEST_F(DefaultCube, FunctionalTestCkwriterFromlist) {
   }
 }
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestCkwriterCantValidate) {
+TEST_F(ObservationPair, FunctionalTestCkwriterCantValidate) {
   Pvl appLog;
   QVector<QString> args = {"fromlist=" + cubeListFile,
                            "to=" + tempDir.path() + "/newKernel.bc"};
@@ -160,7 +160,7 @@ TEST_F(ObservationPair, DISABLED_FunctionalTestCkwriterCantValidate) {
   }
 }
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestCkwriterWarnValidate) {
+TEST_F(ObservationPair, FunctionalTestCkwriterWarnValidate) {
   Pvl appLog;
   QVector<QString> args = {"fromlist=" + cubeListFile,
                            "to=" + tempDir.path() + "/newKernel.bc",

--- a/isis/tests/FunctionalTestsJigsaw.cpp
+++ b/isis/tests/FunctionalTestsJigsaw.cpp
@@ -469,7 +469,7 @@ TEST_F(ApolloNetwork, FunctionalTestJigsawBundleXYZ) {
   }
 }
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestJigsawCamSolveAll) {
+TEST_F(ObservationPair, FunctionalTestJigsawCamSolveAll) {
   // delete to remove old camera for when cam is updated
   delete cubeL;
   delete cubeR;
@@ -789,7 +789,7 @@ TEST_F(ApolloNetwork, FunctionalTestJigsawMEstimator) {
 }
 
 
- TEST_F(ObservationPair, DISABLED_FunctionalTestJigsawErrorNoSolve) {
+ TEST_F(ObservationPair, FunctionalTestJigsawErrorNoSolve) {
   QTemporaryDir prefix;
   QString outCnetFileName = prefix.path() + "/outTemp.net";
   QVector<QString> args = {"fromlist="+cubeListFile, "cnet="+cnetPath, "onet="+outCnetFileName,
@@ -808,7 +808,7 @@ TEST_F(ApolloNetwork, FunctionalTestJigsawMEstimator) {
 }
 
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestJigsawErrorTBParamsNoTarget) {
+TEST_F(ObservationPair, FunctionalTestJigsawErrorTBParamsNoTarget) {
   QTemporaryDir prefix;
   QString outCnetFileName = prefix.path() + "/outTemp.net";
 
@@ -829,7 +829,7 @@ TEST_F(ObservationPair, DISABLED_FunctionalTestJigsawErrorTBParamsNoTarget) {
 }
 
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestJigsawErrorTBParamsNoSolve) {
+TEST_F(ObservationPair, FunctionalTestJigsawErrorTBParamsNoSolve) {
   QTemporaryDir prefix;
   QString outCnetFileName = prefix.path() + "/outTemp.net";
 

--- a/isis/tests/FunctionalTestsLronac2pds.cpp
+++ b/isis/tests/FunctionalTestsLronac2pds.cpp
@@ -16,7 +16,7 @@ using namespace Isis;
 
 static QString APP_XML = FileName("$ISISROOT/bin/xml/lronac2pds.xml").expanded();
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestLronac2pdsIof) {
+TEST_F(ObservationPair, FunctionalTestLronac2pdsIof) {
   QVector<QString> args = {"from=" + cubeLPath,
                            "to=" + tempDir.path() + "/LroNacL.img"};
   UserInterface options(APP_XML, args);
@@ -46,7 +46,7 @@ TEST_F(ObservationPair, DISABLED_FunctionalTestLronac2pdsIof) {
   EXPECT_EQ(QString(imageObject["MD5_CHECKSUM"]), "5f5d7bc236f794ca651cebdde529f8a4");
 }
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestLronac2pdsRadiance) {
+TEST_F(ObservationPair, FunctionalTestLronac2pdsRadiance) {
   QVector<QString> args = {"from=" + cubeLPath,
                            "to=" + tempDir.path() + "/LroNacL.img"};
   UserInterface options(APP_XML, args);

--- a/isis/tests/FunctionalTestsSpkwriter.cpp
+++ b/isis/tests/FunctionalTestsSpkwriter.cpp
@@ -126,7 +126,7 @@ TEST_F(DefaultCube, FunctionalTestSpkwriterFromlist) {
   }
 }
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestSpkwriterCantValidate) {
+TEST_F(ObservationPair, FunctionalTestSpkwriterCantValidate) {
   Pvl appLog;
   QVector<QString> args = {"fromlist=" + cubeListFile,
                            "to=" + tempDir.path() + "/newKernel.bsp"};
@@ -141,7 +141,7 @@ TEST_F(ObservationPair, DISABLED_FunctionalTestSpkwriterCantValidate) {
   }
 }
 
-TEST_F(ObservationPair, DISABLED_FunctionalTestSpkwriterWarnValidate) {
+TEST_F(ObservationPair, FunctionalTestSpkwriterWarnValidate) {
   Pvl appLog;
   QVector<QString> args = {"fromlist=" + cubeListFile,
                            "to=" + tempDir.path() + "/newKernel.bsp",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Re-enables the tests that use the ObservationPair fixture

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Related to #4666 and #4609

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

These tests were disabled in #4664 because #4609 was causing the fixture to error because it's SCLK kernels were no longer around. Now that we've pushed all of the SCLKs to the internal data area for CI these can be re-enabled and ran.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I build and ran this locally on prog28 without issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
