### PR TITLE
Fixed -last not printing program name

### DIFF
--- a/isis/src/base/objs/UserInterface/UserInterface.cpp
+++ b/isis/src/base/objs/UserInterface/UserInterface.cpp
@@ -518,7 +518,7 @@ namespace Isis {
       }
 
     }
-    if(usedDashLast == true){
+    if(usedDashLast) {
       Pvl temp;
       CommandLine(temp);
       cout << BuildNewCommandLineFromPvl(temp) << endl;
@@ -543,7 +543,7 @@ namespace Isis {
   QString UserInterface::BuildNewCommandLineFromPvl(Pvl temp){
     PvlGroup group = temp.group(0);
     int numKeywords = group.keywords();
-    QString returnVal = ""; 
+    QString returnVal = p_progName + " ";
 
     for(int i = 0; i < numKeywords; i++){
       PvlKeyword key = group[i];

--- a/isis/src/base/objs/UserInterface/UserInterface.truth
+++ b/isis/src/base/objs/UserInterface/UserInterface.truth
@@ -83,7 +83,7 @@ Testing Reserved Parameter=Invalid Value
 **USER ERROR** Invalid value for reserve parameter [-VERBOSE].
 
 Testing Unambiguous Reserved Parameter Resolution (-la)
-./unitTest From=It To=Worked 
+./unitTest FROM=It TO=Worked TESTONE=0 TESTTWO=1 TESTTHREE=1 LISTTEST=INCLUDEOPT EXCLUDEDTEST=10 
 FROM:    It
 TO:      Worked
 GUI:     0
@@ -143,11 +143,10 @@ Testing -BATCHLIST with -SAVE
 **USER ERROR** -BATCHLIST cannot be used with -GUI, -SAVE, -RESTORE, or -LAST.
 
 Testing -BATCHLIST with -RESTORE
-./unitTest From=It To=Worked 
 **USER ERROR** -BATCHLIST cannot be used with -GUI, -SAVE, -RESTORE, or -LAST.
 
 Testing -BATCHLIST with -LAST
-./unitTest From=It To=Worked 
+./unitTest FROM=$1 TO=$2 TESTONE=0 TESTTWO=1 TESTTHREE=1 LISTTEST=INCLUDEOPT EXCLUDEDTEST=10 
 **USER ERROR** -BATCHLIST cannot be used with -GUI, -SAVE, -RESTORE, or -LAST.
 
 Testing -BATCHLIST with nonexistent .lis file
@@ -266,13 +265,13 @@ GetInfoFlag() returns: 1
 GetInfoFileName() returns: debug.log
 
 Testing -LAST
-./unitTest From=It To=Worked 
+./unitTest FROM=It TO=Worked TESTONE=0 TESTTWO=1 TESTTHREE=1 LISTTEST=INCLUDEOPT EXCLUDEDTEST=10 
 FROM:    It
 TO:      Worked
 GUI:     0
 
 Testing -LAST with other app parameters
-./unitTest From=It To=Worked 
+./unitTest FROM=otherParam TO=Worked TESTONE=0 TESTTWO=1 TESTTHREE=1 LISTTEST=INCLUDEOPT EXCLUDEDTEST=10 
 FROM:    otherParam
 TO:      Worked
 GUI:     0
@@ -286,7 +285,6 @@ FileOutput = On
 FileName = unitTest.prt
 
 Testing -RESTORE with valid (existing) .par file
-./unitTest From=It To=Worked 
 FROM:    It
 TO:      Worked
 GUI:     0
@@ -310,7 +308,6 @@ TO:      works
 GUI:     0
 
 Restoring Saved Parameters:
-./unitTest FROM=saveParam TO=works 
 FROM:    saveParam
 TO:      works
 GUI:     0


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed the cout in -last so that it prints the program name and then the parameters. Also updated the unit test based on the changes in #4884 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#4617

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

the change in #4884 removed printing out the program name, it also didn't update the unit test to account for printing out the default arguments too.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on Mac to ensure it prints the program name correctly now:

before:

```
(isis_build) jmapel@prog28:/work/users/jmapel/ISIS3/build$ stats from=/work/users/jmapel/Juno/serial_num/JNCE_2020154_27C00007_V01_GREEN_0003.cub 
Group = Results
  From                    = /work/users/jmapel/Juno/serial_num/JNCE_2020154_2-
                            7C00007_V01_GREEN_0003.cub
  Band                    = 1
  Average                 = 3.3909805445995
  StandardDeviation       = 1.7744051067087
  Variance                = 3.1485134827141
  Median                  = 3.0
  Mode                    = 3.0
  Skew                    = 0.66103373427175
  Minimum                 = 0.0
  Maximum                 = 107.0
  Sum                     = 715307.0
  TotalPixels             = 210944
  ValidPixels             = 210944
  OverValidMaximumPixels  = 0
  UnderValidMinimumPixels = 0
  NullPixels              = 0
  LisPixels               = 0
  LrsPixels               = 0
  HisPixels               = 0
  HrsPixels               = 0
End_Group
(isis_build) jmapel@prog28:/work/users/jmapel/ISIS3/build$ stats -last to=last_test.csv format=flat
FROM=/work/users/jmapel/Juno/serial_num/JNCE_2020154_27C00007_V01_GREEN_0003.cub TO=last_test.csv FORMAT=flat APPEND=TRUE 
Group = Results
  From                    = /work/users/jmapel/Juno/serial_num/JNCE_2020154_2-
                            7C00007_V01_GREEN_0003.cub
  Band                    = 1
  Average                 = 3.3909805445995
  StandardDeviation       = 1.7744051067087
  Variance                = 3.1485134827141
  Median                  = 3.0
  Mode                    = 3.0
  Skew                    = 0.66103373427175
  Minimum                 = 0.0
  Maximum                 = 107.0
  Sum                     = 715307.0
  TotalPixels             = 210944
  ValidPixels             = 210944
  OverValidMaximumPixels  = 0
  UnderValidMinimumPixels = 0
  NullPixels              = 0
  LisPixels               = 0
  LrsPixels               = 0
  HisPixels               = 0
  HrsPixels               = 0
End_Group
```

After:

```
(isis_build) jmapel@prog28:/work/users/jmapel/ISIS3/build$ stats from=/work/users/jmapel/Juno/serial_num/JNCE_2020154_27C00007_V01_GREEN_0003.cub 
Group = Results
  From                    = /work/users/jmapel/Juno/serial_num/JNCE_2020154_2-
                            7C00007_V01_GREEN_0003.cub
  Band                    = 1
  Average                 = 3.3909805445995
  StandardDeviation       = 1.7744051067087
  Variance                = 3.1485134827141
  Median                  = 3.0
  Mode                    = 3.0
  Skew                    = 0.66103373427175
  Minimum                 = 0.0
  Maximum                 = 107.0
  Sum                     = 715307.0
  TotalPixels             = 210944
  ValidPixels             = 210944
  OverValidMaximumPixels  = 0
  UnderValidMinimumPixels = 0
  NullPixels              = 0
  LisPixels               = 0
  LrsPixels               = 0
  HisPixels               = 0
  HrsPixels               = 0
End_Group
(isis_build) jmapel@prog28:/work/users/jmapel/ISIS3/build$ stats -last to=last_test.csv format=flat
stats FROM=/work/users/jmapel/Juno/serial_num/JNCE_2020154_27C00007_V01_GREEN_0003.cub TO=last_test.csv FORMAT=flat APPEND=TRUE 
Group = Results
  From                    = /work/users/jmapel/Juno/serial_num/JNCE_2020154_2-
                            7C00007_V01_GREEN_0003.cub
  Band                    = 1
  Average                 = 3.3909805445995
  StandardDeviation       = 1.7744051067087
  Variance                = 3.1485134827141
  Median                  = 3.0
  Mode                    = 3.0
  Skew                    = 0.66103373427175
  Minimum                 = 0.0
  Maximum                 = 107.0
  Sum                     = 715307.0
  TotalPixels             = 210944
  ValidPixels             = 210944
  OverValidMaximumPixels  = 0
  UnderValidMinimumPixels = 0
  NullPixels              = 0
  LisPixels               = 0
  LrsPixels               = 0
  HisPixels               = 0
  HrsPixels               = 0
End_Group
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
