### PR TITLE
Fixed jigsaw observation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ Keywords when running CAMSTATS.  [#3605](https://github.com/USGS-Astrogeology/IS
 - Fixed Maptrim failures when mode=both for PositiveWest longitude direction. [#4646](https://github.com/USGS-Astrogeology/ISIS3/issues/4646)
 - Fixed the Vesta target name not being translated properly in dawnfc2isis. [#4638](https://github.com/USGS-Astrogeology/ISIS3/issues/4638)
 - Fixed a bug where the measure residuals reported in the bundleout.txt file were incorrect. [#4655](https://github.com/USGS-Astrogeology/ISIS3/issues/4655)
+- Fuxed a bug where jigsaw would raise an error when solving for framing camera pointing in observation mode. [#4686](https://github.com/USGS-Astrogeology/ISIS3/issues/4686)
 
 ## [6.0.0] - 2021-08-27
 

--- a/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
+++ b/isis/src/control/objs/BundleUtilities/BundleObservationVector.cpp
@@ -110,6 +110,8 @@ namespace Isis {
       addToExisting = true;
     }
 
+    bool isIsisObservation = bundleImage->camera()->GetCameraType() != Camera::Csm;
+
     if (addToExisting) {
       // if we have already added a BundleObservation with this number, we have to add the new
       // BundleImage to this observation
@@ -125,8 +127,6 @@ namespace Isis {
     }
     else {
       // create new BundleObservation and append to this vector
-
-      bool isIsisObservation = bundleImage->camera()->GetCameraType() != Camera::Csm;
 
       if (isIsisObservation) {
         bundleObservation.reset(new IsisBundleObservation(bundleImage,
@@ -167,14 +167,6 @@ namespace Isis {
 
       append(bundleObservation);
 
-      if (isIsisObservation) {
-        QSharedPointer<IsisBundleObservation> isisObs = qSharedPointerDynamicCast<IsisBundleObservation>(bundleObservation);
-        isisObs->initializeExteriorOrientation();
-        if (bundleSettings->solveTargetBody()) {
-          isisObs->initializeBodyRotation();
-        }
-      }
-
       // update observation number to observation ptr map
       m_observationNumberToObservationMap.insertMulti(observationNumber, bundleObservation);
 
@@ -190,6 +182,15 @@ namespace Isis {
         m_instIdToObservationMap.insertMulti(instrumentId, bundleObservation);
       }
 
+    }
+
+    // If it's an ISIS observation, setup the camera based on the solve settings
+    if (isIsisObservation) {
+      QSharedPointer<IsisBundleObservation> isisObs = qSharedPointerDynamicCast<IsisBundleObservation>(bundleObservation);
+      isisObs->initializeExteriorOrientation();
+      if (bundleSettings->solveTargetBody()) {
+        isisObs->initializeBodyRotation();
+      }
     }
     return bundleObservation;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed a bug introduced in #4537 that caused observation mode in jigsaw to fail for framing images.

The IsisBundleObservation::initializeExteriorOrientation function was only being called within the else block of BundleObservationVector::addNew. This caused the orientation polynomials to only be setup properly when new observations are created. If an image is added to an existing observation, its orientation polynomials are not initialized. This PR moves the call outside of the if/else block so that the orientation polynomials are always initialized for ISIS observations.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #4686 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The changes to add CSM support moved a call to initialize the position and pointing polynomial functions in jigsaw. This resulted in the initialization only happening for the first image in each observation when solving in observation mode. This caused an error when the parameter updates were copied from the first image to subsequent images in the each observation.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I tested with a TGO CaSSIS data set. I generated a simple network using seedgrid and then added the images to it. This resulted in a network that is "perfect" and should bundle with extremely small corrections. With the correction, the network now bundles. Without the correction, the network fails at the end of the first iteration.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
