### PR TITLE
Noproj Test Fixes

### DIFF
--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -184,11 +184,13 @@ namespace Isis {
 
     // Can we do a regular label? Didn't work on 12-15-2006
     cao.setLabelAttachment(Isis::DetachedLabel);
+    FileName matchCubeFile = FileName::createTempFile("./match.cub");
+    QString matchCubeFileNoExt = matchCubeFile.path() + "/" + matchCubeFile.baseName();
 
     // Determine the output image size from
     //   1) the idealInstrument pvl if there or
     //   2) the input size expanded by user specified percentage
-    Cube *ocube = p.SetOutputCube("match.cub", cao, 1, 1, 1);
+    Cube *ocube = p.SetOutputCube(matchCubeFile.expanded(), cao, 1, 1, 1);
     // Extract the times and the target from the instrument group
     QString startTime = inst["StartTime"];
     QString stopTime;
@@ -350,32 +352,32 @@ namespace Isis {
   // Now adjust the label to fake the true size of the image to match without
   // taking all the space it would require for the image data
     Pvl label;
-    label.read("match.lbl");
+    label.read(matchCubeFileNoExt + ".lbl");
     PvlGroup &dims = label.findGroup("Dimensions", Pvl::Traverse);
     dims["Lines"] = toString(numberLines);
     dims["Samples"] = toString(detectorSamples);
     dims["Bands"] = toString(numberBands);
-    label.write("match.lbl");
+    label.write(matchCubeFileNoExt + ".lbl");
 
   // And run cam2cam to apply the transformation
     QVector<QString> args = {"to=" + ui.GetFileName("TO"), "INTERP=" + ui.GetString("INTERP")};
     UserInterface cam2camUI(FileName("$ISISROOT/bin/xml/cam2cam.xml").expanded(), args);
     Cube matchCube;
-    matchCube.open("match.cub", "rw");
+    matchCube.open(matchCubeFile.expanded(), "rw");
     cam2cam(icube, &matchCube, cam2camUI);
 
   //  Cleanup by deleting the match files
-    remove("match.History.IsisCube");
-    remove("match.lbl");
-    remove("match.cub");
-    remove("match.OriginalLabel.IsisCube");
-    remove("match.Table.BodyRotation");
-    remove("match.Table.HiRISE Ancillary");
-    remove("match.Table.HiRISE Calibration Ancillary");
-    remove("match.Table.HiRISE Calibration Image");
-    remove("match.Table.InstrumentPointing");
-    remove("match.Table.InstrumentPosition");
-    remove("match.Table.SunPosition");
+    remove((matchCubeFileNoExt + ".History.IsisCube").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".lbl").toStdString().c_str());
+    remove(matchCubeFile.expanded().toStdString().c_str());
+    remove((matchCubeFileNoExt + ".OriginalLabel.IsisCube").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".Table.BodyRotation").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".Table.HiRISE Ancillary").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".Table.HiRISE Calibration Ancillary").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".Table.HiRISE Calibration Image").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".Table.InstrumentPointing").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".Table.InstrumentPosition").toStdString().c_str());
+    remove((matchCubeFileNoExt + ".Table.SunPosition").toStdString().c_str());
 
   // Finally finish by adding the OriginalInstrument group to the TO cube
     Cube toCube;

--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -184,7 +184,7 @@ namespace Isis {
 
     // Can we do a regular label? Didn't work on 12-15-2006
     cao.setLabelAttachment(Isis::DetachedLabel);
-    FileName matchCubeFile = FileName::createTempFile("./match.cub");
+    FileName matchCubeFile = FileName::createTempFile("$Temporary/match.cub");
     QString matchCubeFileNoExt = matchCubeFile.path() + "/" + matchCubeFile.baseName();
 
     // Determine the output image size from


### PR DESCRIPTION
Change match file creation to a temp file, fixing noproj tests

## Description
Updates a file created in noproj that resulted in collision when running tests in parallel. This file is no created as a temporary file that adds random characters to the file. Thus, avoiding the collision with other noproj tests. This issue wasn't detected in the original noproj conversion PR (#4384) as the tests were run sequentially locally and likely passed by chance in Jenkins

## Related Issue
N/A

## Motivation and Context
Clean Jenkins

## How Has This Been Tested?
This is a test

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
