### PR TITLE
Kerneldb changes for spice kernel timing

### DIFF
--- a/isis/src/system/objs/KernelDb/KernelDb.cpp
+++ b/isis/src/system/objs/KernelDb/KernelDb.cpp
@@ -582,14 +582,6 @@ namespace Isis {
     bool matchTime = !grp.hasKeyword("Time");
     bool matchKeywords = true;
 
-    // If the kernel segment has an instrument specification that doesn't match
-    // the instrument id in the label, don't perform the rest of the checks
-    if (grp.hasKeyword("Instrument")){
-        const PvlGroup &inst = lab.findGroup("Instrument", Pvl::Traverse);
-        if (inst["InstrumentId"][0].toStdString() != grp["Instrument"][0].toStdString()){
-          return false;
-        };
-    }
 
     // First, the time search. Loop through the keywords, if the name isn't
     //  Time then skip it. If it is, then get the start/end times and keep
@@ -598,18 +590,32 @@ namespace Isis {
       PvlKeyword key = grp[keyword];
 
       if (key.isNamed("Time")) {
-        double offset = 0;
+
+        // If the kernel segment has an instrument specification that doesn't match
+        // the instrument id in the label, don't perform the rest of the checks
+        if (grp.hasKeyword("Instrument")){
+            const PvlGroup &inst = lab.findGroup("Instrument", Pvl::Traverse);
+            if (inst["InstrumentId"][0].toStdString() != grp["Instrument"][0].toStdString()){
+              return false;
+            };
+        }
+
+        double startOffset = 0;
+        double endOffset = 0;
         // Pull the selections start and end time out
         iTime kernelStart = (QString) key[0];
         iTime kernelEnd   = (QString) key[1];
 
-        if (grp.hasKeyword("TimeOffset")){
-          offset = (double) grp["TimeOffset"];
+        if (grp.hasKeyword("StartOffset")){
+          startOffset = (double) grp["StartOffset"];
+        }
+        if (grp.hasKeyword("EndOffset")){
+          endOffset = (double) grp["EndOffset"];
         }
 
         // If the kernel times inside of the requested times we
         // set the matchTime to be true.
-        if ((kernelStart - offset <= timeToMatch) && (kernelEnd + offset >= timeToMatch)) {
+        if ((kernelStart - startOffset <= timeToMatch) && (kernelEnd + endOffset >= timeToMatch)) {
           matchTime = true;
         }
       }

--- a/isis/src/system/objs/KernelDb/KernelDb.cpp
+++ b/isis/src/system/objs/KernelDb/KernelDb.cpp
@@ -590,16 +590,6 @@ namespace Isis {
       PvlKeyword key = grp[keyword];
 
       if (key.isNamed("Time")) {
-
-        // If the kernel segment has an instrument specification that doesn't match
-        // the instrument id in the label, don't perform the rest of the checks
-        if (grp.hasKeyword("Instrument")){
-            const PvlGroup &inst = lab.findGroup("Instrument", Pvl::Traverse);
-            if (inst["InstrumentId"][0].toStdString() != grp["Instrument"][0].toStdString()){
-              return false;
-            };
-        }
-
         double startOffset = 0;
         double endOffset = 0;
         // Pull the selections start and end time out
@@ -617,6 +607,16 @@ namespace Isis {
         // set the matchTime to be true.
         if ((kernelStart - startOffset <= timeToMatch) && (kernelEnd + endOffset >= timeToMatch)) {
           matchTime = true;
+        }
+
+
+        // If the kernel segment has an instrument specification that doesn't match
+        // the instrument id in the label then the timing is always invalid
+        if (grp.hasKeyword("Instrument")){
+            const PvlGroup &inst = lab.findGroup("Instrument", Pvl::Traverse);
+            if (inst["InstrumentId"][0].toStdString() != grp["Instrument"][0].toStdString()){
+              matchTime = false;
+            };
         }
       }
       else if (key.isNamed("Match")) {

--- a/isis/src/system/objs/KernelDb/KernelDb.cpp
+++ b/isis/src/system/objs/KernelDb/KernelDb.cpp
@@ -582,7 +582,6 @@ namespace Isis {
     bool matchTime = !grp.hasKeyword("Time");
     bool matchKeywords = true;
 
-
     // First, the time search. Loop through the keywords, if the name isn't
     //  Time then skip it. If it is, then get the start/end times and keep
     //  looking until one is found.
@@ -608,7 +607,6 @@ namespace Isis {
         if ((kernelStart - startOffset <= timeToMatch) && (kernelEnd + endOffset >= timeToMatch)) {
           matchTime = true;
         }
-
 
         // If the kernel segment has an instrument specification that doesn't match
         // the instrument id in the label then the timing is always invalid


### PR DESCRIPTION
Adjusts kerneldb::match to incorporate timing adjustments.

## Description


## Related Issue
Spice kernel timing

## Motivation and Context
There are differences between the start/stop time in the label and the camera model.  This leads to a failure to pick up some kernels in spiceinit.

## How Has This Been Tested?
ctest -VV -R "Spiceinit" 9 tests succeed 0 tests fail.  May need additional tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
