### PR TITLE
Add ability for Cube class to handle input attributes. Closes #3805

### DIFF
--- a/isis/src/base/apps/phocube/phocube.cpp
+++ b/isis/src/base/apps/phocube/phocube.cpp
@@ -18,7 +18,8 @@
 using namespace std;
 
 namespace Isis {
-  // Function to create a keyword with same values of a specified count
+
+// Function to create a keyword with same values of a specified count
   template <typename T> PvlKeyword makeKey(const QString &name,
                                            const int &nvals,
                                            const T &value);
@@ -30,21 +31,20 @@ namespace Isis {
     double m_albedo;
   };
 
+
   // Computes the special MORPHOLOGYRANK and ALBEDORANK planes
   static MosData *getMosaicIndicies(Camera &camera, MosData &md);
   // Updates BandBin keyword
   static void UpdateBandKey(const QString &keyname, PvlGroup &bb, const int &nvals,
                      const QString &default_value = "Null");
 
+
   void phocube(UserInterface &ui) {
     Cube icube;
-    CubeAttributeInput inAtt = ui.GetInputAttribute("FROM");
-    if (inAtt.bands().size() != 0) {
-      icube.setVirtualBands(inAtt.bands());
-    }
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
     phocube(&icube, ui);
   }
+
 
   void phocube(Cube *icube, UserInterface &ui)  {
 

--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -617,7 +617,9 @@ namespace Isis {
 
 
   /**
-   * This method will open an isis cube for reading or reading/writing.
+   * This method will open an existing isis cube for reading or 
+   * reading/writing. Any input cube attributes following the file
+   * name will be applied.
    *
    * @param[in] cubeFileName Name of the cube file to open. Environment
    *     variables in the filename will be automatically expanded.
@@ -625,14 +627,20 @@ namespace Isis {
    *     accessed. Either read-only "r" or read-write "rw".
    */
   void Cube::open(const QString &cubeFileName, QString access) {
-    // Already opened?
 
+    // Already opened?
     if (isOpen()) {
       string msg = "You already have a cube opened";
       throw IException(IException::Programmer, msg, _FILEINFO_);
     }
 
     initLabelFromFile(cubeFileName, (access == "rw"));
+
+    Isis::CubeAttributeInput att(cubeFileName);
+    if(att.bands().size() != 0) {
+      vector<QString> bands = att.bands();
+      setVirtualBands(bands);
+    }
 
     // Figure out the name of the data file
     try {

--- a/isis/src/base/objs/IsisAml/IsisAml.cpp
+++ b/isis/src/base/objs/IsisAml/IsisAml.cpp
@@ -678,6 +678,65 @@ void IsisAml::GetFileName(const QString &paramName,
 }
 
 
+
+
+
+
+
+
+
+/**
+ * Retrieves of a value for a parameter of type "cubename".
+ *
+ * @param paramName The partial or full name of the parameter to be retrieved.
+ * @param extension A default extension to add if it does not already exist on
+ * the file name.  For example, "txt" will make /mydir/myfile into
+ * /mydir/myfile.txt
+ *
+ * @return The value of the parameter.
+ */
+QString IsisAml::GetCubeName(const QString &paramName, QString extension) const {
+
+  const IsisParameterData *param = ReturnParam(paramName);
+
+  if (param->type != "cube") {
+    QString message = "Parameter [" + paramName + "] is not a cubename.";
+    throw Isis::IException(Isis::IException::Programmer, message, _FILEINFO_);
+  }
+
+  QString value;
+  if (param->values.size() == 0) {
+    if (param->defaultValues.size() == 0) {
+      QString message = "Parameter [" + paramName + "] has no value.";
+      throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
+    }
+    else {
+      value = param->defaultValues[0];
+    }
+  }
+  else {
+    value = param->values[0];
+  }
+
+  Isis::FileName name(value);
+  if (extension != "") name = name.addExtension(extension);
+  value = name.expanded();
+  if (name.attributes().length() > 0) {
+    value += "+" + name.attributes();
+  }
+
+  return value;
+}
+
+
+
+
+
+
+
+
+
+
 // Public: Returns the first element of the value member of a parameter whos
 // name starts with paramName as a QString
 /**

--- a/isis/src/base/objs/IsisAml/IsisAml.cpp
+++ b/isis/src/base/objs/IsisAml/IsisAml.cpp
@@ -339,8 +339,6 @@ void IsisAml::PutInteger(const QString &paramName,
 }
 
 
-
-
 // Public: Sets the value member of a parameter of type double whose name
 // starts with paramName
 /**
@@ -423,7 +421,6 @@ void IsisAml::PutDouble(const QString &paramName,
 
   Verify(param);
 }
-
 
 
 // Public: Sets the value member of a parameter of type boolean whose name
@@ -554,6 +551,7 @@ QString IsisAml::GetAsString(const QString &paramName) const {
   return value;
 }
 
+
 // Public: Returns the value member of a parameter whose name starts with paramName
 // as a vector<QString>
 /**
@@ -678,13 +676,6 @@ void IsisAml::GetFileName(const QString &paramName,
 }
 
 
-
-
-
-
-
-
-
 /**
  * Retrieves of a value for a parameter of type "cubename".
  *
@@ -727,14 +718,6 @@ QString IsisAml::GetCubeName(const QString &paramName, QString extension) const 
 
   return value;
 }
-
-
-
-
-
-
-
-
 
 
 // Public: Returns the first element of the value member of a parameter whos
@@ -851,7 +834,6 @@ void IsisAml::GetString(const QString &paramName,
 }
 
 
-
 // Public: Returns the first element of the value member of a parameter whos
 // name starts with paramName as an integer
 /**
@@ -935,7 +917,6 @@ void IsisAml::GetInteger(const QString &paramName,
 }
 
 
-
 // Public: Returns the first element of the value member of a parameter whos
 // name starts with paramName as a doubble
 /**
@@ -972,6 +953,7 @@ double IsisAml::GetDouble(const QString &paramName) const {
 
   return value.ToDouble();
 }
+
 
 // Public: Returns the value member of a parameter whose name starts with paramName
 // as a vector<doubble>
@@ -1138,6 +1120,7 @@ QString IsisAml::Description() const {
   return description;
 }
 
+
 /**
  * Returns the number of groups found in the XML.
  *
@@ -1146,6 +1129,7 @@ QString IsisAml::Description() const {
 int IsisAml::NumGroups() const {
   return groups.size();
 }
+
 
 /**
  * Returns the group name of group[index].
@@ -1158,6 +1142,7 @@ QString IsisAml::GroupName(const int &index) const {
   QString s = groups[index].name;
   return s;
 }
+
 
 /**
  * Given group name return its index in the Gui
@@ -1176,6 +1161,7 @@ int IsisAml::GroupIndex(const QString & grpName) const {
   }
   return -1;
 }
+
 
 /**
  * Create a PVL file from the parameters in a Group given the Gui group name,
@@ -1237,6 +1223,7 @@ void IsisAml::CreatePVL(Isis::Pvl &pvlDef , QString guiGrpName, QString pvlObjNa
   }
 }
 
+
 /**
  * Verify if the Parameter is in the Included list
  *
@@ -1256,6 +1243,8 @@ bool IsisAml::IsParamInPvlInclude(QString & paramName, vector<QString> & include
   }
   return false;
 }
+
+
 /**
  * Returns the number of parameters in a group.
  *
@@ -1266,6 +1255,7 @@ bool IsisAml::IsParamInPvlInclude(QString & paramName, vector<QString> & include
 int IsisAml::NumParams(const int &group) const {
   return groups[group].parameters.size();
 }
+
 
 /**
  * Returns the parameter name.
@@ -1280,6 +1270,7 @@ QString IsisAml::ParamName(const int &group, const int &param) const {
   return s;
 }
 
+
 /**
  * Returns the brief description of a parameter in a specified group.
  *
@@ -1292,6 +1283,7 @@ QString IsisAml::ParamBrief(const int &group, const int &param) const {
   QString s = groups[group].parameters[param].brief;
   return s;
 }
+
 
 /**
  * Returns the long description of a parameter in a specified group.
@@ -1306,6 +1298,7 @@ QString IsisAml::ParamDescription(const int &group, const int &param) const {
   return s;
 }
 
+
 /**
  * Returns the minimum value of a parameter in a specified group.
  *
@@ -1318,6 +1311,7 @@ QString IsisAml::ParamMinimum(const int &group, const int &param) const {
   QString s = groups[group].parameters[param].minimum;
   return s;
 }
+
 
 /**
  * Returns the maximum value of a parameter in a specified group.
@@ -1332,6 +1326,7 @@ QString IsisAml::ParamMaximum(const int &group, const int &param) const {
   return s;
 }
 
+
 /**
  * Returns whether the minimum value is inclusive or not.
  *
@@ -1345,6 +1340,7 @@ QString IsisAml::ParamMinimumInclusive(const int &group, const int &param) const
   return s;
 }
 
+
 /**
  * Returns whether the maximum value is inclusive or not.
  *
@@ -1357,6 +1353,7 @@ QString IsisAml::ParamMaximumInclusive(const int &group, const int &param) const
   QString s = groups[group].parameters[param].maximum_inclusive;
   return s;
 }
+
 
 /**
  * Returns whether the selected parameter has a restriction on odd values or
@@ -1372,6 +1369,7 @@ QString IsisAml::ParamOdd(const int &group, const int &param) const {
   return s;
 }
 
+
 /**
  * Returns the number of values in the parameters greater than list.
  *
@@ -1383,6 +1381,7 @@ QString IsisAml::ParamOdd(const int &group, const int &param) const {
 int IsisAml::ParamGreaterThanSize(const int &group, const int &param) const {
   return groups[group].parameters[param].greaterThan.size();
 }
+
 
 /**
  * Returns the number of values in the parameters greater than or equal list.
@@ -1397,6 +1396,7 @@ int IsisAml::ParamGreaterThanOrEqualSize(const int &group,
   return groups[group].parameters[param].greaterThanOrEqual.size();
 }
 
+
 /**
  * Returns the number of values in the parameters less than list.
  *
@@ -1408,6 +1408,7 @@ int IsisAml::ParamGreaterThanOrEqualSize(const int &group,
 int IsisAml::ParamLessThanSize(const int &group, const int &param) const {
   return groups[group].parameters[param].lessThan.size();
 }
+
 
 /**
  * Returns the number of values in the parameters less than or equal list.
@@ -1422,6 +1423,7 @@ int IsisAml::ParamLessThanOrEqualSize(const int &group,
   return groups[group].parameters[param].lessThanOrEqual.size();
 }
 
+
 /**
  * Returns the number of values in the not equal list.
  *
@@ -1433,6 +1435,7 @@ int IsisAml::ParamLessThanOrEqualSize(const int &group,
 int IsisAml::ParamNotEqualSize(const int &group, const int &param) const {
   return groups[group].parameters[param].notEqual.size();
 }
+
 
 /**
  * Returns the name of the specified greaterThan parameter
@@ -1449,6 +1452,7 @@ QString IsisAml::ParamGreaterThan(const int &group, const int &param,
   return s;
 }
 
+
 /**
  * Returns the name of the specified greaterThanOrEqual parameter
  *
@@ -1463,6 +1467,7 @@ QString IsisAml::ParamGreaterThanOrEqual(const int &group, const int &param,
   QString s = groups[group].parameters[param].greaterThanOrEqual[great];
   return s;
 }
+
 
 /**
  * Returns the name of the specified lessThan parameter
@@ -1479,6 +1484,7 @@ QString IsisAml::ParamLessThan(const int &group, const int &param,
   return s;
 }
 
+
 /**
  * Returns the name of the specified lessThanOrEqual parameter
  *
@@ -1493,6 +1499,7 @@ QString IsisAml::ParamLessThanOrEqual(const int &group, const int &param,
   QString s = groups[group].parameters[param].lessThanOrEqual[les];
   return s;
 }
+
 
 /**
  * Returns the name of the specified notEqual parameter
@@ -1509,6 +1516,7 @@ QString IsisAml::ParamNotEqual(const int &group, const int &param,
   return s;
 }
 
+
 /**
  * Returns the name of the specified excluded parameter
  *
@@ -1523,6 +1531,7 @@ QString IsisAml::ParamExclude(const int &group, const int &param,
   QString s = groups[group].parameters[param].exclude[exclude];
   return s;
 }
+
 
 /**
  * Returns the name of the specified included parameter
@@ -1553,6 +1562,7 @@ QString IsisAml::ParamType(const int &group, const int &param) const {
   return s;
 }
 
+
 /**
  * Returns the default for a parameter in a specified group.
  *
@@ -1571,6 +1581,7 @@ QString IsisAml::ParamDefault(const int &group, const int &param) const {
   }
   return s;
 }
+
 
 /**
  * Returns the internal default for a parameter in a specified group
@@ -1591,6 +1602,7 @@ QString IsisAml::ParamInternalDefault(const int &group, const int &param) const 
   return s;
 }
 
+
 /**
  * Returns the parameter filter for a parameter in a specified group.
  *
@@ -1609,6 +1621,7 @@ QString IsisAml::ParamFilter(const int &group, const int &param) const {
   }
   return s;
 }
+
 
 /**
  * Returns the default path for a filename/cube parameter
@@ -1629,6 +1642,7 @@ QString IsisAml::ParamPath(const int &group, const int &param) const {
   return s;
 }
 
+
 /**
  * Returns the file mode for a parameter in a specified group.
  *
@@ -1647,6 +1661,7 @@ QString IsisAml::ParamFileMode(const int &group, const int &param) const {
   }
   return s;
 }
+
 
 /**
  * Returns the number of options in the specified parameter's list.
@@ -1677,6 +1692,7 @@ QString IsisAml::ParamListValue(const int &group, const int &param,
   return s;
 }
 
+
 /**
  * Returns the brief description for a specific option to a parameter.
  *
@@ -1691,6 +1707,7 @@ QString IsisAml::ParamListBrief(const int &group, const int &param,
   QString s = groups[group].parameters[param].listOptions[option].brief;
   return s;
 }
+
 
 /**
  * Returns the full description for a specific option to a parameter.
@@ -1707,6 +1724,7 @@ QString IsisAml::ParamListDescription(const int &group, const int &param,
   return s;
 }
 
+
 /**
  * Returns the number of items in a parameters list exclude section.
  *
@@ -1720,6 +1738,7 @@ int IsisAml::ParamListExcludeSize(const int &group, const int &param,
                                   const int &option) const {
   return groups[group].parameters[param].listOptions[option].exclude.size();
 }
+
 
 /**
  * Returns the parameter name to be excluded if this option is selected.
@@ -1737,6 +1756,7 @@ QString IsisAml::ParamListExclude(const int &group, const int &param,
   return s;
 }
 
+
 /**
  * Returns the number of items in a parameters list include section.
  *
@@ -1750,6 +1770,7 @@ int IsisAml::ParamListIncludeSize(const int &group, const int &param,
                                   const int &option) const {
   return groups[group].parameters[param].listOptions[option].include.size();
 }
+
 
 /**
  * Returns the parameter name to be included if this option is selected.
@@ -1767,6 +1788,7 @@ QString IsisAml::ParamListInclude(const int &group, const int &param,
   return s;
 }
 
+
 /**
  * Returns the number of parameters excluded in this parameter's exclusions
  *
@@ -1778,6 +1800,7 @@ QString IsisAml::ParamListInclude(const int &group, const int &param,
 int IsisAml::ParamExcludeSize(const int &group, const int &param) const {
   return groups[group].parameters[param].exclude.size();
 }
+
 
 /**
  * Returns the number of parameters included in this parameter's inclusions
@@ -1791,6 +1814,7 @@ int IsisAml::ParamIncludeSize(const int &group, const int &param) const {
   return groups[group].parameters[param].include.size();
 }
 
+
 /**
  * Returns the default pixel type from the XML
  *
@@ -1803,6 +1827,7 @@ QString IsisAml::PixelType(const int &group, const int &param) const {
   return groups[group].parameters[param].pixelType;
 }
 
+
 /**
  * Returns the number of helpers the parameter has
  *
@@ -1814,6 +1839,7 @@ QString IsisAml::PixelType(const int &group, const int &param) const {
 int IsisAml::HelpersSize(const int &group, const int &param) const {
   return groups[group].parameters[param].helpers.size();
 }
+
 
 /**
  * Returns the name of the helper button
@@ -1829,6 +1855,7 @@ QString IsisAml::HelperButtonName(const int &group, const int &param,
   return groups[group].parameters[param].helpers[helper].name;
 }
 
+
 /**
  * Returns the name of the helper function
  *
@@ -1842,6 +1869,7 @@ QString IsisAml::HelperFunction(const int &group, const int &param,
                                const int &helper) const {
   return groups[group].parameters[param].helpers[helper].function;
 }
+
 
 /**
  * Returns the brief description of the helper button
@@ -1857,6 +1885,7 @@ QString IsisAml::HelperBrief(const int &group, const int &param,
   return groups[group].parameters[param].helpers[helper].brief;
 }
 
+
 /**
  * Returns the long description of the helper button
  *
@@ -1871,6 +1900,7 @@ QString IsisAml::HelperDescription(const int &group, const int &param,
   return groups[group].parameters[param].helpers[helper].description;
 }
 
+
 /**
  * Returns the name of the icon for the helper button
  *
@@ -1884,6 +1914,7 @@ QString IsisAml::HelperIcon(const int &group, const int &param,
                            const int &helper) const {
   return groups[group].parameters[param].helpers[helper].icon;
 }
+
 
 /**
  * Returns a true if the parameter has a value, and false if it does not
@@ -1902,6 +1933,7 @@ bool IsisAml::WasEntered(const QString &paramName) const {
 
   return true;
 }
+
 
 /**
  * Clears the value(s) in the named parameter
@@ -1965,6 +1997,7 @@ Isis::CubeAttributeInput &IsisAml::GetInputAttribute(const QString &paramName) {
   return param->inCubeAtt;
 }
 
+
 /**
  * Gets the attributes for an output cube
  *
@@ -2010,6 +2043,7 @@ Isis::CubeAttributeOutput &IsisAml::GetOutputAttribute(const QString &paramName)
   }
   return param->outCubeAtt;
 }
+
 
 /**
  * Returns a pointer to a parameter whose name starts with paramName
@@ -2062,6 +2096,7 @@ const IsisParameterData *IsisAml::ReturnParam(const QString &paramName) const {
   }
   return param;
 }
+
 
 /**
  * Throws an Isis::iExceptionXxxxxxxx if the parameter value(s) is invalid
@@ -2914,6 +2949,7 @@ void IsisAml::VerifyAll() {
   }
 }
 
+
 /**
  * Returns a boolean value based on the QString contents
  *
@@ -3136,4 +3172,3 @@ void IsisAml::StartParser(const char *xmlfile) {
   delete appHandler;
   return;
 }
-

--- a/isis/src/base/objs/IsisAml/IsisAml.cpp
+++ b/isis/src/base/objs/IsisAml/IsisAml.cpp
@@ -258,6 +258,39 @@ void IsisAml::PutFileName(const QString &paramName,
 }
 
 
+/**
+ * Allows the insertion of a value for a parameter of type 
+ * "cubename". A validity check is performed on the value passed
+ * in. 
+ *
+ * @param paramName The partial or full name of the parameter to be modified.
+ * @param value The QString representation of the value to be placed in the
+ * cubename's value data member.
+ */
+void IsisAml::PutCubeName(const QString &paramName,
+                          const QString &value) {
+
+  IsisParameterData *param = const_cast <IsisParameterData *>(ReturnParam(paramName));
+
+  if(param->type != "cube") {
+    QString message = "Parameter [" + paramName + "] is not a cubename.";
+    throw Isis::IException(Isis::IException::Programmer, message, _FILEINFO_);
+  }
+
+  if(param->values.size() > 0) {
+    QString message = "A value for this parameter [" + paramName + "] has "
+                     "already been saved (possibly by IsisGui). If you need to "
+                     "change the value use \"Clear\" before the Put.";
+    throw Isis::IException(Isis::IException::Programmer, message, _FILEINFO_);
+  }
+
+  param->values.clear();
+  param->values.push_back(value);
+
+  Verify(param);
+}
+
+
 // Public: Sets the value member of a parameter of type integer whose name
 // starts with paramName
 

--- a/isis/src/base/objs/IsisAml/IsisAml.h
+++ b/isis/src/base/objs/IsisAml/IsisAml.h
@@ -154,6 +154,8 @@ class IsisAml : protected IsisAmlData {
     void PutFileName(const QString &paramName, const QString &value);
     void PutFileName(const QString &paramName, const std::vector<QString> &value);
 
+    void PutCubeName(const QString &paramName, const QString &value);
+
     void PutDouble(const QString &paramName, const double &value);
     void PutDouble(const QString &paramName, const std::vector<double> &value);
 

--- a/isis/src/base/objs/IsisAml/IsisAml.h
+++ b/isis/src/base/objs/IsisAml/IsisAml.h
@@ -172,6 +172,8 @@ class IsisAml : protected IsisAmlData {
     QString GetFileName(const QString &paramName, QString extension = "") const;
     void GetFileName(const QString &paramName, std::vector<QString> &values) const;
 
+    QString GetCubeName(const QString &paramName, QString extension = "") const;
+
     QString GetString(const QString &paramName) const;
     void GetString(const QString &paramName, std::vector<QString> &values) const;
 

--- a/isis/src/base/objs/IsisAml/IsisAml.truth
+++ b/isis/src/base/objs/IsisAml/IsisAml.truth
@@ -1449,7 +1449,7 @@ Exact and partial name match tests:
   PutFileName:
 **PROGRAMMER ERROR** A value for this parameter [G0P0] has already been saved (possibly by IsisGui). If you need to change the value use "Clear" before the Put.
 
-**PROGRAMMER ERROR** Parameter [G2P4] is not a filename.
+**PROGRAMMER ERROR** Parameter [G2P4] is not a cubename.
 
   Cube tests:
 **PROGRAMMER ERROR** Unable to get input cube attributes.  Parameter [CUBE2] is not an input. Parameter fileMode = [output].

--- a/isis/src/base/objs/IsisAml/unitTest.cpp
+++ b/isis/src/base/objs/IsisAml/unitTest.cpp
@@ -369,8 +369,8 @@ int main(void) {
     }
     aml->Clear("G0P0");
 
-    try { // PARAMETER NOT FILENAME
-      aml->PutFileName("G2P4", "xxxxxx");
+    try { // PARAMETER NOT CUBENAME
+      aml->PutCubeName("G2P4", "xxxxxx");
     }
     catch(IException &error) {
       ReportError(error.toString());
@@ -379,7 +379,7 @@ int main(void) {
     cout << "  Cube tests:" << endl;
 
     try { // UNABLE TO GET INPUT CUBE ATTRIBUTES
-      aml->PutFileName("CUBE2", "xxxxxxx.cub+1,2-4");
+      aml->PutCubeName("CUBE2", "xxxxxxx.cub+1,2-4");
       CubeAttributeInput &att = aml->GetInputAttribute("CUBE2");
       cout << "    " << att.toString() << endl;
     }
@@ -389,7 +389,7 @@ int main(void) {
     aml->Clear("CUBE2");
 
     try { // UNABLE TO GET OUTPUT CUBE ATTRIBUTES
-      aml->PutFileName("CUBE1", "yyyyyyy.cub+8-bit+BSQ+detached");
+      aml->PutCubeName("CUBE1", "yyyyyyy.cub+8-bit+BSQ+detached");
       CubeAttributeOutput &att = aml->GetOutputAttribute("CUBE1");
       QString strng = att.toString();
       cout << "    Att QString  = " << strng << endl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Have the Cube open member process input cube attributes.

## Description
<!--- Describe your changes in detail -->
Input cube attributes are now automatically processed by the Cube.open member. Previously, any cube that was not processed through the ProcessX classes required the input cube attributes (i.e., band specifications) to be added to the a cube before it was opened.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#3805

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
All cubes should honer cube attributes. Some applications did not after they were converted to callable functions. All future conversion would have required the same code to process input cube attributes. Now the only call necessary is ui.GetCubeName instead of ui.GetFileName

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
