### PR TITLE
fixes bug where cam2map doesn't project multiple bands on band dependent camera models (fixes #4635)

### DIFF
--- a/isis/src/base/apps/cam2map/cam2map.cpp
+++ b/isis/src/base/apps/cam2map/cam2map.cpp
@@ -462,7 +462,9 @@ namespace Isis {
   bool cam2mapForward::Xform(double &outSample, double &outLine,
                              const double inSample, const double inLine) {
     // See if the input image coordinate converts to a lat/lon
-    if (!p_incam->SetImage(inSample,inLine)) return false;
+    if (!p_incam->SetImage(inSample,inLine)) {
+      return false;
+    }
 
     // Does that ground coordinate work in the map projection
     double lat = p_incam->UniversalLatitude();
@@ -568,6 +570,7 @@ namespace Isis {
   }
 
   void bandChange(const int band) {
+    // band dependant band change
     incam->SetBand(band);
   }
 }

--- a/isis/src/base/objs/Camera/Camera.cpp
+++ b/isis/src/base/objs/Camera/Camera.cpp
@@ -2690,7 +2690,7 @@ namespace Isis {
    */
   bool Camera::HasProjection() {
     return p_projection != 0;
-    }
+  }
 
 
   /**

--- a/isis/src/lro/objs/LroWideAngleCamera/LroWideAngleCamera.cpp
+++ b/isis/src/lro/objs/LroWideAngleCamera/LroWideAngleCamera.cpp
@@ -232,28 +232,35 @@ namespace Isis {
   void LroWideAngleCamera::SetBand(const int vband) {
 
     // Sanity check on requested band
-    int maxbands = min(p_detectorStartLines.size(), p_frameletOffsets.size());
-    if ((vband <= 0) || (vband > maxbands)) {
+    int maxVirtualBands = min(p_detectorStartLines.size(), p_frameletOffsets.size());
+    if (((vband <= 0) || (vband > maxVirtualBands)) && (vband > Bands())) {
       ostringstream mess;
       mess << "Requested virtual band (" << vband
-           << ") outside valid (BandBin/Center) limits (1 - " << maxbands
+           << ") outside valid (BandBin/Center) limits (1 - " << maxVirtualBands
            <<  ")";
       throw IException(IException::Programmer, mess.str(), _FILEINFO_);
     }
 
     //  Set up valid band access
     Camera::SetBand(vband);
+    if ((vband > maxVirtualBands) && (vband <= Bands())) {
+      // probably switching to a band from phocube or similar
+      // instead of a different filter band, so just re-use the 
+      // properties from the current band. 
+      return;
+    }
+
     PushFrameCameraDetectorMap *dmap = NULL;
     dmap = (PushFrameCameraDetectorMap *) DetectorMap();
-    dmap->SetBandFirstDetectorLine(p_detectorStartLines[vband - 1]);
-    dmap->SetFrameletOffset(p_frameletOffsets[vband - 1]);
+    dmap->SetBandFirstDetectorLine(p_detectorStartLines.at(vband - 1));
+    dmap->SetFrameletOffset(p_frameletOffsets.at(vband - 1));
 
-    SetFocalLength(p_focalLength[vband-1]);
+    SetFocalLength(p_focalLength.at(vband-1));
 
     LroWideAngleCameraFocalPlaneMap *fplane = (LroWideAngleCameraFocalPlaneMap *) FocalPlaneMap();
     fplane->setBand(vband);
-    fplane->SetDetectorOrigin(p_boreSightSample[vband-1] + 1.0,
-                              p_boreSightLine[vband-1]   + 1.0);
+    fplane->SetDetectorOrigin(p_boreSightSample.at(vband-1) + 1.0,
+                              p_boreSightLine.at(vband-1)   + 1.0);
 
     LroWideAngleCameraDistortionMap *distort = (LroWideAngleCameraDistortionMap *) DistortionMap();
     distort->setBand(vband);
@@ -321,7 +328,9 @@ namespace Isis {
    * @return bool False
    */
   bool LroWideAngleCamera::IsBandIndependent() {
-    return false;
+    // only band independant if there is one filter 
+    // band on the image
+    return p_frameletOffsets.size() == 1;
   }
 
 

--- a/isis/tests/UnitTestMarciCam.cpp
+++ b/isis/tests/UnitTestMarciCam.cpp
@@ -1,0 +1,41 @@
+#include "MarciCamera.h" 
+#include "PushFrameCameraDetectorMap.h"
+
+#include "Fixtures.h"
+#include "gmock/gmock.h"
+
+using namespace Isis;
+
+TEST_F(TempTestingFiles, UnitTestMarciCameraPhocubeBandChange) {
+
+  QString cubeFileName = "data/marcical/P12_005901_3391_MA_00N096W_cropped.cub";
+  
+  // simulate phocube 
+  std::istringstream bbin_stream(R"( 
+     Group = BandBin
+       FilterName   = BLUE
+       OriginalBand = (1, 1, 1, 1, 1)
+       Name         = ("Phase Angle", "Emission Angle", "Incidence Angle",
+                       Latitude, Longitude)
+       Center       = (1.0, 1.0, 1.0, 1.0, 1.0)
+       Width        = (1.0, 1.0, 1.0, 1.0, 1.0)
+     End_Group
+  )");
+   
+  PvlGroup newbbin;
+  bbin_stream >> newbbin;
+  
+  Cube cube(cubeFileName);
+  Pvl *isisLabel = cube.label();
+  PvlGroup &ogbbin = isisLabel->findGroup("BandBin", Pvl::Traverse);
+  ogbbin = newbbin;
+  
+  Camera *cam = cube.camera();
+  PushFrameCameraDetectorMap *dmap = (PushFrameCameraDetectorMap*) cam->DetectorMap();
+
+  // properties should BLUE filter's properties after band change 
+  cam->SetBand(1);
+  EXPECT_EQ(dmap->GetBandFirstDetectorLine(), 709);
+  cam->SetBand(4);
+  EXPECT_EQ(dmap->GetBandFirstDetectorLine(), 709);
+}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When phocube is run on a Marci or LRO WAC image, then that image is run through cam2map, only the first band is projected and the rest have only NULL DNs. In the case of LRO WAC, it'll fail with an exception. 

This is because when trying to set camera parameters in the `SetBand` method overwritten in Marci and LRO WAC camera classes, the output of phocube has bands that the camera doesn't expect and doesn't properly set the camera parameters for the new band causing projections for any band number > 1 to fail the projection process.  

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

fixes https://github.com/USGS-Astrogeology/ISIS3/issues/4635

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The original image in the issue projected successfully. Still needs some tests added. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
