### PR TITLE
manually added oglab onto HRSC stereo images, removed unsued functions in hrsc2isis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ release.
 
 ### Fixed
 - Modified cnetcheck noLatLonCheck logic to correctly exclude ignored measures. [#4649](https://github.com/USGS-Astrogeology/ISIS3/issues/4649)
+- Fixed bug where the original label was not attached to stereo HRSC images on import [#4816](https://github.com/USGS-Astrogeology/ISIS3/issues/4816)
 
 
 ## [7.0.0] - 2022-02-11

--- a/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
+++ b/isis/src/mex/apps/hrsc2isis/hrsc2isis.cpp
@@ -15,12 +15,11 @@ find files of those names at the top level of this repository. **/
 #include "LineManager.h"
 #include "IException.h"
 #include "Application.h"
+#include "OriginalLabel.h"
 
 using namespace std;
 namespace Isis{
-  void ImportHrscStereoImage(ProcessImportPds &p, Pvl &label);
-  void ImportHrscStereoImage(ProcessImportPds &p, Pvl &label, UserInterface &ui);
-  void ImportHrscSrcImage(ProcessImportPds &p, Pvl &label);
+  void ImportHrscStereoImage(ProcessImportPds &p, Pvl &label, UserInterface &ui, Pvl &originalLab);
   void ImportHrscSrcImage(ProcessImportPds &p, Pvl &label, UserInterface &ui);
 
   void IgnoreData(Isis::Buffer &buf);
@@ -85,46 +84,11 @@ namespace Isis{
       ImportHrscSrcImage(p, label, ui);
     }
     else {
-      ImportHrscStereoImage(p, label, ui);
+      ImportHrscStereoImage(p, label, ui, label);
     }
 
 
   }
-
-
-  // Import a PDS3, HRSC, SRC Camera image.
-  void ImportHrscSrcImage(ProcessImportPds &p, Pvl &label) {
-
-    outCube = p.SetOutputCube("TO");
-    p.StartProcess();
-
-    Pvl otherLabels;
-    TranslateHrscLabels(label, otherLabels);
-
-    if (otherLabels.hasGroup("Instrument") &&
-        (otherLabels.findGroup("Instrument").keywords() > 0)) {
-      outCube->putGroup(otherLabels.findGroup("Instrument"));
-    }
-
-    if (otherLabels.hasGroup("BandBin") &&
-        (otherLabels.findGroup("BandBin").keywords() > 0)) {
-      outCube->putGroup(otherLabels.findGroup("BandBin"));
-    }
-
-    if (otherLabels.hasGroup("Archive") &&
-        (otherLabels.findGroup("Archive").keywords() > 0)) {
-      outCube->putGroup(otherLabels.findGroup("Archive"));
-    }
-
-    if (otherLabels.hasGroup("Kernels") &&
-        (otherLabels.findGroup("Kernels").keywords() > 0)) {
-      outCube->putGroup(otherLabels.findGroup("Kernels"));
-    }
-
-    p.EndProcess();
-  }
-
-
 
   // Import a PDS3, HRSC, SRC Camera image.
   void ImportHrscSrcImage(ProcessImportPds &p, Pvl &label, UserInterface &ui) {
@@ -178,14 +142,7 @@ namespace Isis{
    * NOTE: Regardless of the input file's byte order IMAGE-SAMPLE_TYPE, the prefix data byte order
    * is always LSB.
    */
-
-  void ImportHrscStereoImage(ProcessImportPds &p, Pvl &label) {
-    UserInterface &ui = Application::GetUserInterface();
-    ImportHrscStereoImage(p, label, ui);
-  }
-
-
-  void ImportHrscStereoImage(ProcessImportPds &p, Pvl &label, UserInterface &ui) {
+  void ImportHrscStereoImage(ProcessImportPds &p, Pvl &label, UserInterface &ui, Pvl &originalLab) {
     lineInFile.clear();
     numLinesSkipped = 0;
 
@@ -292,6 +249,10 @@ namespace Isis{
         (otherLabels.findGroup("Kernels").keywords() > 0)) {
       outCube->putGroup(otherLabels.findGroup("Kernels"));
     }
+
+
+    OriginalLabel ol(originalLab);
+    outCube->write(ol);
 
     p.EndProcess();
 

--- a/isis/tests/FunctionalTestsHrsc2isis.cpp
+++ b/isis/tests/FunctionalTestsHrsc2isis.cpp
@@ -7,6 +7,7 @@
 #include "PvlGroup.h"
 #include "TestUtilities.h"
 #include "Histogram.h"
+#include "OriginalLabel.h"
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -81,6 +82,11 @@ TEST(Hrsc2isis, Hrsc2IsisTestDefault) {
   ASSERT_DOUBLE_EQ(hist->Sum(), 409993);
   ASSERT_EQ(hist->ValidPixels(), 6440);
   ASSERT_NEAR(hist->StandardDeviation(), 6.36599, .00001);
+
+  // check original label exists 
+  Pvl ogLab = cube.readOriginalLabel().ReturnLabels();
+  ASSERT_EQ(archive["DETECTOR_ID"][0].toStdString(), "MEX_HRSC_RED" );
+
 }
 
 
@@ -134,6 +140,10 @@ TEST(Hrsc2isis, Hrsc2IsisTestPhobos) {
   ASSERT_DOUBLE_EQ(hist->Sum(), 2496);
   ASSERT_EQ(hist->ValidPixels(), 25920);
   ASSERT_NEAR(hist->StandardDeviation(), 0.52835, .00001);
+
+  // check original label exists 
+  Pvl ogLab = cube.readOriginalLabel().ReturnLabels();
+  ASSERT_EQ(archive["DETECTOR_ID"][0].toStdString(), "MEX_HRSC_S2" );
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

`hrsc2isis` has two different functions for processing PDS image, stereo vs non-stereo, the latter created an empty cube rather than letting the Process object handle creating the cube, as such `ProcessImportPds::Finalize()` was never called on the output cube which is where the original PDS label would have been attached. 

Also removed some redundant functions in hrsc2isis.cpp that were not being used. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

closes https://github.com/USGS-Astrogeology/ISIS3/issues/4816

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Depending on the `DETECTOR_ID` on the input HRSC image, the original PDS labels were not attached. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
