### PR TITLE
fixed even odd in framestitch

### DIFF
--- a/isis/src/base/apps/framestitch/framestitch.cpp
+++ b/isis/src/base/apps/framestitch/framestitch.cpp
@@ -82,14 +82,14 @@ namespace Isis {
   void framestitch(UserInterface &ui) {
     ProcessByBrick process;
 
-    // It is very important that the even cube gets added first as later on
+    // It is very important that the odd cube gets added first as later on
     // we'll use frameNumber % 2 to index the input cube vector
-    QString evenCubeFile = ui.GetCubeName("EVEN");
-    Cube* evenCube = process.SetInputCube(evenCubeFile,
-                                          CubeAttributeInput(evenCubeFile));
     QString oddCubeFile = ui.GetCubeName("ODD");
     Cube* oddCube = process.SetInputCube(oddCubeFile,
                                          CubeAttributeInput(oddCubeFile));
+    QString evenCubeFile = ui.GetCubeName("EVEN");
+    Cube* evenCube = process.SetInputCube(evenCubeFile,
+                                          CubeAttributeInput(evenCubeFile));
 
 
     // Check that all the inputs are valid
@@ -168,7 +168,7 @@ namespace Isis {
      * Frame stitching processing function
      */
     auto interweaveFrames = [&](std::vector<Buffer *> &in, std::vector<Buffer *> &out)->void {
-      // Assumes even is first and odd is second
+      // Assumes odd is first and even is second
       int inIndex = (in[0]->Line() / frameHeight) % 2;
       if (swapInputCubes) {
         inIndex = 1 - inIndex;

--- a/isis/tests/Fixtures.cpp
+++ b/isis/tests/Fixtures.cpp
@@ -273,10 +273,10 @@ namespace Isis {
       }
       frameBrick.SetBasePosition(1,frameIndex * frameHeight + 1,1);
       if (frameIndex % 2 == 0) {
-        evenCube->write(frameBrick);
+        oddCube->write(frameBrick);
       }
       else {
-        oddCube->write(frameBrick);
+        evenCube->write(frameBrick);
       }
     }
 
@@ -313,10 +313,10 @@ namespace Isis {
       }
       frameBrick.SetBasePosition(1,frameIndex * frameHeight + 1,1);
       if (frameIndex % 2 == 0) {
-        oddCube->write(frameBrick);
+        evenCube->write(frameBrick);
       }
       else {
-        evenCube->write(frameBrick);
+        oddCube->write(frameBrick);
       }
     }
 

--- a/isis/tests/FunctionalTestsFrameStitch.cpp
+++ b/isis/tests/FunctionalTestsFrameStitch.cpp
@@ -390,14 +390,14 @@ TEST_F(PushFramePair, FunctionalTestFramestitchAutoMismatchedHeights) {
 }
 
 TEST_F(PushFramePair, FunctionalTestFramestitchAutoDifferentHeights) {
-  // Make frame 6 NULL so that there is a 36 line null frame
-  Brick frameBrick(numSamps, frameHeight, numBands, evenCube->pixelType());
+  // Make frame 7 NULL so that there is a 36 line null frame
+  Brick frameBrick(numSamps, frameHeight, numBands, oddCube->pixelType());
   for (int brickIndex = 0; brickIndex < frameBrick.size(); brickIndex++) {
     frameBrick[brickIndex] = Null;
   }
   frameBrick.SetBasePosition(1,6 * frameHeight + 1,1);
-  evenCube->write(frameBrick);
-  evenCube->reopen("rw");
+  oddCube->write(frameBrick);
+  oddCube->reopen("rw");
 
   QVector<QString> args = {
         "EVEN="+evenCube->fileName(),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When writing the new framestitch app I accidentally tested it on a flipped image and it resulted in the even and odd inputs being flipped. This PR fixes it so that it follows the 1-based frame indexing where the first frame in the image is in the odd frame cube.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#4924 and #4936

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This gets it working properly with un-flipped images.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested on LRO WAC stereo images from https://github.com/USGS-Astrogeology/usgscsm/issues/365

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
