### PR TITLE
Updated ckwriter offset calculations and added spkwriter calculations

### DIFF
--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
@@ -212,7 +212,9 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
      _camVersion = _kernels.CameraVersion();
 
     QString labStartTime = getKeyValue(*label, "StartTime");
+    QString labEndTime = getKeyValue(*label, "StopTime");
     iTime etLabStart(labStartTime);
+    iTime etLabEnd(labEndTime);
 
     //  Get the SPICE data
     Table ckCache = camera->instrumentRotation()->LineCache(tblname);
@@ -265,9 +267,21 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
     _utcStartTime = toUTC(startTime());
     _utcEndTime   = toUTC(endTime());
 
-    _timeOffset =  fabs(etLabStart.Et() - startTime());
+    _startOffset =  etLabStart.Et() - startTime();
+    _endOffset =  etLabEnd.Et() - endTime();
     // account for padding
-    if (_timeOffset <= 0.003) { _timeOffset = 0; }
+    if (_startOffset >= 0.0031) {
+      _startOffset = 0.0;
+    }
+    else {
+      _startOffset = fabs(_startOffset);
+    }
+    if (_endOffset <= 0.0031) {
+      _endOffset = 0.0;
+    }
+    else {
+      _endOffset = fabs(_endOffset);
+    }
 
     _kernels.UnLoad("CK,FK,SCLK,LSK,IAK");
 
