### PR TITLE
Fixes ckwriter and spkwriter test failures.

### DIFF
--- a/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
+++ b/isis/src/base/apps/ckwriter/CkSpiceSegment.cpp
@@ -212,7 +212,14 @@ void CkSpiceSegment::import(Cube &cube, const QString &tblname) {
      _camVersion = _kernels.CameraVersion();
 
     QString labStartTime = getKeyValue(*label, "StartTime");
-    QString labEndTime = getKeyValue(*label, "StopTime");
+    QString labEndTime;
+    value = getKeyValue(*label, "StopTime");
+    if (!value.isEmpty()) {
+      labEndTime = value;
+    }
+    else {
+      labEndTime = labStartTime;
+    }
     iTime etLabStart(labStartTime);
     iTime etLabEnd(labEndTime);
 

--- a/isis/src/base/apps/spkwriter/SpkSegment.cpp
+++ b/isis/src/base/apps/spkwriter/SpkSegment.cpp
@@ -171,7 +171,14 @@ void SpkSegment::import(Cube &cube) {
 
     Pvl *label = cube.label();
     QString labStartTime = getKeyValue(*label, "StartTime");
-    QString labEndTime = getKeyValue(*label, "StopTime");
+    QString labEndTime;
+    QString value = getKeyValue(*label, "StopTime");
+    if (!value.isEmpty()) {
+      labEndTime = value;
+    }
+    else {
+      labEndTime = labStartTime;
+    }
     iTime etLabStart(labStartTime);
     iTime etLabEnd(labEndTime);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ckwriter and Spkwriter tests were failing due to default cube not having a StopTime in label. Added checks in ckwriter and spkwriter to use StartTime if StopTime does not exist.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Kernel Timing Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Confirmed that ckwriter, spwriter, and kerneldbgen are all passing

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
