### PR TITLE
added custom target to copy over camera.plugin files on ninja install solves #3834

### DIFF
--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -564,10 +564,12 @@ add_custom_target(export ALL COMMAND ${CMAKE_COMMAND} -E copy_if_different
   ${CMAKE_SOURCE_DIR}/appdata/export/* ${CMAKE_BINARY_DIR}/appdata/export)
 add_dependencies(isis export)
 
-# Add custom build target to copy modified Camera.plugin files to the build/lib/Camera.plugin file
-add_custom_target(lib ALL COMMAND ${CMAKE_SOURCE_DIR}/../scripts/updateBuildPlugins.sh)
-add_dependencies(isis lib)
+# Create the updateBuildPlugins.sh.in file
+configure_file(${CMAKE_SOURCE_DIR}/cmake/updateBuildPlugins.sh.in ${CMAKE_BINARY_DIR}/scripts/updateBuildPlugins.sh)
 
+# Add custom build target to copy modified Camera.plugin files to the build/lib/Camera.plugin file
+add_custom_target(cameraPlugins ALL COMMAND ${CMAKE_BINARY_DIR}/scripts/updateBuildPlugins.sh)
+add_dependencies(isis cameraPlugins)
 
 # Add a custom build target to clean out everything that gets added to the source
 #  directory during the build process.
@@ -588,6 +590,7 @@ install(FILES     ${CMAKE_SOURCE_DIR}/../AUTHORS.rst  DESTINATION  ${CMAKE_INSTA
 install(FILES     ${CMAKE_SOURCE_DIR}/../CHANGELOG.md DESTINATION  ${CMAKE_INSTALL_PREFIX})
 install(FILES     ${CMAKE_BINARY_DIR}/version         DESTINATION  ${CMAKE_INSTALL_PREFIX})
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/scripts         DESTINATION  ${CMAKE_INSTALL_PREFIX})
+install(PROGRAMS ${CMAKE_BINARY_DIR}/lib/Camera.plugin DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/)
 
 # Trigger all post-install behavior.
 # - The only way to run commands post-install in CMake is to add a subdirectory at

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -564,6 +564,11 @@ add_custom_target(export ALL COMMAND ${CMAKE_COMMAND} -E copy_if_different
   ${CMAKE_SOURCE_DIR}/appdata/export/* ${CMAKE_BINARY_DIR}/appdata/export)
 add_dependencies(isis export)
 
+# Add custom build target to copy modified Camera.plugin files to the build/lib/Camera.plugin file
+add_custom_target(lib ALL COMMAND ${CMAKE_SOURCE_DIR}/../scripts/updateBuildPlugins.sh)
+add_dependencies(isis lib)
+
+
 # Add a custom build target to clean out everything that gets added to the source
 #  directory during the build process.
 # - Only a few things are added in order to make the tests work properly so

--- a/isis/cmake/AddIsisModule.cmake
+++ b/isis/cmake/AddIsisModule.cmake
@@ -178,9 +178,6 @@ function(add_isis_obj folder reqLibs)
     # Append the plugin file to a single file in the build directory
     # where the .so files will be created.  During installation copy these
     # plugin files to the installation library folder.
-    set(pluginPath ${CMAKE_BINARY_DIR}/lib/${pluginName})
-    cat(${plugins} ${pluginPath})
-    install(PROGRAMS ${pluginPath} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/)
     # Record this library name for the caller
     set(newPluginLib ${libName}  PARENT_SCOPE)
   endif()

--- a/isis/cmake/updateBuildPlugins.sh.in
+++ b/isis/cmake/updateBuildPlugins.sh.in
@@ -1,0 +1,7 @@
+> ${CMAKE_BINARY_DIR}/lib/Camera.plugin
+for i in find ${CMAKE_SOURCE_DIR}/src/*/objs/*/Camera.plugin
+  do
+    if test -f "$i"; then
+        cat "$i" >> ${CMAKE_BINARY_DIR}/lib/Camera.plugin
+    fi
+done

--- a/scripts/updateBuildPlugins.sh
+++ b/scripts/updateBuildPlugins.sh
@@ -1,8 +1,0 @@
-CMAKE_BINARY_DIR=../build/
-> $CMAKE_BINARY_DIR/lib/Camera.plugin
-for i in find ../isis/src/*/objs/*/Camera.plugin
-  do
-    if test -f "$i"; then
-        cat "$i" >> $CMAKE_BINARY_DIR/lib/Camera.plugin
-    fi
-done

--- a/scripts/updateBuildPlugins.sh
+++ b/scripts/updateBuildPlugins.sh
@@ -1,0 +1,8 @@
+CMAKE_BINARY_DIR=../build/
+> $CMAKE_BINARY_DIR/lib/Camera.plugin
+for i in find ../isis/src/*/objs/*/Camera.plugin
+  do
+    if test -f "$i"; then
+        cat "$i" >> $CMAKE_BINARY_DIR/lib/Camera.plugin
+    fi
+done


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
