### PR TITLE
Updated Apollo tests to be faster

### DIFF
--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -1083,22 +1083,24 @@ namespace Isis {
 
 
   void ApolloCube::SetUp() {
+    start_time = std::chrono::steady_clock::now();
     TempTestingFiles::SetUp();
 
     testCube = new Cube();
     testCube->setDimensions(22900, 22900, 1);
     testCube->create(tempDir.path() + "/large.cub");
 
-    LineManager line(*testCube);
-    double pixelValue = 0.0;
-    for(line.begin(); !line.end(); line++) {
-      for(int i = 0; i < line.size(); i++) {
-        line[i] = pixelValue;
-      }
+    // LineManager line(*testCube);
+    // double pixelValue = 0.0;
+    // int stepSize = 100;
+    // for(line.begin(); !line.end(); line += stepSize) {
+    //   for(int i = 0; i < line.size(); i += stepSize) {
+    //     line[i] = pixelValue;
+    //   }
 
-      pixelValue++;
-      testCube->write(line);
-    }
+    //   pixelValue++;
+    //   testCube->write(line);
+    // }
 
     PvlGroup reseaus("Reseaus");
     PvlKeyword samples = PvlKeyword("Sample", "200");

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -5,6 +5,7 @@
 #include "FileName.h"
 
 #include "Blob.h"
+#include "Brick.h"
 #include "csminit.h"
 #include "Fixtures.h"
 #include "Portal.h"
@@ -1083,47 +1084,60 @@ namespace Isis {
 
 
   void ApolloCube::SetUp() {
-    start_time = std::chrono::steady_clock::now();
     TempTestingFiles::SetUp();
 
     testCube = new Cube();
     testCube->setDimensions(22900, 22900, 1);
     testCube->create(tempDir.path() + "/large.cub");
 
-    // LineManager line(*testCube);
-    // double pixelValue = 0.0;
-    // int stepSize = 100;
-    // for(line.begin(); !line.end(); line += stepSize) {
-    //   for(int i = 0; i < line.size(); i += stepSize) {
-    //     line[i] = pixelValue;
-    //   }
+    // Reseau centers as {sample, line} pairs
+    reseaus = {{200, 200}, {400, 400}, {600, 600}};
+    reseauSize = 103;
+    int reseauValue = 100;
 
-    //   pixelValue++;
-    //   testCube->write(line);
-    // }
+    Brick brick(reseauSize,reseauSize,1,testCube->pixelType());
+    for (size_t res=0; res<reseaus.size(); res++) {
+      int baseSamp = (int)(reseaus[res].first+0.5) - (reseauSize/2);
+      int baseLine = (int)(reseaus[res].second+0.5) - (reseauSize/2);
+      brick.SetBasePosition(baseSamp,baseLine,1);
+      testCube->read(brick);
+      // Fill the surrounding area with a base number
+      for (int i = 0; i < reseauSize; i++) {
+        for (int j = 0; j < reseauSize; j++) {
+          brick[reseauSize*i + j] = res;
+        }
+      }
 
-    PvlGroup reseaus("Reseaus");
-    PvlKeyword samples = PvlKeyword("Sample", "200");
-    samples += "400";
-    samples += "600";
+      // Create reseau
+      for (int i = 0; i < reseauSize; i++) {
+        for (int j = -2; j < 3; j++) {
+          // Vertical line
+          brick[reseauSize * i + reseauSize/2 + j] = reseauValue;
 
-    PvlKeyword lines = PvlKeyword("Line", "200");
-    lines += "400";
-    lines += "600";
+          // Horizontal line
+          brick[reseauSize * (reseauSize/2 + j) + i] = reseauValue;
+        }
+      }
+      testCube->write(brick);
+    }
 
+    PvlGroup reseausGroup("Reseaus");
+    PvlKeyword samples = PvlKeyword("Sample", QString::number(reseaus[0].first));
+    PvlKeyword lines = PvlKeyword("Line", QString::number(reseaus[0].second));
     PvlKeyword types = PvlKeyword("Type", "5");
-    types += "5";
-    types += "5";
-
     PvlKeyword valid = PvlKeyword("Valid", "1");
-    valid += "1";
-    valid += "1";
+    for (size_t i = 1; i < reseaus.size(); i++) {
+      samples += QString::number(reseaus[i].first);
+      lines += QString::number(reseaus[i].second);
+      types += "5";
+      valid += "1";
+    }
 
-    reseaus += lines;
-    reseaus += samples;
-    reseaus += types;
-    reseaus += valid;
-    reseaus += PvlKeyword("Status", "Nominal");
+    reseausGroup += lines;
+    reseausGroup += samples;
+    reseausGroup += types;
+    reseausGroup += valid;
+    reseausGroup += PvlKeyword("Status", "Nominal");
 
     std::istringstream instStr (R"(
       Group = Instrument
@@ -1138,7 +1152,7 @@ namespace Isis {
     instStr >> instGroup;
 
     Pvl *lab = testCube->label();
-    lab->findObject("IsisCube").addGroup(reseaus);
+    lab->findObject("IsisCube").addGroup(reseausGroup);
     lab->findObject("IsisCube").addGroup(instGroup);
 
     testCube->reopen("r");

--- a/isis/tests/Fixtures.h
+++ b/isis/tests/Fixtures.h
@@ -4,7 +4,6 @@
 #include "gtest/gtest.h"
 
 #include <string>
-#include <chrono>
 
 #include <QString>
 #include <QTemporaryDir>
@@ -257,8 +256,10 @@ namespace Isis {
 
   class ApolloCube : public LargeCube {
     protected:
+      std::vector<std::pair<int, int>> reseaus;
+      int reseauSize;
+
       void SetUp() override;
-      std::chrono::steady_clock::time_point start_time;
   };
 
   class RingsCube : public TempTestingFiles {

--- a/isis/tests/Fixtures.h
+++ b/isis/tests/Fixtures.h
@@ -4,6 +4,7 @@
 #include "gtest/gtest.h"
 
 #include <string>
+#include <chrono>
 
 #include <QString>
 #include <QTemporaryDir>
@@ -257,6 +258,7 @@ namespace Isis {
   class ApolloCube : public LargeCube {
     protected:
       void SetUp() override;
+      std::chrono::steady_clock::time_point start_time;
   };
 
   class RingsCube : public TempTestingFiles {

--- a/isis/tests/FunctionalTestsApollocal.cpp
+++ b/isis/tests/FunctionalTestsApollocal.cpp
@@ -4,6 +4,8 @@
 #include "TestUtilities.h"
 #include "Histogram.h"
 
+#include <chrono>
+
 #include "apollocal.h"
 
 #include "gtest/gtest.h"
@@ -13,6 +15,7 @@ using namespace Isis;
 static QString APP_XML = FileName("$ISISROOT/bin/xml/apollocal.xml").expanded();
 
 TEST_F(ApolloCube, FunctionalTestApollocalDefault) {
+  std::chrono::steady_clock::time_point begin = std::chrono::steady_clock::now();
   QTemporaryDir prefix;
 
   QString outCubeFileName = prefix.path()+"/outTEMP.cub";
@@ -26,6 +29,7 @@ TEST_F(ApolloCube, FunctionalTestApollocalDefault) {
   catch (IException &e) {
     FAIL() << "Call failed, Unable to process cube: " << e.what() << std::endl;
   }
+  std::chrono::steady_clock::time_point after_cal = std::chrono::steady_clock::now();
 
   Cube oCube(outCubeFileName, "r");
 
@@ -35,4 +39,10 @@ TEST_F(ApolloCube, FunctionalTestApollocalDefault) {
   EXPECT_NEAR(oCubeStats->Sum(), -65125546242.836,   0.001);
   EXPECT_NEAR(oCubeStats->ValidPixels(), 524410000,     0.001);
   EXPECT_NEAR(oCubeStats->StandardDeviation(), 1056.736, 0.001);
+  std::chrono::steady_clock::time_point after_check = std::chrono::steady_clock::now();
+
+  std::cout << "Time to setup: " << (double)std::chrono::duration_cast<std::chrono::milliseconds>(begin - start_time).count() / 1000 << " [s]" << std::endl;
+  std::cout << "Time to calibrate: " << (double)std::chrono::duration_cast<std::chrono::milliseconds>(after_cal - begin).count() / 1000 << " [s]" << std::endl;
+  std::cout << "Time to check: " << (double)std::chrono::duration_cast<std::chrono::milliseconds>(after_check - after_cal).count() / 1000 << " [s]" << std::endl;
+  FAIL();
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Updated the apolloremrx and apollocal tests to use a test image with reseaus instead of linear data.
* Updated them to only check specific regions of the output region instead of collecting the entire cube histogram.
* Added a test for apolloremrx's patch option

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

These tests were taking quite a long time as they use a VERY large cube. By changing to only working on specific regions of the cube it saves a lot of processing time. Using data that mimics actual reseaus also improves tests coverage and better matches real use cases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally and all tests passed. apollocal test time went down by ~50% and apolloremrx test times went down by ~25%.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
