### PR TITLE
nanolfann needs version pinned to < 1.4.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -40,7 +40,7 @@ dependencies:
   - mesalib
   - mysql
   - mysql-connector-c
-  - nanoflann
+  - nanoflann < 1.4.0
   - nlohmann_json
   - ninja==1.7.2
   - nn

--- a/environment_gcc4.yml
+++ b/environment_gcc4.yml
@@ -40,7 +40,7 @@ dependencies:
   - mesalib
   - mysql
   - mysql-connector-c
-  - nanoflann
+  - nanoflann < 1.4.0
   - nlohmann_json
   - ninja==1.7.2
   - nn=1.86.0=h470a237_1003


### PR DESCRIPTION
ISIS applications that use nanonflann were failing in the recent update of nanoflann to 1.4.0. This update pins the nanoflann < 1.4.0 in the conda enviroment YAML files.

## Description
A very recent update to nanoflann broke some ISIS applications that use it. Pinning to an earlier version is one potential solution to the problem.

Another option would be to fix the applications to conform to the new version of nanoflann.

## Related Issue
This PR is but one option to fix #4742.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Build on MacOSX 10.15 with recent state of dev branch.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
