### PR TITLE
Revert "added custom target to copy over camera.plugin files on ninja install solves #3834"

### DIFF
--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -574,13 +574,6 @@ add_custom_target(export ALL COMMAND ${CMAKE_COMMAND} -E copy_if_different
   ${CMAKE_SOURCE_DIR}/appdata/export/* ${CMAKE_BINARY_DIR}/appdata/export)
 add_dependencies(isis export)
 
-# Create the updateBuildPlugins.sh.in file
-configure_file(${CMAKE_SOURCE_DIR}/cmake/updateBuildPlugins.sh.in ${CMAKE_BINARY_DIR}/scripts/updateBuildPlugins.sh)
-
-# Add custom build target to copy modified Camera.plugin files to the build/lib/Camera.plugin file
-add_custom_target(cameraPlugins ALL COMMAND ${CMAKE_BINARY_DIR}/scripts/updateBuildPlugins.sh)
-add_dependencies(isis cameraPlugins)
-
 # Add a custom build target to clean out everything that gets added to the source
 #  directory during the build process.
 # - Only a few things are added in order to make the tests work properly so
@@ -600,7 +593,6 @@ install(FILES     ${CMAKE_SOURCE_DIR}/../AUTHORS.rst  DESTINATION  ${CMAKE_INSTA
 install(FILES     ${CMAKE_SOURCE_DIR}/../CHANGELOG.md DESTINATION  ${CMAKE_INSTALL_PREFIX})
 install(FILES     ${CMAKE_BINARY_DIR}/version         DESTINATION  ${CMAKE_INSTALL_PREFIX})
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/scripts         DESTINATION  ${CMAKE_INSTALL_PREFIX})
-install(PROGRAMS ${CMAKE_BINARY_DIR}/lib/Camera.plugin DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/)
 
 # Trigger all post-install behavior.
 # - The only way to run commands post-install in CMake is to add a subdirectory at

--- a/isis/cmake/AddIsisModule.cmake
+++ b/isis/cmake/AddIsisModule.cmake
@@ -178,6 +178,9 @@ function(add_isis_obj folder reqLibs)
     # Append the plugin file to a single file in the build directory
     # where the .so files will be created.  During installation copy these
     # plugin files to the installation library folder.
+    set(pluginPath ${CMAKE_BINARY_DIR}/lib/${pluginName})
+    cat(${plugins} ${pluginPath})
+    install(PROGRAMS ${pluginPath} DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/)
     # Record this library name for the caller
     set(newPluginLib ${libName}  PARENT_SCOPE)
   endif()

--- a/isis/cmake/updateBuildPlugins.sh.in
+++ b/isis/cmake/updateBuildPlugins.sh.in
@@ -1,7 +1,0 @@
-> ${CMAKE_BINARY_DIR}/lib/Camera.plugin
-for i in find ${CMAKE_SOURCE_DIR}/src/*/objs/*/Camera.plugin
-  do
-    if test -f "$i"; then
-        cat "$i" >> ${CMAKE_BINARY_DIR}/lib/Camera.plugin
-    fi
-done


### PR DESCRIPTION
This change is causing a bug where none of the non-camera plugin libraries (projections, etc.) are being built and installed. For the time being we are going to revert this PR and come back later to determine what's going on.