### PR TITLE
Consolidate testing options

### DIFF
--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -136,10 +136,6 @@ message("\tINSTALL PREFIX: ${CMAKE_INSTALL_PREFIX}")
 #===============================================================================
 #===============================================================================
 
-# Set up the ctest tool which is used to run all of the tests.
-enable_testing()
-include(CTest)
-
 # Set up Anaconda prefix in the case with a non-default conda env is activated
 if(EXISTS $ENV{CONDA_PREFIX})
   message("CONDA PREFIX: $ENV{CONDA_PREFIX}")
@@ -152,10 +148,6 @@ endif()
 if(JP2KFLAG)
  set(JP2KFLAG 1)
 endif()
-
-# Set up the ctest tool which is used to run all of the tests.
-enable_testing()
-include(CTest)
 
 # Specify flags used
 # on linux, add the conda prefix to handle possible issues with rpaths at link time
@@ -608,8 +600,7 @@ install(PROGRAMS ${CMAKE_BINARY_DIR}/lib/Camera.plugin DESTINATION ${CMAKE_INSTA
 #   the end of this file containing a CMakeLists.txt file which includes all of
 #   the desired post-install commands inside.
 add_subdirectory(cmake)
-option (BUILD_TESTS "Build tests" ON)
-if(BUILD_TESTS)
+if(buildTests)
   include(CTest)
   enable_testing()
   add_subdirectory(tests)

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -17,8 +17,6 @@ include(AddIsisModule)
 include(Utilities)
 include(TestSetup)
 include(InstallThirdParty)
-include(cmake/gtest.cmake)
-include(GoogleTest)
 
 include(CMakePrintHelpers)
 
@@ -601,6 +599,8 @@ install(PROGRAMS ${CMAKE_BINARY_DIR}/lib/Camera.plugin DESTINATION ${CMAKE_INSTA
 #   the desired post-install commands inside.
 add_subdirectory(cmake)
 if(buildTests)
+  include(cmake/gtest.cmake)
+  include(GoogleTest)
   include(CTest)
   enable_testing()
   add_subdirectory(tests)

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -17,6 +17,8 @@ include(AddIsisModule)
 include(Utilities)
 include(TestSetup)
 include(InstallThirdParty)
+include(cmake/gtest.cmake)
+include(GoogleTest)
 
 include(CMakePrintHelpers)
 
@@ -599,8 +601,6 @@ install(PROGRAMS ${CMAKE_BINARY_DIR}/lib/Camera.plugin DESTINATION ${CMAKE_INSTA
 #   the desired post-install commands inside.
 add_subdirectory(cmake)
 if(buildTests)
-  include(cmake/gtest.cmake)
-  include(GoogleTest)
   include(CTest)
   enable_testing()
   add_subdirectory(tests)

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -133,7 +133,6 @@ namespace Isis {
 
       TextFile cameraAngle(cameraAngleDefs);
       int numLines = cameraAngle.LineCount();
-      bool foundfilter = false;
       for(int i = 0; i < numLines; i++) {
         QString line;
         cameraAngle.GetLine(line, true);
@@ -142,7 +141,6 @@ namespace Isis {
         if(tokens.count() > 2 && tokens.first() == filter) {
           center = toDouble(tokens[1]);
           width = toDouble(tokens[2]);
-          foundfilter = true;
           break;
         }
       }

--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -663,7 +663,7 @@ namespace Isis {
     }
     else {
       throw IException(IException::Unknown,
-                       QObject::tr("No existing files found with a numerial version matching [%1] "
+                       QObject::tr("No existing files found with a numerical version matching [%1] "
                                    "in [%2]")
                          .arg(FileName(expanded()).name()).arg(path()),
                        _FILEINFO_);

--- a/isis/src/base/objs/FileName/FileName.truth
+++ b/isis/src/base/objs/FileName/FileName.truth
@@ -638,7 +638,7 @@ Testing Numerical-Only Versioning
 		New version changed FileName: 1
 
 	Testing Versioning Methods [??tttt]
-		Highest Version Name:          		Highest Version Failed:     **ERROR** No existing files found with a numerial version matching [??tttt] in [.].
+		Highest Version Name:          		Highest Version Failed:     **ERROR** No existing files found with a numerical version matching [??tttt] in [.].
 		New Version Name:              01tttt
 		New Version Orig:              ./01tttt
 		New Version Orig Path:         .
@@ -655,7 +655,7 @@ Testing Numerical-Only Versioning
 		New version changed FileName: 1
 
 	Testing Versioning Methods [junk?]
-		Highest Version Name:          		Highest Version Failed:     **ERROR** No existing files found with a numerial version matching [junk?] in [.].
+		Highest Version Name:          		Highest Version Failed:     **ERROR** No existing files found with a numerical version matching [junk?] in [.].
 		New Version Name:              junk1
 		New Version Orig:              ./junk1
 		New Version Orig Path:         .

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -282,7 +282,7 @@ namespace Isis {
   QString fileListToString(QVector<QString> fileList) {
     QString filesAsString("(");
 
-    for (size_t i = 0; i < fileList.size(); i++) {
+    for (int i = 0; i < fileList.size(); i++) {
       FileName file(fileList[i]);
 
       filesAsString += file.expanded();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The isis/CMakeLists.txt file had two options named buildTests and BUILD_TESTS. The first wasn't doing anything but was being set in recipe/build.sh, and the second one wasn't listened to when adding testing logic.  Now these variables are merged and 3 instances of "enable_testing()" are consolidated into one.

Note that this will have the following impact: now ./recipe/build.sh will actually not build tests as it was intended.

## How Has This Been Tested?

I tested building both with tests on and off, and the build completes without errors.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
