### PR TITLE
Fixed lrowac2pds FROMLIST

### DIFF
--- a/isis/src/lro/apps/lrowac2pds/lrowac2pds.cpp
+++ b/isis/src/lro/apps/lrowac2pds/lrowac2pds.cpp
@@ -75,10 +75,10 @@ namespace Isis {
       Pvl pdsLab;
 
       FileList list;
-      list.read(ui.GetCubeName("FROMLIST"));
+      list.read(ui.GetFileName("FROMLIST"));
 
       if (list.size() < 1) {
-          QString msg = "The list file [" + ui.GetCubeName("FROMLIST") + "does not contain any data";
+          QString msg = "The list file [" + ui.GetFileName("FROMLIST") + "does not contain any data";
           throw IException(IException::User, msg, _FILEINFO_);
       }
 

--- a/isis/src/lro/apps/lrowac2pds/lrowac2pds.xml
+++ b/isis/src/lro/apps/lrowac2pds/lrowac2pds.xml
@@ -31,10 +31,10 @@
         <type>File</type>
         <fileMode>input</fileMode>
         <brief>
-          Input File to be converted
+          A list of cubes to import
         </brief>
         <description>
-          The File to be converted to PDS IMG format.
+          A file containing a list of PDS3 files to be imported.
         </description>
         <filter>
           *.cub

--- a/isis/src/lro/apps/lrowac2pds/lrowac2pds.xml
+++ b/isis/src/lro/apps/lrowac2pds/lrowac2pds.xml
@@ -28,13 +28,13 @@
   <groups>
     <group name="Files">
       <parameter name="FROMLIST">
-        <type>cube</type>
+        <type>File</type>
         <fileMode>input</fileMode>
         <brief>
-          Input cube to be converted
+          Input File to be converted
         </brief>
         <description>
-          The cube to be converted to PDS IMG format.
+          The File to be converted to PDS IMG format.
         </description>
         <filter>
           *.cub


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The FROMLIST for lrowac2pds was defined as a cube when it should have been a file. 

## Description
<!--- Describe your changes in detail -->
Changed references of `GetCubeName` to `GetFileName`

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
https://github.com/USGS-Astrogeology/ISIS3/issues/4826
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
