### PR TITLE
Fixed disk trashing on input cube reads. Fixes #3711

### DIFF
--- a/isis/src/base/objs/ProcessMapMosaic/ProcessMapMosaic.cpp
+++ b/isis/src/base/objs/ProcessMapMosaic/ProcessMapMosaic.cpp
@@ -63,6 +63,7 @@ namespace Isis {
 
     CubeAttributeInput inAtt(inputFile);
     Cube *inCube = ProcessMosaic::SetInputCube(inputFile, inAtt);
+    inCube->addCachingAlgorithm(new UniqueIOCachingAlgorithm(2));
 
     Cube *mosaicCube = OutputCubes[0];
     Projection *iproj = inCube->projection();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes very slow run times when using band priority.

## Description
<!--- Describe your changes in detail -->
The band priority mode has to read extra data (i.e., the band used to set the priority). The default cube IO caching algorithm was causing Cube IO cache memory to be flushed too soon. Resulting in multiple reads of the same data, aka thrashing. The change shows automos to run 13 times faster than before with no difference in output values.

## Related Issue
#3711
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Unnecessarily slow execution when using band priority

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests pass locally. Hand testing shows the band priority option running 13 times faster. There are no timing test in the test suite.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
