### PR TITLE
Added Ckwriter to write Timing Offset to Comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,6 @@ Keywords when running CAMSTATS.  [#3605](https://github.com/USGS-Astrogeology/IS
 - Fixed issue where serial numbers for Kaguya TC and MI image could not be generated. [4235](https://github.com/USGS-Astrogeology/ISIS3/issues/4235)
 - Fixed hardcoded file naming in the hijitter app dealing with output from pipeline. [#4372](https://github.com/USGS-Astrogeology/ISIS3/pull/4372)
 - Fixed "About Qview" to point to website documentation. [4333](https://github.com/USGS-Astrogeology/ISIS3/issues/4333)
-- Fixed bug where the time bias was not being added to the ephemeris times in ckwriter. [4129](https://github.com/USGS-Astrogeology/ISIS3/issues/4129)
 
 ### Changed
 

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
@@ -264,7 +264,10 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
 
     _utcStartTime = toUTC(startTime());
     _utcEndTime   = toUTC(endTime());
-    _timeOffset =  etLabStart.Et() - startTime();
+
+    _timeOffset =  fabs(etLabStart.Et() - startTime());
+    // account for padding
+    if (_timeOffset <= 0.003) { _timeOffset = 0; }
 
     _kernels.UnLoad("CK,FK,SCLK,LSK,IAK");
 

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
@@ -42,6 +42,7 @@
 #include "FileName.h"
 #include "IException.h"
 #include "IString.h"
+#include "iTime.h"
 #include "NaifStatus.h"
 #include "CkSpiceSegment.h"
 #include "Table.h"
@@ -210,13 +211,16 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
     if (!value.isEmpty()) { _target = value; }
      _camVersion = _kernels.CameraVersion();
 
+    QString labStartTime = getKeyValue(*label, "StartTime");
+    iTime etLabStart(labStartTime);
+
     //  Get the SPICE data
     Table ckCache = camera->instrumentRotation()->LineCache(tblname);
     SMatrix spice = load(ckCache);
 
     _quats = getQuaternions(spice);
     _avvs = getAngularVelocities(spice);
-    _times = getTimes(spice, camera->instrumentRotation()->TimeBias());
+    _times = getTimes(spice);
 
     _startTime = _times[0];
     _endTime = _times[size(_times)-1];
@@ -260,6 +264,8 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
 
     _utcStartTime = toUTC(startTime());
     _utcEndTime   = toUTC(endTime());
+    _timeOffset =  etLabStart.Et() - startTime();
+
     _kernels.UnLoad("CK,FK,SCLK,LSK,IAK");
 
   } catch ( IException &ie  ) {
@@ -303,13 +309,13 @@ CkSpiceSegment::SMatrix CkSpiceSegment::getAngularVelocities(const SMatrix &spic
 }
 
 
-CkSpiceSegment::SVector CkSpiceSegment::getTimes(const SMatrix &spice, const double timeBias) const {
+CkSpiceSegment::SVector CkSpiceSegment::getTimes(const SMatrix &spice) const {
   int nrecs = size(spice);
   SVector etdp(nrecs);
   int tcol = spice.dim2() - 1;
 
   for ( int i = 0 ; i < nrecs ; i++ ) {
-    etdp[i] = spice[i][tcol] + timeBias;
+    etdp[i] = spice[i][tcol];
   }
   return (etdp);
 }
@@ -688,6 +694,11 @@ QString CkSpiceSegment::getComment() const {
 "  RefFrame:   " << _refFrame << endl <<
 "  Records:    " << size() << endl;
 
+  if (_timeOffset != 0) {
+    comment <<
+"  TimeOffset: " << _timeOffset << endl;
+  }
+
   QString hasAV = (size(_avvs) > 0) ? "YES" : "NO";
   comment <<
 "  HasAV:      " << hasAV << endl;
@@ -715,6 +726,7 @@ void CkSpiceSegment::init() {
   _instId = _target = "UNKNOWN";
   _instCode = 0;
   _instFrame = _refFrame = "";
+  _timeOffset = 0;
   _quats = _avvs = SMatrix(0,0);
   _times = SVector(0);
   _tickRate = 0.0;

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.h
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.h
@@ -86,6 +86,11 @@ class PvlObject;
  *
  * @history 2019-12-05 Adam Paquette - Changed how kernels are loaded so CkSpiceSegment
  *                          no longer needs to use the Spice class.
+ *
+ * @history 2021-12-22 Amy Stamile - Added timing offset information to kernel comments
+ *                          by calculating difference between label StartTime and camera model
+ *                          StartTime. This is to allow for spiceinit to handle offsets
+ *                          when finding associated smithed kernels. References #3363.
  */
 class CkSpiceSegment {
   public:

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.h
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.h
@@ -86,8 +86,6 @@ class PvlObject;
  *
  * @history 2019-12-05 Adam Paquette - Changed how kernels are loaded so CkSpiceSegment
  *                          no longer needs to use the Spice class.
- *                          
- * @history 2021-03-23 Kaitlyn Lee - Added time bias to ET times in getTimes(). Fixes #4129
  */
 class CkSpiceSegment {
   public:
@@ -156,6 +154,7 @@ class CkSpiceSegment {
     QString _utcEndTime;   //  requires leap seconds kernel
     QString _instId;       //  Instrument ID
     QString _target;       //  Target name
+    double  _timeOffset;
     int         _instCode;     //  NAIF instrument code of the SPICE segment
     QString _instFrame;    //  NAIF instrument frame
     QString _refFrame;     //  NAIF reference frame
@@ -174,7 +173,7 @@ class CkSpiceSegment {
     SMatrix load(Table &cache);
     SMatrix getQuaternions(const SMatrix &spice) const;
     SMatrix getAngularVelocities(const SMatrix &spice) const;
-    SVector getTimes(const SMatrix &spice, const double timeBias) const;
+    SVector getTimes(const SMatrix &spice) const;
 
     bool getTimeDependentFrameIds(Table &table, int &toId, int &fromId) const;
     bool getFrameChains(Table &table, const int &leftBase,

--- a/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
+++ b/isis/src/base/objs/SpiceRotation/SpiceRotation.cpp
@@ -186,7 +186,7 @@ namespace Isis {
 
     if (rotToCopy.m_orientation) {
       m_orientation = new ale::Orientations;
-      *m_orientation = *rotToCopy.m_orientation; 
+      *m_orientation = *rotToCopy.m_orientation;
     }
     else {
       m_orientation = NULL;
@@ -309,16 +309,6 @@ namespace Isis {
 
 
   /**
-   * Accessor method to get current time bias.
-   *
-   * @return @b double The current time bias.
-   */
-  double SpiceRotation::TimeBias() const {
-    return p_timeBias;
-  }
-
-
-  /**
    * Checks if the cache is empty.
    *
    * @return @b bool Indicates whether this rotation is cached.
@@ -385,7 +375,7 @@ namespace Isis {
     p_fullCacheEndTime = endTime;
     p_fullCacheSize = size;
 
-    if (m_orientation != NULL) { 
+    if (m_orientation != NULL) {
       delete m_orientation;
       m_orientation = NULL;
     }
@@ -417,11 +407,11 @@ namespace Isis {
     }
 
     if (p_TC.size() > 1) {
-      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                             ale::Rotation(p_TC), p_constantFrames, p_timeFrames);
     }
     else {
-      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                             ale::Rotation(1,0,0,0), p_constantFrames, p_timeFrames);
     }
 
@@ -471,7 +461,7 @@ namespace Isis {
     p_cacheTime.clear();
     p_hasAngularVelocity = false;
     m_frameType = CK;
-    
+
     if (m_orientation) {
       delete m_orientation;
       m_orientation = NULL;
@@ -506,14 +496,14 @@ namespace Isis {
 
     if (hasConstantFrames) {
       p_constantFrames = isdRot["constant_frames"].get<std::vector<int>>();
-      p_TC = isdRot["constant_rotation"].get<std::vector<double>>(); 
-      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+      p_TC = isdRot["constant_rotation"].get<std::vector<double>>();
+      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                           ale::Rotation(p_TC), p_constantFrames, p_timeFrames);
     }
     else {
       p_TC.resize(9);
       ident_c((SpiceDouble( *)[3]) &p_TC[0]);
-      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                           ale::Rotation(1,0,0,0), p_constantFrames, p_timeFrames);
     }
 
@@ -643,11 +633,11 @@ namespace Isis {
         p_cacheTime.push_back((double)rec[4]);
       }
       if (p_TC.size() > 1) {
-        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                               ale::Rotation(p_TC), p_constantFrames, p_timeFrames);
       }
       else {
-        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                               ale::Rotation(1,0,0,0), p_constantFrames, p_timeFrames);
       }
       p_source = Memcache;
@@ -683,11 +673,11 @@ namespace Isis {
       }
 
       if (p_TC.size() > 1) {
-        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                               ale::Rotation(p_TC), p_constantFrames, p_timeFrames);
       }
       else {
-        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                               ale::Rotation(1,0,0,0), p_constantFrames, p_timeFrames);
       }
       p_source = Memcache;
@@ -794,16 +784,16 @@ namespace Isis {
     }
 
     if (m_orientation) {
-      delete m_orientation; 
+      delete m_orientation;
       m_orientation = NULL;
     }
 
     if (p_TC.size() > 1) {
-      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+      m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                             ale::Rotation(p_TC), p_constantFrames, p_timeFrames);
     }
     else {
-        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                               ale::Rotation(1,0,0,0), p_constantFrames, p_timeFrames);
     }
 
@@ -911,7 +901,7 @@ namespace Isis {
       for (int i = 0; i < (int) p_cacheTime.size(); i++) {
         std::vector<double> quat = rots[i].toQuaternion();
 
-        // If the first component is less than zero, multiply the whole quaternion by -1. This 
+        // If the first component is less than zero, multiply the whole quaternion by -1. This
         // matches NAIF.
         if (quat[0] < 0) {
           quat[0] = -1 * quat[0];
@@ -920,7 +910,7 @@ namespace Isis {
           quat[3] = -1 * quat[3];
         }
 
-        record[0] = quat[0]; 
+        record[0] = quat[0];
         record[1] = quat[1];
         record[2] = quat[2];
         record[3] = quat[3];
@@ -1327,7 +1317,7 @@ namespace Isis {
    * Set the rotation angles (phi, delta, and w) for the current time to define the
    * time-based matrix CJ. This method was created for unitTests and should not
    * be used otherwise.  It only works for cached data with a cache size of 1.
-   *  
+   *
    * @param[in]  angles The angles defining the rotation (phi, delta, and w) in radians
    * @param[in]  axis3    The rotation axis for the third angle
    * @param[in]  axis2    The rotation axis for the second angle
@@ -2500,7 +2490,7 @@ namespace Isis {
       double avvs[p_fullCacheSize][3]; // Angular velocity vector
 
       // We will treat et as the sclock time and avoid converting back and forth
-     std::vector<ale::Rotation> fullRotationCache = m_orientation->getRotations(); 
+     std::vector<ale::Rotation> fullRotationCache = m_orientation->getRotations();
      std::vector<ale::Vec3d> angularVelocities = m_orientation->getAngularVelocities();
      for (int r = 0; r < p_fullCacheSize; r++) {
         timeSclkdp[r] = p_cacheTime[r];
@@ -2553,7 +2543,7 @@ namespace Isis {
       }
 
       if (p_TC.size() > 1 ) {
-        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache, 
+        m_orientation = new ale::Orientations(rotationCache, p_cacheTime, avCache,
                                               ale::Rotation(p_TC), p_constantFrames, p_timeFrames);
       }
       else {
@@ -3271,7 +3261,7 @@ namespace Isis {
     if (p_cacheTime.size() == 1) {
       p_CJ = m_orientation->getRotations()[0].toRotationMatrix();
       if (p_hasAngularVelocity) {
-        ale::Vec3d av = m_orientation->getAngularVelocities()[0]; 
+        ale::Vec3d av = m_orientation->getAngularVelocities()[0];
         p_av[0] = av.x;
         p_av[1] = av.y;
         p_av[2] = av.z;

--- a/isis/src/base/objs/SpiceRotation/SpiceRotation.h
+++ b/isis/src/base/objs/SpiceRotation/SpiceRotation.h
@@ -200,7 +200,6 @@ namespace Isis {
    *                           The current example is the comet 67P/CHURYUMOV-GERASIMENKO
    *                           imaged by Rosetta. Some future comet/astroid missions are expected
    *                           to use a CK defined body fixed reference frame. Fixes #5408.
-   * @history 2021-03-23 Kaitlyn Lee - Added getter function for time bias. Fixes #4129.
    *
    *  @todo Downsize using Hermite cubic spline and allow Nadir tables to be downsized again.
    *  @todo Consider making this a base class with child classes based on frame type or
@@ -224,7 +223,6 @@ namespace Isis {
       int Frame();
 
       void SetTimeBias(double timeBias);
-      double TimeBias() const;
 
       /**
        * The rotation can come from one of 3 places for an Isis cube.  The class

--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
@@ -237,6 +237,18 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
   kinfo_c(tmp.toLatin1().data(), 32, 2048, fileType, source, &handle, &found);
   QString currFile = fileType;
 
+  if (found == SPICETRUE) {
+    SpiceChar commnt[1001];
+    SpiceBoolean done(SPICEFALSE);
+    SpiceInt n;
+    // extract all comments of kernel
+    while (!done) {
+      dafec_c(handle, 25, sizeof(commnt), &n, commnt, &done);
+
+      //TODO: Grab Instrument and Offset information, if exists
+    }
+  }
+
   //create a spice cell capable of containing all the objects in the kernel.
   SPICEINT_CELL(currCell, 1000);
   //this resizing is done because otherwise a spice cell will append new data

--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
@@ -232,6 +232,8 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
   furnsh_c(tmp.toLatin1().data());
   SpiceChar fileType[32], source[2048];
   SpiceInt handle;
+  QString instrument = "";
+  QString timeoffset = "";
 
   SpiceBoolean found;
   kinfo_c(tmp.toLatin1().data(), 32, 2048, fileType, source, &handle, &found);
@@ -241,11 +243,21 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
     SpiceChar commnt[1001];
     SpiceBoolean done(SPICEFALSE);
     SpiceInt n;
+
     // extract all comments of kernel
     while (!done) {
-      dafec_c(handle, 25, sizeof(commnt), &n, commnt, &done);
+      dafec_c(handle, 1, sizeof(commnt), &n, commnt, &done);
+      QString cmmt(commnt);
 
-      //TODO: Grab Instrument and Offset information, if exists
+      // Grab Instrument and Offset information, if exists
+      int instPos = 0;
+      if ( (instPos = cmmt.indexOf("Instrument:", instPos, Qt::CaseInsensitive)) != -1 ) {
+        instrument = cmmt.split(": ")[1];
+      }
+      int timePos = 0;
+      if ( (timePos = cmmt.indexOf("TimeOffset:", timePos, Qt::CaseInsensitive)) != -1 ) {
+        timeoffset = cmmt.split(": ")[1];
+      }
     }
   }
 
@@ -310,6 +322,12 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
         result = FormatIntervals(cover, currFile, startOffset, endOffset);
       }
     }
+  }
+
+  // add instrument and timing offset only if timing offset is found in comments
+  if (!timeoffset.isEmpty()) {
+    result += PvlKeyword("TimeOffset", timeoffset);
+    result += PvlKeyword("Instrument", instrument);
   }
 
   QString outFile = fileIn.originalPath();

--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.h
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.h
@@ -42,6 +42,11 @@ find files of those names at the top level of this repository. **/
  *   @history 2019-08-13 Jesse Mapel - Added the ability to pass an explicit lsit
  *                           of files to the Direct method. Fixes #3390.
  *
+ *   @history 2021-12-22 Amy Stamile - Added the ability to include timing offset information
+ *                          in db if information exists in the kernel comments.
+ *                          This information will be use in spiceinit to handle time offsets
+ *                          when selecting smithed kernels. References #3363.
+ *
  */
 class SpiceDbGen {
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ckwriter checks for differences in start time between camera model and the original label and adds this offset information to comments of kernel. 

kerneldbgen looks for timing offset in comments and adds information to db alongside instrument name.

Example output of db for ck smithed kernel created in ckwriter:
```
Object = SpacecraftPointing
  RunTime = 2021-12-22T10:47:06

  Group = Dependencies
    SpacecraftClockKernel = /Volumes/pkgs/isis3/isis_data/odyssey/kernels/scl-
                            k/ORB1_SCLKSCET.00274.tsc
    LeapsecondKernel      = /Volumes/pkgs/isis3/isis_data/base/kernels/lsk/na-
                            if0008.tls
  End_Group

  Group = Selection
    Time       = ("2002 FEB 20 22:58:59.720231 TDB",
                  "2002 FEB 20 22:59:11.726211 TDB")
    TimeOffset = 1.71801
    Instrument = THEMIS_IR
    File       = /Users/astamile/testData/kernelTiming//kernTime.bc
    Type       = Smithed
  End_Group
End_Object
End
```

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Kernel Timing Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested that Themis IRs return an offset in written kernel. Also tested that other instruments such as Themis VIS do not calculate an offset as expected.

Tested that kerneldbgen outputs timing offset only if exists in kernel comments.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
