### PR TITLE
fixed error where footprint fails to generate on some map projected images. fixes #4390

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ release.
 
 ## [Unreleased]
 
+- Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
+
 ### Changed
 
 ### Added

--- a/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
+++ b/isis/src/base/objs/ImagePolygon/ImagePolygon.cpp
@@ -641,6 +641,7 @@ namespace Isis {
 
     // Find the edge of the polygon
     geos::geom::Coordinate firstPoint = FindFirstPoint();
+
     points.push_back(firstPoint);
     //************************
     // Start walking the edge
@@ -653,8 +654,6 @@ namespace Isis {
 
     do {
       tempPoint = FindNextPoint(&currentPoint, lastPoint);
-      //exit(1);
-
 
       // First check if the distance is within range of skipping
       bool snapToFirstPoint = true;
@@ -687,7 +686,6 @@ namespace Isis {
           }
         }
       }
-
       // Failed to find the next point
       if (tempPoint.equals(currentPoint)) {
         geos::geom::Coordinate oldDuplicatePoint = tempPoint;
@@ -852,7 +850,8 @@ namespace Isis {
 
       if (nPoleSample >= 0.5 && nPoleLine >= 0.5 &&
          nPoleSample <= p_cube->sampleCount() + 0.5 &&
-         nPoleLine <= p_cube->lineCount() + 0.5) {
+         nPoleLine <= p_cube->lineCount() + 0.5 &&
+         SetImage(nPoleSample, nPoleLine)) {
         hasNorthPole = true;
       }
     }
@@ -872,7 +871,8 @@ namespace Isis {
 
       if (sPoleSample >= 0.5 && sPoleLine >= 0.5 &&
          sPoleSample <= p_cube->sampleCount() + 0.5 &&
-         sPoleLine <= p_cube->lineCount() + 0.5) {
+         sPoleLine <= p_cube->lineCount() + 0.5 &&
+         SetImage(sPoleSample, sPoleLine)) {
         hasSouthPole = true;
       }
     }
@@ -1153,6 +1153,7 @@ namespace Isis {
     for (unsigned int i = 1; i < p_pts->getSize(); i++) {
       lon = p_pts->getAt(i).x;
       lat = p_pts->getAt(i).y;
+      
       // check to see if you just crossed the Meridian
       if (abs(lon - prevLon) > 180 && (prevLat != 90 && prevLat != -90)) {
         newCoords = true;
@@ -1328,6 +1329,11 @@ namespace Isis {
       std::string msg = "Unable to create image footprint (Fix360Poly) due to ";
       msg += "isis operation exception [" + IString(e.what()) + "]";
       throw IException(e, IException::Unknown, msg, _FILEINFO_);
+    }
+    catch(std::exception &e) {
+      std::string msg = "Caught std::exception: ";
+      msg += e.what();
+      throw IException(IException::Unknown, msg, _FILEINFO_); 
     }
     catch(...) {
       std::string msg = "Unable to create image footprint (Fix360Poly) due to ";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixes bug where footprints fail to generate when these specific conditions are met: 

1. Input image is map projected 
2. target crosses the 0/360 boundary
3. some line/sample in the image projects to the polar lat lons: (90,0) and/or (-90/0) 
4. that line sample that projects to (90,0)/(-90, 0) does not project onto the body/is a null pixel. 

Which results in the image footprint becoming mangled. 

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/USGS-Astrogeology/ISIS3/issues/4390

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Some map projected images were not generating valid footprints. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Original image in the issue successfully generated it's footprint when it previous excepted with incomplete linear ring coordinates. 

## Screenshots (if appropriate):

using image: `/archive/projects/europa/GLL_FinProducts/*/33ESGLOCOL01_GalileoSSI_Equi.cub`

Footprint trying to cross the pole, had to use a web geojson app since I had incomplete coords I was just printing out: 

<img width="282" alt="Screen Shot 2022-04-11 at 2 48 44 PM" src="https://user-images.githubusercontent.com/13245976/163527125-58126ce9-6cba-43fb-b423-c43eb9ce289b.png">

After fix, viewed in qmos:

<img width="295" alt="Screen Shot 2022-04-14 at 10 19 35 PM" src="https://user-images.githubusercontent.com/13245976/163527111-357e29c8-7432-43c6-97e8-81e0dc50a82e.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