@@ -697,9 +711,14 @@ QString CkSpiceSegment::getComment() const {
 "  RefFrame:   " << _refFrame << endl <<
 "  Records:    " << size() << endl;
 
-  if (_timeOffset != 0) {
+  if (_startOffset != 0) {
     comment <<
-"  TimeOffset: " << _timeOffset << endl;
+"  StartOffset: " << _startOffset << endl;
+  }
+
+  if (_endOffset != 0) {
+    comment <<
+"  EndOffset: " << _endOffset << endl;
   }
 
   QString hasAV = (size(_avvs) > 0) ? "YES" : "NO";
@@ -729,7 +748,8 @@ void CkSpiceSegment::init() {
   _instId = _target = "UNKNOWN";
   _instCode = 0;
   _instFrame = _refFrame = "";
-  _timeOffset = 0;
+  _startOffset = 0.0;
+  _endOffset = 0.0;
   _quats = _avvs = SMatrix(0,0);
   _times = SVector(0);
   _tickRate = 0.0;

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
@@ -269,14 +269,19 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
 
     _startOffset =  etLabStart.Et() - startTime();
     _endOffset =  etLabEnd.Et() - endTime();
+
+    // round offsets by 3 decimal places
+    _startOffset = qRound(_startOffset * 1000.0) / 1000.0;
+    _endOffset = qRound(_endOffset * 1000.0) / 1000.0;
+
     // account for padding
-    if (_startOffset >= 0.0031) {
+    if (_startOffset >= 0.003) {
       _startOffset = 0.0;
     }
     else {
       _startOffset = fabs(_startOffset);
     }
-    if (_endOffset <= 0.0031) {
+    if (_endOffset <= 0.003) {
       _endOffset = 0.0;
     }
     else {

--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.h
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.h
@@ -151,18 +151,19 @@ class CkSpiceSegment {
     // Mutable for full loading/unloading of kernels w/o restrictions
     mutable Kernels  _kernels;
     int         _camVersion;
-    QString _name;
-    QString _fname;
+    QString     _name;
+    QString     _fname;
     double      _startTime;
     double      _endTime;
-    QString _utcStartTime; //  Need to store these as conversion from ET
-    QString _utcEndTime;   //  requires leap seconds kernel
-    QString _instId;       //  Instrument ID
-    QString _target;       //  Target name
-    double  _timeOffset;
+    QString     _utcStartTime; //  Need to store these as conversion from ET
+    QString     _utcEndTime;   //  requires leap seconds kernel
+    QString     _instId;       //  Instrument ID
+    QString     _target;       //  Target name
+    double      _startOffset;  // time offset between camera model and label start time
+    double      _endOffset;    // time offset between camera model and label end time
     int         _instCode;     //  NAIF instrument code of the SPICE segment
-    QString _instFrame;    //  NAIF instrument frame
-    QString _refFrame;     //  NAIF reference frame
+    QString     _instFrame;    //  NAIF instrument frame
+    QString     _refFrame;     //  NAIF reference frame
     SMatrix     _quats;
     SMatrix     _avvs;
     SVector     _times;

--- a/isis/src/base/apps/spkwriter/SpkSegment.cpp
+++ b/isis/src/base/apps/spkwriter/SpkSegment.cpp
@@ -177,14 +177,19 @@ void SpkSegment::import(Cube &cube) {
 
     m_startOffset = etLabStart.Et() - m_epochs[0];
     m_endOffset = etLabEnd.Et() - m_epochs[size(m_epochs)-1];
+
+    // round offsets by 3 decimal places
+    m_startOffset = qRound(m_startOffset * 1000.0) / 1000.0;
+    m_endOffset = qRound(m_endOffset * 1000.0) / 1000.0;
+
     // account for padding
-    if (m_startOffset >= 0.0031) {
+    if (m_startOffset >= 0.003) {
       m_startOffset = 0.0;
     }
     else {
       m_startOffset = fabs(m_startOffset);
     }
-    if (m_endOffset <= 0.0031) {
+    if (m_endOffset <= 0.003) {
       m_endOffset = 0.0;
     }
     else {

--- a/isis/src/base/apps/spkwriter/SpkSegment.cpp
+++ b/isis/src/base/apps/spkwriter/SpkSegment.cpp
@@ -37,6 +37,7 @@
 #include "FileName.h"
 #include "IException.h"
 #include "IString.h"
+#include "iTime.h"
 #include "NaifStatus.h"
 #include "SpkSegment.h"
 #include "Table.h"
@@ -168,6 +169,30 @@ void SpkSegment::import(Cube &cube) {
     setStartTime(m_epochs[0]);
     setEndTime(m_epochs[size(m_epochs)-1]);
 
+    Pvl *label = cube.label();
+    QString labStartTime = getKeyValue(*label, "StartTime");
+    QString labEndTime = getKeyValue(*label, "StopTime");
+    iTime etLabStart(labStartTime);
+    iTime etLabEnd(labEndTime);
+
+    m_startOffset = etLabStart.Et() - m_epochs[0];
+    m_endOffset = etLabEnd.Et() - m_epochs[size(m_epochs)-1];
+    // account for padding
+    if (m_startOffset >= 0.0031) {
+      m_startOffset = 0.0;
+    }
+    else {
+      m_startOffset = fabs(m_startOffset);
+    }
+    if (m_endOffset <= 0.0031) {
+      m_endOffset = 0.0;
+    }
+    else {
+      m_endOffset = fabs(m_endOffset);
+    }
+
+    m_instId = getKeyValue(*label, "InstrumentId");
+
   } catch ( IException &ie  ) {
     ostringstream mess;
     mess << "Failed to construct SPK content from ISIS file " << Source();
@@ -291,10 +316,21 @@ QString SpkSegment::getComment() const {
 "  Segment ID:  " << Id() << " (ProductId)" << endl <<
 "  StartTime:   " << utcStartTime() << endl <<
 "  EndTime:     " << utcEndTime() << endl <<
+"  Instrument:  " << m_instId << endl <<
 "  Target Body: " << "Body " << m_body << ", " << m_bodyFrame << endl <<
 "  Center Body: " << "Body " << m_center << ", " << m_centerFrame << endl <<
 "  RefFrame:    " << m_refFrame << endl <<
 "  Records:     " << size() << endl;
+
+  if (m_startOffset != 0) {
+    comment <<
+"  StartOffset: " << m_startOffset << endl;
+  }
+
+  if (m_endOffset != 0) {
+    comment <<
+"  EndOffset:   " << m_endOffset << endl;
+  }
 
   string hasVV = (m_hasVV) ? "YES" : "NO";
   comment <<
@@ -358,10 +394,12 @@ void SpkSegment::init(const int spkType) {
   m_spkType = spkType;
   m_body = m_center = 1;
   m_bodyFrame = m_centerFrame = m_refFrame = "";
+  m_instId = "UNKNOWN";
   m_states = SMatrix(0,0);
   m_epochs = SVector(0);
   m_hasVV = false;
   m_degree = 1;
+  m_startOffset = 0.0;
   return;
 }
 

--- a/isis/src/base/apps/spkwriter/SpkSegment.h
+++ b/isis/src/base/apps/spkwriter/SpkSegment.h
@@ -108,12 +108,15 @@ class SpkSegment : public SpkSpiceSegment {
     int         m_body;         //  NAIF body code of the SPICE segment
     QString     m_bodyFrame;    //  NAIF body frame
     int         m_center;       //  NAIF center code of the SPICE segment
+    QString     m_instId;       //  Instrument ID
     QString     m_centerFrame;  //  NAIF center frame
     QString     m_refFrame;     //  NAIF reference frame
     SMatrix     m_states;       //  Position states
     SVector     m_epochs;       //  ET times of records
     bool        m_hasVV;        //  Has velocity vectors?
     int         m_degree;       //  Degree of polynomial to fit in NAIF kernel
+    double      m_startOffset;  // time offset between camera model and label start time
+    double      m_endOffset;    // time offset between camera model and label end time
 
     // Internal processing methods
     void init(const int spkType = 13);

--- a/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
+++ b/isis/src/system/apps/kerneldbgen/SpiceDbGen.cpp
@@ -233,7 +233,8 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
   SpiceChar fileType[32], source[2048];
   SpiceInt handle;
   QString instrument = "";
-  QString timeoffset = "";
+  QString startoffset = "";
+  QString endoffset = "";
 
   SpiceBoolean found;
   kinfo_c(tmp.toLatin1().data(), 32, 2048, fileType, source, &handle, &found);
@@ -252,11 +253,15 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
       // Grab Instrument and Offset information, if exists
       int instPos = 0;
       if ( (instPos = cmmt.indexOf("Instrument:", instPos, Qt::CaseInsensitive)) != -1 ) {
-        instrument = cmmt.split(": ")[1];
+        instrument = cmmt.remove(" ").split(":")[1];
       }
-      int timePos = 0;
-      if ( (timePos = cmmt.indexOf("TimeOffset:", timePos, Qt::CaseInsensitive)) != -1 ) {
-        timeoffset = cmmt.split(": ")[1];
+      int startPos = 0;
+      if ( (startPos = cmmt.indexOf("StartOffset:", startPos, Qt::CaseInsensitive)) != -1 ) {
+        startoffset = cmmt.remove(" ").split(":")[1];
+      }
+      int endPos = 0;
+      if ( (endPos = cmmt.indexOf("EndOffset:", endPos, Qt::CaseInsensitive)) != -1 ) {
+        endoffset = cmmt.remove(" ").split(":")[1];
       }
     }
   }
@@ -324,10 +329,15 @@ PvlGroup SpiceDbGen::AddSelection(FileName fileIn, double startOffset, double en
     }
   }
 
-  // add instrument and timing offset only if timing offset is found in comments
-  if (!timeoffset.isEmpty()) {
-    result += PvlKeyword("TimeOffset", timeoffset);
+  // add instrument and timing offsets only if timing offsets found in comments
+  if (!startoffset.isEmpty() || !endoffset.isEmpty()) {
     result += PvlKeyword("Instrument", instrument);
+    if(!startoffset.isEmpty()){
+      result += PvlKeyword("StartOffset", startoffset);
+    }
+    if(!endoffset.isEmpty()){
+      result += PvlKeyword("EndOffset", endoffset);
+    }
   }
 
   QString outFile = fileIn.originalPath();


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
In spiceinit, Kernels are matched to the cube based on the original labels start and end times.

This comparison checks if the kernel start time is less than the label start time and the kernel end time is greater than the label end time. Therefore checking that the label's start and end time lie between the kernel's start and end time.

`kernelStartTime <= labelStartTime  < labelEndTime <= kernelEndTime`


Therefore when checking the offsets, there is only a need to apply an offset if the label's start time is less than the camera start time and if the label's end time is greater than the kernel's end time. 

Also found out that these offsets are not the same for both start time and end time. Therefore this PR adds the end time offset to the comments as well.

```
Object = SpacecraftPosition
  RunTime = 2021-12-27T11:34:33

  Group = Dependencies
    LeapsecondKernel = $Base/kernels/lsk/naif0008.tls
  End_Group

  Group = Selection
    Time        = ("2002 FEB 20 22:59:01.701369 TDB",
                   "2002 FEB 20 22:59:09.296828 TDB")
    Instrument  = THEMIS_IR
    StartOffset = 0.26313
    EndOffset   = 171.871
    File        = /Users/astamile/testData/kernelTiming/thmIR.bsp
    Type        = Smithed
  End_Group
End_Object
End
```

These offsets are in absolute values therefore if there is a StartOffset, then this must be added to the label's original start time and if there is a EndOffset, then the offset must be subtracted from the label's original end time.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Kernel Timing sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
