### PR TITLE
First pass at EIS ingest template

### DIFF
--- a/isis/appdata/import/PDS4/ClipperEIS.tpl
+++ b/isis/appdata/import/PDS4/ClipperEIS.tpl
@@ -1,0 +1,121 @@
+{% set Product_Observational="Product_Observational" %}
+{% set IdArea="Product_Observational.Identification_Area" %}
+{% set FileArea="Product_Observational.File_Area_Observational" %}
+{% set ImageFileArea="Product_Observational.File_Area_Observational.0" %}
+{% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image") %}
+{% set imageArray="Product_Observational.File_Area_Observational.0.Array_2D_Image" %}
+{% else %}
+{% set imageArray="Product_Observational.File_Area_Observational.0.Array_3D_Image" %}
+{% set exposure="Product_Observational.Observation_Area.Discipline_Area.img:Exposure" %}
+{% endif %}
+
+{% if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC PB" %}
+{% set sensor="WAC" %}
+{% else if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "NAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "NAC PB" %}
+{% set sensor="NAC" %}
+{% else %}
+{% set sensor="UNK" %}
+{% endif %}
+
+Object = IsisCube
+  Object = Core
+    Group = Dimensions
+      Samples = {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.0.elements }}
+      Lines   = {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.1.elements }}
+      Bands   = {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.2.elements") %}
+                {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.2.elements }}
+                {% else %}
+                1
+                {% endif %}
+    End_Group
+
+
+
+    Group = Pixels
+      {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type") %}
+      {% set type=Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type %}
+      Type       = {% if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBDouble" %} Double
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBSingle" %} Real
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBDouble" %} Double
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBSingle" %} Real
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedByte" %} SignedByte
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB2" %} SignedWord
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB4" %} SignedInteger
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB2" %} SignedWord
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB4" %} SignedInteger
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedByte" %} UnsignedByte
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB2" %} UnsignedWord
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB4" %} UnsignedInteger
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB2" %} UnsignedWord
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB4" %} UnsignedInteger
+                   {% else %} Real
+                   {% endif %}
+      ByteOrder  = {% if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBDouble" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBSingle" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBDouble" %} MSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBSingle" %} MSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedByte" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB2" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB4" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB2" %} MSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB4" %} MSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedByte" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB2" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB4" %} LSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB2" %} MSB
+                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB4" %} MSB
+                   {% else %} Lsb
+                   {% endif %}
+      {% else %}
+      Type       = Real
+      ByteOrder  = Lsb
+      {% endif %}
+
+      Base       = {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.value_offset") %}
+                   {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.value_offset }}
+                   {% else if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.offset._text") %}
+                   {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.offset._text }}
+                   {% else %}
+                   0
+                   {% endif %}
+      Multiplier = {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.scaling_factor") %}
+                   {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.scaling_factor._text }}
+                   {% else %}
+                   1
+                   {% endif %}
+    End_Group
+  End_Object
+
+  Group = Instrument
+    SpacecraftName            = "{{ Product_Observational.Observation_Area.Investigation_Area.name }}"
+    InstrumentId              = "{{ Product_Observational.Observation_Area.Observing_System.Observing_System_Component.1.name }} {{ Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name }}"
+    TargetName                = {{ at(splitOnChar(Product_Observational.Observation_Area.Target_Identification.name, " "), 1) }}
+    StartTime                 = {{ RemoveStartTimeZ(Product_Observational.Observation_Area.Time_Coordinates.start_date_time) }}
+    ExposureDuration          = {{ Product_Observational.Observation_Area.Discipline_Area.img_Exposure.img_exposure_duration._text }}<seconds>
+  End_Group
+
+  Group = BandBin
+    {# Hard code to clear filter #}
+    FilterName = Clear
+    {% if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC PB" %}
+    Center     = 712.5 <nm>
+    Width      = 675 <nm>
+    {% else %}
+    Center     = 702.5 <nm>
+    Width      = 695 <nm>
+    {% endif %}
+  End_Group
+
+  Group = Kernels
+    NaifFrameCode = {% if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC PB" %}
+                    -159104
+                    {% else %}
+                    -159103
+                    {% endif %}
+
+  End_Group
+End_Object
+
+Object = Translation
+End_Object
+End

--- a/isis/appdata/import/PDS4/ClipperEIS.tpl
+++ b/isis/appdata/import/PDS4/ClipperEIS.tpl
@@ -1,6 +1,7 @@
-{% if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC PB" %}
+{% set sub_sensor = Product_Observational.Label_TBD.Observation_Area.Observing_System.Observing_System_Component.0.name %}
+{% if sub_sensor == "WAC FC" or sub_sensor == "WAC PB" %}
 {% set sensor="WAC" %}
-{% else if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "NAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "NAC PB" %}
+{% else if sub_sensor == "NAC FC" or sub_sensor == "NAC PB" %}
 {% set sensor="NAC" %}
 {% else %}
 {% set sensor="UNK" %}
@@ -74,31 +75,79 @@ Object = IsisCube
   End_Object
 
   Group = Instrument
-    Sensor = {{sensor}}
     SpacecraftName            = "{{ Product_Observational.Observation_Area.Investigation_Area.name }}"
-    InstrumentId              = "{{ Product_Observational.Observation_Area.Observing_System.Observing_System_Component.1.name }} {{ Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name }}"
+    InstrumentId              = "{{ Product_Observational.Observation_Area.Observing_System.Observing_System_Component.1.name }} {{ Product_Observational.Label_TBD.Observation_Area.Observing_System.Observing_System_Component.0.name }}"
     TargetName                = {{ at(splitOnChar(Product_Observational.Observation_Area.Target_Identification.name, " "), 1) }}
     StartTime                 = {{ RemoveStartTimeZ(Product_Observational.Observation_Area.Time_Coordinates.start_date_time) }}
     ExposureDuration          = {{ Product_Observational.Observation_Area.Discipline_Area.img_Exposure.img_exposure_duration._text }}<seconds>
   End_Group
 
+{% set filter=Product_Observational.Label_TBD.Observation_Area.Observing_System.Observing_System_Component.1.name %}
   Group = BandBin
-    {# Hard code to clear filter #}
-    FilterName = Clear
-    {% if sensor == "WAC" %}
-    Center     = 712.5 <nm>
-    Width      = 675 <nm>
-    {% else %}
-    Center     = 702.5 <nm>
-    Width      = 695 <nm>
-    {% endif %}
+    FilterName = {{ filter }}
+    Center = {% if filter == "CLEAR" %}
+               {% if sensor == "WAC" %}
+               712.5 <nm>
+               {% else if sensor == "NAC" %}
+               702.5 <nm>
+               {% else %}
+               UNK
+               {% endif %}
+             {% else if filter == "NUV" %}
+               {% if sensor == "WAC" %}
+               387.5 <nm>
+               {% else if sensor == "NAC"  %}
+               377.5 <nm>
+               {% else %}
+               UNK
+               {% endif %}
+             {% else if filter == "BLU" %}
+             427.5 <nm>
+             {% else if filter == "GRN" %}
+             555 <nm>
+             {% else if filter == "RED" %}
+             670 <nm>
+             {% else if filter == "IR1" %}
+             850 <nm>
+             {% else if filter == "1MC" %}
+             1000 <nm>
+             {% else %}
+             UNK
+             {% endif %}
+    Width = {% if filter == "CLEAR" %}
+              {% if sensor == "WAC" %}
+              675 <nm>
+              {% else %}
+              695 <nm>
+              {% endif %}
+            {% else if filter == "NUV" %}
+              {% if sensor == "WAC" %}
+              25 <nm>
+              {% else %}
+              45 <nm>
+              {% endif %}
+            {% else if filter == "BLU" %}
+            95 <nm>
+            {% else if filter == "GRN" %}
+            70 <nm>
+            {% else if filter == "RED" %}
+            60 <nm>
+            {% else if filter == "IR1" %}
+            40 <nm>
+            {% else if filter == "1MC" %}
+            100 <nm>
+            {% else %}
+            UNK
+            {% endif %}
   End_Group
 
   Group = Kernels
     NaifFrameCode = {% if sensor == "WAC" %}
                     -159104
-                    {% else %}
+                    {% else if sensor == "NAC" %}
                     -159103
+                    {% else %}
+                    UNK
                     {% endif %}
 
   End_Group

--- a/isis/appdata/import/PDS4/ClipperEIS.tpl
+++ b/isis/appdata/import/PDS4/ClipperEIS.tpl
@@ -1,14 +1,3 @@
-{% set Product_Observational="Product_Observational" %}
-{% set IdArea="Product_Observational.Identification_Area" %}
-{% set FileArea="Product_Observational.File_Area_Observational" %}
-{% set ImageFileArea="Product_Observational.File_Area_Observational.0" %}
-{% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image") %}
-{% set imageArray="Product_Observational.File_Area_Observational.0.Array_2D_Image" %}
-{% else %}
-{% set imageArray="Product_Observational.File_Area_Observational.0.Array_3D_Image" %}
-{% set exposure="Product_Observational.Observation_Area.Discipline_Area.img:Exposure" %}
-{% endif %}
-
 {% if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC PB" %}
 {% set sensor="WAC" %}
 {% else if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "NAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "NAC PB" %}
@@ -17,53 +6,51 @@
 {% set sensor="UNK" %}
 {% endif %}
 
+{% set ImageArray = Product_Observational.File_Area_Observational.0.Array_2D_Image %}
+
 Object = IsisCube
   Object = Core
     Group = Dimensions
-      Samples = {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.0.elements }}
-      Lines   = {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.1.elements }}
-      Bands   = {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.2.elements") %}
-                {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Axis_Array.2.elements }}
-                {% else %}
-                1
-                {% endif %}
+      Samples = {{ ImageArray.Axis_Array.0.elements }}
+      Lines   = {{ ImageArray.Axis_Array.1.elements }}
+      Bands   = 1
     End_Group
 
 
 
     Group = Pixels
+      {% set pixelType = ImageArray.Element_Array.data_type %}
       {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type") %}
-      {% set type=Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type %}
-      Type       = {% if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBDouble" %} Double
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBSingle" %} Real
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBDouble" %} Double
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBSingle" %} Real
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedByte" %} SignedByte
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB2" %} SignedWord
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB4" %} SignedInteger
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB2" %} SignedWord
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB4" %} SignedInteger
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedByte" %} UnsignedByte
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB2" %} UnsignedWord
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB4" %} UnsignedInteger
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB2" %} UnsignedWord
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB4" %} UnsignedInteger
+      Type       = {% if pixelType == "IEEE754LSBDouble" %} Double
+                   {% else if pixelType == "IEEE754LSBSingle" %} Real
+                   {% else if pixelType == "IEEE754MSBDouble" %} Double
+                   {% else if pixelType == "IEEE754MSBSingle" %} Real
+                   {% else if pixelType == "SignedByte" %} SignedByte
+                   {% else if pixelType == "SignedLSB2" %} SignedWord
+                   {% else if pixelType == "SignedLSB4" %} SignedInteger
+                   {% else if pixelType == "SignedMSB2" %} SignedWord
+                   {% else if pixelType == "SignedMSB4" %} SignedInteger
+                   {% else if pixelType == "UnsignedByte" %} UnsignedByte
+                   {% else if pixelType == "UnsignedLSB2" %} UnsignedWord
+                   {% else if pixelType == "UnsignedLSB4" %} UnsignedInteger
+                   {% else if pixelType == "UnsignedMSB2" %} UnsignedWord
+                   {% else if pixelType == "UnsignedMSB4" %} UnsignedInteger
                    {% else %} Real
                    {% endif %}
-      ByteOrder  = {% if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBDouble" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754LSBSingle" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBDouble" %} MSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "IEEE754MSBSingle" %} MSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedByte" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB2" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedLSB4" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB2" %} MSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "SignedMSB4" %} MSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedByte" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB2" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedLSB4" %} LSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB2" %} MSB
-                   {% else if Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.data_type == "UnsignedMSB4" %} MSB
+      ByteOrder  = {% if pixelType == "IEEE754LSBDouble" %} LSB
+                   {% else if pixelType == "IEEE754LSBSingle" %} LSB
+                   {% else if pixelType == "IEEE754MSBDouble" %} MSB
+                   {% else if pixelType == "IEEE754MSBSingle" %} MSB
+                   {% else if pixelType == "SignedByte" %} LSB
+                   {% else if pixelType == "SignedLSB2" %} LSB
+                   {% else if pixelType == "SignedLSB4" %} LSB
+                   {% else if pixelType == "SignedMSB2" %} MSB
+                   {% else if pixelType == "SignedMSB4" %} MSB
+                   {% else if pixelType == "UnsignedByte" %} LSB
+                   {% else if pixelType == "UnsignedLSB2" %} LSB
+                   {% else if pixelType == "UnsignedLSB4" %} LSB
+                   {% else if pixelType == "UnsignedMSB2" %} MSB
+                   {% else if pixelType == "UnsignedMSB4" %} MSB
                    {% else %} Lsb
                    {% endif %}
       {% else %}
@@ -72,14 +59,14 @@ Object = IsisCube
       {% endif %}
 
       Base       = {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.value_offset") %}
-                   {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.value_offset }}
+                   {{ ImageArray.Element_Array.value_offset }}
                    {% else if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.offset._text") %}
-                   {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.offset._text }}
+                   {{ ImageArray.offset._text }}
                    {% else %}
                    0
                    {% endif %}
       Multiplier = {% if exists("Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.scaling_factor") %}
-                   {{ Product_Observational.File_Area_Observational.0.Array_2D_Image.Element_Array.scaling_factor._text }}
+                   {{ ImageArray.Element_Array.scaling_factor._text }}
                    {% else %}
                    1
                    {% endif %}
@@ -87,6 +74,7 @@ Object = IsisCube
   End_Object
 
   Group = Instrument
+    Sensor = {{sensor}}
     SpacecraftName            = "{{ Product_Observational.Observation_Area.Investigation_Area.name }}"
     InstrumentId              = "{{ Product_Observational.Observation_Area.Observing_System.Observing_System_Component.1.name }} {{ Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name }}"
     TargetName                = {{ at(splitOnChar(Product_Observational.Observation_Area.Target_Identification.name, " "), 1) }}
@@ -97,7 +85,7 @@ Object = IsisCube
   Group = BandBin
     {# Hard code to clear filter #}
     FilterName = Clear
-    {% if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC PB" %}
+    {% if sensor == "WAC" %}
     Center     = 712.5 <nm>
     Width      = 675 <nm>
     {% else %}
@@ -107,7 +95,7 @@ Object = IsisCube
   End_Group
 
   Group = Kernels
-    NaifFrameCode = {% if Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC FC" or Product_Observational.Observation_Area.Observing_System.Observing_System_Component.2.name == "WAC PB" %}
+    NaifFrameCode = {% if sensor == "WAC" %}
                     -159104
                     {% else %}
                     -159103

--- a/isis/appdata/import/fileTemplate.tpl
+++ b/isis/appdata/import/fileTemplate.tpl
@@ -50,6 +50,9 @@
 {#- or when the instrument name is long or contains spaces, ... -#}
 {%- if SpacecraftName == "TRACE GAS ORBITER" -%}
   {%- set SpacecraftId="TGO" -%}
+{%- else if SpacecraftName == "Europa Clipper" -%}
+  {%- set SpacecraftId="Clipper" -%}
+  {%- set InstrumentId="EIS" -%}
 {%- else if SpacecraftName == "VIKING_ORBITER_1" or SpacecraftName == "VIKING_ORBITER_2" -%}
   {%- set SpacecraftId="Viking" -%}
   {%- set InstrumentId="VIS" -%}

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -3,6 +3,7 @@
 
 #include <inja/inja.hpp>
 #include <nlohmann/json.hpp>
+#include <QRegularExpression>
 #include <QString>
 #include <QtMath>
 
@@ -194,11 +195,11 @@ namespace Isis {
     env.add_callback("splitOnChar", 2, [](Arguments& args){
       std::string text = args.at(0)->get<string>();
 
-    string delimiter = args.at(1)->get<string>();
-    vector<string> words{};
+      string delimiter = args.at(1)->get<string>();
+      vector<string> words{};
 
-    size_t pos;
-    while ((pos = text.find(delimiter)) != string::npos) {
+      size_t pos;
+      while ((pos = text.find(delimiter)) != string::npos) {
         words.push_back(text.substr(0, pos));
         words.push_back(text.substr(pos + 1));
         text.erase(0, pos + delimiter.length());

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -3,7 +3,6 @@
 
 #include <inja/inja.hpp>
 #include <nlohmann/json.hpp>
-#include <QRegularExpression>
 #include <QString>
 #include <QtMath>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Adds an EIS ingestion template for isisimport. This is prelimenary as the final PDS4 label format is not finalized.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

This is a start on #4964

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Currently the EIS ingestion is inside of eis2isis. We need to update several things in the ingestion, so this is a good time to move it to the new universal import approach.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on preliminary label for an EIS WAC FC image

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
