### PR TITLE
Fix Conda Build Test

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -161,7 +161,7 @@ test:
     - test -e $PREFIX/lib/libisis${SHLIB_EXT}
     - test -e $PREFIX/include/isis/Isis.h
     - test -e $PREFIX/bin/isisimport
-    - ISISROOT=$PREFIX && isisimport -HELP
+    - ISISROOT=$PREFIX isisimport -HELP
  
 
 about:


### PR DESCRIPTION
Updates the conda build test to work properly. Replicates a fix present in the 7.0 branch

## Description
The command has an unnecessary command line && when trying to run an ISIS application. The && needs to be removed to ensure that ISISROOT is set when the ISIS application is run.

## Related Issue
N/A

## Motivation and Context
Clean conda builds

## How Has This Been Tested?
By hand

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
