### PR TITLE
fixed build warnings on bigsur OS

### DIFF
--- a/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
+++ b/isis/src/base/objs/OriginalXmlLabel/OriginalXmlLabel.cpp
@@ -57,8 +57,8 @@ namespace Isis {
    */
   void OriginalXmlLabel::fromBlob(Isis::Blob blob) {
     QString errorMessage;
-    int errorLine;
-    int errorColumn;
+    int errorLine = 0;
+    int errorColumn = 0;
 
     if ( !m_originalLabel.setContent( QByteArray(blob.getBuffer(), blob.Size()) ) ) {
       QString msg = "XML read/parse error when parsing original label. "

--- a/isis/src/base/objs/Ransac/Ransac.h
+++ b/isis/src/base/objs/Ransac/Ransac.h
@@ -137,7 +137,7 @@ namespace Isis {
        flag  -> type of solutions sought: 1 decomposition only, 2 decomposition and solve, 3 decompose solve and inverse a
      */
 
-    if (flag < 1 && flag > 3)
+    if (flag < 1 || flag > 3)
       return NOT_SOLVABLE;
 
     /*************** STEP 1:  DECOMPOSE THE A MATRIX ***************/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Changed exiting uninitialized variables to be initialized, as well as changing a broken if check. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
https://github.com/USGS-Astrogeology/ISIS3/issues/4765

<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Before fixing, there were a few warnings upon building ISIS with BigSur OS


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Started with a fresh build to verify what warnings were being triggered, after changing the code I created a fresh build again to ensure that the warnings were fixed. 

<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Before:
![Pasted Graphic](https://user-images.githubusercontent.com/78241862/162829734-86985deb-e8ae-443d-bf86-3afc7071db10.png)

After:
![igswzawglt1898build gnelson$ ninja](https://user-images.githubusercontent.com/78241862/162830066-5bc4edea-d623-465a-bb65-a852b646fa51.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
