### PR TITLE
Incremental bugfix for stitching WAC framelets

### DIFF
--- a/isis/src/base/apps/framestitch/framestitch.cpp
+++ b/isis/src/base/apps/framestitch/framestitch.cpp
@@ -145,10 +145,10 @@ namespace Isis {
       frameHeight = evenFrameHeight;
     }
 
-    int numLinesOverlap = 0; // The default value
-    if (ui.WasEntered("NUM_LINES_OVERLAP")) {
+    int numLinesOverlap = 2; // The default value
+    if (ui.WasEntered("NUM_LINES_OVERLAP"))
       numLinesOverlap = ui.GetInteger("NUM_LINES_OVERLAP");
-    }
+
     if (numLinesOverlap %2 != 0 || numLinesOverlap < 0) {
       QString msg = "Expecting a non-negative and even value for NUM_LINES_OVERLAP.";
       throw IException(IException::User, msg, _FILEINFO_);
@@ -242,13 +242,10 @@ namespace Isis {
     for (int line = 0; line < outCube->lineCount(); line++) {
       int frame = line / frameHeight; // block index
       int lineInFrame = line - frameHeight * frame; // line index in the current block
-      
-      if (lineInFrame < numLinesOverlap / 2) 
-        continue; // these get wiped
-      
-      if (lineInFrame >= frameHeight - numLinesOverlap / 2) {
-        continue; // gets wiped 
-      }
+
+      // Skip these lines, which will result in them being wiped
+      if (lineInFrame < numLinesOverlap / 2 || lineInFrame >= frameHeight - numLinesOverlap / 2)
+        continue;
 
       // Same book-keeping is needed to compute where the line will go
       int src = line;

--- a/isis/src/base/apps/framestitch/framestitch.cpp
+++ b/isis/src/base/apps/framestitch/framestitch.cpp
@@ -1,6 +1,7 @@
 #include "framestitch.h"
 
 #include <QString>
+#include <iostream>
 
 #include "Brick.h"
 #include "Buffer.h"
@@ -129,8 +130,7 @@ namespace Isis {
     int frameHeight = 1;
     if (ui.WasEntered("frameHeight")) {
       frameHeight = ui.GetInteger("FRAMEHEIGHT");
-    }
-    else {
+    } else {
       // User didn't pass the size of the frames so attempt to infer it from
       // the cubes
       int evenFrameHeight = computeFrameHeight(evenCube);
@@ -145,6 +145,15 @@ namespace Isis {
       frameHeight = evenFrameHeight;
     }
 
+    int numLinesOverlap = 0; // The default value
+    if (ui.WasEntered("NUM_LINES_OVERLAP")) {
+      numLinesOverlap = ui.GetInteger("NUM_LINES_OVERLAP");
+    }
+    if (numLinesOverlap %2 != 0 || numLinesOverlap < 0) {
+      QString msg = "Expecting a non-negative and even value for NUM_LINES_OVERLAP.";
+      throw IException(IException::User, msg, _FILEINFO_);
+    }
+    
     // If there's an even number of frames and the inputs are flipped, we have to
     // swap even and odd because the first frame in the even cube is valid and the
     // first frame in the odd cube is now all NULL.
@@ -173,6 +182,9 @@ namespace Isis {
       if (swapInputCubes) {
         inIndex = 1 - inIndex;
       }
+      // in[0] is first input cube and in[1] is the second. Copy from
+      // one of these, depending on how inIndex changes, to out[0],
+      // which is the only output cube.
       out[0]->Copy(*in[inIndex]);
     };
 
@@ -189,24 +201,30 @@ namespace Isis {
     }
     outInst["Framelets"].setValue("All");
 
-    // ProcessByBrick requires that all buffers move through the cubes the same
-    // way so we have to do a second manual pass to flip the output cube if requested.
+    // At this stage the merging of the two input cubes has been scheduled,
+    // with the result in outCube.
+    
+    // ProcessByBrick requires that all buffers move through the cubes
+    // the same way so we have to do a second manual pass to flip the
+    // output cube if requested.
     if (ui.GetBoolean("FLIP")) {
+      // Need a temporary buffer to help with the swapping of top and
+      // bottom portions of outCube.
       Brick topBuff(outCube->sampleCount(), frameHeight, outCube->bandCount(), outCube->pixelType());
-      Brick bottomBuff(outCube->sampleCount(), frameHeight, outCube->bandCount(), outCube->pixelType());
-      Brick tempBuff(outCube->sampleCount(), frameHeight, outCube->bandCount(), outCube->pixelType());
+      Brick botBuff(outCube->sampleCount(), frameHeight, outCube->bandCount(), outCube->pixelType());
+      Brick tmpBuff(outCube->sampleCount(), frameHeight, outCube->bandCount(), outCube->pixelType());
 
       for (int frame = 0; frame < numFrames / 2; frame++) {
         topBuff.SetBasePosition(1,frame * frameHeight + 1,1);
         outCube->read(topBuff);
-        bottomBuff.SetBasePosition(1,outCube->lineCount() - (frame + 1) * frameHeight + 1,1);
-        outCube->read(bottomBuff);
+        botBuff.SetBasePosition(1,outCube->lineCount() - (frame + 1) * frameHeight + 1,1);
+        outCube->read(botBuff);
 
-        tempBuff.Copy(topBuff);
-        topBuff.Copy(bottomBuff);
+        tmpBuff.Copy(topBuff);
+        topBuff.Copy(botBuff);
         outCube->write(topBuff);
-        bottomBuff.Copy(tempBuff);
-        outCube->write(bottomBuff);
+        botBuff.Copy(tmpBuff);
+        outCube->write(botBuff);
       }
 
       if (!outInst.hasKeyword("DataFlipped")) {
@@ -214,9 +232,53 @@ namespace Isis {
       }
       outInst["DataFlipped"].setValue(toString(!inputFlipped));
     }
+  
+    // Wipe numLinesOverlap/2 lines at the top and same amount at the bottom
+    // of each framelet to reduce their overlap.
 
+    Brick srcBuff(outCube->sampleCount(), 1, outCube->bandCount(), outCube->pixelType());
+    Brick dstBuff(outCube->sampleCount(), 1, outCube->bandCount(), outCube->pixelType());
+    
+    for (int line = 0; line < outCube->lineCount(); line++) {
+      int frame = line / frameHeight; // block index
+      int lineInFrame = line - frameHeight * frame; // line index in the current block
+      
+      if (lineInFrame < numLinesOverlap / 2) 
+        continue; // these get wiped
+      
+      if (lineInFrame >= frameHeight - numLinesOverlap / 2) {
+        continue; // gets wiped 
+      }
+
+      // Same book-keeping is needed to compute where the line will go
+      int src = line;
+      int dst = lineInFrame - numLinesOverlap / 2 + (frameHeight - numLinesOverlap) * frame;
+
+      srcBuff.SetBasePosition(1, src + 1, 1);
+      dstBuff.SetBasePosition(1, dst + 1, 1);
+
+      outCube->read(srcBuff);  // read into srcBuf
+      dstBuff.Copy(srcBuff);   // copy from srcBuff to dstBuff
+      outCube->write(dstBuff); // write into outCube
+    }
+    
+    // Wipe the last lines of the image after they are transferred
+    // TODO: Figure out how to resize the cube.
+    for (int line = outCube->lineCount() - numFrames * numLinesOverlap;
+         line < outCube->lineCount(); line++) {
+
+      srcBuff.SetBasePosition(1, line + 1, 1);
+      outCube->read(srcBuff);
+
+      for (int it = 0; it < srcBuff.size(); it++)
+        srcBuff[it] = Isis::NULL8;
+      
+      outCube->write(srcBuff);
+    }
+    
     process.EndProcess();
-
+    
+    return;
   }
 
-}
+} // end namespace Isis

--- a/isis/src/base/apps/framestitch/framestitch.xml
+++ b/isis/src/base/apps/framestitch/framestitch.xml
@@ -152,7 +152,7 @@
 			of 2 or 4 works reasonably for WAC images.
           </p>
         </description>
-        <internalDefault>Camera</internalDefault>
+        <internalDefault>0</internalDefault>
         <minimum>0</minimum>
       </parameter>
 

--- a/isis/src/base/apps/framestitch/framestitch.xml
+++ b/isis/src/base/apps/framestitch/framestitch.xml
@@ -148,9 +148,8 @@
           non-negative number.
           </p>
           <p>
-            If not entered, the program will assume the value 2, which
-            is what the PushFrame CSM camera model for this sensor
-            assumes.
+            If not entered, the program will assume the value 0. A value
+			of 2 or 4 works reasonably for WAC images.
           </p>
         </description>
         <internalDefault>Camera</internalDefault>

--- a/isis/src/base/apps/framestitch/framestitch.xml
+++ b/isis/src/base/apps/framestitch/framestitch.xml
@@ -136,7 +136,8 @@
       <parameter name="NUM_LINES_OVERLAP">
         <type>integer</type>
         <brief>
-          The number of lines in each frame repeating information present in neighboring frames.
+          The number of lines in each frame repeating information
+          present in neighboring frames.
         </brief>
         <description>
           <p>
@@ -147,7 +148,9 @@
           non-negative number.
           </p>
           <p>
-            If not entered, the program will assume the value 0.
+            If not entered, the program will assume the value 2, which
+            is what the PushFrame CSM camera model for this sensor
+            assumes.
           </p>
         </description>
         <internalDefault>Camera</internalDefault>

--- a/isis/src/base/apps/framestitch/framestitch.xml
+++ b/isis/src/base/apps/framestitch/framestitch.xml
@@ -6,11 +6,16 @@
 
   <description>
     <p>
-      This program combines the even and odd frames from push frame <def link="Cube">cubes</def> back
-      into a single interwoven <def link="Cube">cube</def>. It can also optionally flip the frame order
-      so that adjacent ground features appear adjacent between frames. This program
-      is designed to be run before processing the data in another software package
-      as it removes the camera information from the output <def link="Cube">cube</def>.
+      This program combines the even and odd frames from push frame
+      <def link="Cube">cubes</def> back into a single interwoven <def
+      link="Cube">cube</def>. It can also optionally flip the frame
+      order so that adjacent ground features appear adjacent between
+      frames. If the last several rows of a frame have the same
+      data as the first several rows of the next frame, reduntant
+      lines can be eliminated with the num_lines_overlap parameter.
+      This program is designed to be run before processing the
+      data in another software package as it removes the camera
+      information from the output <def link="Cube">cube</def>.
     </p>
     <p>
       When many push frame images are ingested into ISIS, their frames are separated
@@ -127,6 +132,28 @@
         <internalDefault>Camera</internalDefault>
         <minimum>1</minimum>
       </parameter>
+
+      <parameter name="NUM_LINES_OVERLAP">
+        <type>integer</type>
+        <brief>
+          The number of lines in each frame repeating information present in neighboring frames.
+        </brief>
+        <description>
+          <p>
+          The estimated total number of lines in each frame which have
+          the same pixel values as frames above and below it. During
+          processing, half this amount of lines will be removed from
+          each of the top and bottom of the frame. Must be an even
+          non-negative number.
+          </p>
+          <p>
+            If not entered, the program will assume the value 0.
+          </p>
+        </description>
+        <internalDefault>Camera</internalDefault>
+        <minimum>0</minimum>
+      </parameter>
+
     </group>
   </groups>
 

--- a/isis/src/base/apps/framestitch/framestitch.xml
+++ b/isis/src/base/apps/framestitch/framestitch.xml
@@ -149,7 +149,7 @@
           </p>
           <p>
             If not entered, the program will assume the value 0. A value
-			of 2 or 4 works reasonably for WAC images.
+			of 2 or 4 works reasonably for LRO WAC images.
           </p>
         </description>
         <internalDefault>0</internalDefault>

--- a/isis/tests/FunctionalTestsFrameStitch.cpp
+++ b/isis/tests/FunctionalTestsFrameStitch.cpp
@@ -419,3 +419,30 @@ TEST_F(PushFramePair, FunctionalTestFramestitchAutoDifferentHeights) {
     FAIL() << "Expected an IException, got exception with error " << e.what() << std::endl;
   }
 }
+
+// Test removing a total of this many lines from each framelet
+// (half at the top of each framelet and half at the bottom).
+TEST_F(PushFramePair, FunctionalTestFramestitchRemoveOverlap) {
+  QString outCubePath = tempDir.path() + "/stitched.cub";
+  int numLinesOverlap = 2;
+  QVector<QString> args = {
+        "EVEN="+evenCube->fileName(),
+        "ODD="+oddCube->fileName(),
+        "FRAMEHEIGHT="+toString(frameHeight),
+        "NUM_LINES_OVERLAP=" + toString(numLinesOverlap),
+        "TO="+outCubePath};
+
+  UserInterface ui(APP_XML, args);
+
+  framestitch(ui);
+
+  Cube outCube(outCubePath);
+  std::shared_ptr<Statistics> bandStats(outCube.statistics());
+  EXPECT_EQ(bandStats->Minimum(), 1);
+  EXPECT_EQ(bandStats->Maximum(), numFrames);
+  EXPECT_DOUBLE_EQ(bandStats->Average(), (numFrames + 1) / 2.0);
+  EXPECT_EQ(bandStats->NullPixels(), 0);
+
+  // The output cube should have fewer lines
+  EXPECT_EQ(evenCube->lineCount(), outCube.lineCount() + numFrames * numLinesOverlap);
+}

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -282,7 +282,7 @@ namespace Isis {
   QString fileListToString(QVector<QString> fileList) {
     QString filesAsString("(");
 
-    for (size_t i = 0; i < fileList.size(); i++) {
+    for (int i = 0; i < fileList.size(); i++) {
       FileName file(fileList[i]);
 
       filesAsString += file.expanded();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is an incremental improvement upon the issues noted in https://github.com/USGS-Astrogeology/ISIS3/issues/4944 and https://github.com/USGS-Astrogeology/ISIS3/issues/4945, which state that each WAC framelet has the same data in its last several rows as the earliest rows in the next framelet, and moreover, some of those rows have pixel values flagged as invalid (null) even though they look reasonably valid.

The proposed fix wipes several top and bottom lines in each framelet before stitching. With this fix, the *framestitch* tool is called as:

framestitch even = img.even.cub odd = img.odd.cub to = stitched_img.cub flip = true num_lines_overlap = 2

With this choice of num_lines_overlap, 1 line is wiped at the top and 1 at the bottom of each framelet. 

Here's an illustration of the stitched image before (left) and after (right) this fix. Note how black pixels and repeated lines go away.

![framestitch](https://user-images.githubusercontent.com/1325676/168193640-8dc631f5-5577-4f9a-9a12-8562e3fd68eb.png)

The camera model is adjusted accordingly (https://github.com/USGS-Astrogeology/usgscsm/pull/397).

## How Has This Been Tested?

The produced images were tested very carefully with stereo in ASP and the resulting terrain models have a lot less artifacts. The triangulated rays intersect better as well, hence the intersection error map has lower values. The image-to-ground and ground-to-image operations after this fix agree better than before (see the CSM pull request above).

This does not eliminate the problem fully. Framelets can overlap by more than 2 pixels, depending on the image, and the amount of overlap is likely terrain-dependent (lower-lying terrain should result in more overlap). 

For the purposes of stereo it is likely best to first mapproject the obtained stitched images. This reduces any remaining repetition of rows even further. This was tried and works decently, but some residual artifacts still can be seen, though things improve quite a bit in that mode as well. 

More work and research needs to be done here but there's no more time in this cycle. 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
