### PR TITLE
Update calls to GetFileName with get GetCubeName

### DIFF
--- a/isis/src/apollo/apps/apollo2isis/main.cpp
+++ b/isis/src/apollo/apps/apollo2isis/main.cpp
@@ -56,7 +56,7 @@ void IsisMain() {
   p.SetPdsFile(inFile.expanded(), "", pdsLabel);
 
   QString filename = FileName(ui.GetFileName("FROM")).baseName();
-  FileName toFile = ui.GetFileName("TO");
+  FileName toFile = ui.GetCubeName("TO");
 
   apollo = new Apollo(filename);
 

--- a/isis/src/apollo/apps/apollocal/apollocal.cpp
+++ b/isis/src/apollo/apps/apollocal/apollocal.cpp
@@ -24,7 +24,7 @@ namespace Isis {
 
 
   void apollocal(UserInterface &ui) {
-    Cube cube(ui.GetFileName("FROM"), "r");
+    Cube cube(ui.GetCubeName("FROM"), "r");
     apollocal(&cube, ui);
   }
 

--- a/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
+++ b/isis/src/apollo/apps/apollofindrx/apollofindrx.cpp
@@ -41,7 +41,7 @@ namespace Isis {
     double GoodnessOfFit = 1.0;
 
     void apollofindrx(UserInterface &ui) {
-        Cube *cube = new Cube(ui.GetFileName("FROM"), "rw");
+        Cube *cube = new Cube(ui.GetCubeName("FROM"), "rw");
         apollofindrx(cube, ui);
     }
 

--- a/isis/src/apollo/apps/apollopaninit/main.cpp
+++ b/isis/src/apollo/apps/apollopaninit/main.cpp
@@ -118,11 +118,11 @@ void IsisMain() {
   insCode = scFrameCode - 230;
 
   try {
-    panCube.open(ui.GetCubeName("FROM"),"rw");
+    panCube.open(ui.GetFileName("FROM"),"rw");
   }
   catch (IException &e) {
     throw IException(IException::User,
-                     "Unable to open the file [" + ui.GetCubeName("FROM") + "] as a cube.",
+                     "Unable to open the file [" + ui.GetFileName("FROM") + "] as a cube.",
                      _FILEINFO_);
   }
 
@@ -769,7 +769,7 @@ void IsisMain() {
   panCube.write(tableFid);
   //close the new cube
   panCube.close(false);
-  panCube.open(ui.GetCubeName("FROM"),"rw");
+  panCube.open(ui.GetFileName("FROM"),"rw");
 
   delete spPos;
   delete spRot;

--- a/isis/src/apollo/apps/apollopaninit/main.cpp
+++ b/isis/src/apollo/apps/apollopaninit/main.cpp
@@ -640,7 +640,7 @@ void IsisMain() {
   CentroidApolloPan centroid(resolution);
   Chip inputChip,selectionChip;
   inputChip.SetSize(int(ceil(200*5.0/resolution)), int(ceil(200*5.0/resolution)));
-  fileName = ui.GetCubeName("FROM");
+  fileName = ui.GetFileName("FROM");
   if( panCube.pixelType() == 1)  //UnsignedByte
     centroid.setDNRange(12, 1e99);  //8 bit bright target
   else

--- a/isis/src/apollo/apps/apollopaninit/main.cpp
+++ b/isis/src/apollo/apps/apollopaninit/main.cpp
@@ -118,11 +118,11 @@ void IsisMain() {
   insCode = scFrameCode - 230;
 
   try {
-    panCube.open(ui.GetFileName("FROM"),"rw");
+    panCube.open(ui.GetCubeName("FROM"),"rw");
   }
   catch (IException &e) {
     throw IException(IException::User,
-                     "Unable to open the file [" + ui.GetFileName("FROM") + "] as a cube.",
+                     "Unable to open the file [" + ui.GetCubeName("FROM") + "] as a cube.",
                      _FILEINFO_);
   }
 
@@ -640,7 +640,7 @@ void IsisMain() {
   CentroidApolloPan centroid(resolution);
   Chip inputChip,selectionChip;
   inputChip.SetSize(int(ceil(200*5.0/resolution)), int(ceil(200*5.0/resolution)));
-  fileName = ui.GetFileName("FROM");
+  fileName = ui.GetCubeName("FROM");
   if( panCube.pixelType() == 1)  //UnsignedByte
     centroid.setDNRange(12, 1e99);  //8 bit bright target
   else
@@ -769,7 +769,7 @@ void IsisMain() {
   panCube.write(tableFid);
   //close the new cube
   panCube.close(false);
-  panCube.open(ui.GetFileName("FROM"),"rw");
+  panCube.open(ui.GetCubeName("FROM"),"rw");
 
   delete spPos;
   delete spRot;

--- a/isis/src/apollo/apps/apollopanstitcher/apollopanstitcher.cpp
+++ b/isis/src/apollo/apps/apollopanstitcher/apollopanstitcher.cpp
@@ -725,7 +725,7 @@ namespace Isis {
     //define an output cube
     outputC.setDimensions(int(maxS), int(maxL), 1);
     outputC.setPixelType(panC[0]->pixelType());  //set pixel type
-    tempString = ui.GetFileName("TO");
+    tempString = ui.GetCubeName("TO");
     outputC.create(tempString);
     outputC.close();  //closing the output cube so that it can be opened by the mosaic process
     ProcessMosaic mosaic;

--- a/isis/src/apollo/apps/apolloremrx/apolloremrx.cpp
+++ b/isis/src/apollo/apps/apolloremrx/apolloremrx.cpp
@@ -22,15 +22,17 @@ namespace Isis {
 
   void cpy(Buffer &in, Buffer &out);
 
+
   void apolloremrx(UserInterface &ui) {
     Cube cube;
     CubeAttributeInput inAtt = ui.GetInputAttribute("FROM");
     if (inAtt.bands().size() != 0) {
       cube.setVirtualBands(inAtt.bands());
     }
-    cube.open(ui.GetFileName("FROM"));
+    cube.open(ui.GetCubeName("FROM"));
     apolloremrx(&cube, ui);
   }
+
 
   void apolloremrx(Cube *info, UserInterface &ui) {
     int dim;
@@ -68,7 +70,7 @@ namespace Isis {
     status = "Removed";
 
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    p.SetOutputCube(ui.GetFileName("TO"), att);
+    p.SetOutputCube(ui.GetCubeName("TO"), att);
 
     // Start the processing
     p.StartProcess(cpy);
@@ -77,7 +79,7 @@ namespace Isis {
     dim = apollo.ReseauDimension();
 
     // Get other user entered options
-    QString out = ui.GetFileName("TO");
+    QString out = ui.GetCubeName("TO");
     resvalid = ui.GetBoolean("RESVALID");
     action = ui.GetString("ACTION");
 

--- a/isis/src/base/apps/appjit/main.cpp
+++ b/isis/src/base/apps/appjit/main.cpp
@@ -37,13 +37,13 @@ void IsisMain() {
 
   int ifile = 0;
   // Make sure the master file is included in the input file list
-  while(ifile < (int) list.size() && list[ifile].toString() != FileName(ui.GetFileName("MASTER")).expanded()) {
+  while(ifile < (int) list.size() && list[ifile].toString() != FileName(ui.GetCubeName("MASTER")).expanded()) {
     ifile++;
   }
 
   if(ifile >= list.size()) {
-    QString msg = "The master file, [" + FileName(ui.GetFileName("MASTER")).expanded() + " is not included in " +
-                 "the input list file " + ui.GetFileName("FROMLIST") + "]";
+    QString msg = "The master file, [" + FileName(ui.GetCubeName("MASTER")).expanded() + " is not included in " +
+                 "the input list file " + ui.GetCubeName("FROMLIST") + "]";
     throw IException(IException::User, msg, _FILEINFO_);
   }
 
@@ -55,7 +55,7 @@ void IsisMain() {
   try {
     // Open the master cube
     Cube cube;
-    cube.open(ui.GetFileName("MASTER"), "rw");
+    cube.open(ui.GetCubeName("MASTER"), "rw");
 
     //check for existing polygon, if exists delete it
     if(cube.label()->hasObject("Polygon")) {
@@ -65,7 +65,7 @@ void IsisMain() {
     // Get the camera
     Camera *cam = cube.camera();
     if(cam->DetectorMap()->LineRate() == 0.0) {
-      QString msg = "[" + ui.GetFileName("MASTER") + "] is not a line scan camera image";
+      QString msg = "[" + ui.GetCubeName("MASTER") + "] is not a line scan camera image";
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
@@ -127,12 +127,12 @@ void IsisMain() {
 
     cube.putGroup(kernels);
     cube.close();
-    gp += PvlKeyword("StatusMaster", ui.GetFileName("MASTER") + ":  camera pointing updated");
+    gp += PvlKeyword("StatusMaster", ui.GetCubeName("MASTER") + ":  camera pointing updated");
 
     // Apply the dejittered pointing to the rest of the files
     step2 = true;
     for(int ifile = 0; ifile < list.size(); ifile++) {
-      if(list[ifile].toString() != ui.GetFileName("MASTER")) {
+      if(list[ifile].toString() != ui.GetCubeName("MASTER")) {
         // Open the cube
         cube.open(list[ifile].toString(), "rw");
         //check for existing polygon, if exists delete it
@@ -142,7 +142,7 @@ void IsisMain() {
         // Get the camera and make sure it is a line scan camera
         Camera *cam = cube.camera();
         if(cam->DetectorMap()->LineRate() == 0.0) {
-          QString msg = "[" + ui.GetFileName("FROM") + "] is not a line scan camera";
+          QString msg = "[" + ui.GetCubeName("FROM") + "] is not a line scan camera";
           throw IException(IException::User, msg, _FILEINFO_);
         }
         // Write out the pointing cache as a table
@@ -168,7 +168,7 @@ void IsisMain() {
   catch(IException &e) {
     QString msg;
     if(!step2) {
-      msg = "Unable to fit pointing for [" + ui.GetFileName("MASTER") + "]";
+      msg = "Unable to fit pointing for [" + ui.GetCubeName("MASTER") + "]";
     }
     else {
       msg = "Unable to update pointing for nonMaster file(s)";

--- a/isis/src/base/apps/ascii2isis/main.cpp
+++ b/isis/src/base/apps/ascii2isis/main.cpp
@@ -78,7 +78,7 @@ void IsisMain() {
     ProcessByLine p;
 
     
-    p.SetOutputCube(ui.GetFileName("TO"), att, ns, nl, nb);
+    p.SetOutputCube(ui.GetCubeName("TO"), att, ns, nl, nb);
     p.StartProcess(ascii2isis);
     p.EndProcess();
   }
@@ -87,7 +87,7 @@ void IsisMain() {
 
     
     // Set Special Pixel ranges
-    p.SetOutputCube(ui.GetFileName("TO"), att, ns, nl, nb);
+    p.SetOutputCube(ui.GetCubeName("TO"), att, ns, nl, nb);
     p.StartProcess(ascii2isis);
     p.EndProcess();
   }
@@ -95,7 +95,7 @@ void IsisMain() {
     ProcessBySpectra p(Isis::ProcessBySpectra::PerPixel);
 
     
-    p.SetOutputCube(ui.GetFileName("TO"), att, ns, nl, nb);
+    p.SetOutputCube(ui.GetCubeName("TO"), att, ns, nl, nb);
     p.StartProcess(ascii2isis);
     p.EndProcess();
   }

--- a/isis/src/base/apps/automos/automos.cpp
+++ b/isis/src/base/apps/automos/automos.cpp
@@ -55,10 +55,10 @@ namespace Isis {
       m.SetOutputCube(list,
                       ui.GetDouble("MINLAT"), ui.GetDouble("MAXLAT"),
                       ui.GetDouble("MINLON"), ui.GetDouble("MAXLON"),
-                      oAtt, ui.GetFileName("MOSAIC"));
+                      oAtt, ui.GetCubeName("MOSAIC"));
     }
     else {
-      m.SetOutputCube(list, oAtt, ui.GetFileName("MOSAIC"));
+      m.SetOutputCube(list, oAtt, ui.GetCubeName("MOSAIC"));
     }
 
     m.SetHighSaturationFlag(ui.GetBoolean("HIGHSATURATION"));

--- a/isis/src/base/apps/bandnorm/bandnorm.cpp
+++ b/isis/src/base/apps/bandnorm/bandnorm.cpp
@@ -31,7 +31,7 @@ namespace Isis {
                 const QString &delimiters = " ");
   
   void bandnorm(UserInterface &ui) {
-    Cube icube(ui.GetFileName("FROM"), "r");
+    Cube icube(ui.GetCubeName("FROM"), "r");
     bandnorm(&icube, ui);
   }
   
@@ -110,7 +110,7 @@ namespace Isis {
     }
   
     // Setup the output file and apply the correction
-    p.SetOutputCube(ui.GetFileName("TO"), ui.GetOutputAttribute("TO"), icube->sampleCount(), icube->lineCount(), icube->bandCount());
+    p.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"), icube->sampleCount(), icube->lineCount(), icube->bandCount());
     p.StartProcess(normalize);
   
     // Cleanup

--- a/isis/src/base/apps/barscale/main.cpp
+++ b/isis/src/base/apps/barscale/main.cpp
@@ -29,7 +29,7 @@ void IsisMain() {
   // projection information
   Process p;
   Cube icube;
-  icube.open(ui.GetFileName("FROM") );
+  icube.open(ui.GetCubeName("FROM") );
 
   // Determine where in image to get resolution from and get it
   int numSamps = icube.sampleCount();
@@ -441,7 +441,7 @@ void IsisMain() {
   lblStr = lblStr + " " + unitStr;
   painter.drawText(rightDisplayRect, lblStr);
 
-  QString inFile = ui.GetFileName("FROM");
+  QString inFile = ui.GetCubeName("FROM");
   QString outFile = ui.GetFileName("TO");
   FileName tmpBarFile = FileName::createTempFile("barscale.tif");
   QString scaleTif = tmpBarFile.expanded();

--- a/isis/src/base/apps/bit2bit/main.cpp
+++ b/isis/src/base/apps/bit2bit/main.cpp
@@ -64,7 +64,8 @@ void IsisMain(){
 
 
   if(ui.GetBoolean("STATS")) { //! Run extended statistics
-    Cube* ocubeptr = p.SetOutputCube (ui.GetCubeName("TO"),outputProperties,
+    // The TO parameter is a filename not a cubename, so we can ignore the command line attributes
+    Cube* ocubeptr = p.SetOutputCube (ui.GetFileName("TO"),outputProperties,
                      cubeptr->sampleCount(),cubeptr->lineCount(),
                      cubeptr->bandCount());
 

--- a/isis/src/base/apps/bit2bit/main.cpp
+++ b/isis/src/base/apps/bit2bit/main.cpp
@@ -64,7 +64,7 @@ void IsisMain(){
 
 
   if(ui.GetBoolean("STATS")) { //! Run extended statistics
-    Cube* ocubeptr = p.SetOutputCube (ui.GetFileName("TO"),outputProperties,
+    Cube* ocubeptr = p.SetOutputCube (ui.GetCubeName("TO"),outputProperties,
                      cubeptr->sampleCount(),cubeptr->lineCount(),
                      cubeptr->bandCount());
 

--- a/isis/src/base/apps/cam2cam/cam2cam.cpp
+++ b/isis/src/base/apps/cam2cam/cam2cam.cpp
@@ -27,9 +27,9 @@ namespace Isis {
    */
   void cam2cam(UserInterface &ui) {
     Cube *icube = new Cube();
-    icube->open(ui.GetFileName("FROM"));
+    icube->open(ui.GetCubeName("FROM"));
     Cube *mcube = new Cube();
-    mcube->open(ui.GetFileName("MATCH"));
+    mcube->open(ui.GetCubeName("MATCH"));
     return cam2cam(icube, mcube, ui);
   }
 
@@ -47,7 +47,7 @@ namespace Isis {
 
     ProcessRubberSheet m;
     m.SetInputCube(mcube);
-    Cube *ocube = m.SetOutputCube(ui.GetFileName("TO"), ui.GetOutputAttribute("TO"),
+    Cube *ocube = m.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"),
                                   mcube->sampleCount(), mcube->lineCount(), mcube->bandCount());
 
     // Set up the default reference band to the middle of the cube

--- a/isis/src/base/apps/cam2map/cam2map.cpp
+++ b/isis/src/base/apps/cam2map/cam2map.cpp
@@ -26,7 +26,7 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
 
     // Get the map projection file provided by the user
     Pvl userMap;
@@ -52,7 +52,7 @@ namespace Isis {
 
     // Make sure it is not the sky
     if (incam->target()->isSky()) {
-      QString msg = "The image [" + ui.GetFileName("FROM") +
+      QString msg = "The image [" + ui.GetCubeName("FROM") +
                     "] is targeting the sky, use skymap instead.";
       throw IException(IException::User, msg, _FILEINFO_);
     }
@@ -218,7 +218,7 @@ namespace Isis {
           }
 
           else if (ui.GetString("LONSEAM") == "ERROR") {
-            QString msg = "The image [" + ui.GetFileName("FROM") + "] crosses the " +
+            QString msg = "The image [" + ui.GetCubeName("FROM") + "] crosses the " +
                           "longitude seam";
             throw IException(IException::User, msg, _FILEINFO_);
           }
@@ -256,7 +256,7 @@ namespace Isis {
     PvlGroup cleanMapping = outmap->Mapping();
 
     // Allocate the output cube and add the mapping labels
-    QString fname = ui.GetFileName("TO");
+    QString fname = ui.GetCubeName("TO");
     Isis::CubeAttributeOutput &atts = ui.GetOutputAttribute("TO");
     Cube *ocube = p.SetOutputCube(fname, atts, samples, lines, icube->bandCount());
 

--- a/isis/src/base/apps/cam2map/main.cpp
+++ b/isis/src/base/apps/cam2map/main.cpp
@@ -94,7 +94,7 @@ void loadMapRes() {
 //Helper function to get camera resolution.
 void loadCameraRes() {
   UserInterface &ui = Application::GetUserInterface();
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
 
   // Open the input cube, get the camera object, and the cam map projection
   Cube c;
@@ -157,7 +157,7 @@ void loadMapRange() {
 //Helper function to load camera range.
 void loadCameraRange() {
   UserInterface &ui = Application::GetUserInterface();
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
 
   // Get the map projection file provided by the user
   Pvl userMap;

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -195,7 +195,7 @@ namespace Isis{
             cubeFile.setVirtualBands(inAtt.bands());
         }
 
-        cubeFile.open(ui.GetFileName("FROM"), "r");
+        cubeFile.open(ui.GetCubeName("FROM"), "r");
         caminfo(&cubeFile, ui);
     }
 

--- a/isis/src/base/apps/campt/campt.cpp
+++ b/isis/src/base/apps/campt/campt.cpp
@@ -28,7 +28,7 @@ namespace Isis{
   void writePoints(const UserInterface &ui, QList<PvlGroup*> camPoints, Pvl *log);
 
   void campt(UserInterface &ui, Pvl *log) {
-    Cube *cube = new Cube(ui.GetFileName("FROM"), "r");
+    Cube *cube = new Cube(ui.GetCubeName("FROM"), "r");
     campt(cube, ui, log);
   }
 

--- a/isis/src/base/apps/camrange/camrange.cpp
+++ b/isis/src/base/apps/camrange/camrange.cpp
@@ -12,7 +12,7 @@ using namespace Isis;
 namespace Isis {
   
   void camrange(UserInterface &ui, Pvl *log) {
-    Cube *cube = new Cube( ui.GetFileName("FROM"), "r");
+    Cube *cube = new Cube( ui.GetCubeName("FROM"), "r");
     camrange(cube, ui, log);
   }
 
@@ -32,7 +32,7 @@ namespace Isis {
     cam->radii(radii);
     Target *camTarget = cam->target();
     PvlGroup target("Target");
-    target += PvlKeyword("From", ui.GetFileName("FROM"));
+    target += PvlKeyword("From", ui.GetCubeName("FROM"));
     target += PvlKeyword("TargetName", camTarget->name());
     target += PvlKeyword("RadiusA", toString(radii[0].meters()), "meters");
     target += PvlKeyword("RadiusB", toString(radii[1].meters()), "meters");

--- a/isis/src/base/apps/camstats/camstats.cpp
+++ b/isis/src/base/apps/camstats/camstats.cpp
@@ -30,7 +30,7 @@ namespace Isis {
     Process p;
 
     CubeAttributeInput cai;
-    Cube *icube = p.SetInputCube(ui.GetFileName("FROM"), cai, ReadWrite);
+    Cube *icube = p.SetInputCube(ui.GetCubeName("FROM"), cai, ReadWrite);
     camstats(icube, ui, log);
 
     p.EndProcess();

--- a/isis/src/base/apps/camtrim/main.cpp
+++ b/isis/src/base/apps/camtrim/main.cpp
@@ -33,7 +33,7 @@ void IsisMain() {
   // Make sure the cube isn't projected (i.e. level 2). If it is, the user
   // should be using maptrim instead of this program.
   if (icube->hasGroup("Mapping")) {
-    IString msg = "Input cube [" + ui.GetFileName("FROM") + "] is level 2 "
+    IString msg = "Input cube [" + ui.GetCubeName("FROM") + "] is level 2 "
         "(projected). This application is only designed to operate on level 1 "
         "(non-projected) cubes. Please use maptrim instead";
     throw IException(IException::User, msg, _FILEINFO_);

--- a/isis/src/base/apps/cathist/main.cpp
+++ b/isis/src/base/apps/cathist/main.cpp
@@ -21,7 +21,7 @@ void IsisMain() {
   FileName tofile;
   bool append = false;
   if (ui.WasEntered("TO")) {
-    tofile = FileName(ui.GetCubeName("TO"));
+    tofile = FileName(ui.GetFileName("TO"));
     append = ui.GetBoolean("APPEND");
   }
 

--- a/isis/src/base/apps/cathist/main.cpp
+++ b/isis/src/base/apps/cathist/main.cpp
@@ -15,13 +15,13 @@ void IsisMain() {
 
   // Get user entered file name & mode
   UserInterface &ui = Application::GetUserInterface();
-  FileName fromfile(ui.GetFileName("FROM"));
+  FileName fromfile(ui.GetCubeName("FROM"));
   QString mode = ui.GetString("MODE");
 
   FileName tofile;
   bool append = false;
   if (ui.WasEntered("TO")) {
-    tofile = FileName(ui.GetFileName("TO"));
+    tofile = FileName(ui.GetCubeName("TO"));
     append = ui.GetBoolean("APPEND");
   }
 

--- a/isis/src/base/apps/catlab/main.cpp
+++ b/isis/src/base/apps/catlab/main.cpp
@@ -14,7 +14,7 @@ void IsisMain() {
 
   // Get filename provided by the user
   UserInterface &ui = Application::GetUserInterface();
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
   
   // Extract label from file
   Pvl label(file);

--- a/isis/src/base/apps/catoriglab/main.cpp
+++ b/isis/src/base/apps/catoriglab/main.cpp
@@ -20,7 +20,7 @@ void IsisMain() {
 
   // Get user entered file name & mode
   UserInterface &ui = Application::GetUserInterface();
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
 
   Pvl fromLabel(file);
   if ( fromLabel.hasObject("OriginalLabel") ) {

--- a/isis/src/base/apps/center/main.cpp
+++ b/isis/src/base/apps/center/main.cpp
@@ -75,8 +75,8 @@ void IsisMain() {
     }
     double sTrans = sMiddle - csamp;
     double lTrans = lMiddle - cline;
-    QString params = "from=" + ui.GetFileName("FROM") + 
-                     " to=" + ui.GetFileName("TO") + 
+    QString params = "from=" + ui.GetCubeName("FROM") + 
+                     " to=" + ui.GetCubeName("TO") + 
                      " strans=" + toString(sTrans) + 
                      " ltrans=" + toString(lTrans) + 
                      " interp=" + ui.GetString("INTERP");

--- a/isis/src/base/apps/ckwriter/ckwriter.cpp
+++ b/isis/src/base/apps/ckwriter/ckwriter.cpp
@@ -16,7 +16,7 @@ namespace Isis {
 
     // Get the list of names of input CCD cubes to stitch together
     FileList flist;
-    if (ui.WasEntered("FROM")) flist.push_back(FileName(ui.GetFileName("FROM")));
+    if (ui.WasEntered("FROM")) flist.push_back(FileName(ui.GetCubeName("FROM")));
     if (ui.WasEntered("FROMLIST")) flist.read(FileName(ui.GetFileName("FROMLIST")));
     if (flist.size() < 1) {
       QString msg = "Files must be specified in FROM and/or FROMLIST - none found!";

--- a/isis/src/base/apps/ckwriter/ckwriter.cpp
+++ b/isis/src/base/apps/ckwriter/ckwriter.cpp
@@ -16,7 +16,7 @@ namespace Isis {
 
     // Get the list of names of input CCD cubes to stitch together
     FileList flist;
-    if (ui.WasEntered("FROM")) flist.push_back(FileName(ui.GetCubeName("FROM")));
+    if (ui.WasEntered("FROM")) flist.push_back(FileName(ui.GetFileeName("FROM")));
     if (ui.WasEntered("FROMLIST")) flist.read(FileName(ui.GetFileName("FROMLIST")));
     if (flist.size() < 1) {
       QString msg = "Files must be specified in FROM and/or FROMLIST - none found!";

--- a/isis/src/base/apps/ckwriter/ckwriter.cpp
+++ b/isis/src/base/apps/ckwriter/ckwriter.cpp
@@ -16,7 +16,7 @@ namespace Isis {
 
     // Get the list of names of input CCD cubes to stitch together
     FileList flist;
-    if (ui.WasEntered("FROM")) flist.push_back(FileName(ui.GetFileeName("FROM")));
+    if (ui.WasEntered("FROM")) flist.push_back(FileName(ui.GetFileName("FROM")));
     if (ui.WasEntered("FROMLIST")) flist.read(FileName(ui.GetFileName("FROMLIST")));
     if (flist.size() < 1) {
       QString msg = "Files must be specified in FROM and/or FROMLIST - none found!";

--- a/isis/src/base/apps/copylabel/main.cpp
+++ b/isis/src/base/apps/copylabel/main.cpp
@@ -24,11 +24,11 @@ void IsisMain() {
 
   // Make cube and open Read/Write
   Cube inOut;
-  inOut.open(ui.GetFileName("From"),"rw");
+  inOut.open(ui.GetCubeName("From"),"rw");
 
   Pvl * mergeTo = NULL;
   Pvl * source = NULL;
-  QString sourceFileName = ui.GetFileName("Source");
+  QString sourceFileName = ui.GetCubeName("Source");
   mergeTo = inOut.label();
   source = new Pvl(sourceFileName);
 

--- a/isis/src/base/apps/crop/crop.cpp
+++ b/isis/src/base/apps/crop/crop.cpp
@@ -16,7 +16,7 @@ namespace Isis {
    */
   PvlGroup crop(UserInterface &ui) {
     Cube *icube = new Cube();
-    icube->open(ui.GetFileName("FROM"));
+    icube->open(ui.GetCubeName("FROM"));
     return crop(icube, ui);
   }
 
@@ -58,7 +58,7 @@ namespace Isis {
     CubeAttributeInput inAtt(from);
     cube = new Cube();
     cube->setVirtualBands(inAtt.bands());
-    from = ui.GetFileName("FROM");
+    from = ui.GetCubeName("FROM");
     cube->open(from);
 
     // Determine the sub-area to extract
@@ -116,9 +116,9 @@ namespace Isis {
 
     // Allocate the output file and make sure things get propogated nicely
     CubeAttributeInput &inputAtt =ui.GetInputAttribute("FROM");
-    p.SetInputCube(ui.GetFileName("FROM"), inputAtt);
+    p.SetInputCube(ui.GetCubeName("FROM"), inputAtt);
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), att, ns, nl, nb);
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), att, ns, nl, nb);
     p.PropagateTables(false);
     p.ClearInputCubes();
 

--- a/isis/src/base/apps/cropspecial/main.cpp
+++ b/isis/src/base/apps/cropspecial/main.cpp
@@ -31,10 +31,7 @@ void IsisMain() {
 
   // Open the input cube
   UserInterface &ui = Application::GetUserInterface();
-  QString from = ui.GetAsString("FROM");
-  CubeAttributeInput inAtt(from);
-  cube.setVirtualBands(inAtt.bands());
-  from = ui.GetFileName("FROM");
+  QString from = ui.GetCubeName("FROM");
   cube.open(from);
 
   g_cropNulls = ui.GetBoolean("NULL");

--- a/isis/src/base/apps/csminit/csminit.cpp
+++ b/isis/src/base/apps/csminit/csminit.cpp
@@ -45,7 +45,7 @@ namespace Isis {
     // managing the Cube in memory and adding history
     Process p;
     // Get the cube here so that we check early if it doesn't exist
-    Cube *cube = p.SetInputCube(ui.GetFileName("FROM"), ui.GetInputAttribute("FROM"), ReadWrite);
+    Cube *cube = p.SetInputCube(ui.GetCubeName("FROM"), ui.GetInputAttribute("FROM"), ReadWrite);
 
     // We have to call this to get the plugin list loaded.
     CameraFactory::initPlugin();

--- a/isis/src/base/apps/csv2table/main.cpp
+++ b/isis/src/base/apps/csv2table/main.cpp
@@ -123,7 +123,7 @@ void IsisMain() {
   }
 
   // Write the table to the cube
-  QString outCubeFileName(ui.GetFileName("to"));
+  QString outCubeFileName(ui.GetCubeName("to"));
   Cube outCube;
   try {
     outCube.open(outCubeFileName, "rw");

--- a/isis/src/base/apps/cubeatt/cubeatt.cpp
+++ b/isis/src/base/apps/cubeatt/cubeatt.cpp
@@ -14,7 +14,7 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
     cubeatt(&icube, ui);
   }
 
@@ -22,7 +22,7 @@ namespace Isis {
   // Doesn't allow specification of input attributes
   void cubeatt(Cube *icube, UserInterface &ui) {
     bool propTables = ui.GetBoolean("PROPTABLES");
-    QString outputFileName = ui.GetFileName("TO");
+    QString outputFileName = ui.GetCubeName("TO");
     CubeAttributeOutput outputAttributes= ui.GetOutputAttribute("TO");
     cubeatt(icube, outputFileName, outputAttributes, propTables);
   }

--- a/isis/src/base/apps/cubeit/main.cpp
+++ b/isis/src/base/apps/cubeit/main.cpp
@@ -149,7 +149,7 @@ void IsisMain() {
   int index = 0;
   if(ui.WasEntered("PROPLAB")) {
     bool match = false;
-    QString fname = ui.GetFileName("PROPLAB");
+    QString fname = ui.GetCubeName("PROPLAB");
     for(int i = 0; i < cubeList.size(); i++) {
       if(fname == cubeList[i].toString()) {
         index = i;
@@ -158,7 +158,7 @@ void IsisMain() {
       }
     }
     if(!match) {
-      QString msg = "FileName [" + ui.GetFileName("PROPLAB") +
+      QString msg = "FileName [" + ui.GetCubeName("PROPLAB") +
                     "] to propagate labels from is not in the list file [" +
                     ui.GetFileName("FROMLIST") + "]";
       throw IException(IException::User, msg, _FILEINFO_);

--- a/isis/src/base/apps/demprep/demprep.cpp
+++ b/isis/src/base/apps/demprep/demprep.cpp
@@ -32,7 +32,7 @@ namespace Isis{
     ProcessByLine p;
 
     CubeAttributeInput &inputAtt = ui.GetInputAttribute("FROM");
-    Cube *icube = p.SetInputCube(ui.GetFileName("FROM"), inputAtt);
+    Cube *icube = p.SetInputCube(ui.GetCubeName("FROM"), inputAtt);
     int ins = icube->sampleCount();
     inl = icube->lineCount();
     int inb = icube->bandCount();

--- a/isis/src/base/apps/desmile/main.cpp
+++ b/isis/src/base/apps/desmile/main.cpp
@@ -40,7 +40,7 @@ void IsisMain() {
   Cube *inCube = procSpectra.SetInputCube("FROM");
 
   // Get the spectral information for the input cube
-  FileName smileDef = ui.GetFileName("SMILEDEF");
+  FileName smileDef = ui.GetCubeName("SMILEDEF");
   // TODO: May want to add the cube to the constructor args so some error checks can be done
   SpectralDefinition* inputSpectralDef = SpectralDefinitionFactory::NewSpectralDefinition(smileDef);
 

--- a/isis/src/base/apps/dstripe/main.cpp
+++ b/isis/src/base/apps/dstripe/main.cpp
@@ -67,7 +67,7 @@ void IsisMain() {
   // Run lowpass filter on input
   QString tempFileName = FileName::createTempFile("$TEMPORARY/dstripe.temporary.cub").expanded();
   QString lowParams = "";
-  lowParams += "from= " + ui.GetFileName("FROM");
+  lowParams += "from= " + ui.GetCubeName("FROM");
   lowParams += " to= " + tempFileName + " ";
   lowParams += " samples= " + toString(lowSamples);
   lowParams += " lines= " + toString(lowLines);
@@ -77,8 +77,8 @@ void IsisMain() {
   // Make a copy of the lowpass filter results if the user wants it
   if(!ui.GetBoolean("DELETENOISE")) {
     QString lowParams = "";
-    lowParams += "from= " + ui.GetFileName("FROM");
-    lowParams += " to= " + ui.GetFileName("LPFNOISE");
+    lowParams += "from= " + ui.GetCubeName("FROM");
+    lowParams += " to= " + ui.GetCubeName("LPFNOISE");
     lowParams += " samples= " + toString(lowSamples);
     lowParams += " lines= " + toString(lowLines);
     ProgramLauncher::RunIsisProgram("lowpass", lowParams);

--- a/isis/src/base/apps/editlab/main.cpp
+++ b/isis/src/base/apps/editlab/main.cpp
@@ -17,7 +17,7 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
 
   // Extract label from file
-  Pvl *label = new Pvl(ui.GetFileName("FROM"));
+  Pvl *label = new Pvl(ui.GetCubeName("FROM"));
   PvlObject *pvl = label;
   QString option = ui.GetString("OPTION");
 
@@ -25,7 +25,7 @@ void IsisMain() {
   Cube *cube = NULL;
   if(label->hasObject("IsisCube")) {
     cube = new Cube();
-    cube->open(ui.GetFileName("FROM"), "rw");
+    cube->open(ui.GetCubeName("FROM"), "rw");
     pvl = &(cube->label()->findObject("IsisCube"));
   }
 
@@ -110,7 +110,7 @@ void IsisMain() {
     cube = NULL;
   }
   else {
-    label->write(ui.GetFileName("FROM"));
+    label->write(ui.GetCubeName("FROM"));
   }
 
   delete label;

--- a/isis/src/base/apps/editlab/main.cpp
+++ b/isis/src/base/apps/editlab/main.cpp
@@ -17,7 +17,7 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
 
   // Extract label from file
-  Pvl *label = new Pvl(ui.GetCubeName("FROM"));
+  Pvl *label = new Pvl(ui.GetFileName("FROM"));
   PvlObject *pvl = label;
   QString option = ui.GetString("OPTION");
 
@@ -25,7 +25,7 @@ void IsisMain() {
   Cube *cube = NULL;
   if(label->hasObject("IsisCube")) {
     cube = new Cube();
-    cube->open(ui.GetCubeName("FROM"), "rw");
+    cube->open(ui.GetFileName("FROM"), "rw");
     pvl = &(cube->label()->findObject("IsisCube"));
   }
 
@@ -110,7 +110,7 @@ void IsisMain() {
     cube = NULL;
   }
   else {
-    label->write(ui.GetCubeName("FROM"));
+    label->write(ui.GetFileName("FROM"));
   }
 
   delete label;

--- a/isis/src/base/apps/enlarge/enlarge_app.cpp
+++ b/isis/src/base/apps/enlarge/enlarge_app.cpp
@@ -15,7 +15,7 @@ namespace Isis{
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
     enlarge(&icube, ui, log);
   }
 
@@ -74,7 +74,7 @@ namespace Isis{
     }
     
     // Allocate the output file, the number of bands does not change in the output
-    QString outputFileName = ui.GetFileName("TO");
+    QString outputFileName = ui.GetCubeName("TO");
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
     Cube *ocube = p.SetOutputCube(outputFileName, att, ons, onl, inb);
     

--- a/isis/src/base/apps/explode/main.cpp
+++ b/isis/src/base/apps/explode/main.cpp
@@ -19,7 +19,7 @@ void IsisMain() {
 
   // We the output filename so we can add attributes and extensions
   UserInterface &ui = Application::GetUserInterface();
-  QString outbase = ui.GetFileName("TO");
+  QString outbase = ui.GetCubeName("TO");
   CubeAttributeOutput &outatt = ui.GetOutputAttribute("TO");
 
   // Loop and extract each band

--- a/isis/src/base/apps/fillgap/fillgap.cpp
+++ b/isis/src/base/apps/fillgap/fillgap.cpp
@@ -25,7 +25,7 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       cubeFile->setVirtualBands(inAtt.bands());
     }
-    cubeFile->open(ui.GetFileName("FROM"), "r");
+    cubeFile->open(ui.GetCubeName("FROM"), "r");
 
     fillgap(cubeFile, ui, log);
   }
@@ -53,21 +53,21 @@ namespace Isis {
     if(Dir == "SAMPLE") {
       ProcessBySample p;
       p.SetInputCube(inCube);
-      p.SetOutputCube(ui.GetFileName("TO"), att);
+      p.SetOutputCube(ui.GetCubeName("TO"), att);
       p.StartProcess(fill);
       p.EndProcess();
     }
     else if(Dir == "LINE") {
       ProcessByLine p;
       p.SetInputCube(inCube);
-      p.SetOutputCube(ui.GetFileName("TO"), att);
+      p.SetOutputCube(ui.GetCubeName("TO"), att);
       p.StartProcess(fill);
       p.EndProcess();
     }
     else if(Dir == "BAND") {
       ProcessBySpectra p;
       p.SetInputCube(inCube);
-      p.SetOutputCube(ui.GetFileName("TO"), att);
+      p.SetOutputCube(ui.GetCubeName("TO"), att);
       p.StartProcess(fill);
       p.EndProcess();
     }

--- a/isis/src/base/apps/findgaps/findgaps.cpp
+++ b/isis/src/base/apps/findgaps/findgaps.cpp
@@ -46,7 +46,7 @@ namespace Isis {
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
 
     Cube *iCube = new Cube();
-    iCube->open(ui.GetFileName("FROM"), "r");
+    iCube->open(ui.GetCubeName("FROM"), "r");
 
     if (outputCubeSpecified || logFileSpecified) {
       ProcessByLine p;
@@ -59,7 +59,7 @@ namespace Isis {
       if (outputCubeSpecified) {
         gapsFunctor.setModification("NULL buffers added to output cube");
         
-        p.SetOutputCube(ui.GetFileName("TO"), att);
+        p.SetOutputCube(ui.GetCubeName("TO"), att);
 
         p.ProcessCube(gapsFunctor, false);
       }

--- a/isis/src/base/apps/fits2isis/fits2isis.cpp
+++ b/isis/src/base/apps/fits2isis/fits2isis.cpp
@@ -39,7 +39,7 @@ namespace Isis{
     pfits.setProcessFileStructure(ui.GetInteger("IMAGENUMBER"));
 
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *output = pfits.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *output = pfits.SetOutputCube(ui.GetCubeName("TO"), att);
 
     // Add instrument group if any keywords were put into it.
     PvlGroup instGrp = pfits.standardInstrumentGroup(pfits.fitsImageLabel(0));

--- a/isis/src/base/apps/footprintinit/footprintinit.cpp
+++ b/isis/src/base/apps/footprintinit/footprintinit.cpp
@@ -18,7 +18,7 @@ namespace Isis {
 
   void footprintinit(UserInterface &ui, Pvl *log) {
     Cube cube;
-    cube.open(ui.GetFileName("FROM"), "rw");
+    cube.open(ui.GetCubeName("FROM"), "rw");
 
     footprintinit(&cube, ui, log);
     cube.close();

--- a/isis/src/base/apps/getsn/getsn.cpp
+++ b/isis/src/base/apps/getsn/getsn.cpp
@@ -22,7 +22,7 @@ namespace Isis {
 
   void getsn( UserInterface &ui, Pvl *log ) {
     // Open the input cube
-    Cube *cube = new Cube( ui.GetFileName("FROM"), "r");
+    Cube *cube = new Cube( ui.GetCubeName("FROM"), "r");
     
     getsn( cube, ui, log );
 

--- a/isis/src/base/apps/greyscale/main.cpp
+++ b/isis/src/base/apps/greyscale/main.cpp
@@ -55,7 +55,7 @@ void IsisMain() {
     p->SetBrickSize(1, lines, 1);
   }
   //Make the cube
-  p->SetOutputCube(ui.GetFileName("TO"), att, samps, lines);
+  p->SetOutputCube(ui.GetCubeName("TO"), att, samps, lines);
   p->StartProcess(GreyScale);
   p->EndProcess();
 

--- a/isis/src/base/apps/grid/grid.cpp
+++ b/isis/src/base/apps/grid/grid.cpp
@@ -35,7 +35,7 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
     grid(&icube, ui);
   }
 
@@ -43,7 +43,7 @@ namespace Isis {
     // We will be processing by line
     ProcessByLine p;
     p.SetInputCube(icube);
-    p.SetOutputCube(ui.GetFileName("TO"), ui.GetOutputAttribute("TO"), 
+    p.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"), 
                     icube->sampleCount(), icube->lineCount(), icube->bandCount());
 
     QString mode = ui.GetString("MODE");

--- a/isis/src/base/apps/handmos/main.cpp
+++ b/isis/src/base/apps/handmos/main.cpp
@@ -31,7 +31,7 @@ void IsisMain() {
   p.SetTrackFlag(bTrack);
 
   QString inputFile = ui.GetAsString("FROM");
-  QString mosaicFile = ui.GetFileName("MOSAIC");
+  QString mosaicFile = ui.GetCubeName("MOSAIC");
 
   // Set up the mosaic priority, either the input cube will be
   // placed ontop of the mosaic or beneath it

--- a/isis/src/base/apps/hist/hist.cpp
+++ b/isis/src/base/apps/hist/hist.cpp
@@ -26,7 +26,7 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       cube.setVirtualBands(inAtt.bands());
     }
-    cube.open(ui.GetFileName("FROM"));
+    cube.open(ui.GetCubeName("FROM"));
     hist(&cube, ui);
   }
 

--- a/isis/src/base/apps/hist/main.cpp
+++ b/isis/src/base/apps/hist/main.cpp
@@ -28,7 +28,7 @@ void helperButtonCalcMinMax() {
   UserInterface &ui = Application::GetUserInterface();
 
   // Setup a cube for gathering stats from the user requested band
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
 
   Cube inCube;
   CubeAttributeInput attrib = ui.GetInputAttribute("FROM");

--- a/isis/src/base/apps/interestcube/main.cpp
+++ b/isis/src/base/apps/interestcube/main.cpp
@@ -37,7 +37,7 @@ void IsisMain() {
   p.SetOutputCube("TO");
   Pvl pvl = Pvl(ui.GetFileName("PVL"));
 
-  cube.open(ui.GetFileName("FROM"));
+  cube.open(ui.GetCubeName("FROM"));
 
   try {
     // Get info from the operator group

--- a/isis/src/base/apps/isis2ascii/isis2ascii.cpp
+++ b/isis/src/base/apps/isis2ascii/isis2ascii.cpp
@@ -62,7 +62,7 @@ namespace Isis {
 
   void isis2ascii(UserInterface &ui) {
     Cube icube;
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
 
     isis2ascii(&icube, ui);
   }

--- a/isis/src/base/apps/isis2gml/main.cpp
+++ b/isis/src/base/apps/isis2gml/main.cpp
@@ -20,7 +20,7 @@ void IsisMain() {
   // Get the polygon from the input cube. NOTE: the generated poly is always in the 0 to 360 domain.
   // Use the linc/sinc requested by the user.
   Cube cube;
-  cube.open(ui.GetFileName("FROM"));
+  cube.open(ui.GetCubeName("FROM"));
   int sinc = ui.GetInteger("SINC");
   int linc = ui.GetInteger("LINC");
   ImagePolygon poly;
@@ -59,7 +59,7 @@ void IsisMain() {
     }
   }
   else {
-    FileName inputFile = ui.GetFileName("FROM");
+    FileName inputFile = ui.GetCubeName("FROM");
     outgml = inputFile.removeExtension().addExtension("gml").expanded();
   }
 

--- a/isis/src/base/apps/isis2pds/isis2pds.cpp
+++ b/isis/src/base/apps/isis2pds/isis2pds.cpp
@@ -26,7 +26,7 @@ namespace Isis{
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
     isis2pds(&icube, ui, log);
   }
 
@@ -131,7 +131,7 @@ namespace Isis{
 
       PvlObject *label= icube->label();
       if (!label->hasObject("IsisCube")) {
-        QString msg = "Input file [" + ui.GetFileName("FROM") +
+        QString msg = "Input file [" + ui.GetCubeName("FROM") +
                       "] does not appear to be an ISIS cube.";
         throw  IException(IException::User, msg, _FILEINFO_);
       }

--- a/isis/src/base/apps/isis2std/main.cpp
+++ b/isis/src/base/apps/isis2std/main.cpp
@@ -111,7 +111,7 @@ void IsisMain() {
 
 int addChannel(ExportDescription &desc, QString param, QString mode) {
   UserInterface &ui = Application::GetUserInterface();
-  FileName name = ui.GetFileName(param);
+  FileName name = ui.GetCubeName(param);
   CubeAttributeInput &att = ui.GetInputAttribute(param);
 
   int index = -1;

--- a/isis/src/base/apps/isisexport/isisexport.cpp
+++ b/isis/src/base/apps/isisexport/isisexport.cpp
@@ -29,7 +29,7 @@ namespace Isis {
 
   void isisexport(UserInterface &ui, Pvl *log) {
     Cube *icube = new Cube();
-    icube->open(ui.GetFileName("FROM"));
+    icube->open(ui.GetCubeName("FROM"));
     CubeAttributeInput inAtt = ui.GetInputAttribute("FROM");
     if (inAtt.bands().size() != 0) {
       icube->setVirtualBands(inAtt.bands());

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -495,7 +495,7 @@ namespace Isis {
       cubeAtts = QString(translation["CubeAtts"]);
     }
     CubeAttributeOutput att = CubeAttributeOutput(cubeAtts);
-    Cube *outputCube = importer.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *outputCube = importer.SetOutputCube(ui.GetCubeName("TO"), att);
 
     if (isPDS4) {
       OriginalXmlLabel xmlLabel;

--- a/isis/src/base/apps/makecube/main.cpp
+++ b/isis/src/base/apps/makecube/main.cpp
@@ -94,7 +94,7 @@ void IsisMain() {
   int samps = ui.GetInteger("SAMPLES");
   int lines = ui.GetInteger("LINES");
   int bands = ui.GetInteger("BANDS");
-  p.SetOutputCube(ui.GetFileName("TO"), att, samps, lines, bands);
+  p.SetOutputCube(ui.GetCubeName("TO"), att, samps, lines, bands);
 
   // Make the cube
   p.ProcessCubeInPlace(ConstantValueFunctor(value), false);

--- a/isis/src/base/apps/makeflat/main.cpp
+++ b/isis/src/base/apps/makeflat/main.cpp
@@ -375,7 +375,7 @@ void IsisMain() {
   ocube->setDimensions(numOutputSamples, tempFileLength, 2);
   PvlGroup &prefs = Preference::Preferences().findGroup("DataDirectory", Pvl::Traverse);
   QString outTmpName = (QString)prefs["Temporary"][0] + "/";
-  outTmpName += FileName(ui.GetFileName("TO")).baseName() + ".tmp.cub";
+  outTmpName += FileName(ui.GetCubeName("TO")).baseName() + ".tmp.cub";
   ocube->create(outTmpName);
   oLineMgr = new LineManager(*ocube);
   oLineMgr->SetLine(1);
@@ -461,7 +461,7 @@ void IsisMain() {
     ocube->setDimensions(numOutputSamples, tempFileLength, 1);
   }
 
-  ocube->create(FileName(ui.GetFileName("TO")).expanded());
+  ocube->create(FileName(ui.GetCubeName("TO")).expanded());
   oLineMgr = new LineManager(*ocube);
   oLineMgr->SetLine(1);
 

--- a/isis/src/base/apps/map2cam/map2cam.cpp
+++ b/isis/src/base/apps/map2cam/map2cam.cpp
@@ -17,17 +17,17 @@ namespace Isis{
 
     // Open the input camera cube that we will be matching and create
     // the camera object
-    FileName match = FileName(ui.GetFileName("MATCH"));
+    FileName match = FileName(ui.GetCubeName("MATCH"));
 
     Process p;
-    QString fname = ui.GetFileName("MATCH");
+    QString fname = ui.GetCubeName("MATCH");
     Isis::CubeAttributeInput &inputAtt = ui.GetInputAttribute("MATCH");
     mcube = p.SetInputCube(fname, inputAtt);
     outcam = mcube->camera();
 
     // Open the input projection cube and get the projection information
     ProcessRubberSheet rub;
-    fname = ui.GetFileName("FROM");
+    fname = ui.GetCubeName("FROM");
     inputAtt = ui.GetInputAttribute("FROM");
     Cube *icube = rub.SetInputCube(fname, inputAtt);
     TProjection *inmap = (TProjection *) icube->projection();
@@ -44,7 +44,7 @@ namespace Isis{
     // Allocate the output cube but don't propagate any labels from the map
     // file. Instead propagate from the camera file
     rub.PropagateLabels(false);
-    fname = ui.GetFileName("TO");
+    fname = ui.GetCubeName("TO");
     Isis::CubeAttributeOutput &outputAtt = ui.GetOutputAttribute("TO");
     rub.SetOutputCube(fname, outputAtt,
                       transform->OutputSamples(),

--- a/isis/src/base/apps/map2map/main.cpp
+++ b/isis/src/base/apps/map2map/main.cpp
@@ -64,7 +64,7 @@ catch(IException &e) {
 Pvl fromMap;
 
 try {
-fromMap.read(ui.GetFileName("FROM"));
+fromMap.read(ui.GetCubeName("FROM"));
 }
 catch(IException &e) {
 }

--- a/isis/src/base/apps/map2map/map2map.cpp
+++ b/isis/src/base/apps/map2map/map2map.cpp
@@ -14,7 +14,7 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       cube.setVirtualBands(inAtt.bands());
     }
-    cube.open(ui.GetFileName("FROM"));
+    cube.open(ui.GetCubeName("FROM"));
     map2map(&cube, ui);
   }
 
@@ -27,7 +27,7 @@ namespace Isis {
     PvlGroup &userMappingGrp = userPvl.findGroup("Mapping", Pvl::Traverse);
 
     CubeAttributeInput &inputAtt =ui.GetInputAttribute("FROM");
-    p.SetInputCube(ui.GetFileName("FROM"), inputAtt);
+    p.SetInputCube(ui.GetCubeName("FROM"), inputAtt);
 
     // Get the mapping group
     PvlGroup fromMappingGrp = icube->group("Mapping");
@@ -333,7 +333,7 @@ namespace Isis {
 
     // Allocate the output cube and add the mapping labels
     CubeAttributeOutput & att = ui.GetOutputAttribute("TO");
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), att, transform->OutputSamples(),
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), att, transform->OutputSamples(),
                                 transform->OutputLines(),
                                 icube->bandCount());
 

--- a/isis/src/base/apps/maplab/main.cpp
+++ b/isis/src/base/apps/maplab/main.cpp
@@ -17,7 +17,7 @@ void IsisMain() {
 
   // Open the input cube
   Cube cube;
-  cube.open(ui.GetFileName("FROM"), "rw");
+  cube.open(ui.GetCubeName("FROM"), "rw");
 
   //Get the map projection file provided by the user
   Pvl userMap;

--- a/isis/src/base/apps/mapmos/mapmos.cpp
+++ b/isis/src/base/apps/mapmos/mapmos.cpp
@@ -11,7 +11,7 @@ using namespace Isis;
 namespace Isis {
 
   void mapmos(UserInterface &ui, Pvl *log) {
-    Cube *inCube = new Cube( ui.GetFileName("FROM"), "r");
+    Cube *inCube = new Cube( ui.GetCubeName("FROM"), "r");
     mapmos(inCube, ui, log);
   }
 
@@ -84,10 +84,10 @@ namespace Isis {
       }
       
       CubeAttributeOutput oAtt = ui.GetOutputAttribute("MOSAIC");
-      m.SetOutputCube(sInputFile, mapGroup, oAtt, ui.GetFileName("MOSAIC"));
+      m.SetOutputCube(sInputFile, mapGroup, oAtt, ui.GetCubeName("MOSAIC"));
     }
     else {
-      m.SetOutputCube(ui.GetFileName("MOSAIC"));
+      m.SetOutputCube(ui.GetCubeName("MOSAIC"));
     }
 
 

--- a/isis/src/base/apps/mappt/mappt.cpp
+++ b/isis/src/base/apps/mappt/mappt.cpp
@@ -29,7 +29,7 @@ void mappt(UserInterface &ui, Pvl *log) {
     cube->setVirtualBands(inAtt.bands());
   }
   
-  cube->open(ui.GetFileName("FROM"), "r");
+  cube->open(ui.GetCubeName("FROM"), "r");
   mappt(cube, ui, log, &inAtt);
 }
 

--- a/isis/src/base/apps/maptrim/maptrim.cpp
+++ b/isis/src/base/apps/maptrim/maptrim.cpp
@@ -25,7 +25,7 @@ namespace Isis{
 
   void maptrim(UserInterface &ui, Pvl *log) {
     // Get the projection
-    Pvl pvl(ui.GetFileName("FROM"));
+    Pvl pvl(ui.GetCubeName("FROM"));
     proj = (TProjection *) ProjectionFactory::CreateFromCube(pvl);
 
     // Determine ground range to crop and/or trim
@@ -55,7 +55,7 @@ namespace Isis{
 
       ProcessByLine p;
       CubeAttributeInput &inputAtt = ui.GetInputAttribute("FROM");
-      p.SetInputCube(ui.GetFileName("FROM"), inputAtt);
+      p.SetInputCube(ui.GetCubeName("FROM"), inputAtt);
       p.StartProcess(getSize);
       p.EndProcess();
 
@@ -64,7 +64,7 @@ namespace Isis{
 
       // Run external crop
       QString cropParams = "";
-      cropParams += "from=" + ui.GetFileName("FROM");
+      cropParams += "from=" + ui.GetCubeName("FROM");
       if(mode == "CROP") {
         cropParams += " to=" + ui.GetAsString("TO");
       }
@@ -102,11 +102,11 @@ namespace Isis{
       }
       else { //if its trim
         CubeAttributeInput &inputAtt = ui.GetInputAttribute("FROM");
-        p.SetInputCube(ui.GetFileName("FROM"), inputAtt);
+        p.SetInputCube(ui.GetCubeName("FROM"), inputAtt);
       }
 
       CubeAttributeOutput &outputAtt = ui.GetOutputAttribute("TO");
-      p.SetOutputCube(ui.GetFileName("TO"), outputAtt);
+      p.SetOutputCube(ui.GetCubeName("TO"), outputAtt);
       p.StartProcess(trim);
       p.EndProcess();
       if(mode == "BOTH") {

--- a/isis/src/base/apps/mvstats/main.cpp
+++ b/isis/src/base/apps/mvstats/main.cpp
@@ -28,7 +28,7 @@ void IsisMain() {
     throw IException(IException::User, message, _FILEINFO_);
   }
 
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
 
   //Use a Process to get the number of bands in the input cube
   Process q;

--- a/isis/src/base/apps/mvstats/main.cpp
+++ b/isis/src/base/apps/mvstats/main.cpp
@@ -112,7 +112,7 @@ void IsisMain() {
     ProcessByLine p;
     CubeAttributeOutput set;
     set.setPixelType(Real);
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("CUBE"),
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("CUBE"),
                                   set, bands, bands, 2);
     p.StartProcess(WriteCube);
     ocube->putGroup(bandBin);

--- a/isis/src/base/apps/nocam2map/main.cpp
+++ b/isis/src/base/apps/nocam2map/main.cpp
@@ -200,7 +200,7 @@ void ComputeInputRange() {
       //Else read the target name from the input cube
       else {
         Pvl fromFile;
-        fromFile.read(ui.GetFileName("FROM"));
+        fromFile.read(ui.GetCubeName("FROM"));
         target = (QString)fromFile.findKeyword("TargetName", Pvl::Traverse);
       }
 

--- a/isis/src/base/apps/nocam2map/nocam2map.cpp
+++ b/isis/src/base/apps/nocam2map/nocam2map.cpp
@@ -31,7 +31,7 @@ namespace Isis {
   static void DeleteTables(Pvl *label, PvlGroup kernels);
 
   void nocam2map(UserInterface &ui, Pvl *log) {
-    QString inputFileName = ui.GetFileName("FROM");
+    QString inputFileName = ui.GetCubeName("FROM");
     Cube iCube(inputFileName);
     nocam2map(&iCube, ui, log);
   }
@@ -42,8 +42,8 @@ namespace Isis {
     Process p;
 
     //Create the input cubes, matching sample/lines
-    Cube *latCube = p.SetInputCube(ui.GetFileName("LATCUB"), ui.GetInputAttribute("LATCUB"), SpatialMatch);
-    Cube *lonCube = p.SetInputCube(ui.GetFileName("LONCUB"), ui.GetInputAttribute("LONCUB"), SpatialMatch);
+    Cube *latCube = p.SetInputCube(ui.GetCubeName("LATCUB"), ui.GetInputAttribute("LATCUB"), SpatialMatch);
+    Cube *lonCube = p.SetInputCube(ui.GetCubeName("LONCUB"), ui.GetInputAttribute("LONCUB"), SpatialMatch);
   
     //A 1x1 brick to read in the latitude and longitude DN values from
     //the specified cubes
@@ -202,11 +202,11 @@ namespace Isis {
       //Reopen the lat and long cubes
       latCube = new Cube();
       latCube->setVirtualBands(ui.GetInputAttribute("LATCUB").bands());
-      latCube->open(ui.GetFileName("LATCUB"));
+      latCube->open(ui.GetCubeName("LATCUB"));
   
       lonCube = new Cube();
       lonCube->setVirtualBands(ui.GetInputAttribute("LONCUB").bands());
-      lonCube->open(ui.GetFileName("LONCUB"));
+      lonCube->open(ui.GetCubeName("LONCUB"));
   
       PvlKeyword targetName;
   
@@ -428,7 +428,7 @@ namespace Isis {
                                            samples, lines);
   
       //Allocate the output cube and add the mapping labels
-      Cube *oCube = r.SetOutputCube(ui.GetFileName("TO"), ui.GetOutputAttribute("TO"), transform->OutputSamples(),
+      Cube *oCube = r.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"), transform->OutputSamples(),
                                     transform->OutputLines(),
                                     inCube->bandCount());
       oCube->putGroup(mapGrp);

--- a/isis/src/base/apps/noproj/main.cpp
+++ b/isis/src/base/apps/noproj/main.cpp
@@ -31,10 +31,10 @@ void LoadMatchSummingMode() {
 
   // Get camera from cube to match
   if((ui.GetString("SOURCE") == "FROMMATCH") && (ui.WasEntered("MATCH"))) {
-    file = ui.GetFileName("MATCH");
+    file = ui.GetCubeName("MATCH");
   }
   else {
-    file = ui.GetFileName("FROM");
+    file = ui.GetCubeName("FROM");
   }
 
 // Open the input cube and get the camera object
@@ -54,7 +54,7 @@ void LoadInputSummingMode() {
   UserInterface &ui = Application::GetUserInterface();
 
   // Get camera from cube to match
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
   // Open the input cube and get the camera object
   Cube c;
   c.open(file);

--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -38,11 +38,11 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       icube.setVirtualBands(inAtt.bands());
     }
-    icube.open(ui.GetFileName("FROM"));
+    icube.open(ui.GetCubeName("FROM"));
 
     Cube mcube;
     if((ui.WasEntered("MATCH"))) {
-      mcube.open(ui.GetFileName("MATCH"));
+      mcube.open(ui.GetCubeName("MATCH"));
     }
 
     noproj(&icube, &mcube, ui);
@@ -358,7 +358,7 @@ namespace Isis {
     label.write("match.lbl");
 
   // And run cam2cam to apply the transformation
-    QVector<QString> args = {"to=" + ui.GetFileName("TO"), "INTERP=" + ui.GetString("INTERP")};
+    QVector<QString> args = {"to=" + ui.GetCubeName("TO"), "INTERP=" + ui.GetString("INTERP")};
     UserInterface cam2camUI(FileName("$ISISROOT/bin/xml/cam2cam.xml").expanded(), args);
     Cube matchCube;
     matchCube.open("match.cub", "rw");
@@ -379,7 +379,7 @@ namespace Isis {
 
   // Finally finish by adding the OriginalInstrument group to the TO cube
     Cube toCube;
-    toCube.open(ui.GetFileName("TO"), "rw");
+    toCube.open(ui.GetCubeName("TO"), "rw");
   // Extract label and create cube object
     Pvl *toLabel = toCube.label();
     PvlObject &o = toLabel->findObject("IsisCube");

--- a/isis/src/base/apps/noseam/main.cpp
+++ b/isis/src/base/apps/noseam/main.cpp
@@ -67,7 +67,7 @@ void IsisMain() {
   //Finally combines the highpass and lowpass mosaics
   parameters = "FROM=" + pathName + "HighpassMosaic.cub" +
                " FROM2=" + pathName + "LowpassMosaic.cub" +
-               " TO=" + ui.GetFileName("TO") +
+               " TO=" + ui.GetCubeName("TO") +
                " OPERATOR= add";
   ProgramLauncher::RunIsisProgram("algebra", parameters);
 

--- a/isis/src/base/apps/pds2isis/pds2isis.cpp
+++ b/isis/src/base/apps/pds2isis/pds2isis.cpp
@@ -18,7 +18,7 @@ namespace Isis {
 
   
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), att);
 
     // Get user entered special pixel ranges
     if(ui.GetBoolean("SETNULLRANGE")) {

--- a/isis/src/base/apps/phocube/phocube.cpp
+++ b/isis/src/base/apps/phocube/phocube.cpp
@@ -74,7 +74,7 @@ namespace Isis {
         cam = icube->camera();
       }
       catch(IException &e) {
-        QString msg = "If " + FileName(ui.GetFileName("FROM")).name() + " is a mosaic, make sure the SOURCE "
+        QString msg = "If " + FileName(ui.GetCubeName("FROM")).name() + " is a mosaic, make sure the SOURCE "
         "option is set to PROJECTION";
         throw IException(e, IException::User, msg, _FILEINFO_);
       }
@@ -627,7 +627,7 @@ namespace Isis {
       p.SetInputCube(icube, OneBand);
     }
 
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), ui.GetOutputAttribute("TO"),
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"),
                                   icube->sampleCount(), icube->lineCount(), nbands);
     p.SetBrickSize(64, 64, nbands);
     p.StartProcess(phocube);

--- a/isis/src/base/apps/phoemplocal/main.cpp
+++ b/isis/src/base/apps/phoemplocal/main.cpp
@@ -328,7 +328,7 @@ void IsisMain() {
       mainpvl.addGroup(note);
     }
     mainpvl.addGroup(results);
-    QString sOutFile = ui.GetCubeName("TO");
+    QString sOutFile = ui.GetFileName("TO");
     bool append = ui.GetBoolean("APPEND");
     ofstream os;
     if (append) {

--- a/isis/src/base/apps/phoemplocal/main.cpp
+++ b/isis/src/base/apps/phoemplocal/main.cpp
@@ -328,7 +328,7 @@ void IsisMain() {
       mainpvl.addGroup(note);
     }
     mainpvl.addGroup(results);
-    QString sOutFile = ui.GetFileName("TO");
+    QString sOutFile = ui.GetCubeName("TO");
     bool append = ui.GetBoolean("APPEND");
     ofstream os;
     if (append) {

--- a/isis/src/base/apps/photomet/main.cpp
+++ b/isis/src/base/apps/photomet/main.cpp
@@ -1779,7 +1779,7 @@ void IsisMain() {
   p.SetOutputCube("TO");
 
   Pvl inLabel;
-  inLabel.read(ui.GetFileName("FROM"));
+  inLabel.read(ui.GetCubeName("FROM"));
 
   // If the source of photometric angles is the center of the image,
   // then get the angles at the center of the image.

--- a/isis/src/base/apps/pixel2map/main.cpp
+++ b/isis/src/base/apps/pixel2map/main.cpp
@@ -284,7 +284,7 @@ void IsisMain() {
       }
 
       else if (ui.GetString("LONSEAM") == "ERROR") {
-        QString msg = "The image [" + ui.GetFileName("FROM") + "] crosses the " +
+        QString msg = "The image [" + ui.GetCubeName("FROM") + "] crosses the " +
                      "longitude seam";
         throw IException(IException::User, msg, _FILEINFO_);
       }

--- a/isis/src/base/apps/reduce/reduce_app.cpp
+++ b/isis/src/base/apps/reduce/reduce_app.cpp
@@ -23,14 +23,14 @@ namespace Isis{
       // To propogate labels, set input cube,
       // this cube will be cleared after output cube is set.
       CubeAttributeInput &inputAtt = ui.GetInputAttribute("FROM");
-      p.SetInputCube(ui.GetFileName("FROM"), inputAtt);
+      p.SetInputCube(ui.GetCubeName("FROM"), inputAtt);
 
       // Setup the input and output cubes
       QString replaceMode = ui.GetAsString("VPER_REPLACE");
       CubeAttributeInput cai(ui.GetAsString("FROM"));
       bands = cai.bands();
 
-      QString from = ui.GetFileName("FROM");
+      QString from = ui.GetCubeName("FROM");
       inCube.setVirtualBands(bands);
       inCube.open(from);
 
@@ -62,7 +62,7 @@ namespace Isis{
 
       //  Allocate output file
       CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-      Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), att, ons, onl, inb);
+      Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), att, ons, onl, inb);
       // Our processing routine only needs 1
       // the original set was for info about the cube only
       p.ClearInputCubes();

--- a/isis/src/base/apps/remrx/main.cpp
+++ b/isis/src/base/apps/remrx/main.cpp
@@ -27,7 +27,7 @@ void IsisMain() {
   Cube *icube = p.SetInputCube("FROM");
   PvlKeyword &status = icube->group("RESEAUS")["STATUS"];
   UserInterface &ui = Application::GetUserInterface();
-  QString in = ui.GetFileName("FROM");
+  QString in = ui.GetCubeName("FROM");
 
   // Check reseau status and make sure it is not nominal or removed
   if((QString)status == "Nominal") {
@@ -54,7 +54,7 @@ void IsisMain() {
   ldim = ui.GetInteger("LDIM");
 
   // Get other user entered options
-  QString out = ui.GetFileName("TO");
+  QString out = ui.GetCubeName("TO");
   resvalid = ui.GetBoolean("RESVALID");
   action = ui.GetString("ACTION");
 

--- a/isis/src/base/apps/remrx/main.cpp
+++ b/isis/src/base/apps/remrx/main.cpp
@@ -27,7 +27,7 @@ void IsisMain() {
   Cube *icube = p.SetInputCube("FROM");
   PvlKeyword &status = icube->group("RESEAUS")["STATUS"];
   UserInterface &ui = Application::GetUserInterface();
-  QString in = ui.GetFileName("FROM");
+  QString in = ui.GetCubeName("FROM");
 
   // Check reseau status and make sure it is not nominal or removed
   if((QString)status == "Nominal") {

--- a/isis/src/base/apps/remrx/main.cpp
+++ b/isis/src/base/apps/remrx/main.cpp
@@ -27,7 +27,7 @@ void IsisMain() {
   Cube *icube = p.SetInputCube("FROM");
   PvlKeyword &status = icube->group("RESEAUS")["STATUS"];
   UserInterface &ui = Application::GetUserInterface();
-  QString in = ui.GetCubeName("FROM");
+  QString in = ui.GetFileName("FROM");
 
   // Check reseau status and make sure it is not nominal or removed
   if((QString)status == "Nominal") {

--- a/isis/src/base/apps/ringsautomos/ringsautomos.cpp
+++ b/isis/src/base/apps/ringsautomos/ringsautomos.cpp
@@ -57,10 +57,10 @@ namespace Isis {
       m.RingsSetOutputCube(list,
                       ui.GetDouble("MINRINGRAD"), ui.GetDouble("MAXRINGRAD"),
                       ui.GetDouble("MINRINGLON"), ui.GetDouble("MAXRINGLON"),
-                      oAtt, ui.GetFileName("MOSAIC"));
+                      oAtt, ui.GetCubeName("MOSAIC"));
     }
     else {
-      m.RingsSetOutputCube(list, oAtt, ui.GetFileName("MOSAIC"));
+      m.RingsSetOutputCube(list, oAtt, ui.GetCubeName("MOSAIC"));
     }
 
     m.SetHighSaturationFlag(ui.GetBoolean("HIGHSATURATION"));

--- a/isis/src/base/apps/ringscam2map/main.cpp
+++ b/isis/src/base/apps/ringscam2map/main.cpp
@@ -54,7 +54,7 @@ void IsisMain() {
 
   // Make sure it is not the sky
   if(incam->target()->isSky()) {
-    QString msg = "The image [" + ui.GetFileName("FROM") +
+    QString msg = "The image [" + ui.GetCubeName("FROM") +
                   "] is targeting the sky, use skymap instead.";
     throw IException(IException::User, msg, _FILEINFO_);
   }
@@ -209,7 +209,7 @@ void IsisMain() {
           }
         }
         else if(ui.GetString("RINGLONSEAM") == "ERROR") {
-          QString msg = "The image [" + ui.GetFileName("FROM") + "] crosses the " +
+          QString msg = "The image [" + ui.GetCubeName("FROM") + "] crosses the " +
                        "ring longitude seam";
           throw IException(IException::User, msg, _FILEINFO_);
         }
@@ -597,7 +597,7 @@ void LoadMapRes() {
 //Helper function to get camera resolution.
 void LoadCameraRes() {
   UserInterface &ui = Application::GetUserInterface();
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
 
   // Open the input cube, get the camera object, and the cam map projection
   Cube c;
@@ -660,7 +660,7 @@ void LoadMapRange() {
 //Helper function to load camera range.
 void LoadCameraRange() {
   UserInterface &ui = Application::GetUserInterface();
-  QString file = ui.GetFileName("FROM");
+  QString file = ui.GetCubeName("FROM");
 
   // Get the map projection file provided by the user
   Pvl userMap;

--- a/isis/src/base/apps/ringsmappt/main.cpp
+++ b/isis/src/base/apps/ringsmappt/main.cpp
@@ -130,7 +130,7 @@ void IsisMain() {
   if(proj->IsGood()) {
     PvlGroup results("Results");
     results += PvlKeyword("Filename",
-                          FileName(ui.GetFileName("FROM")).expanded());
+                          FileName(ui.GetCubeName("FROM")).expanded());
     results += PvlKeyword("Sample", toString(proj->WorldX()));
     results += PvlKeyword("Line", toString(proj->WorldY()));
     results += PvlKeyword("PixelValue", PixelToString(b[0]));

--- a/isis/src/base/apps/ringspt/main.cpp
+++ b/isis/src/base/apps/ringspt/main.cpp
@@ -20,7 +20,7 @@ void IsisMain() {
 
   // Set up CameraRingsPointInfo and set  file
   CameraRingsPointInfo ringspt;
-  ringspt.SetCube(ui.GetFileName("FROM") + "+" + ui.GetInputAttribute("FROM").toString());
+  ringspt.SetCube(ui.GetCubeName("FROM"));
 
   Progress prog;
   prog.SetMaximumSteps(1);

--- a/isis/src/base/apps/segment/segment.cpp
+++ b/isis/src/base/apps/segment/segment.cpp
@@ -10,7 +10,7 @@ namespace Isis {
 
   void segment(UserInterface &ui) {
     Cube *incube = new Cube();
-    incube->open(ui.GetFileName("FROM"));
+    incube->open(ui.GetCubeName("FROM"));
     segment(incube, ui);
   }
 

--- a/isis/src/base/apps/shade/main.cpp
+++ b/isis/src/base/apps/shade/main.cpp
@@ -42,7 +42,7 @@ void IsisMain() {
           inCube->label()->findObject("IsisCube").findGroup("Mapping")["PixelResolution"]);
     }
     else {
-      QString msg = "The file [" + ui.GetFileName("FROM") + "] does not have a mapping group,"
+      QString msg = "The file [" + ui.GetCubeName("FROM") + "] does not have a mapping group,"
                     + " you must enter a Pixel Resolution";
       throw IException(IException::User, msg, _FILEINFO_);
     }

--- a/isis/src/base/apps/shadow/shadow.cpp
+++ b/isis/src/base/apps/shadow/shadow.cpp
@@ -18,7 +18,7 @@ namespace Isis {
                       UserInterface &ui);
 
   void shadow(UserInterface &ui, Pvl *log) {
-    Cube *demCube = new Cube(ui.GetFileName("FROM"));
+    Cube *demCube = new Cube(ui.GetCubeName("FROM"));
 
     shadow(demCube, ui, log);
   }
@@ -118,7 +118,7 @@ namespace Isis {
     int ns = demCube->sampleCount();
     int nl = demCube->lineCount();
     int nb = demCube->bandCount();
-    Cube *outputCube = p.SetOutputCube(ui.GetFileName("TO"), atts, ns, nl, nb);
+    Cube *outputCube = p.SetOutputCube(ui.GetCubeName("TO"), atts, ns, nl, nb);
 
     p.ProcessCube(functor, false);
 

--- a/isis/src/base/apps/skymap/main.cpp
+++ b/isis/src/base/apps/skymap/main.cpp
@@ -301,7 +301,7 @@ void LoadCameraRes() {
 
   // Open the input cube, get the camera object, and the cam map projection
   Cube c;
-  c.open(ui.GetFileName("FROM"));
+  c.open(ui.GetCubeName("FROM"));
   Camera *cam = c.camera();
   double res = cam->RaDecResolution();
 
@@ -359,7 +359,7 @@ void LoadCameraRange() {
 
   // Open the input cube, get the camera object, and the cam map projection
   Cube c;
-  c.open(ui.GetFileName("FROM"));
+  c.open(ui.GetCubeName("FROM"));
   Camera *cam = c.camera();
 
   // Make the target info match the user mapfile

--- a/isis/src/base/apps/skypt/main.cpp
+++ b/isis/src/base/apps/skypt/main.cpp
@@ -69,7 +69,7 @@ void IsisMain() {
   // Write an output label file if necessary
   if (ui.WasEntered("TO")) {
     // Get user params from ui
-    QString outFile = FileName(ui.GetCubeName("TO")).expanded();
+    QString outFile = FileName(ui.GetFileName("TO")).expanded();
     bool exists = FileName(outFile).fileExists();
     bool append = ui.GetBoolean("APPEND");
 

--- a/isis/src/base/apps/skypt/main.cpp
+++ b/isis/src/base/apps/skypt/main.cpp
@@ -13,7 +13,7 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
 
   // Get input cube and get camera model for it
-  QString channel = ui.GetFileName("FROM");
+  QString channel = ui.GetCubeName("FROM");
   Cube cube;
   cube.open(channel);
   Camera *cam = cube.camera();
@@ -69,7 +69,7 @@ void IsisMain() {
   // Write an output label file if necessary
   if (ui.WasEntered("TO")) {
     // Get user params from ui
-    QString outFile = FileName(ui.GetFileName("TO")).expanded();
+    QString outFile = FileName(ui.GetCubeName("TO")).expanded();
     bool exists = FileName(outFile).fileExists();
     bool append = ui.GetBoolean("APPEND");
 

--- a/isis/src/base/apps/skyrange/main.cpp
+++ b/isis/src/base/apps/skyrange/main.cpp
@@ -56,7 +56,7 @@ void IsisMain() {
     Pvl temp;
     temp.addGroup(results);
     temp.addGroup(orient);
-    temp.write(ui.GetFileName("TO", "txt"));
+    temp.write(ui.GetCubeName("TO", "txt"));
   }
 
   p.EndProcess();

--- a/isis/src/base/apps/skyrange/main.cpp
+++ b/isis/src/base/apps/skyrange/main.cpp
@@ -56,7 +56,7 @@ void IsisMain() {
     Pvl temp;
     temp.addGroup(results);
     temp.addGroup(orient);
-    temp.write(ui.GetCubeName("TO", "txt"));
+    temp.write(ui.GetFileName("TO", "txt"));
   }
 
   p.EndProcess();

--- a/isis/src/base/apps/smtk/main.cpp
+++ b/isis/src/base/apps/smtk/main.cpp
@@ -103,18 +103,12 @@ void IsisMain() {
 
   // Open the first cube.  It is the left hand image.
   Cube lhImage;
-  CubeAttributeInput &attLeft = ui.GetInputAttribute("FROM");
-  vector<QString> bandLeft = attLeft.bands();
-  lhImage.setVirtualBands(bandLeft);
-  lhImage.open(ui.GetFileName("FROM"),"r");
+  lhImage.open(ui.GetCubeName("FROM"),"r");
 
   // Open the second cube, it is geomertricallty altered.  We will be matching the
   // first to this one by attempting to compute a sample/line offsets
   Cube rhImage;
-  CubeAttributeInput &attRight = ui.GetInputAttribute("MATCH");
-  vector<QString> bandRight = attRight.bands();
-  rhImage.setVirtualBands(bandRight);
-  rhImage.open(ui.GetFileName("MATCH"),"r");
+  rhImage.open(ui.GetCubeName("MATCH"),"r");
 
   // Ensure only single bands
   if (lhImage.bandCount() != 1 || rhImage.bandCount() != 1) {

--- a/isis/src/base/apps/spicefit/main.cpp
+++ b/isis/src/base/apps/spicefit/main.cpp
@@ -13,7 +13,7 @@ void IsisMain() {
   try {
     // Open the cube
     Cube cube;
-    cube.open(ui.GetFileName("FROM"), "rw");
+    cube.open(ui.GetCubeName("FROM"), "rw");
 
     //check for existing polygon, if exists delete it
     if(cube.label()->hasObject("Polygon")) {
@@ -23,7 +23,7 @@ void IsisMain() {
     // Get the camera, interpolate to a parabola
     Camera *cam = cube.camera();
     if(cam->DetectorMap()->LineRate() == 0.0) {
-      QString msg = "[" + ui.GetFileName("FROM") + "] is not a line scan camera";
+      QString msg = "[" + ui.GetCubeName("FROM") + "] is not a line scan camera";
       throw IException(IException::User, msg, _FILEINFO_);
     }
     cam->instrumentRotation()->SetPolynomial();

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -48,7 +48,7 @@ namespace Isis {
     Process p;
 
     CubeAttributeInput cai;
-    Cube *icube = p.SetInputCube(ui.GetFileName("FROM"), cai, ReadWrite);
+    Cube *icube = p.SetInputCube(ui.GetCubeName("FROM"), cai, ReadWrite);
     spiceinit(icube, ui, log);
     p.EndProcess();
   }
@@ -191,7 +191,7 @@ namespace Isis {
       if ((ck.size() == 0 || ck.at(0).size() == 0) && !ui.WasEntered("CK")) {
         // no ck was found in system and user did not enter ck, throw error
         throw IException(IException::Unknown,
-                         "No Camera Kernels found for the image [" + ui.GetFileName("FROM")
+                         "No Camera Kernels found for the image [" + ui.GetCubeName("FROM")
                          + "]",
                          _FILEINFO_);
       }
@@ -675,7 +675,7 @@ namespace Isis {
     }
 
     if (ui.GetString("SHAPE") == "USER") {
-      kernelsGroup["ShapeModel"] = ui.GetFileName("MODEL");
+      kernelsGroup["ShapeModel"] = ui.GetCubeName("MODEL");
     }
 
     icube->putGroup(kernelsGroup);

--- a/isis/src/base/apps/spkwriter/spkwriter.cpp
+++ b/isis/src/base/apps/spkwriter/spkwriter.cpp
@@ -48,7 +48,7 @@ namespace Isis {
 
     // Get the list of names of input CCD cubes to stitch together
     FileList flist;
-    if (ui.WasEntered("FROM")) flist.push_back(ui.GetFileName("FROM"));
+    if (ui.WasEntered("FROM")) flist.push_back(ui.GetCubeName("FROM"));
     if (ui.WasEntered("FROMLIST")) flist.read(ui.GetFileName("FROMLIST"));
     if (flist.size() < 1) {
       QString msg = "Files must be specified in FROM and/or FROMLIST - none found!";

--- a/isis/src/base/apps/stats/stats.cpp
+++ b/isis/src/base/apps/stats/stats.cpp
@@ -24,11 +24,7 @@ namespace Isis {
    */
   void stats(UserInterface &ui) {
     Cube *inputCube = new Cube();
-
-    CubeAttributeInput inAtt(ui.GetAsString("FROM"));
-    inputCube->setVirtualBands(inAtt.bands());
-
-    inputCube->open(ui.GetFileName("FROM"));
+    inputCube->open(ui.GetCubeName("FROM"));
     stats(inputCube, ui);
   }
 

--- a/isis/src/base/apps/std2isis/std2isis.cpp
+++ b/isis/src/base/apps/std2isis/std2isis.cpp
@@ -26,7 +26,7 @@ namespace Isis {
         importer->setLrsRange(ui.GetDouble("LRSMIN"), ui.GetDouble("LRSMAX"));
 
     // Import the image
-    FileName outputName = ui.GetFileName("TO");
+    FileName outputName = ui.GetCubeName("TO");
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
     importer->import(outputName, att);
 

--- a/isis/src/base/apps/stretch/stretch_app.cpp
+++ b/isis/src/base/apps/stretch/stretch_app.cpp
@@ -19,7 +19,7 @@ namespace Isis {
     if (inAtt.bands().size() != 0) {
       cubeFile->setVirtualBands(inAtt.bands());
     }
-    cubeFile->open(ui.GetFileName("FROM"), "r");
+    cubeFile->open(ui.GetCubeName("FROM"), "r");
 
     QString pairs;
 

--- a/isis/src/base/apps/tabledump/main.cpp
+++ b/isis/src/base/apps/tabledump/main.cpp
@@ -25,7 +25,7 @@ map <QString, void *> GuiHelpers() {
 void IsisMain() {
   // Gather parameters from the UserInterface
   UserInterface &ui = Application::GetUserInterface();
-  FileName file = ui.GetFileName("FROM");
+  FileName file = ui.GetCubeName("FROM");
   QString tableName = ui.GetString("NAME");
   Table table(tableName, file.expanded());
 
@@ -146,7 +146,7 @@ void helperButtonGetTableList() {
   bool match = false;
 
   UserInterface &ui = Application::GetUserInterface();
-  QString currentFile = ui.GetFileName("FROM");
+  QString currentFile = ui.GetCubeName("FROM");
   const Pvl label(FileName(currentFile).expanded());
 
   // Check to see if the "FILE" parameter has changed since last press

--- a/isis/src/base/apps/tonematch/main.cpp
+++ b/isis/src/base/apps/tonematch/main.cpp
@@ -25,8 +25,8 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
 
   Cube from, match;
-  from.open( ui.GetFileName("FROM") );
-  match.open( ui.GetFileName("MATCH") );
+  from.open( ui.GetCubeName("FROM") );
+  match.open( ui.GetCubeName("MATCH") );
 
   if( (from.bandCount() != 1) || (match.bandCount() != 1) ) {
     string msg = "tonematch only works for single band images.";

--- a/isis/src/base/apps/trackextract/main.cpp
+++ b/isis/src/base/apps/trackextract/main.cpp
@@ -75,8 +75,8 @@ class CopyPixelsFunctor {
 
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
-  QString inputName = ui.GetFileName("FROM");
-  QString outputName = ui.GetFileName("TO");
+  QString inputName = ui.GetCubeName("FROM");
+  QString outputName = ui.GetCubeName("TO");
 
   // Confirm that the input mosaic is of pixel-type "Real" as trackextract does not work on other
   // bit types due to corruption of these files

--- a/isis/src/base/objs/Enlarge/unitTest.cpp
+++ b/isis/src/base/objs/Enlarge/unitTest.cpp
@@ -48,7 +48,7 @@ void IsisMain() {
   delete interp;
 
   UserInterface &ui = Application::GetUserInterface();
-  QFile::remove(ui.GetFileName("TO"));
+  QFile::remove(ui.GetCubeName("TO"));
 }
 
 

--- a/isis/src/base/objs/IsisAml/IsisAml.cpp
+++ b/isis/src/base/objs/IsisAml/IsisAml.cpp
@@ -639,7 +639,7 @@ QString IsisAml::GetFileName(const QString &paramName, QString extension) const 
 
   const IsisParameterData *param = ReturnParam(paramName);
 
-  if((param->type != "filename") && (param->type != "cube")) {
+  if(param->type != "filename") {
     QString message = "Parameter [" + paramName + "] is not a filename.";
     throw Isis::IException(Isis::IException::Programmer, message, _FILEINFO_);
   }
@@ -680,7 +680,7 @@ void IsisAml::GetFileName(const QString &paramName,
 
   const IsisParameterData *param = ReturnParam(paramName);
 
-  if((param->type != "filename") && (param->type != "cube")) {
+  if(param->type != "filename") {
     QString message = "Parameter [" + paramName + "] is not a filename.";
     throw Isis::IException(Isis::IException::Programmer, message, _FILEINFO_);
   }

--- a/isis/src/base/objs/Pipeline/Pipeline.cpp
+++ b/isis/src/base/objs/Pipeline/Pipeline.cpp
@@ -306,7 +306,7 @@ namespace Isis {
    */
   void Pipeline::SetInputFile(const QString &inputParam) {
     UserInterface &ui = Application::GetUserInterface();
-    p_originalInput.push_back(ui.GetFileName(inputParam));
+    p_originalInput.push_back(ui.GetCubeName(inputParam));
     p_inputBranches.push_back(inputParam);
     p_virtualBands.push_back(ui.GetInputAttribute(inputParam).toString());
   }

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -24,6 +24,7 @@ find files of those names at the top level of this repository. **/
 using namespace std;
 namespace Isis {
 
+
   //! Constructs a Process Object
   Process::Process() {
     m_ownedCubes = NULL;
@@ -47,6 +48,7 @@ namespace Isis {
     delete m_ownedCubes;
     m_ownedCubes = NULL;
   }
+
 
   /**
    * Opens an input cube specified by the programmer and verifies requirements
@@ -77,7 +79,8 @@ namespace Isis {
         cube->open(fname, "rw");
       }
       else {
-        cube->open(fname);
+        // Make sure attributes don't get processed twice
+        cube->open(FileName(fname).expanded());
       }
     }
     catch(IException &e) {
@@ -135,9 +138,9 @@ namespace Isis {
    */
   Isis::Cube *Process::SetInputCube(const QString &parameter,
                                     const int requirements) {
-    QString fname = Application::GetUserInterface().GetFileName(parameter);
+    QString fname = Application::GetUserInterface().GetCubeName(parameter);
     Isis::CubeAttributeInput &att = Application::GetUserInterface().GetInputAttribute(parameter);
-    return SetInputCube(fname, att, requirements);
+    return SetInputCube(FileName(fname).expanded(), att, requirements);
   }
 
 
@@ -204,6 +207,7 @@ namespace Isis {
     return SetOutputCubeStretch(parameter, ns, nl, nb, ui);
   }
 
+
   /**
    * Allocates a user specified output cube whose size is specified by the
    * programmer.
@@ -237,10 +241,11 @@ namespace Isis {
     }
     QString fname;
     Isis::CubeAttributeOutput atts;
-    fname = Application::GetUserInterface().GetFileName(parameter);
+    fname = Application::GetUserInterface().GetCubeName(parameter);
     atts = Application::GetUserInterface().GetOutputAttribute(parameter);
     return SetOutputCube(fname, atts, ns, nl, nb);
 }
+
 
 /**
  * Allocates a user specified output cube whose size is specified by the
@@ -279,15 +284,16 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
   QString fname;
   Isis::CubeAttributeOutput atts;
   if(ui==nullptr){
-    fname = Application::GetUserInterface().GetFileName(parameter);
+    fname = Application::GetUserInterface().GetCubeName(parameter);
     atts = Application::GetUserInterface().GetOutputAttribute(parameter);
   }
   else{
-    fname = ui->GetFileName(parameter);
+    fname = ui->GetCubeName(parameter);
     atts = ui->GetOutputAttribute(parameter);
   }
   return SetOutputCube(fname, atts, ns, nl, nb);
 }
+
 
   /**
    * Allocates a output cube whose name and size is specified by the programmer.
@@ -446,6 +452,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     return cube;
   }
 
+
   /**
    * End the processing sequence and cleans up by closing cubes, freeing memory,
    * etc.
@@ -456,6 +463,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     Process::Finalize();
   }
 
+
   /**
    * Cleans up by closing cubes and freeing memory for owned cubes.  Clears the
    * lists for all cubes.
@@ -464,10 +472,12 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     ClearCubes();
   }
 
+
   void Process::AddInputCube(Cube *cube, bool owned) {
     InputCubes.push_back(cube);
     if (owned) m_ownedCubes->insert(cube);
   }
+
 
   void Process::AddOutputCube(Cube *cube, bool owned) {
     OutputCubes.push_back(cube);
@@ -597,6 +607,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     m_ownedCubes->clear();
   }
 
+
   /**
    * Close owned input cubes from the list and clear the list
    */
@@ -610,6 +621,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     }
     InputCubes.clear();
   }
+
 
   /**
    * Close owned output cubes from the list and clear the list
@@ -625,6 +637,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     OutputCubes.clear();
   }
 
+
   /**
    * This method allows the programmer to turn on/off the propagation of labels
    * from the 1st input cube to any of the output cubes.  By default, propagation
@@ -639,6 +652,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
   void Process::PropagateLabels(const bool prop) {
     p_propagateLabels = prop;
   }
+
 
   /**
    * This method allows the programmer to propagate labels from a specific
@@ -668,6 +682,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     }
   }
 
+
   /**
    * This method allows the programmer to propagate input tables to the output
    * cube (default is true)
@@ -678,6 +693,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
   void Process::PropagateTables(const bool prop) {
     p_propagateTables = prop;
   }
+
 
   /**
    * Propagate the tables from the cube with the given filename to the output
@@ -717,6 +733,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     delete fromCube;
   }
 
+
   /**
    * This method allows the programmer to propagate input blobs to the output
    * cube (default is true)
@@ -728,6 +745,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     p_propagatePolygons = prop;
   }
 
+
   /**
    * This method allows the programmer to propagate history to the output cube
    * (default is true)
@@ -737,6 +755,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
   void Process::PropagateHistory(const bool prop) {
     p_propagateHistory = prop;
   }
+
 
   /**
   * This method allows the programmer to propagate original labels
@@ -748,6 +767,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
   void Process::PropagateOriginalLabel(const bool prop) {
     p_propagateOriginalLabel = prop;
   }
+
 
   /**
    * This method reads the mission specific data directory from the user
@@ -783,6 +803,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     return expanded.expanded();
   }
 
+
   /**
    * Writes out the History blob to the cube
    */
@@ -810,6 +831,7 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
       }
     }
   }
+
 
   /**
    * Calculates and stores off statistics on every band of every

--- a/isis/src/base/objs/ProcessByBrick/unitTest.cpp
+++ b/isis/src/base/objs/ProcessByBrick/unitTest.cpp
@@ -291,7 +291,7 @@ void IsisMain() {
     p.ProcessCube(functor,false);
     p.EndProcess();
     Cube cube;
-    cube.open(Application::GetUserInterface().GetFileName("TO"));
+    cube.open(Application::GetUserInterface().GetCubeName("TO"));
     Statistics *statsBand1 = cube.statistics(1);
     Statistics *statsBand2 = cube.statistics(2);
     std::cerr << "Averages: " << statsBand1->Average() << ", " <<
@@ -302,7 +302,7 @@ void IsisMain() {
   {
     cout << "Functor5 - ProcessCubeInPlace Threaded\n";
     Cube *cube = new Cube;
-    cube->open(Application::GetUserInterface().GetFileName("TO"), "rw");
+    cube->open(Application::GetUserInterface().GetCubeName("TO"), "rw");
     p.SetBrickSize(10, 10, 2);
     p.SetInputCube(cube);
     Functor5 functor;
@@ -323,7 +323,7 @@ void IsisMain() {
     p.EndProcess();
     cube->close();
     cube = new Cube;
-    cube->open(Application::GetUserInterface().GetFileName("TO"), "rw");
+    cube->open(Application::GetUserInterface().GetCubeName("TO"), "rw");
     Statistics *statsBand1 = cube->statistics(1);
     Statistics *statsBand2 = cube->statistics(2);
     delete cube;

--- a/isis/src/base/objs/ProcessGroundPolygons/ProcessGroundPolygons.cpp
+++ b/isis/src/base/objs/ProcessGroundPolygons/ProcessGroundPolygons.cpp
@@ -245,7 +245,7 @@ namespace Isis {
       QString &cube) {
 
     QString avgString =
-      Application::GetUserInterface().GetFileName(parameter);
+      Application::GetUserInterface().GetCubeName(parameter);
     CubeAttributeOutput atts =
       Application::GetUserInterface().GetOutputAttribute(parameter);
 
@@ -270,7 +270,7 @@ namespace Isis {
       Isis::Pvl &map, int bands) {
 
     QString avgString =
-      Application::GetUserInterface().GetFileName(parameter);
+      Application::GetUserInterface().GetCubeName(parameter);
     CubeAttributeOutput atts =
       Application::GetUserInterface().GetOutputAttribute(parameter);
 

--- a/isis/src/base/objs/ProcessImport/ProcessImport.cpp
+++ b/isis/src/base/objs/ProcessImport/ProcessImport.cpp
@@ -1264,7 +1264,7 @@ namespace Isis {
 
     SetAttributes(att);
 
-    return Process::SetOutputCube(Application::GetUserInterface().GetFileName(parameter), att, p_ns, p_nl, p_nb);
+    return Process::SetOutputCube(Application::GetUserInterface().GetCubeName(parameter), att, p_ns, p_nl, p_nb);
   }
 
 
@@ -1275,7 +1275,7 @@ namespace Isis {
   Isis::Cube *ProcessImport::SetOutputCube(const QString &parameter, UserInterface &ui){
     CubeAttributeOutput &att = ui.GetOutputAttribute(parameter);
     SetAttributes(att);
-    return Isis::Process::SetOutputCube(ui.GetFileName(parameter), att, p_ns, p_nl, p_nb);
+    return Isis::Process::SetOutputCube(ui.GetCubeName(parameter), att, p_ns, p_nl, p_nb);
   }
 
   /**

--- a/isis/src/base/objs/ProcessImport/unitTest.cpp
+++ b/isis/src/base/objs/ProcessImport/unitTest.cpp
@@ -53,7 +53,7 @@ void IsisMain() {
 
   Process p2;
   CubeAttributeInput att;
-  QString file = Application::GetUserInterface().GetFileName("TO");
+  QString file = Application::GetUserInterface().GetCubeName("TO");
   Cube *icube = p2.SetInputCube(file, att);
   Statistics *stat = icube->statistics();
   cout << endl << "Average: " << stat->Average() << endl;
@@ -65,7 +65,7 @@ void IsisMain() {
 
   ProcessImport core_cub;
   core_cub.SetInputFile("$ISISTESTDATA/isis/src/base/unitTestData/30i001ci.qub");
-  QString coreFile = Application::GetUserInterface().GetFileName("CORE_CUBE");
+  QString coreFile = Application::GetUserInterface().GetCubeName("CORE_CUBE");
   core_cub.SetVAXConvert(true);
   core_cub.SetPixelType(Isis::Real);
   core_cub.SetByteOrder(Isis::Lsb);
@@ -90,7 +90,7 @@ void IsisMain() {
 
 
   suffix_cub.SetInputFile("$ISISTESTDATA/isis/src/base/unitTestData/30i001ci.qub");
-  QString suffixFile = Application::GetUserInterface().GetFileName("SUFFIX_CUBE");
+  QString suffixFile = Application::GetUserInterface().GetCubeName("SUFFIX_CUBE");
   suffix_cub.SetVAXConvert(true);
   suffix_cub.SetPixelType(Isis::Real);
   suffix_cub.SetByteOrder(Isis::Lsb);

--- a/isis/src/base/objs/ProcessImportPds/unitTest.cpp
+++ b/isis/src/base/objs/ProcessImportPds/unitTest.cpp
@@ -43,7 +43,7 @@ void IsisMain() {
     cout << plab << endl;
     Isis::Process p2;
     Isis::CubeAttributeInput att;
-    QString file = Isis::Application::GetUserInterface().GetFileName("TO");
+    QString file = Isis::Application::GetUserInterface().GetCubeName("TO");
     Isis::Cube *cube = p2.SetInputCube(file, att);
     Isis::Statistics *stat = cube->statistics();
     cout << stat->Average() << endl;
@@ -73,7 +73,7 @@ void IsisMain() {
     cout << plab << endl;
     Isis::Process p2;
     Isis::CubeAttributeInput att;
-    QString file = Isis::Application::GetUserInterface().GetFileName("TO");
+    QString file = Isis::Application::GetUserInterface().GetCubeName("TO");
     Isis::Cube *cube = p2.SetInputCube(file, att);
     Isis::Statistics *stat = cube->statistics();
     cout << stat->Average() << endl;
@@ -108,7 +108,7 @@ void IsisMain() {
     p.EndProcess();
 
     cout << ilab << endl;
-    QString file = Isis::Application::GetUserInterface().GetFileName("TO");
+    QString file = Isis::Application::GetUserInterface().GetCubeName("TO");
     QFile::remove(file);
   }
   catch(Isis::IException &e) {
@@ -130,7 +130,7 @@ void IsisMain() {
     cout << plab << endl;
     Isis::Process p2;
     Isis::CubeAttributeInput att;
-    QString file = Isis::Application::GetUserInterface().GetFileName("TO");
+    QString file = Isis::Application::GetUserInterface().GetCubeName("TO");
     Isis::Cube *cube = p2.SetInputCube(file, att);
     Pvl isisCubeLab = *(cube->label());
     (isisCubeLab.findObject("IsisCube").findObject("Core")["StartByte"]).setValue("");
@@ -187,7 +187,7 @@ void IsisMain() {
     }
     
     p.EndProcess();
-    QFile::remove(Isis::Application::GetUserInterface().GetFileName("TO"));
+    QFile::remove(Isis::Application::GetUserInterface().GetCubeName("TO"));
   }
   
 }

--- a/isis/src/base/objs/ProcessImportVicar/unitTest.cpp
+++ b/isis/src/base/objs/ProcessImportVicar/unitTest.cpp
@@ -31,7 +31,7 @@ void IsisMain() {
   cout << vlab << endl;
   Process p2;
   CubeAttributeInput att;
-  QString file = Application::GetUserInterface().GetFileName("TO");
+  QString file = Application::GetUserInterface().GetCubeName("TO");
   Cube *icube = p2.SetInputCube(file, att);
   Statistics *stat = icube->statistics();
   cout << stat->Average() << endl;

--- a/isis/src/base/objs/ProcessMosaic/ProcessMosaic.cpp
+++ b/isis/src/base/objs/ProcessMosaic/ProcessMosaic.cpp
@@ -693,8 +693,9 @@ namespace Isis {
     return SetOutputCube(psParameter, Application::GetUserInterface());
   }
 
+
   Cube *ProcessMosaic::SetOutputCube(const QString &psParameter, UserInterface &ui) {
-    QString fname = ui.GetFileName(psParameter);
+    QString fname = ui.GetCubeName(psParameter);
 
     // Make sure there is only one output cube
     if (OutputCubes.size() > 0) {

--- a/isis/src/base/objs/ProcessMosaic/unitTest.cpp
+++ b/isis/src/base/objs/ProcessMosaic/unitTest.cpp
@@ -568,7 +568,7 @@ void IsisMain() {
 void testIn(int iss, int isl, int isb, int ins, int inl, int inb) {
   Cube cInCube;
   UserInterface &ui = Isis::Application::GetUserInterface();
-  QString sFrom = ui.GetFileName("FROM");
+  QString sFrom = ui.GetCubeName("FROM");
   cInCube.open(sFrom);
 
   qDebug() << "";
@@ -619,9 +619,9 @@ void testOut(int piSamples, int piLines,
   UserInterface &ui = Isis::Application::GetUserInterface();
   QString sTo;
   if (piPriority == ProcessMosaic::AverageImageWithMosaic)
-    sTo = ui.GetFileName("TO_AVG");
+    sTo = ui.GetCubeName("TO_AVG");
   else
-    sTo = ui.GetFileName("TO");
+    sTo = ui.GetCubeName("TO");
   cOutCube.open(sTo);
 
   int iBands = cOutCube.bandCount();

--- a/isis/src/base/objs/ProcessPolygons/ProcessPolygons.cpp
+++ b/isis/src/base/objs/ProcessPolygons/ProcessPolygons.cpp
@@ -357,7 +357,7 @@ namespace Isis {
                                       const int nbands) {
 
     QString avgString =
-      Application::GetUserInterface().GetFileName(parameter);
+      Application::GetUserInterface().GetCubeName(parameter);
 
     Isis::CubeAttributeOutput atts =
       Application::GetUserInterface().GetOutputAttribute(parameter);

--- a/isis/src/base/objs/ProcessRubberSheet/unitTest.cpp
+++ b/isis/src/base/objs/ProcessRubberSheet/unitTest.cpp
@@ -108,7 +108,7 @@ void IsisMain() {
   delete interp;
 
   UserInterface &ui = Application::GetUserInterface();
-  QFile::remove(ui.GetFileName("TO"));
+  QFile::remove(ui.GetCubeName("TO"));
 }
 
 

--- a/isis/src/base/objs/Reduce/unitTest.cpp
+++ b/isis/src/base/objs/Reduce/unitTest.cpp
@@ -36,7 +36,7 @@ void IsisMain() {
   bands = cai.bands();
 
   icube.setVirtualBands(bands);
-  icube.open(ui.GetFileName("FROM"));
+  icube.open(ui.GetCubeName("FROM"));
 
   double sscale = 3;
   double lscale = 4;
@@ -65,6 +65,6 @@ void IsisMain() {
 
   p.Finalize();
   icube.close();
-  QFile::remove(ui.GetFileName("TO"));
-  QFile::remove(ui.GetFileName("TO2"));
+  QFile::remove(ui.GetCubeName("TO"));
+  QFile::remove(ui.GetCubeName("TO2"));
 }

--- a/isis/src/base/objs/SubArea/unitTest.cpp
+++ b/isis/src/base/objs/SubArea/unitTest.cpp
@@ -31,7 +31,7 @@ void IsisMain() {
   int onl, ons;
 
   p1.SetInputCube("FROM1");
-  QString from1 = ui.GetFileName("FROM1");
+  QString from1 = ui.GetCubeName("FROM1");
   Cube inomapcube;
   inomapcube.open(from1);
   inl = inomapcube.lineCount();
@@ -81,7 +81,7 @@ void IsisMain() {
   p1.EndProcess();
 
   cout << "Output cube label: " << endl << endl;
-  QString file = ui.GetFileName("TO");
+  QString file = ui.GetCubeName("TO");
   Pvl label(file);
   cout << label.findObject("IsisCube").findObject("Core").findGroup("Dimensions") << endl << endl;
   if(label.findObject("IsisCube").hasGroup("Instrument")) {
@@ -291,7 +291,7 @@ void IsisMain() {
 
   ProcessByLine p6;
   p6.SetInputCube("FROM2");
-  QString from2 = ui.GetFileName("FROM2");
+  QString from2 = ui.GetCubeName("FROM2");
   Cube imapcube;
   imapcube.open(from2);
   inl = imapcube.lineCount();
@@ -546,7 +546,7 @@ void IsisMain() {
   results.clear();
 
   Cube smapcube;
-  QString from3 = ui.GetFileName("FROM3");
+  QString from3 = ui.GetCubeName("FROM3");
   smapcube.open(from3);
   inl = smapcube.lineCount();
   ins = smapcube.sampleCount();

--- a/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
+++ b/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
@@ -61,7 +61,7 @@ namespace Isis{
     outAtt.setPixelType(SignedWord);
     outAtt.setMinimum((double)VALID_MIN2);
     outAtt.setMaximum((double)VALID_MAX2);
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), outAtt);
+    Cube *ocube = p.SetOutputCube(FileName(ui.GetCubeName("TO")).expanded(), outAtt);
 
     TranslateCassIssLabels(in, ocube, log);
 
@@ -114,7 +114,7 @@ namespace Isis{
 
     // PROCESS 2 : Do 8 bit to 12 bit conversion for image ==============================================//
     ProcessByLine p2;
-    QString ioFile = ui.GetFileName("TO");
+    QString ioFile = ui.GetCubeName("TO");
     CubeAttributeInput att;
     p2.SetInputCube(ioFile, att, ReadWrite);
     //if ConversionType == 12Bit or 8LSB, only save off overclocked pixels

--- a/isis/src/cassini/apps/ciss2isis/main.cpp
+++ b/isis/src/cassini/apps/ciss2isis/main.cpp
@@ -19,6 +19,7 @@ void IsisMain() {
   Pvl appLog;
   try {
     ciss2isis(ui, &appLog);
+
   }
   catch (...) {
     for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {

--- a/isis/src/cassini/apps/cisscal/main.cpp
+++ b/isis/src/cassini/apps/cisscal/main.cpp
@@ -95,7 +95,7 @@ namespace gbl {
 void IsisMain() {
   // Initialize Globals
   UserInterface &ui = Application::GetUserInterface();
-  gbl::cissLab = new CissLabels(ui.GetFileName("FROM"));
+  gbl::cissLab = new CissLabels(ui.GetCubeName("FROM"));
   gbl::incube = NULL;
   gbl::stretch.ClearPairs();
   gbl::numberOfOverclocks = 0;

--- a/isis/src/cassini/apps/vims2isis/main.cpp
+++ b/isis/src/cassini/apps/vims2isis/main.cpp
@@ -49,8 +49,8 @@ void ProcessBands(Pvl &pdsLab, Cube *vimscube, VimsType vtype);
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   FileName in = ui.GetFileName("FROM");
-  FileName outIr = ui.GetFileName("IR");
-  FileName outVis = ui.GetFileName("VIS");
+  FileName outIr = ui.GetCubeName("IR");
+  FileName outVis = ui.GetCubeName("VIS");
   Pvl lab(in.expanded());
 
   //Checks if in file is rdr

--- a/isis/src/cassini/apps/vimscal/main.cpp
+++ b/isis/src/cassini/apps/vimscal/main.cpp
@@ -873,7 +873,7 @@ void calculateIrDarkCurrent(Cube *icube) {
     return;
   }
 
-  Table sideplane("SideplaneIr", ui.GetFileName("FROM"));
+  Table sideplane("SideplaneIr", ui.GetCubeName("FROM"));
 
   // If spectal summing is on OR compressor_id isnt N/A then
   //   just return.

--- a/isis/src/chandrayaan1/apps/chan1m32isis/chan1m32isis.cpp
+++ b/isis/src/chandrayaan1/apps/chan1m32isis/chan1m32isis.cpp
@@ -52,6 +52,7 @@ namespace Isis {
   Table *g_utcTable;
   PvlGroup g_results("Results");
 
+
   Pvl chan1m32isis(UserInterface &ui) {
     Pvl log;
     importImage("TO", (ProcessImportPds::PdsFileType)(ProcessImportPds::Rdn|ProcessImportPds::L0), ui);
@@ -61,10 +62,12 @@ namespace Isis {
     return log;
   }
 
+
   void importImage(QString outputParamName, ProcessImportPds::PdsFileType fileType) {
     UserInterface &ui = Application::GetUserInterface();
     importImage(outputParamName, fileType, ui);
   }
+
 
   void importImage(QString outputParamName, ProcessImportPds::PdsFileType fileType, UserInterface &ui) {
     if (!ui.WasEntered(outputParamName)) {
@@ -192,7 +195,7 @@ namespace Isis {
         g_oCube->setPixelType(importPds.PixelType());
       }
       g_oCube->setDimensions(importPds.Samples(), outputLines, importPds.Bands());
-      g_oCube->create(ui.GetFileName(outputParamName));
+      g_oCube->create(ui.GetCubeName(outputParamName));
       g_oCube->addCachingAlgorithm(new BoxcarCachingAlgorithm());
 
       g_oBuff = new Isis::Brick(importPds.Samples(), outputLines, importPds.Bands(),
@@ -238,7 +241,7 @@ namespace Isis {
     if (linesNeedFlipped) {
       ProcessBySample flipLines;
       flipLines.Progress()->SetText("Flipping Lines");
-      Cube *cube = flipLines.SetInputCube(ui.GetFileName(outputParamName), inAttribute);
+      Cube *cube = flipLines.SetInputCube(ui.GetCubeName(outputParamName), inAttribute);
       cube->reopen("rw");
       flipLines.ProcessCubeInPlace(flip, false);
     }
@@ -246,7 +249,7 @@ namespace Isis {
     if (samplesNeedFlipped) {
       ProcessByLine flipSamples;
       flipSamples.Progress()->SetText("Flipping Samples");
-      Cube *cube = flipSamples.SetInputCube(ui.GetFileName(outputParamName), inAttribute);
+      Cube *cube = flipSamples.SetInputCube(ui.GetCubeName(outputParamName), inAttribute);
       cube->reopen("rw");
       flipSamples.ProcessCubeInPlace(flip, false);
     }

--- a/isis/src/clementine/apps/clem2isis/main.cpp
+++ b/isis/src/clementine/apps/clem2isis/main.cpp
@@ -35,7 +35,7 @@ void IsisMain() {
   // Grab the file to import
   UserInterface &ui = Application::GetUserInterface();
   FileName in = ui.GetFileName("FROM");
-  FileName out = ui.GetFileName("TO");
+  FileName out = ui.GetCubeName("TO");
 
   // Make sure it is a Clementine EDR
   bool projected;
@@ -72,7 +72,7 @@ void IsisMain() {
 
   ProcessByLine p;
   CubeAttributeOutput cubeAtt("+unsignedByte+1.0:254.0");
-  Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), cubeAtt, pdsi->image_ncols, pdsi->image_nrows);
+  Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), cubeAtt, pdsi->image_ncols, pdsi->image_nrows);
   p.StartProcess(writeLine);
   translateLabels(in, ocube);
   p.EndProcess();

--- a/isis/src/clipper/apps/eis2isis/eis2isis.cpp
+++ b/isis/src/clipper/apps/eis2isis/eis2isis.cpp
@@ -64,7 +64,7 @@ namespace Isis {
 
       translateEISLabels(xmlFileName, outputLabel);
 
-      FileName outputCubeFileName(ui.GetFileName("TO"));
+      FileName outputCubeFileName(ui.GetCubeName("TO"));
 
       OriginalXmlLabel xmlLabel;
       xmlLabel.readFromXmlFile(xmlFileName);
@@ -244,7 +244,7 @@ namespace Isis {
     if (ui.WasEntered("MAINREADOUT")) {
 
       // Create and write normalized time values in the range [-1,1] to the primary EIS cube
-      Table normalizedReadout = normalizeTimeTable(FileName(ui.GetFileName("MAINREADOUT")),
+      Table normalizedReadout = normalizeTimeTable(FileName(ui.GetCubeName("MAINREADOUT")),
                                   "Normalized Main Readout Line Times",
                                   outputCube->lineCount());
 
@@ -265,7 +265,7 @@ namespace Isis {
 
     // Handle an optional checkline cube.
     if (ui.WasEntered("FROM2")) {
-      FileName checklineXmlFileName = ui.GetFileName("FROM2");
+      FileName checklineXmlFileName = ui.GetCubeName("FROM2");
 
       if (ui.WasEntered("CHECKLINEREADOUT")) {
         // Process the checkline image to an ISIS cube and write the checkline tables

--- a/isis/src/clipper/apps/jitterfit/jitterfit.cpp
+++ b/isis/src/clipper/apps/jitterfit/jitterfit.cpp
@@ -38,10 +38,10 @@ namespace Isis{
     bool registrationFileSpecified = false;
 
     Cube jitterCube;
-    jitterCube.open(ui.GetFileName("FROM"), "rw");
+    jitterCube.open(ui.GetCubeName("FROM"), "rw");
 
     Cube checkCube;
-    checkCube.open(ui.GetFileName("FROM2"), "r");
+    checkCube.open(ui.GetCubeName("FROM2"), "r");
 
     Pvl defFile;
     defFile.read(ui.GetFileName("DEFFILE"));
@@ -55,7 +55,7 @@ namespace Isis{
     ofstream outputFile;
     if (ui.WasEntered("TO")) {
       registrationFileSpecified = true;
-      QString to(FileName(ui.GetFileName("TO")).expanded());
+      QString to(FileName(ui.GetCubeName("TO")).expanded());
       outputFile.open(to.toLatin1().data());
       outputFile << "# checkline line, checkline sample, checkline time taken, "
                     "matched jittered image line, matched jittered image "

--- a/isis/src/control/apps/cnetnewradii/main.cpp
+++ b/isis/src/control/apps/cnetnewradii/main.cpp
@@ -34,7 +34,7 @@ void IsisMain() {
   ControlNet cnet(ui.GetFileName("CNET"));
 
   // Get input DEM cube and get ground map for it
-  QString demFile = ui.GetFileName("MODEL");
+  QString demFile = ui.GetCubeName("MODEL");
   Cube demCube;
   demCube.open(demFile);
   UniversalGroundMap *ugm = NULL;

--- a/isis/src/control/apps/coreg/main.cpp
+++ b/isis/src/control/apps/coreg/main.cpp
@@ -60,7 +60,7 @@ void IsisMain() {
   CubeAttributeInput &attTrans = ui.GetInputAttribute("FROM");
   std::vector<QString> bandTrans = attTrans.bands();
   trans.setVirtualBands(bandTrans);
-  trans.open(ui.GetFileName("FROM"), "r");
+  trans.open(ui.GetCubeName("FROM"), "r");
 
   // Open the second cube, it is held in place.  We will be matching the
   // first to this one by attempting to compute a sample/line translation
@@ -68,7 +68,7 @@ void IsisMain() {
   CubeAttributeInput &attMatch = ui.GetInputAttribute("MATCH");
   std::vector<QString> bandMatch = attMatch.bands();
   match.setVirtualBands(bandMatch);
-  match.open(ui.GetFileName("MATCH"), "r");
+  match.open(ui.GetCubeName("MATCH"), "r");
 
   // Input cube Lines and Samples must be the same and each must have only
   // one band
@@ -271,17 +271,17 @@ void IsisMain() {
   // second input image
   if (ui.WasEntered("TO")) {
     if (ui.GetString("TRANSFORM") == "TRANSLATE") {
-      QString params = " from="   + ui.GetFileName("FROM") +
-                      " to="     + ui.GetFileName("TO") +
+      QString params = " from="   + ui.GetCubeName("FROM") +
+                      " to="     + ui.GetCubeName("TO") +
                       " strans=" + toString(sTrans) +
                       " ltrans=" + toString(lTrans) +
                       " interp=" + ui.GetString("INTERP");
       ProgramLauncher::RunIsisProgram("translate", params);
     }
     else {
-      QString params = " from="    + ui.GetFileName("FROM") +
-                      " to="     + ui.GetFileName("TO") +
-                      " cube="   + ui.GetFileName("MATCH") +
+      QString params = " from="    + ui.GetCubeName("FROM") +
+                      " to="     + ui.GetCubeName("TO") +
+                      " cube="   + ui.GetCubeName("MATCH") +
                       " cnet="   + ui.GetFileName("ONET") +
                       " interp=" + ui.GetString("INTERP") +
                       " degree=" + toString(ui.GetInteger("DEGREE"));

--- a/isis/src/control/apps/coreg/main.cpp
+++ b/isis/src/control/apps/coreg/main.cpp
@@ -57,17 +57,11 @@ void IsisMain() {
 
   // Open the first cube.  It will be matched to the second input cube.
   Cube trans;
-  CubeAttributeInput &attTrans = ui.GetInputAttribute("FROM");
-  std::vector<QString> bandTrans = attTrans.bands();
-  trans.setVirtualBands(bandTrans);
   trans.open(ui.GetCubeName("FROM"), "r");
 
   // Open the second cube, it is held in place.  We will be matching the
   // first to this one by attempting to compute a sample/line translation
   Cube match;
-  CubeAttributeInput &attMatch = ui.GetInputAttribute("MATCH");
-  std::vector<QString> bandMatch = attMatch.bands();
-  match.setVirtualBands(bandMatch);
   match.open(ui.GetCubeName("MATCH"), "r");
 
   // Input cube Lines and Samples must be the same and each must have only

--- a/isis/src/control/apps/deltack/main.cpp
+++ b/isis/src/control/apps/deltack/main.cpp
@@ -53,7 +53,7 @@ void printMatrix(const SpiceDouble m[3][3]);
 void IsisMain() {
   Progress progress;
   UserInterface &ui = Application::GetUserInterface();
-  QString filename = ui.GetFileName("FROM");
+  QString filename = ui.GetCubeName("FROM");
   //ControlNet m_cnet(ui.GetFileName("NET"),&progress);
   //QList<ControlPoint *> cntrlPts = m_cnet.GetPoints();
   //int npts = cntrlPts.length();
@@ -207,7 +207,7 @@ void IsisMain() {
         rad1 = Distance(ui.GetDouble("RAD1"), Distance::Meters);
       }
       else {
-        rad1 = GetRadius(ui.GetFileName("FROM"), lat1, lon1);
+        rad1 = GetRadius(ui.GetCubeName("FROM"), lat1, lon1);
       }
 
       // In order to use the bundle adjustment class we will need a control
@@ -243,7 +243,7 @@ void IsisMain() {
           rad2 = Distance(ui.GetDouble("RAD2"), Distance::Meters);
         }
         else {
-          rad2 = GetRadius(ui.GetFileName("FROM"), lat2, lon2);
+          rad2 = GetRadius(ui.GetCubeName("FROM"), lat2, lon2);
         }
 
         ControlMeasure * m = new ControlMeasure;

--- a/isis/src/control/apps/fplanemap/main.cpp
+++ b/isis/src/control/apps/fplanemap/main.cpp
@@ -53,7 +53,7 @@ void IsisMain() {
   CubeAttributeInput &attFrom = ui.GetInputAttribute("FROM");
   vector<QString> bandFrom = attFrom.bands();
   from.setVirtualBands(bandFrom);
-  from.open(ui.GetFileName("FROM"), "r");
+  from.open(ui.GetCubeName("FROM"), "r");
   Camera *fcamera = from.camera();
   CameraDistortionMap *dmap = fcamera->DistortionMap();
 

--- a/isis/src/control/apps/sumspice/sumspice.cpp
+++ b/isis/src/control/apps/sumspice/sumspice.cpp
@@ -65,7 +65,7 @@ namespace Isis {
     //  Get the list of input cubes to be processed
     FileList cubeNameList;
     if ( ui.WasEntered("FROM") ) {
-      cubeNameList.append(ui.GetFileName("FROM"));
+      cubeNameList.append(ui.GetCubeName("FROM"));
     }
     else if ( ui.WasEntered("FROMLIST") ) {
       cubeNameList.read(ui.GetFileName("FROMLIST"));

--- a/isis/src/control/apps/sumspice/sumspice.cpp
+++ b/isis/src/control/apps/sumspice/sumspice.cpp
@@ -65,7 +65,7 @@ namespace Isis {
     //  Get the list of input cubes to be processed
     FileList cubeNameList;
     if ( ui.WasEntered("FROM") ) {
-      cubeNameList.append(ui.GetCubeName("FROM"));
+      cubeNameList.append(ui.GetFileName("FROM"));
     }
     else if ( ui.WasEntered("FROMLIST") ) {
       cubeNameList.read(ui.GetFileName("FROMLIST"));

--- a/isis/src/control/apps/warp/main.cpp
+++ b/isis/src/control/apps/warp/main.cpp
@@ -60,7 +60,7 @@ void IsisMain() {
   int onl, ons;
   if (ui.GetString("OSIZE") == "MATCH") {
     Cube c;
-    c.open(ui.GetFileName("CUBE"), "r");
+    c.open(ui.GetCubeName("CUBE"), "r");
     onl = c.lineCount();
     ons = c.sampleCount();
     c.close();

--- a/isis/src/control/apps/warp/main.cpp
+++ b/isis/src/control/apps/warp/main.cpp
@@ -60,7 +60,7 @@ void IsisMain() {
   int onl, ons;
   if (ui.GetString("OSIZE") == "MATCH") {
     Cube c;
-    c.open(ui.GetCubeName("CUBE"), "r");
+    c.open(ui.GetFileName("CUBE"), "r");
     onl = c.lineCount();
     ons = c.sampleCount();
     c.close();

--- a/isis/src/dev/apps/camdev/camdev.cpp
+++ b/isis/src/dev/apps/camdev/camdev.cpp
@@ -117,7 +117,7 @@ namespace Isis {
 
 
   void camdev(UserInterface &ui) {
-    Cube icube(ui.GetFileName("FROM"), "r");
+    Cube icube(ui.GetCubeName("FROM"), "r");
     camdev(&icube, ui);
   }
 
@@ -149,7 +149,7 @@ namespace Isis {
         cam = icube->camera();
       }
       catch(IException &e) {
-        QString msg = "If " + FileName(ui.GetFileName("FROM")).name() + " is a mosaic, make sure the SOURCE "
+        QString msg = "If " + FileName(ui.GetCubeName("FROM")).name() + " is a mosaic, make sure the SOURCE "
         "option is set to PROJECTION";
         throw IException(e, IException::User, msg, _FILEINFO_);
       }
@@ -352,7 +352,7 @@ namespace Isis {
     // If DN is chosen by the user, then we propagate the input buffer with a
     // different function - one that accepts both input and output buffers.
     p.SetInputCube(icube, OneBand);
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), ui.GetOutputAttribute("TO"), icube->sampleCount(),
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"), icube->sampleCount(),
                                   icube->lineCount(), nbands);
     p.SetBrickSize(64, 64, nbands);
     if (dn) {

--- a/isis/src/dev/apps/camdev/main.cpp
+++ b/isis/src/dev/apps/camdev/main.cpp
@@ -144,7 +144,7 @@ void IsisMain() {
       cam = icube->camera();
     }
     catch(IException &e) {
-      QString msg = "If " + FileName(ui.GetFileName("FROM")).name() + " is a mosaic, make sure the SOURCE "
+      QString msg = "If " + FileName(ui.GetCubeName("FROM")).name() + " is a mosaic, make sure the SOURCE "
       "option is set to PROJECTION";
       throw IException(e, IException::User, msg, _FILEINFO_);
     }

--- a/isis/src/dev/apps/m3loc2net/main.cpp
+++ b/isis/src/dev/apps/m3loc2net/main.cpp
@@ -41,11 +41,11 @@ void IsisMain() {
   }
   cnet.SetUserName(Application::Name());
 
-  QString filename = ui.GetFileName("FROM");
+  QString filename = ui.GetCubeName("FROM");
   Cube inputCube;
   inputCube.open(filename, "r");
 
-  QString locFilename = ui.GetFileName("LOC");
+  QString locFilename = ui.GetCubeName("LOC");
   Cube locCube;
   locCube.open(locFilename, "r");
 

--- a/isis/src/galileo/apps/gllnims2isis/main.cpp
+++ b/isis/src/galileo/apps/gllnims2isis/main.cpp
@@ -251,8 +251,8 @@ PvlGroup originalMappingGroup = qube.findGroup("IMAGE_MAP_PROJECTION", Pvl::Trav
   importPds.EndProcess();
 
 // New nocam2map hint PvlGroup
-  Cube coreCube(FileName(ui.GetFileName("CORE")).expanded(),"rw");
-  Cube suffixCube(FileName(ui.GetFileName("SUFFIX")).expanded(), "rw");
+  Cube coreCube(FileName(ui.GetCubeName("CORE")).expanded(),"rw");
+  Cube suffixCube(FileName(ui.GetCubeName("SUFFIX")).expanded(), "rw");
 
   PvlGroup mappingInfo("MappingInformation");
 

--- a/isis/src/galileo/apps/gllssi2isis/main.cpp
+++ b/isis/src/galileo/apps/gllssi2isis/main.cpp
@@ -41,7 +41,7 @@ void IsisMain() {
   ProcessImportPds p;
   UserInterface &ui = Application::GetUserInterface();
   FileName inFile = ui.GetFileName("FROM");
-  FileName outFile = ui.GetFileName("TO");
+  FileName outFile = ui.GetCubeName("TO");
 
   // Apply a fix to the gallileo pds labels so they can be read
   fixPvl(inFile.toString());

--- a/isis/src/galileo/apps/gllssical/gllssical.cpp
+++ b/isis/src/galileo/apps/gllssical/gllssical.cpp
@@ -58,7 +58,7 @@ namespace Isis {
   static void calculateScaleFactor0(Cube *icube, Cube *gaincube);
   
   void gllssical(UserInterface &ui, Pvl *log) {
-    Cube icube(ui.GetFileName("FROM"));
+    Cube icube(ui.GetCubeName("FROM"));
     gllssical(&icube, ui, log);
   }   
 
@@ -116,7 +116,7 @@ namespace Isis {
     }
     p.StartProcess(Calibrate);
     PvlGroup calibrationLog("RadiometricCalibration");
-    calibrationLog.addKeyword(PvlKeyword("From", ui.GetFileName("FROM")));
+    calibrationLog.addKeyword(PvlKeyword("From", ui.GetCubeName("FROM")));
   
     FileName shutterFileName = FindShutterFile(icube);
     calibrationLog.addKeyword(PvlKeyword("DarkCurrentFile", darkFileName.originalPath() + "/" +

--- a/isis/src/hayabusa/apps/hyb1pds4gen/main.cpp
+++ b/isis/src/hayabusa/apps/hyb1pds4gen/main.cpp
@@ -31,13 +31,6 @@ void generateCSVOutput(Pvl &inputCubeLabel);
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
 
-  // Check if input file is indeed, a cube
-  if (ui.GetFileName("FROM").right(3) != "cub") {
-    QString msg = "Input file [" + ui.GetFileName("FROM") +
-                  "] does not appear to be a cube";
-    throw  IException(IException::User, msg, _FILEINFO_);
-  }
-
   // Setup the process and set the input cube
   ProcessExportPds4 process;
   Cube *inputCube = process.SetInputCube("FROM");

--- a/isis/src/hayabusa/apps/nirs2isis/main.cpp
+++ b/isis/src/hayabusa/apps/nirs2isis/main.cpp
@@ -101,10 +101,10 @@ void IsisMain() {
 
   // Write the image data to the output cubes
 
-  Cube* reflectanceCube = processPDS.SetOutputCube(ui.GetFileName("TO"),
+  Cube* reflectanceCube = processPDS.SetOutputCube(ui.GetCubeName("TO"),
                                                    outputAtts,
                                                    1, 1, 64);
-  Cube* stdevCube = processPDS.SetOutputCube(ui.GetFileName("TOSTDDEV"),
+  Cube* stdevCube = processPDS.SetOutputCube(ui.GetCubeName("TOSTDDEV"),
                                              outputAtts,
                                              1, 1, 64);
 

--- a/isis/src/juno/apps/junocam2isis/main.cpp
+++ b/isis/src/juno/apps/junocam2isis/main.cpp
@@ -109,7 +109,7 @@ void IsisMain() {
     int numFullFrames = importPds.Lines() / g_fullFrameLines;
 
     // Allocate this number of total cubes of the correct size
-    FileName outputFileName(ui.GetFileName("TO"));
+    FileName outputFileName(ui.GetCubeName("TO"));
     QString outputBaseName = outputFileName.removeExtension().expanded();
 
     // Now this will be a list of output Fullframes 1-N.cub
@@ -185,7 +185,7 @@ void IsisMain() {
                          .addKeyword(PvlKeyword("NumberFramelets", toString(frameletsPerFilter)));
 
     // get output file name and remove cube extension, if entered
-    FileName outputFileName(ui.GetFileName("TO"));
+    FileName outputFileName(ui.GetCubeName("TO"));
     QString outputBaseName = outputFileName.removeExtension().expanded();
 
     QFile allCubesListFile(outputBaseName + ".lis");

--- a/isis/src/kaguya/apps/kaguyami2isis/kaguyami2isis.cpp
+++ b/isis/src/kaguya/apps/kaguyami2isis/kaguyami2isis.cpp
@@ -49,7 +49,7 @@ namespace Isis {
 
     p.SetPdsFile(inFile.expanded(), "", label);
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *outcube = p.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *outcube = p.SetOutputCube(ui.GetCubeName("TO"), att);
 
     // Get user entered special pixel ranges
     if(ui.GetBoolean("SETNULLRANGE")) {

--- a/isis/src/kaguya/apps/kaguyasp2isis/main.cpp
+++ b/isis/src/kaguya/apps/kaguyasp2isis/main.cpp
@@ -29,7 +29,7 @@ void IsisMain() {
   Pvl lab(inFile.expanded());
 
   ofstream os;
-  QString outFile = FileName(ui.GetCubeName("TO")).expanded();
+  QString outFile = FileName(ui.GetFileName("TO")).expanded();
   os.open(outFile.toLatin1().data(), ios::out);
 
   int minobs = 1;

--- a/isis/src/kaguya/apps/kaguyasp2isis/main.cpp
+++ b/isis/src/kaguya/apps/kaguyasp2isis/main.cpp
@@ -29,7 +29,7 @@ void IsisMain() {
   Pvl lab(inFile.expanded());
 
   ofstream os;
-  QString outFile = FileName(ui.GetFileName("TO")).expanded();
+  QString outFile = FileName(ui.GetCubeName("TO")).expanded();
   os.open(outFile.toLatin1().data(), ios::out);
 
   int minobs = 1;

--- a/isis/src/kaguya/apps/kaguyatc2isis/kaguyatc2isis.cpp
+++ b/isis/src/kaguya/apps/kaguyatc2isis/kaguyatc2isis.cpp
@@ -68,7 +68,7 @@ namespace Isis {
     importPds.SetPdsFile(label, dataFile);
 
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *outcube = importPds.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *outcube = importPds.SetOutputCube(ui.GetCubeName("TO"), att);
 
     // Get user entered special pixel ranges
     if (ui.GetBoolean("SETNULLRANGE")) {

--- a/isis/src/lo/apps/lo2isis/lo2isis.cpp
+++ b/isis/src/lo/apps/lo2isis/lo2isis.cpp
@@ -36,7 +36,7 @@ namespace Isis{
     p.SetPdsFile(in.expanded(), "", label);
     // Segfault here
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), att);
     p.StartProcess();
     TranslateLunarLabels(in, ocube);
     p.EndProcess();

--- a/isis/src/lo/apps/lopdsgen/main.cpp
+++ b/isis/src/lo/apps/lopdsgen/main.cpp
@@ -78,7 +78,7 @@ void IsisMain() {
   Pvl &pdsLabel = p.StandardPdsLabel(ProcessExportPds::Image);
 
   // Add PRODUCT_ID keyword, the first part of the output filename
-  FileName outFileNoExt(ui.GetCubeName("TO"));
+  FileName outFileNoExt(ui.GetFileName("TO"));
   outFileNoExt = outFileNoExt.removeExtension();
   QString productID(outFileNoExt.baseName());
   PvlKeyword productId("PRODUCT_ID", productID.toUpper());

--- a/isis/src/lo/apps/lopdsgen/main.cpp
+++ b/isis/src/lo/apps/lopdsgen/main.cpp
@@ -78,7 +78,7 @@ void IsisMain() {
   Pvl &pdsLabel = p.StandardPdsLabel(ProcessExportPds::Image);
 
   // Add PRODUCT_ID keyword, the first part of the output filename
-  FileName outFileNoExt(ui.GetFileName("TO"));
+  FileName outFileNoExt(ui.GetCubeName("TO"));
   outFileNoExt = outFileNoExt.removeExtension();
   QString productID(outFileNoExt.baseName());
   PvlKeyword productId("PRODUCT_ID", productID.toUpper());
@@ -155,7 +155,7 @@ void IsisMain() {
       pdsLabel.findObject("IMAGE").addKeyword(PvlKeyword("MAXIMUM", toString(p.CubeStatistics(0)->Maximum())), Pvl::Replace);
     }
     else {
-      FileName inputFile(ui.GetFileName("FROM"));
+      FileName inputFile(ui.GetCubeName("FROM"));
       QString msg = "[" + inputFile.expanded() + "] does not appear to be an LO file.  ";
       throw IException(IException::User, msg, _FILEINFO_);
     }
@@ -203,7 +203,7 @@ void IsisMain() {
     bandLab.Auto(pdsLabel);
   }
   else {
-    FileName inputFile(ui.GetFileName("FROM"));
+    FileName inputFile(ui.GetCubeName("FROM"));
     QString msg = "[" + inputFile.expanded() + "] does not contain boresight or fiducial information.  ";
     msg += "Try ingesting your data with lo2isis first.";
     throw IException(IException::User, msg, _FILEINFO_);

--- a/isis/src/lro/apps/lromakeflat/main.cpp
+++ b/isis/src/lro/apps/lromakeflat/main.cpp
@@ -179,9 +179,9 @@ void IsisMain() {
   oMedianCube->setDimensions(g_sampleCount, oLineCount, 1);
   oMeanCube->setDimensions(g_sampleCount, oLineCount, 1);
   // Set name of cubes
-  oStdevCube->create(FileName(ui.GetFileName("TO")).expanded() + ".stdev.cub");
-  oMedianCube->create(FileName(ui.GetFileName("TO")).expanded() + ".median.cub");
-  oMeanCube->create(FileName(ui.GetFileName("TO")).expanded() + ".mean.cub");
+  oStdevCube->create(FileName(ui.GetCubeName("TO")).expanded() + ".stdev.cub");
+  oMedianCube->create(FileName(ui.GetCubeName("TO")).expanded() + ".median.cub");
+  oMeanCube->create(FileName(ui.GetCubeName("TO")).expanded() + ".mean.cub");
   // create new line manager
   oStdevlineMgr = new LineManager(*oStdevCube);
   oMedianLineMgr = new LineManager(*oMedianCube);
@@ -250,7 +250,7 @@ void IsisMain() {
     }
     catch (IException &e) {
       //cout << "It's no use at this point. Just go. Leave me here. I'll only slow you down.";
-      string err = "Could not write to output cube " + IString(FileName(ui.GetFileName("TO")).expanded()) + ".\n";
+      string err = "Could not write to output cube " + IString(FileName(ui.GetCubeName("TO")).expanded()) + ".\n";
       throw IException(IException::Programmer, err, _FILEINFO_);
     }
     pixelMatrix.clear();

--- a/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
+++ b/isis/src/lro/apps/lronac2isis/lronac2isis.cpp
@@ -110,7 +110,7 @@ namespace Isis {
     g_ocube->setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
     g_ocube->setDimensions(p.Samples(), p.Lines(), p.Bands());
     g_ocube->setPixelType(Isis::Real);
-    g_ocube->create(ui.GetFileName("TO"));
+    g_ocube->create(ui.GetCubeName("TO"));
     // Do 8 bit to 12 bit conversion
     // And if NAC-R, flip the frame
     p.StartProcess(Import);

--- a/isis/src/lro/apps/lronac2pds/lronac2pds.cpp
+++ b/isis/src/lro/apps/lronac2pds/lronac2pds.cpp
@@ -48,11 +48,11 @@ namespace Isis {
 
       ProcessByLine p;
       CubeAttributeInput &att = ui.GetInputAttribute("FROM");
-      Cube *inCube = p.SetInputCube(ui.GetFileName("FROM"), att);
+      Cube *inCube = p.SetInputCube(ui.GetCubeName("FROM"), att);
 
       g_isIof = inCube->label()->findGroup("Radiometry", Pvl::Traverse).findKeyword("RadiometricType")[0].toUpper() == "IOF";
 
-      FileName scaledCube("$TEMPORARY/" + FileName(ui.GetFileName("FROM")).name());
+      FileName scaledCube("$TEMPORARY/" + FileName(ui.GetCubeName("FROM")).name());
       scaledCube.addExtension("cub");
 
       scaledCube = FileName::createTempFile(scaledCube);

--- a/isis/src/lro/apps/lronaccal/main.cpp
+++ b/isis/src/lro/apps/lronaccal/main.cpp
@@ -69,7 +69,7 @@ void IsisMain() {
   g_radiometric = ui.GetBoolean("RADIOMETRIC");
   g_iof = (ui.GetString("RADIOMETRICTYPE") == "IOF");
 
-  Isis::Pvl lab(ui.GetFileName("FROM"));
+  Isis::Pvl lab(ui.GetCubeName("FROM"));
   Isis::PvlGroup &inst = lab.findGroup("Instrument", Pvl::Traverse);
 
   // Check if it is a NAC image

--- a/isis/src/lro/apps/lronacecho/main.cpp
+++ b/isis/src/lro/apps/lronacecho/main.cpp
@@ -36,7 +36,7 @@ void IsisMain() {
   g_delta = ui.GetDouble("DELTA");
   g_halfDelta = g_delta/2.0;
 
-  Pvl lab(ui.GetFileName("FROM"));
+  Pvl lab(ui.GetCubeName("FROM"));
   PvlGroup &inst = lab.findGroup("Instrument", Pvl::Traverse);
 
   // Check if it is a NAC image

--- a/isis/src/lro/apps/lronacpho/main.cpp
+++ b/isis/src/lro/apps/lronacpho/main.cpp
@@ -56,7 +56,7 @@ void IsisMain (){
     CubeAttributeInput backplaneCai = ui.GetInputAttribute("BACKPLANE");
 
     Cube bpCube;
-    bpCube.open(ui.GetFileName("BACKPLANE"));
+    bpCube.open(ui.GetCubeName("BACKPLANE"));
     int bpBands = bpCube.bandCount();
     bpCube.close();
 
@@ -74,11 +74,11 @@ void IsisMain (){
 
     CubeAttributeInput cai;
     bpCaiBands == 3 ? cai.setAttributes("+" + backplaneCai.bands()[0]) : cai.setAttributes("+1" ) ;
-    p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+    p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
     bpCaiBands == 3 ? cai.setAttributes("+" + backplaneCai.bands()[1]) : cai.setAttributes("+2" ) ;
-    p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+    p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
     bpCaiBands == 3 ? cai.setAttributes("+" + backplaneCai.bands()[2]) : cai.setAttributes("+3" ) ;
-    p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+    p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
 
     useBackplane = true;
   }

--- a/isis/src/lro/apps/lrowac2isis/lrowac2isis.cpp
+++ b/isis/src/lro/apps/lrowac2isis/lrowac2isis.cpp
@@ -169,7 +169,7 @@ namespace Isis {
       }
     }
 
-    FileName baseFileName(ui.GetFileName("TO"));
+    FileName baseFileName(ui.GetCubeName("TO"));
 
     if(uveven && uvodd) {
       // padding[1] is max padding for UV

--- a/isis/src/lro/apps/lrowacpho/main.cpp
+++ b/isis/src/lro/apps/lrowacpho/main.cpp
@@ -63,11 +63,11 @@ void IsisMain () {
 
         CubeAttributeInput cai;
         cai.setAttributes("+" + backplaneCai.bands()[0]);
-        p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+        p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
         cai.setAttributes("+" + backplaneCai.bands()[1]);
-        p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+        p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
         cai.setAttributes("+" + backplaneCai.bands()[2]);
-        p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+        p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
 
         useBackplane = true;
     }

--- a/isis/src/lro/apps/mrf2pds/main.cpp
+++ b/isis/src/lro/apps/mrf2pds/main.cpp
@@ -35,7 +35,7 @@ static unsigned int iCheckSum = 0;
 
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
-  FileName inFile = ui.GetFileName("FROM");
+  FileName inFile = ui.GetCubeName("FROM");
 
   // Set the processing object
   ProcessExportMiniRFLroPds cProcess;

--- a/isis/src/mariner/apps/mar10cal/main.cpp
+++ b/isis/src/mariner/apps/mar10cal/main.cpp
@@ -42,7 +42,7 @@ void IsisMain() {
   // Setup the input and make sure it is a mariner10 file
   UserInterface & ui = Application::GetUserInterface();
 
-  Isis::Pvl lab(ui.GetFileName("FROM"));
+  Isis::Pvl lab(ui.GetCubeName("FROM"));
   Isis::PvlGroup & inst = lab.findGroup("Instrument", Pvl::Traverse);
 
   QString mission = inst["SpacecraftName"];
@@ -119,7 +119,7 @@ void IsisMain() {
   }
 
   if (ui.WasEntered ("COEFCUBE")) {
-    coCube.open(ui.GetFileName("COEFCUBE"));
+    coCube.open(ui.GetCubeName("COEFCUBE"));
   }
   else {
     FileName coFile("$mariner10/calibration/mariner_10_" + filter + "_" +

--- a/isis/src/mariner/apps/mar10clean/main.cpp
+++ b/isis/src/mariner/apps/mar10clean/main.cpp
@@ -22,10 +22,10 @@ void IsisMain() {
 
   // Check that it is a Mariner10 cube.
   Cube iCube;
-  iCube.open(ui.GetFileName("FROM"));
+  iCube.open(ui.GetCubeName("FROM"));
   Pvl * labels = iCube.label();
   if ("Mariner_10" != (QString)labels->findKeyword("SpacecraftName", Pvl::Traverse)) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] does not appear" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] does not appear" +
         " to be a Mariner10 cube";
     throw IException(IException::User, msg, _FILEINFO_);
   }
@@ -39,12 +39,12 @@ void IsisMain() {
   stats = cp.Statistics();
   cout << "Valid pixels: "<< stats->ValidPixels() << endl;
   if (stats->ValidPixels() == 7) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] needs" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] needs" +
       " reconstruction, try mar10restore instead";
     throw IException(IException::User, msg, _FILEINFO_);
   }
   else if (stats->ValidPixels() == 0) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "]" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "]" +
       " appears to have already been cleaned";
     throw IException(IException::User, msg, _FILEINFO_);
   }

--- a/isis/src/mariner/apps/mar10nonoise/main.cpp
+++ b/isis/src/mariner/apps/mar10nonoise/main.cpp
@@ -21,10 +21,10 @@ void IsisMain() {
 
   // Check that it is a Mariner10 cube.
   Cube iCube;
-  iCube.open(ui.GetFileName("FROM"));
+  iCube.open(ui.GetCubeName("FROM"));
   Pvl * labels = iCube.label();
   if ("Mariner_10" != (QString)labels->findKeyword("SpacecraftName", Pvl::Traverse)) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] does not appear" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] does not appear" +
         " to be a Mariner10 cube";
     throw IException(IException::User, msg, _FILEINFO_);
   }

--- a/isis/src/mariner/apps/mar10restore/main.cpp
+++ b/isis/src/mariner/apps/mar10restore/main.cpp
@@ -23,12 +23,12 @@ void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
   Cube cube;
-  cube.open(ui.GetFileName("FROM"));
+  cube.open(ui.GetCubeName("FROM"));
 
   // Check that it is a Mariner10 cube.
   Pvl * labels = cube.label();
   if ("Mariner_10" != (QString)labels->findKeyword("SpacecraftName", Pvl::Traverse)) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] does not appear" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] does not appear" +
       " to be a Mariner10 cube";
     throw IException(IException::User, msg, _FILEINFO_);
   }
@@ -41,7 +41,7 @@ void IsisMain() {
   stats = cp.Statistics();
   // Maximum possible number of good pixels in a 5x5
   if(stats->ValidPixels() > 8) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] does not need" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] does not need" +
       " reconstruction, try mar10clean instead";
     throw IException(IException::User, msg, _FILEINFO_);
   }

--- a/isis/src/mer/apps/mer2isis/main.cpp
+++ b/isis/src/mer/apps/mer2isis/main.cpp
@@ -36,7 +36,7 @@ void IsisMain() {
 
   QString output;
   if(ui.WasEntered("TO")) {
-    output = ui.GetFileName("TO");
+    output = ui.GetCubeName("TO");
   }
   else {
     output = input.path() + input.baseName() + ".cub";

--- a/isis/src/mer/apps/mical/main.cpp
+++ b/isis/src/mer/apps/mical/main.cpp
@@ -131,7 +131,7 @@ void IsisMain() {
   else if(ui.WasEntered("REFPIXIMAGE")) {
     Brick *b;
     Cube ERPfile;
-    ERPfile.open(ui.GetFileName("REFPIXIMAGE"));
+    ERPfile.open(ui.GetCubeName("REFPIXIMAGE"));
     b = new Brick(11, 201, 1, ERPfile.pixelType());
     b->SetBasePosition(4, 412, 1);
     ERPfile.read(*b);
@@ -143,7 +143,7 @@ void IsisMain() {
     gbl::ReferencePixelValue = stat.Average();
 
     calgrp += PvlKeyword("ReferencePixelValueSource", "ERPImage");
-    calgrp += PvlKeyword("ReferencePixelValueImage", ui.GetFileName("REFPIXIMAGE"));
+    calgrp += PvlKeyword("ReferencePixelValueImage", ui.GetCubeName("REFPIXIMAGE"));
     calgrp += PvlKeyword("ReferencePixelValue", toString(gbl::ReferencePixelValue));
   }
   else {
@@ -185,7 +185,7 @@ void IsisMain() {
   //
 
   if(ui.WasEntered("FLATFIELD")) {
-    p.SetInputCube(ui.GetFileName("FLATFIELD"), att);
+    p.SetInputCube(ui.GetCubeName("FLATFIELD"), att);
     if(stagestop == "FLAT" || stagestop == "IOF") {
       calgrp += PvlKeyword("FlatFieldImage", gbl::mi->FlatImageOpen());
     }

--- a/isis/src/messenger/apps/mdis2isis/main.cpp
+++ b/isis/src/messenger/apps/mdis2isis/main.cpp
@@ -128,7 +128,7 @@ void IsisMain() {
     // We're not going to unlut the data, so just set output cube
     //   and let ProcessImportPds do the writing for us.
     CubeAttributeOutput &outAtt = ui.GetOutputAttribute("TO");
-    outCube = p.SetOutputCube(ui.GetFileName("TO"), outAtt);
+    outCube = p.SetOutputCube(ui.GetCubeName("TO"), outAtt);
 
     // Write the Instrument, BandBin, Archive, and Kernels groups to the output
     // cube label
@@ -159,7 +159,7 @@ void IsisMain() {
 
     outCube = new Cube();
     outCube->setDimensions(p.Samples(), p.Lines(), p.Bands());
-    outCube->create(ui.GetFileName("TO"));
+    outCube->create(ui.GetCubeName("TO"));
 
     PvlGroup &group =  outLabel.findGroup("Instrument", Pvl::Traverse);
     group.addKeyword(PvlKeyword("Unlutted", toString((int)true)));

--- a/isis/src/messenger/apps/mdis2pds/main.cpp
+++ b/isis/src/messenger/apps/mdis2pds/main.cpp
@@ -101,7 +101,7 @@ void IsisMain() {
   const QString mdis2pdsRuntime = Application::DateTime();
 
   UserInterface &ui = Application::GetUserInterface();
-  FileName input(ui.GetFileName("FROM"));
+  FileName input(ui.GetCubeName("FROM"));
   FileName output = ui.GetFileName("TO");
   output = output.addExtension("IMG");
 

--- a/isis/src/messenger/apps/mdisddr/main.cpp
+++ b/isis/src/messenger/apps/mdisddr/main.cpp
@@ -116,7 +116,7 @@ void IsisMain() {
   const QString dataSetID = "MESS-E/V/H-MDIS-6-DDR-GEOMDATA-V1.0";
 
   UserInterface &ui = Application::GetUserInterface();
-  FileName input(ui.GetFileName("FROM"));
+  FileName input(ui.GetCubeName("FROM"));
   QString to = "";
   bool toEntered = ui.WasEntered("TO");
   if (toEntered) {

--- a/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
+++ b/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
@@ -129,7 +129,7 @@ namespace Isis{
   // Import a PDS3, HRSC, SRC Camera image.
   void ImportHrscSrcImage(ProcessImportPds &p, Pvl &label, UserInterface &ui) {
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    outCube = p.SetOutputCube(ui.GetFileName("TO"), att);
+    outCube = p.SetOutputCube(ui.GetCubeName("TO"), att);
     p.StartProcess();
 
     Pvl otherLabels;
@@ -189,7 +189,7 @@ namespace Isis{
     lineInFile.clear();
     numLinesSkipped = 0;
 
-    CubeAttributeOutput outAtt(ui.GetFileName("TO"));
+    CubeAttributeOutput outAtt(ui.GetCubeName("TO"));
     outCube = new Cube();
 
     outCube->setByteOrder(outAtt.byteOrder());
@@ -263,7 +263,7 @@ namespace Isis{
     outCube->setDimensions(p.Samples(), lineInFile.size(), p.Bands());
 
     p.Progress()->SetText("Importing");
-    outCube->create(ui.GetFileName("TO"));
+    outCube->create(ui.GetCubeName("TO"));
     p.StartProcess(WriteOutput);
 
     outCube->write(timesTable);

--- a/isis/src/mgs/apps/moccal/moccal.cpp
+++ b/isis/src/mgs/apps/moccal/moccal.cpp
@@ -49,7 +49,7 @@ namespace Isis {
 
 
   void moccal(UserInterface &ui) {
-    Cube icube(ui.GetFileName("FROM"), "rw");
+    Cube icube(ui.GetCubeName("FROM"), "rw");
     moccal(&icube, ui);
   }
 

--- a/isis/src/mgs/apps/mocevenodd/main.cpp
+++ b/isis/src/mgs/apps/mocevenodd/main.cpp
@@ -40,7 +40,7 @@ void IsisMain() {
   // Make sure we have a moc cube
   ProcessByLine p;
   p.SetInputCube("FROM");
-  MocLabels moc(Application::GetUserInterface().GetFileName("FROM"));
+  MocLabels moc(Application::GetUserInterface().GetCubeName("FROM"));
 
   // It must have crosstrack summing of 1
   if(moc.CrosstrackSumming() != 1) {

--- a/isis/src/mgs/apps/mocnoise50/main.cpp
+++ b/isis/src/mgs/apps/mocnoise50/main.cpp
@@ -38,7 +38,7 @@ void IsisMain() {
   // message
   ProcessByLine p;
   Cube *icube = p.SetInputCube("FROM", OneBand);
-  MocLabels moc(Application::GetUserInterface().GetFileName("FROM"));
+  MocLabels moc(Application::GetUserInterface().GetCubeName("FROM"));
   int nlines = icube->lineCount();
 
   // Must be narrow angle

--- a/isis/src/mro/apps/crism2isis/crism2isis.cpp
+++ b/isis/src/mro/apps/crism2isis/crism2isis.cpp
@@ -28,7 +28,7 @@ namespace Isis{
     p.SetNull(65535, 65535);
 
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), att);
 
     Pvl outLabel;
 

--- a/isis/src/mro/apps/ctxcal/ctxcal.cpp
+++ b/isis/src/mro/apps/ctxcal/ctxcal.cpp
@@ -37,7 +37,7 @@ namespace Isis {
     static double iof;          // conversion from counts/ms to IOF
 
     void ctxcal(UserInterface &ui) {
-      Cube icube(ui.GetFileName("FROM"));
+      Cube icube(ui.GetCubeName("FROM"));
       ctxcal(&icube, ui);
     }
 
@@ -59,7 +59,7 @@ namespace Isis {
 
       Cube flatFile;
       if(ui.WasEntered("FLATFILE")) {
-          flatFile.open(ui.GetFileName("FLATFILE"));
+          flatFile.open(ui.GetCubeName("FLATFILE"));
       }
       else {
           FileName flat = FileName("$mro/calibration/ctxFlat_????.cub").highestVersion();

--- a/isis/src/mro/apps/ctxevenodd/main.cpp
+++ b/isis/src/mro/apps/ctxevenodd/main.cpp
@@ -41,7 +41,7 @@ void IsisMain() {
 
   // Make sure we have a ctx cube and it has SpatialSumming of 1
   UserInterface &ui = Application::GetUserInterface();
-  Isis::Pvl lab(ui.GetFileName("FROM"));
+  Isis::Pvl lab(ui.GetCubeName("FROM"));
   Isis::PvlGroup &inst =
     lab.findGroup("Instrument", Pvl::Traverse);
 

--- a/isis/src/mro/apps/hi2isis/hi2isis.cpp
+++ b/isis/src/mro/apps/hi2isis/hi2isis.cpp
@@ -118,7 +118,7 @@ namespace Isis {
     outAtt.setPixelType(Isis::SignedWord);
     outAtt.setMinimum((double)VALID_MIN2);
     outAtt.setMaximum((double)VALID_MAX2);
-    Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), outAtt);
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), outAtt);
     p.StartProcess();
     TranslateHiriseEdrLabels(inFile, ocube);
 
@@ -173,7 +173,7 @@ namespace Isis {
     // counts
     lsbGap = ui.GetBoolean("LSBGAP");
     ProcessByLine p2;
-    QString ioFile = ui.GetFileName("TO");
+    QString ioFile = ui.GetCubeName("TO");
     CubeAttributeInput att;
     p2.SetInputCube(ioFile, att, ReadWrite);
     p2.Progress()->SetText("Converting special pixels");

--- a/isis/src/mro/apps/hical/hical.cpp
+++ b/isis/src/mro/apps/hical/hical.cpp
@@ -61,7 +61,7 @@ namespace Isis {
       // The output from the last processing is the input into subsequent processing
       ProcessByLine p;
 
-      Cube *hifrom = p.SetInputCube(ui.GetFileName("FROM"), ui.GetInputAttribute("FROM"));
+      Cube *hifrom = p.SetInputCube(ui.GetCubeName("FROM"), ui.GetInputAttribute("FROM"));
       int nsamps = hifrom->sampleCount();
       int nlines = hifrom->lineCount();
 
@@ -71,7 +71,7 @@ namespace Isis {
       DbProfile hiprof = hiconf.getMatrixProfile();
 
       // Check for label propagation and set the output cube
-      Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), ui.GetOutputAttribute("TO"));
+      Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"));
       if ( !IsTrueValue(hiprof,"PropagateTables", "TRUE") ) {
         RemoveHiBlobs(*(ocube->label()));
       }

--- a/isis/src/mro/apps/hicalproc/main.cpp
+++ b/isis/src/mro/apps/hicalproc/main.cpp
@@ -50,7 +50,7 @@ void IsisMain() {
 
     // Get the cube info
     inFile  = ui.GetCubeName("FROM");
-    outFile = ui.GetCubeName("TO");
+    outFile = ui.GetFileName("TO");
     Pvl cubeLabel;
     if (bIngestion) {
       int sDotPos = outFile.indexOf('.');

--- a/isis/src/mro/apps/hicalproc/main.cpp
+++ b/isis/src/mro/apps/hicalproc/main.cpp
@@ -49,8 +49,8 @@ void IsisMain() {
     bool bRemoveFurrows = ui.GetBoolean("FURROWS");
 
     // Get the cube info
-    inFile  = ui.GetFileName("FROM");
-    outFile = ui.GetFileName("TO");
+    inFile  = ui.GetCubeName("FROM");
+    outFile = ui.GetCubeName("TO");
     Pvl cubeLabel;
     if (bIngestion) {
       int sDotPos = outFile.indexOf('.');

--- a/isis/src/mro/apps/hicolormos/hicolormos.cpp
+++ b/isis/src/mro/apps/hicolormos/hicolormos.cpp
@@ -30,9 +30,9 @@ using namespace std;
 namespace Isis {
 
 void hicolormos(UserInterface &ui) {
-  Cube from1(ui.GetFileName("FROM1"), "r");
+  Cube from1(ui.GetCubeName("FROM1"), "r");
   if (ui.WasEntered("FROM2")) {
-    Cube from2(ui.GetFileName("FROM2"), "r");
+    Cube from2(ui.GetCubeName("FROM2"), "r");
     hicolormos(&from1, &from2, ui);
   }
   else {
@@ -247,7 +247,7 @@ void hicolormos(Cube *from1, Cube* from2, UserInterface &ui) {
   QString MosaicPriority = ui.GetString("PRIORITY");
 
   QString parameters = "FROMLIST=" + tempFile.expanded() +
-                      " MOSAIC=" + ui.GetFileName("TO") +
+                      " MOSAIC=" + ui.GetCubeName("TO") +
                       " PRIORITY=" + MosaicPriority;
   ProgramLauncher::RunIsisProgram("automos", parameters);
 
@@ -273,7 +273,7 @@ void hicolormos(Cube *from1, Cube* from2, UserInterface &ui) {
   OriginalLabel from1OrgLab(from1->fileName());
 
   Cube c;
-  c.open(ui.GetFileName("TO"), "rw");
+  c.open(ui.GetCubeName("TO"), "rw");
   c.label()->findObject("IsisCube", Pvl::Traverse).addGroup(mos);
   c.write(from1OrgLab);
   c.close();

--- a/isis/src/mro/apps/hicrop/hicrop.cpp
+++ b/isis/src/mro/apps/hicrop/hicrop.cpp
@@ -61,11 +61,11 @@ namespace Isis {
   int g_cropLineCount = 0;
 
   void hicrop(UserInterface &ui, Pvl *log) {
-    QString inputFileName = ui.GetFileName("FROM");
+    QString inputFileName = ui.GetCubeName("FROM");
     CubeAttributeInput inAtt(inputFileName);
     g_cube = new Cube();
     g_cube->setVirtualBands(inAtt.bands());
-    inputFileName = ui.GetFileName("FROM");
+    inputFileName = ui.GetCubeName("FROM");
     g_cube->open(inputFileName);
 
     hicrop(g_cube, ui, log);
@@ -321,7 +321,7 @@ namespace Isis {
       int inputLineCount = g_cube->lineCount();
 
       Isis::CubeAttributeOutput atts = ui.GetOutputAttribute("TO");
-      FileName outFileName = ui.GetFileName("TO");
+      FileName outFileName = ui.GetCubeName("TO");
       Cube *ocube = p.SetOutputCube(outFileName.expanded(), atts, numSamps, g_cropLineCount, numBands);
 
       p.ClearInputCubes();

--- a/isis/src/mro/apps/hicubeit/hicubeit.cpp
+++ b/isis/src/mro/apps/hicubeit/hicubeit.cpp
@@ -20,9 +20,9 @@ using namespace std;
 namespace Isis {
 
   void hicubeit(UserInterface &ui) {
-    QString redFile = ui.GetFileName("RED");
-    QString irFile  = ui.GetFileName("IR");
-    QString bgFile  = ui.GetFileName("BG");
+    QString redFile = ui.GetCubeName("RED");
+    QString irFile  = ui.GetCubeName("IR");
+    QString bgFile  = ui.GetCubeName("BG");
 
     FileName tempFile = FileName::createTempFile("$TEMPORARY/hicubeit.temp.lis");
     TextFile tf;
@@ -33,7 +33,7 @@ namespace Isis {
     tf.Close();
 
     QString parameters = QString(" FROMLIST = ")    + tempFile.expanded() +
-                        QString(" TO = ")      + ui.GetFileName("TO") +
+                        QString(" TO = ")      + ui.GetCubeName("TO") +
                         QString(" PROPLAB = ") + redFile;
     ProgramLauncher::RunIsisProgram("cubeit", parameters);
     remove(tempFile.expanded().toLatin1().data());
@@ -181,7 +181,7 @@ namespace Isis {
 
     // Add the group to the output cube
     Cube c;
-    c.open(ui.GetFileName("TO"), "rw");
+    c.open(ui.GetCubeName("TO"), "rw");
     c.label()->findObject("IsisCube", Pvl::Traverse).addGroup(mos);
     c.close();
   }

--- a/isis/src/mro/apps/hicubenorm/hicubenorm.cpp
+++ b/isis/src/mro/apps/hicubenorm/hicubenorm.cpp
@@ -59,7 +59,7 @@ namespace Isis {
     void CorrectCubenormStats(int piFilterSize, bool pbPauseCrop, int piChannelNum, QString psMode);
 
     void hicubenorm(UserInterface &ui) {
-        Cube *cube = new Cube(ui.GetFileName("FROM"), "r");
+        Cube *cube = new Cube(ui.GetCubeName("FROM"), "r");
         hicubenorm(cube, ui);
     }
 
@@ -170,7 +170,7 @@ namespace Isis {
             }
 
             Isis::CubeAttributeOutput atts = ui.GetOutputAttribute("TO");
-            FileName outFileName = ui.GetFileName("TO");
+            FileName outFileName = ui.GetCubeName("TO");
 
             // Setup the output file and apply the coefficients by either
             // subtracting or multipling them

--- a/isis/src/mro/apps/hideal2pds/main.cpp
+++ b/isis/src/mro/apps/hideal2pds/main.cpp
@@ -172,7 +172,7 @@ void IsisMain() {
   // create generic pds label - this will be finalized with proper line/byte counts later
   Pvl &pdsLabel = p.StandardPdsLabel(ProcessExportPds::Image);
 
-  QString isisLabelFile = ui.GetFileName("FROM");
+  QString isisLabelFile = ui.GetCubeName("FROM");
 
   // Translate the keywords from the input cube label that go in the PDS label
   PvlToPvlTranslationManager cubeLab(*(inputCube->label()),

--- a/isis/src/mro/apps/hideal2pds/main.cpp
+++ b/isis/src/mro/apps/hideal2pds/main.cpp
@@ -172,7 +172,7 @@ void IsisMain() {
   // create generic pds label - this will be finalized with proper line/byte counts later
   Pvl &pdsLabel = p.StandardPdsLabel(ProcessExportPds::Image);
 
-  QString isisLabelFile = ui.GetCubeName("FROM");
+  QString isisLabelFile = ui.GetFileName("FROM");
 
   // Translate the keywords from the input cube label that go in the PDS label
   PvlToPvlTranslationManager cubeLab(*(inputCube->label()),

--- a/isis/src/mro/apps/hidestripe/main.cpp
+++ b/isis/src/mro/apps/hidestripe/main.cpp
@@ -55,7 +55,7 @@ const int num_phases = 4;
 void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
-  Isis::FileName fromFile = ui.GetFileName("FROM");
+  Isis::FileName fromFile = ui.GetCubeName("FROM");
 
   Isis::Cube inputCube;
   inputCube.open(fromFile.expanded());

--- a/isis/src/mro/apps/hidtmgen/hidtmgen.cpp
+++ b/isis/src/mro/apps/hidtmgen/hidtmgen.cpp
@@ -188,8 +188,8 @@ namespace Isis{
         setUpProcessPixels(ui, pdsExportProcess, DTM);
         // set the input cube to process
         CubeAttributeInput inAttribute;
-        Cube *inCube = pdsExportProcess.SetInputCube(ui.GetFileName("DTM"), inAttribute);
-        verifyDTM(inCube,  ui.GetFileName("DTM"));
+        Cube *inCube = pdsExportProcess.SetInputCube(ui.GetCubeName("DTM"), inAttribute);
+        verifyDTM(inCube,  ui.GetCubeName("DTM"));
 
         // These are our output labels, will be modifying heavily
         Pvl &pdsLabel = pdsExportProcess.StandardPdsLabel(ProcessExportPds::Image);
@@ -218,7 +218,7 @@ namespace Isis{
         }
         else {
           dtmProductId = ui.GetString("DTM_PRODUCT_ID");
-          outFile = FileName(ui.GetFileName("DTMTO"));
+          outFile = FileName(ui.GetCubeName("DTMTO"));
         } // End scope of defaultNames true
 
         // identification labels that are pretty set in stone

--- a/isis/src/mro/apps/hifringe/main.cpp
+++ b/isis/src/mro/apps/hifringe/main.cpp
@@ -49,7 +49,7 @@ void pvlOut(Statistics stats1, Statistics stats2, QString name, int start,
 
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
-  Isis::FileName fromFile = ui.GetFileName("FROM");
+  Isis::FileName fromFile = ui.GetCubeName("FROM");
 
   Isis::Cube inputCube;
   inputCube.open(fromFile.expanded());

--- a/isis/src/mro/apps/hifurrows/main.cpp
+++ b/isis/src/mro/apps/hifurrows/main.cpp
@@ -251,7 +251,7 @@ void RemoveFurrows_Version_1_42(void)
   QString sTempFile("./FixFurrows.cub");
   if(bFurrowsFound) {
     Pipeline p;
-    p.SetInputFile(FileName(ui.GetFileName("TO")));
+    p.SetInputFile(FileName(ui.GetCubeName("TO")));
     p.SetOutputFile(FileName(sTempFile));
     p.KeepTemporaryFiles(false);
 

--- a/isis/src/mro/apps/higlob/main.cpp
+++ b/isis/src/mro/apps/higlob/main.cpp
@@ -39,7 +39,7 @@ void IsisMain() {
 
   // Open the input cube
   UserInterface &ui = Application::GetUserInterface();
-  QString from = ui.GetFileName("FROM");
+  QString from = ui.GetCubeName("FROM");
   g_cube.open(from);
 
   samples = g_cube.sampleCount();

--- a/isis/src/mro/apps/hijitreg/main.cpp
+++ b/isis/src/mro/apps/hijitreg/main.cpp
@@ -95,7 +95,7 @@ void IsisMain() {
   CubeAttributeInput &attTrans = ui.GetInputAttribute("FROM");
   vector<QString> bandTrans = attTrans.bands();
   trans.setVirtualBands(bandTrans);
-  trans.OpenCube(ui.GetFileName("FROM"), stitch);
+  trans.OpenCube(ui.GetCubeName("FROM"), stitch);
 
 
   // Open the second cube, it is held in place.  We will be matching the
@@ -104,7 +104,7 @@ void IsisMain() {
   CubeAttributeInput &attMatch = ui.GetInputAttribute("MATCH");
   vector<QString> bandMatch = attMatch.bands();
   match.setVirtualBands(bandMatch);
-  match.OpenCube(ui.GetFileName("MATCH"), stitch);
+  match.OpenCube(ui.GetCubeName("MATCH"), stitch);
 
 //  Ensure only one band
   if ((trans.bandCount() != 1) || (match.bandCount() != 1)) {

--- a/isis/src/mro/apps/himos/himos.cpp
+++ b/isis/src/mro/apps/himos/himos.cpp
@@ -245,7 +245,7 @@ namespace Isis {
 
       // automos step
       QString list = ui.GetFileName("FROMLIST");
-      QString toMosaic = ui.GetFileName("TO");
+      QString toMosaic = ui.GetCubeName("TO");
       QString MosaicPriority = ui.GetString("PRIORITY");
 
       QString parameters = "FROMLIST=" + list + " MOSAIC=" + toMosaic + " PRIORITY=" + MosaicPriority;
@@ -271,7 +271,7 @@ namespace Isis {
       mos += specialProcessingFlag;
 
       Cube mosCube;
-      mosCube.open(ui.GetFileName("TO"), "rw");
+      mosCube.open(ui.GetCubeName("TO"), "rw");
       PvlObject &lab = mosCube.label()->findObject("IsisCube");
       lab.addGroup(mos);
       //add orginal label blob to the output cube
@@ -285,7 +285,7 @@ namespace Isis {
         delete clist[i];
       }
       std::cout << e.what() << '\n';
-      QString msg = "The mosaic [" + ui.GetFileName("TO") + "] was NOT created";
+      QString msg = "The mosaic [" + ui.GetCubeName("TO") + "] was NOT created";
       throw IException(IException::User, msg, _FILEINFO_);
     }
   } // end of isis main

--- a/isis/src/mro/apps/hirdrgen/main.cpp
+++ b/isis/src/mro/apps/hirdrgen/main.cpp
@@ -48,7 +48,7 @@ void IsisMain() {
   // Check to see if the input cube looks like a HiRISE RDR
   if (icube->bandCount() > 3) {
     QString msg = "Input file [" +
-                 Application::GetUserInterface().GetFileName("FROM") +
+                 Application::GetUserInterface().GetCubeName("FROM") +
                  "] does not appear to be a HiRISE RDR product. Number of " +
                  "bands is greater than 3";
     throw IException(IException::Programmer, msg, _FILEINFO_);

--- a/isis/src/mro/apps/hisharpen/main.cpp
+++ b/isis/src/mro/apps/hisharpen/main.cpp
@@ -138,7 +138,7 @@ void CreatePsf(Pipeline &p) {
 
   // We need the base input and psf cubes to make the temporary psf cube
   Cube fromCube;
-  fromCube.open(ui.GetFileName("FROM"));
+  fromCube.open(ui.GetCubeName("FROM"));
 
   // Verify the image looks like a hirise image
   try {

--- a/isis/src/mro/apps/histat/main.cpp
+++ b/isis/src/mro/apps/histat/main.cpp
@@ -59,7 +59,7 @@ void IsisMain() {
   }
 
 
-  Isis::FileName fromFile = ui.GetFileName("FROM");
+  Isis::FileName fromFile = ui.GetCubeName("FROM");
   Isis::Cube inputCube;
   inputCube.open(fromFile.expanded());
 

--- a/isis/src/mro/apps/marci2isis/marci2isis.cpp
+++ b/isis/src/mro/apps/marci2isis/marci2isis.cpp
@@ -126,7 +126,7 @@ namespace Isis{
     outputCubes[0]->setDimensions(numSamples, numLines, numFilters);
     outputCubes[1]->setDimensions(numSamples, numLines, numFilters);
 
-    FileName outputFile(ui.GetFileName("TO"));
+    FileName outputFile(ui.GetCubeName("TO"));
     QString evenFile = outputFile.path() + "/" + outputFile.baseName() + ".even.cub";
     QString oddFile = outputFile.path() + "/" + outputFile.baseName() + ".odd.cub";
 

--- a/isis/src/mro/apps/marcical/marcical.cpp
+++ b/isis/src/mro/apps/marcical/marcical.cpp
@@ -172,10 +172,10 @@ namespace Isis {
       icube.setVirtualBands(inAtt.bands());
     }
 
-    icube.open(FileName(ui.GetFileName("FROM")).expanded());
+    icube.open(FileName(ui.GetCubeName("FROM")).expanded());
 
     // Make sure it is a Marci cube
-    FileName inFileName = ui.GetFileName("FROM");
+    FileName inFileName = ui.GetCubeName("FROM");
     try {
       if (icube.group("Instrument")["InstrumentID"][0] != "Marci") {
         throw IException();
@@ -310,7 +310,7 @@ namespace Isis {
     ocube.setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
     ocube.setPixelType(outAtt.pixelType());
 
-    ocube.create(FileName(ui.GetFileName("TO")).expanded());
+    ocube.create(FileName(ui.GetCubeName("TO")).expanded());
 
     LineManager icubeMgr(icube);
 

--- a/isis/src/mro/apps/marciflip/marciflip.cpp
+++ b/isis/src/mro/apps/marciflip/marciflip.cpp
@@ -31,7 +31,7 @@ namespace Isis {
         Isis::Cube *icube;
         Isis::CubeAttributeInput inAtt;
 
-        cubeFn = ui.GetFileName("FROM");
+        cubeFn = ui.GetCubeName("FROM");
         icube = new Cube(cubeFn);
         inAtt = ui.GetInputAttribute("FROM");
 
@@ -46,7 +46,7 @@ namespace Isis {
         outputCube = new Cube();
         outputCube->setDimensions(icube->sampleCount(), icube->lineCount(), icube->bandCount());
 
-        outputCube->create(ui.GetFileName("TO"));
+        outputCube->create(ui.GetCubeName("TO"));
 
         if(icube->hasGroup("Instrument")) {
             PvlGroup inst = icube->group("Instrument");

--- a/isis/src/mro/apps/mroctx2isis/main.cpp
+++ b/isis/src/mro/apps/mroctx2isis/main.cpp
@@ -174,7 +174,7 @@ void IsisMain() {
   outAtt.setPixelType(Isis::SignedWord);
   outAtt.setMinimum((double)VALID_MIN2);
   outAtt.setMaximum((double)VALID_MAX2);
-  Cube *ocube = p.SetOutputCube(ui.GetFileName("TO"), outAtt);
+  Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), outAtt);
 
   // Translate the labels
   p.StartProcess();
@@ -203,7 +203,7 @@ void IsisMain() {
   // Do 8 bit to 12 bit conversion
   fillGap = ui.GetBoolean("FILLGAP");
   ProcessByLine p2;
-  QString ioFile = ui.GetFileName("TO");
+  QString ioFile = ui.GetCubeName("TO");
   CubeAttributeInput att;
   p2.SetInputCube(ioFile, att, ReadWrite);
   p2.Progress()->SetText("Converting 8 bit pixels to 16 bit");

--- a/isis/src/newhorizons/apps/leisa2isis/leisa2isis.cpp
+++ b/isis/src/newhorizons/apps/leisa2isis/leisa2isis.cpp
@@ -137,7 +137,7 @@ namespace Isis {
         importFits.SetPixelType(Isis::Real);
       }
       importFits.SetAttributes(att);
-      output = importFits.SetOutputCube(ui.GetFileName("TO"), att);
+      output = importFits.SetOutputCube(ui.GetCubeName("TO"), att);
     }
 
     // Get the path where the New Horizons translation tables are.
@@ -244,7 +244,7 @@ namespace Isis {
       QString parameters;
       parameters += " F1= " + outputFile.toString();
       parameters += " F2= " + qualityFile.toString();
-      parameters += " TO= " + ui.GetFileName("TO");
+      parameters += " TO= " + ui.GetCubeName("TO");
       parameters += " EQUATION=" + QString("\"f1+f2\"");
       ProgramLauncher::RunIsisProgram("fx", parameters);
 

--- a/isis/src/newhorizons/apps/lorri2isis/lorri2isis.cpp
+++ b/isis/src/newhorizons/apps/lorri2isis/lorri2isis.cpp
@@ -67,7 +67,7 @@ namespace Isis {
     importFits.setProcessFileStructure(0);
 
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *output = importFits.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *output = importFits.SetOutputCube(ui.GetCubeName("TO"), att);
 
     // Get the path where the New Horizons translation tables are.
     QString transDir = "$ISISROOT/appdata/translations/";
@@ -129,7 +129,7 @@ namespace Isis {
       importFits.setProcessFileStructure(1);
 
       CubeAttributeOutput &attErr = ui.GetOutputAttribute("ERROR");
-      Cube *outputError = importFits.SetOutputCube(ui.GetFileName("ERROR"), attErr);
+      Cube *outputError = importFits.SetOutputCube(ui.GetCubeName("ERROR"), attErr);
 
       // Save the input FITS label in the Cube original labels
       Pvl pvlError;
@@ -150,7 +150,7 @@ namespace Isis {
       importFits.setProcessFileStructure(2);
 
       CubeAttributeOutput &attQual = ui.GetOutputAttribute("QUALITY");
-      Cube *outputError = importFits.SetOutputCube(ui.GetFileName("QUALITY"), attQual);
+      Cube *outputError = importFits.SetOutputCube(ui.GetCubeName("QUALITY"), attQual);
 
       // Save the input FITS label in the Cube original labels
       Pvl pvlError;

--- a/isis/src/newhorizons/apps/mvic2isis/mvic2isis.cpp
+++ b/isis/src/newhorizons/apps/mvic2isis/mvic2isis.cpp
@@ -114,7 +114,7 @@ namespace Isis {
 
     // Set up the output cube
     CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-    Cube *output = importFits.SetOutputCube(ui.GetFileName("TO"), att);
+    Cube *output = importFits.SetOutputCube(ui.GetCubeName("TO"), att);
 
     translateLabels(primaryLabel, output); // Results are put directly into the cube label (output)
 

--- a/isis/src/odyssey/apps/thm2isis/thm2isis.cpp
+++ b/isis/src/odyssey/apps/thm2isis/thm2isis.cpp
@@ -68,7 +68,7 @@ namespace Isis {
     TranslateLabels(pdsLab, isis3Lab, p.Bands(), ui);
 
     // Set up the output cube
-    FileName outFile(ui.GetFileName("TO"));
+    FileName outFile(ui.GetCubeName("TO"));
     PvlGroup &inst = isis3Lab.findGroup("Instrument", Pvl::Traverse);
     CubeAttributeOutput outAttr = ui.GetOutputAttribute("to");
     

--- a/isis/src/odyssey/apps/thmnoseam/main.cpp
+++ b/isis/src/odyssey/apps/thmnoseam/main.cpp
@@ -97,12 +97,12 @@ void IsisMain() {
   try {
     if(evenCube->group("Instrument")["InstrumentID"][0] != "THEMIS_VIS") {
       QString msg = "This program is intended for use on THEMIS VIS images only";
-      msg += " [" + ui.GetFileName("INEVEN") + "] does not appear to be a ";
+      msg += " [" + ui.GetCubeName("INEVEN") + "] does not appear to be a ";
       msg += "THEMIS VIS image.";
       throw IException(IException::User, msg, _FILEINFO_);
     }
     if (evenCube->group("Instrument")["Framelets"][0] != "Even") {
-      QString msg = "The image [" + ui.GetFileName("INEVEN") + "] does not appear "
+      QString msg = "The image [" + ui.GetCubeName("INEVEN") + "] does not appear "
           "to contain the EVEN framelets of a Themis VIS cube";
       throw IException(IException::User, msg, _FILEINFO_);
     }
@@ -115,12 +115,12 @@ void IsisMain() {
   try {
     if(oddCube->group("Instrument")["InstrumentID"][0] != "THEMIS_VIS") {
       QString msg = "This program is intended for use on THEMIS VIS images only";
-      msg += " [" + ui.GetFileName("INODD") + "] does not appear to be a ";
+      msg += " [" + ui.GetCubeName("INODD") + "] does not appear to be a ";
       msg += "THEMIS VIS image.";
       throw IException(IException::User, msg, _FILEINFO_);
     }
     if (oddCube->group("Instrument")["Framelets"][0] != "Odd") {
-      QString msg = "The image [" + ui.GetFileName("INODD") + "] does not appear "
+      QString msg = "The image [" + ui.GetCubeName("INODD") + "] does not appear "
           "to contain the ODD framelets of a Themis VIS cube";
       throw IException(IException::User, msg, _FILEINFO_);
     }

--- a/isis/src/odyssey/apps/thmproc/main.cpp
+++ b/isis/src/odyssey/apps/thmproc/main.cpp
@@ -53,7 +53,7 @@ void IsisMain() {
     }
   }
   if(ui.WasEntered("MODEL")) {
-    FileName modelPreference = ui.GetFileName("MODEL");
+    FileName modelPreference = ui.GetCubeName("MODEL");
     if(!modelPreference.fileExists()){
       QString msg = "Please provide a valid MODEL preference file.";
       throw IException(IException::User, msg, _FILEINFO_);

--- a/isis/src/odyssey/apps/thmvisflat/main.cpp
+++ b/isis/src/odyssey/apps/thmvisflat/main.cpp
@@ -27,10 +27,10 @@ void IsisMain() {
     icube.setVirtualBands(inAtt.bands());
   }
 
-  icube.open(FileName(ui.GetFileName("FROM")).expanded());
+  icube.open(FileName(ui.GetCubeName("FROM")).expanded());
 
   // Make sure it is a Themis EDR/RDR
-  FileName inFileName = ui.GetFileName("FROM");
+  FileName inFileName = ui.GetCubeName("FROM");
   try {
     if(icube.group("Instrument")["InstrumentID"][0] != "THEMIS_VIS") {
       QString msg = "This program is intended for use on THEMIS VIS images only. [";
@@ -71,7 +71,7 @@ void IsisMain() {
   ocube.setLabelsAttached(outAtt.labelAttachment() == AttachedLabel);
   ocube.setPixelType(outAtt.pixelType());
 
-  ocube.create(FileName(ui.GetFileName("TO")).expanded());
+  ocube.create(FileName(ui.GetCubeName("TO")).expanded());
 
   LineManager icubeMgr(icube);
   vector<int> filter;

--- a/isis/src/odyssey/apps/thmvistrim/main.cpp
+++ b/isis/src/odyssey/apps/thmvistrim/main.cpp
@@ -37,7 +37,7 @@ void IsisMain() {
   // Make sure it is a Themis EDR/RDR
   try {
     if(icube->group("Instrument")["InstrumentID"][0] != "THEMIS_VIS") {
-      FileName inFileName = ui.GetFileName("FROM");
+      FileName inFileName = ui.GetCubeName("FROM");
       QString msg = "This program is intended for use on THEMIS VIS images only. [";
       msg += inFileName.expanded() + "] does not appear to be a THEMIS VIS image.";
       throw IException(IException::User, msg, _FILEINFO_);

--- a/isis/src/socet/apps/socetframesettings/main.cpp
+++ b/isis/src/socet/apps/socetframesettings/main.cpp
@@ -48,7 +48,7 @@ void IsisMain() {
   Process p;
 
   UserInterface &ui = Application::GetUserInterface();
-  QString from = ui.GetFileName("FROM");
+  QString from = ui.GetCubeName("FROM");
   QString to = FileName(ui.GetFileName("TO")).expanded();
   QString socetProject = ui.GetString("SS_PROJECT");
   QString socetImageLocation = ui.GetString("SS_IMG_LOC");

--- a/isis/src/socet/apps/socetlinescankeywords/socetlinescankeywords.cpp
+++ b/isis/src/socet/apps/socetlinescankeywords/socetlinescankeywords.cpp
@@ -41,7 +41,7 @@ namespace Isis {
 
 void socetlinescankeywords (UserInterface &ui) {  
   // Get user parameters and error check
-  Cube input(ui.GetFileName("FROM"), "rw");    
+  Cube input(ui.GetCubeName("FROM"), "rw");    
   socetlinescankeywords(&input, ui);
 }
 

--- a/isis/src/system/apps/blobdump/main.cpp
+++ b/isis/src/system/apps/blobdump/main.cpp
@@ -34,7 +34,7 @@ map <QString, void *> GuiHelpers() {
 
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
-  FileName file = ui.GetFileName("FROM");
+  FileName file = ui.GetCubeName("FROM");
   QString blobname = ui.GetString("NAME");
   QString blobtype = ui.GetString("TYPE");
   Blob blob(blobname, blobtype, file.expanded());
@@ -48,7 +48,7 @@ void helperButtonGetBlobList() {
   bool match = false;
 
   UserInterface &ui = Application::GetUserInterface();
-  QString currentFile = ui.GetFileName("FROM");
+  QString currentFile = ui.GetCubeName("FROM");
   const Pvl label(FileName(currentFile).expanded());
 
   // Check to see if the "FILE" parameter has changed since last press

--- a/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
@@ -53,7 +53,7 @@ namespace Isis {
       }
 
       CubeAttributeOutput &att = ui.GetOutputAttribute("TO");
-      Cube *outputCube = importer.SetOutputCube(ui.GetFileName("TO"), att);
+      Cube *outputCube = importer.SetOutputCube(ui.GetCubeName("TO"), att);
 
       QString transRawFile = "TgoCassisInstrument.trn";
       QFile xmlFile(xmlFileName.expanded());
@@ -95,7 +95,7 @@ namespace Isis {
         convertUniqueIdToObservationId(*outputLabel);
       }
 
-      FileName outputCubeFileName(ui.GetFileName("TO"));
+      FileName outputCubeFileName(ui.GetCubeName("TO"));
 
       OriginalXmlLabel xmlLabel;
       xmlLabel.readFromXmlFile(xmlFileName);

--- a/isis/src/tgo/apps/tgocassismos/tgocassismos.cpp
+++ b/isis/src/tgo/apps/tgocassismos/tgocassismos.cpp
@@ -226,7 +226,7 @@ namespace Isis {
 
       // automos step
       QString list = ui.GetFileName("FROMLIST");
-      QString toMosaic = ui.GetFileName("TO");
+      QString toMosaic = ui.GetCubeName("TO");
       QString mosaicPriority = ui.GetString("PRIORITY");
 
       QString parameters = "FROMLIST=" + list + " MOSAIC=" + toMosaic + " PRIORITY=" + mosaicPriority
@@ -259,7 +259,7 @@ namespace Isis {
       mos += PvlKeyword("NorthAzimuth ", toString(northAzimuth), "degrees");
 
       Cube mosCube;
-      mosCube.open(ui.GetFileName("TO"), "rw");
+      mosCube.open(ui.GetCubeName("TO"), "rw");
       PvlObject &lab = mosCube.label()->findObject("IsisCube");
       lab.addGroup(mos);
 
@@ -272,7 +272,7 @@ namespace Isis {
         cubeList[i]->close();
         delete cubeList[i];
       }
-      QString msg = "The mosaic [" + ui.GetFileName("TO") + "] was NOT created";
+      QString msg = "The mosaic [" + ui.GetCubeName("TO") + "] was NOT created";
       throw IException(IException::User, msg, _FILEINFO_);
     }
   } // end of isis main

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -31,7 +31,7 @@ namespace Isis {
     Cube icube;
     
     // Check if input file is indeed, a cube
-    if (ui.GetFileName("FROM").right(3) != "cub") {
+    if (FileName(ui.GetCubeName("FROM")).expanded().right(3) != "cub") {
       QString msg = "Input file [" + ui.GetFileName("FROM") +
                   "] does not appear to be a cube";
       throw  IException(IException::User, msg, _FILEINFO_);
@@ -42,7 +42,7 @@ namespace Isis {
         icube.setVirtualBands(inAtt.bands());
     }
 
-    icube.open(ui.GetFileName("FROM"), "r");
+    icube.open(ui.GetCubeName("FROM"), "r");
     tgocassisrdrgen(&icube, ui);
   }
 
@@ -73,7 +73,7 @@ namespace Isis {
     // Check if the cube is able to be translated into a CaSSIS xml file
     // This could very well be unnecessary
     if (!targetGroup.findKeyword("InstrumentId").isEquivalent("CaSSIS")) {
-      QString msg = "Input file [" + ui.GetFileName("FROM") +
+      QString msg = "Input file [" + ui.GetCubeName("FROM") +
                   "] does not appear to be a CaSSIS RDR product. The image" +
                   "instrument is not the CaSSIS instrument";
       throw  IException(IException::User, msg, _FILEINFO_);

--- a/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
+++ b/isis/src/tgo/apps/tgocassisrdrgen/tgocassisrdrgen.cpp
@@ -32,16 +32,11 @@ namespace Isis {
     
     // Check if input file is indeed, a cube
     if (FileName(ui.GetCubeName("FROM")).expanded().right(3) != "cub") {
-      QString msg = "Input file [" + ui.GetFileName("FROM") +
+      QString msg = "Input file [" + ui.GetCubeName("FROM") +
                   "] does not appear to be a cube";
       throw  IException(IException::User, msg, _FILEINFO_);
     }
     
-    CubeAttributeInput inAtt = ui.GetInputAttribute("FROM");
-    if (inAtt.bands().size() != 0) {
-        icube.setVirtualBands(inAtt.bands());
-    }
-
     icube.open(ui.GetCubeName("FROM"), "r");
     tgocassisrdrgen(&icube, ui);
   }

--- a/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisunstitch/tgocassisunstitch.cpp
@@ -70,7 +70,7 @@ namespace Isis {
     CubeAttributeInput inAtt(from);
     cube = new Cube();
     cube->setVirtualBands(inAtt.bands());
-    from = ui.GetFileName("FROM");
+    from = ui.GetCubeName("FROM");
     cube->open(from);
 
     // Determine the filters / framelets in input fullframe image
@@ -153,7 +153,7 @@ namespace Isis {
 
     // Unstitch
     CubeAttributeInput &att = ui.GetInputAttribute("FROM");
-    p.SetInputCube(ui.GetFileName("FROM"), att);
+    p.SetInputCube(ui.GetCubeName("FROM"), att);
     p.Progress()->SetText("Processing output cubes.");
     p.StartProcess(unstitchFullFrame);
     p.EndProcess();

--- a/isis/src/viking/apps/vikcal/main.cpp
+++ b/isis/src/viking/apps/vikcal/main.cpp
@@ -36,7 +36,7 @@ void IsisMain() {
   // segment found in the CalParameters documentation to the vikcal.xml file
   linear = false;
 // linear = ui.GetBoolean("LINEAR");
-  const QString in = ui.GetFileName("FROM");
+  const QString in = ui.GetCubeName("FROM");
 
   // Open the input cube
   Cube icube;

--- a/isis/src/viking/apps/vikcal/vikcal.cpp
+++ b/isis/src/viking/apps/vikcal/vikcal.cpp
@@ -25,7 +25,7 @@ namespace Isis {
   static bool linear;
 
   void vikcal(UserInterface &ui) {
-    const QString in = ui.GetFileName("FROM");
+    const QString in = ui.GetCubeName("FROM");
   
     // Open the input cube
     Cube icube(in, "r");

--- a/isis/src/viking/apps/viknobutter/main.cpp
+++ b/isis/src/viking/apps/viknobutter/main.cpp
@@ -23,7 +23,7 @@ void IsisMain() {
   pipeline.KeepTemporaryFiles(!rmv);
 
   // Figure out which masking cube to use
-  Pvl p(ui.GetFileName("FROM"));
+  Pvl p(ui.GetCubeName("FROM"));
   PvlGroup &inst = p.findGroup("Instrument", Pvl::Traverse);
   int spn;
   QString scn = (QString)inst["SpacecraftName"];

--- a/isis/src/voyager/apps/voycal/main.cpp
+++ b/isis/src/voyager/apps/voycal/main.cpp
@@ -66,7 +66,7 @@ void IsisMain() {
 
   // Check for projection
   if (incube->isProjected()) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] has a projection" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] has a projection" +
                   " and cannot be radiometrically calibrated";
     throw IException(IException::User, msg, _FILEINFO_);
   }
@@ -79,7 +79,7 @@ void IsisMain() {
 
   // Verify not radiometrically corrected
   if (isiscube.hasGroup("Radiometry")) {
-    QString msg = "Cube [" + ui.GetFileName("FROM") + "] has already been" +
+    QString msg = "Cube [" + ui.GetCubeName("FROM") + "] has already been" +
                   " radiometrically corrected";
     throw IException(IException::User,msg,_FILEINFO_);
   }
@@ -87,7 +87,7 @@ void IsisMain() {
   // Verify Voyager spacecraft and get number, 1 or 2
   QString scNumber = instrument["SpacecraftName"][0];
   if (scNumber != "VOYAGER_1" && scNumber != "VOYAGER_2") {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] does not appear" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] does not appear" +
                   " to be a Voyager image";
     throw IException(IException::User, msg, _FILEINFO_);
   }

--- a/isis/src/voyager/apps/voyramp/main.cpp
+++ b/isis/src/voyager/apps/voyramp/main.cpp
@@ -72,14 +72,14 @@ void IsisMain() {
 
   // Verify Voyager1 spacecraft
   if (inst["SpacecraftName"][0] != "VOYAGER_1") {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] does not appear" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] does not appear" +
                   " to be a Voyager1 image";
     throw IException(IException::User, msg, _FILEINFO_);
   }
 
   // Verify has been radiometrically calibrated
   if (!isiscube.hasGroup("Radiometry")) {
-    QString msg = "The cube [" + ui.GetFileName("FROM") + "] has not been" +
+    QString msg = "The cube [" + ui.GetCubeName("FROM") + "] has not been" +
                   "radiometrically corrected, run voycal first";
   }
 
@@ -92,7 +92,7 @@ void IsisMain() {
 
   // From Isis2, the time range is day 64, hours 1-16, inclusive.
   if (time < min || time >= max) {
-    QString message = "The cube [" + ui.GetFileName("FROM") + "] has image" +
+    QString message = "The cube [" + ui.GetCubeName("FROM") + "] has image" +
                       " time [" + time.UTC() + "] outside of allowable" +
                       "range [" + min.UTC() + "] to [" + max.UTC() + "]";
     throw IException(IException::User, message, _FILEINFO_);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Change calls of GetFileName(some_cube_name) to GetCubeName

## Description
<!--- Describe your changes in detail -->
These changes will allow Input cubes to automatically process the cube attributes (i.e., band numbers). New apps should always use GetCubeName when the apps XML file uses TYPE set to CUBE

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Apps converted to callable routines often don't process input cube attributes, and when they do the code is repeated exactly for every callable conversion.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
