### PR TITLE
BundleObservationVector updates for lidar support

### DIFF
--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
@@ -147,6 +147,8 @@ namespace Isis {
         throw IException(IException::Programmer, message, _FILEINFO_);
       }
 
+      bundleImage->setParentObservation(bundleObservation);
+
       // Find the bundle observation solve settings for this new observation
       BundleObservationSolveSettings solveSettings;
       // When there is only one bundle observation solve setting, use it for all observations
@@ -249,5 +251,23 @@ namespace Isis {
     // multimap returns them in reverse order they were put in, so invert them to preserve order
     std::reverse(std::begin(list), std::end(list));
     return list;
+  }
+}
+
+
+  /**
+   * Compute vtpv, the weighted sum of squares of constrained image parameter residuals.
+   *
+   * @return double Weighted sum of squares of constrained image parameter residuals.
+   */
+  double BundleObservationVector::vtpvContribution() {
+    double vtpvImage = 0;
+
+    for (int i = 0; i < size(); i++) {
+      BundleObservationQsp bundleObservation = at(i);
+      vtpvImage += bundleObservation->vtpv();
+    }
+
+    return vtpvImage;
   }
 }

--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.h
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.h
@@ -51,6 +51,8 @@ namespace Isis {
    *   @history 2016-10-13 Ian Humphrey - Modified addnew so that we set solve settings based
    *                           on the BundleObsevation's observation number. Renamed addnew to
    *                           addNew(). References #4293.
+   *   @history 2018-02-12 Ken Edmundson Renamed initializeBodyRotation method to setBodyRotation.
+   *   @history 2018-11-29 Ken Edmundson Modified addNew method. Removed setBodyRotation method.
    */
   class BundleObservationVector : public QVector<BundleObservationQsp> {
 
@@ -68,6 +70,8 @@ namespace Isis {
       int numberParameters();
 
       BundleObservationQsp observationByCubeSerialNumber(QString cubeSerialNumber);
+
+      double vtpvContribution();
 
       QList<QString> instrumentIds() const;
       QList<BundleObservationQsp> observationsByInstId(QString instrumentId) const;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Moving over the relevant lines in BundleObservationVector object from [LroLidar_Infrastructure](https://github.com/USGS-Astrogeology/ISIS3/tree/LroLidar_Infrastructure/) branch.

## Description
<!--- Describe your changes in detail -->
Moving over the relevant lines in BundleObservationVector object from [LroLidar_Infrastructure](https://github.com/USGS-Astrogeology/ISIS3/tree/LroLidar_Infrastructure/) branch. There are some lines in the LroLidar_Infrastructure BundleObservationVector which support piecewise polynomials, those were not moved over, as it was decided taht functionality is highly specialized and as such would not be helpful to a majority of users. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to issue #4704 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This continue the work of supporting Lidar in the jigsaw bundle

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No tests were written for this new functionality, as it is a partial transfer of Lidar support for the Bundle utilities. New test should be added later. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
