### PR TITLE
swaps listing of env var method setting methods, 

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,23 +104,7 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
 
     There are two methods to configure the environment variables for ISIS:
 
-    7.1 Using the provided isisVarInit.py script:
-
-      To use the default values for: `$ISISROOT` and `$ISISDATA`, run the ISIS variable initialization script with default arguments:
-
-          python $CONDA_PREFIX/scripts/isisVarInit.py
-
-      Executing this script with no arguments will result in $ISISROOT=$CONDA\_PREFIX and $ISISDATA=$CONDA\_PREFIX/data. The user can specify different directories for `$ISISDATA` using the optional value:
-
-          python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]
-
-      Now every time the isis environment is activated, $ISISROOT and $ISISDATA will be set to the values passed to isisVarInit.py.
-      This does not happen retroactively, so re-activate the isis environment with one of the following commands:
-
-          for Anaconda 3.4 and up - conda activate isis
-          prior to Anaconda 3.4 - source activate isis
-
-    7.2 Using `conda env config vars`
+    7.1 Using `conda env config vars` *preferred*
 
       Conda has a built in method for configuring environment variables that are specific to a conda environment since version 4.8.
       This version number applies only to the conda package, not to the version of miniconda or anaconda that was installed.
@@ -151,6 +135,23 @@ This installation guide is for ISIS users interested in installing ISIS (3.6.0)+
       The environment variables are now set and ISIS is ready for use every time the isis environment is activated.
 
       **Note** This method will not enable tab completion for arguments in C-Shell.
+
+
+    7.2 Using the provided isisVarInit.py script:
+
+      To use the default values for: `$ISISROOT` and `$ISISDATA`, run the ISIS variable initialization script with default arguments:
+
+          python $CONDA_PREFIX/scripts/isisVarInit.py
+
+      Executing this script with no arguments will result in $ISISROOT=$CONDA\_PREFIX and $ISISDATA=$CONDA\_PREFIX/data. The user can specify different directories for `$ISISDATA` using the optional value:
+
+          python $CONDA_PREFIX/scripts/isisVarInit.py --data-dir=[path to data directory]
+
+      Now every time the isis environment is activated, $ISISROOT and $ISISDATA will be set to the values passed to isisVarInit.py.
+      This does not happen retroactively, so re-activate the isis environment with one of the following commands:
+
+          for Anaconda 3.4 and up - conda activate isis
+          prior to Anaconda 3.4 - source activate isis
 
 
 


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->
As per phase 2/3 from https://github.com/USGS-Astrogeology/ISIS3/issues/4499#issuecomment-853106918 , this pr indicates preference for users to use the conda env config vars method.

## Description
<!--- Describe your changes in detail -->

## Related Issue
- https://github.com/USGS-Astrogeology/ISIS3/issues/4499

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Documentation change (update to the documentation; no code change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
