### PR TITLE
KernelDB Tests

### DIFF
--- a/isis/src/system/objs/KernelDb/KernelDb.cpp
+++ b/isis/src/system/objs/KernelDb/KernelDb.cpp
@@ -586,10 +586,10 @@ namespace Isis {
     QString instrument = "";
 
     if (grp.hasKeyword("StartOffset")){
-      startOffset = (double) grp["StartOffset"];
+      startOffset = (double) grp["StartOffset"] + 0.001;
     }
     if (grp.hasKeyword("EndOffset")){
-      endOffset = (double) grp["EndOffset"];
+      endOffset = (double) grp["EndOffset"] + 0.001;
     }
     if (grp.hasKeyword("Instrument")){
       instrument = (QString) grp["Instrument"];

--- a/isis/src/system/objs/KernelDb/KernelDb.h
+++ b/isis/src/system/objs/KernelDb/KernelDb.h
@@ -12,6 +12,7 @@ find files of those names at the top level of this repository. **/
 
 #include <iostream>
 #include <queue>
+#include <gtest/gtest_prod.h>
 
 #include <QList>
 #include <QString>
@@ -20,6 +21,8 @@ find files of those names at the top level of this repository. **/
 #include "iTime.h"//???
 #include "Kernel.h"
 #include "Pvl.h"
+
+class TestKernelDb_TestKernelsSmithOffset_Test;
 
 namespace Isis {
   class FileName;
@@ -130,6 +133,8 @@ namespace Isis {
       static bool matches(const Pvl &lab, PvlGroup &kernelDbGrp,
                           iTime timeToMatch, int cameraVersion);
     private:
+      FRIEND_TEST(::TestKernelDb, TestKernelsSmithOffset);
+
       void loadKernelDbFiles(PvlGroup &dataDir,
                              QString directory,
                              const Pvl &lab);

--- a/isis/tests/data/kernelDB/ck/kernels.0001.db
+++ b/isis/tests/data/kernelDB/ck/kernels.0001.db
@@ -1,0 +1,18 @@
+Object = SpacecraftPointing
+  RunTime = 2022-02-16T12:54:11
+
+  Group = Dependencies
+    SpacecraftClockKernel = $Odyssey/kernels/sclk/ORB1_SCLKSCET.00274.tsc
+    LeapsecondKernel      = $base/kernels/lsk/naif0008.tls
+  End_Group
+
+  Group = Selection
+    Time       = ("2002 FEB 20 22:58:59.720231 TDB",
+                  "2002 FEB 20 22:59:11.726211 TDB")
+    Instrument = THEMIS_IR
+    EndOffset  = 169.442
+    File       = data/kerneldbgen/thmIR.bc
+    Type       = Smithed
+  End_Group
+End_Object
+End

--- a/isis/tests/data/kernelDB/spk/kernels.0001.db
+++ b/isis/tests/data/kernelDB/spk/kernels.0001.db
@@ -1,0 +1,18 @@
+Object = SpacecraftPosition
+  RunTime = 2022-02-16T12:54:13
+
+  Group = Dependencies
+    LeapsecondKernel = $base/kernels/lsk/naif0008.tls
+  End_Group
+
+  Group = Selection
+    Time        = ("2002 FEB 20 22:59:01.701369 TDB",
+                   "2002 FEB 20 22:59:09.296828 TDB")
+    Instrument  = THEMIS_IR
+    StartOffset = 0.263
+    EndOffset   = 171.871
+    File        = data/kerneldbgen/thmIR.bsp
+    Type        = Smithed
+  End_Group
+End_Object
+End


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Spiceinit using KernelDB to grab matching kernels for particular cube. This tests that Themis IR cubes are grabbing the smithed kernels by using the time offsets in db files.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Kernel Timing Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
