### PR TITLE
Fixed qnet combo boxes allowing inserts

### DIFF
--- a/isis/src/qisis/objs/QnetTools/QnetTool.cpp
+++ b/isis/src/qisis/objs/QnetTools/QnetTool.cpp
@@ -332,6 +332,7 @@ namespace Isis {
 
     m_leftCombo = new QComboBox;
     m_leftCombo->setEditable(true);
+    m_leftCombo->setInsertPolicy(QComboBox::NoInsert);
     m_leftCombo->setToolTip("Choose left control measure");
     m_leftCombo->setWhatsThis("Choose left control measure identified by "
                               "cube filename.");
@@ -405,6 +406,7 @@ namespace Isis {
     // create widgets for the right groupbox
     m_rightCombo = new QComboBox;
     m_rightCombo->setEditable(true);
+    m_rightCombo->setInsertPolicy(QComboBox::NoInsert);
 
     // Attach shortcuts to Qnet Tool's window for selecting right measures
     // Note: Qt handles this memory for us since m_qnetTool is the parent of these shortcuts


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed the qnet tool measure selection combo boxes allow users to insert new values causing crashes.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#4581

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The combo boxes were made editable in #4595 but that also allowed users to insert new values which causes a crash.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on two networks with 2-10 measure deep points.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
