### PR TITLE
Modify framestitch to preserve tables and kernels

### DIFF
--- a/isis/src/base/apps/framestitch/framestitch.cpp
+++ b/isis/src/base/apps/framestitch/framestitch.cpp
@@ -82,6 +82,7 @@ namespace Isis {
    */
   void framestitch(UserInterface &ui) {
     ProcessByBrick process;
+    process.PropagatePolygons(false);
 
     // It is very important that the odd cube gets added first as later on
     // we'll use frameNumber % 2 to index the input cube vector
@@ -151,12 +152,12 @@ namespace Isis {
     }
 
     int reducedFrameHeight = frameHeight - numLinesOverlap;
-    
+
     QString outCubeFile = ui.GetCubeName("TO");
     Cube *outCube = process.SetOutputCube(
           outCubeFile, CubeAttributeOutput(outCubeFile),
           evenCube->sampleCount(), numFrames * reducedFrameHeight, evenCube->bandCount());
-    
+
     // If there's an even number of frames and the inputs are flipped, we have to
     // swap even and odd because the first frame in the even cube is valid and the
     // first frame in the odd cube is now all NULL.
@@ -172,8 +173,6 @@ namespace Isis {
 
     // Processing setup
     process.SetBrickSize(evenCube->sampleCount(), frameHeight, evenCube->bandCount());
-    process.PropagateTables(false);
-    process.PropagatePolygons(false);
 
     // Put together the frames from the two input cubes. Note that we
     // wipe a total of numLinesOverlap lines from each frame as we do
@@ -182,7 +181,7 @@ namespace Isis {
 
       Brick buff(evenCube->sampleCount(), reducedFrameHeight, evenCube->bandCount(),
                    evenCube->pixelType());
-      
+
       // Set reading position
       buff.SetBasePosition(1, frame * frameHeight + numLinesOverlap/2 + 1, 1);
 
@@ -190,19 +189,18 @@ namespace Isis {
       if (swapInputCubes)
         inIndex = 1 - inIndex;
 
-      if (inIndex == 0) 
+      if (inIndex == 0)
         oddCube->read(buff);
       else
         evenCube->read(buff);
 
       // Set writing position
       buff.SetBasePosition(1, frame * reducedFrameHeight + 1, 1);
-      
+
       outCube->write(buff);
     }
 
     // Update the output label
-    outCube->deleteGroup("Kernels");
     if (!outCube->hasGroup("Instrument")) {
       outCube->putGroup(PvlGroup("Instrument"));
     }
@@ -243,9 +241,9 @@ namespace Isis {
     if (!outInst.hasKeyword("NumLinesOverlap"))
       outInst.addKeyword(PvlKeyword("NumLinesOverlap"));
     outInst["numLinesOverlap"].setValue(toString(numLinesOverlap));
-    
+
     process.EndProcess();
-    
+
     return;
   }
 

--- a/isis/src/base/apps/framestitch/framestitch.xml
+++ b/isis/src/base/apps/framestitch/framestitch.xml
@@ -14,8 +14,8 @@
       data as the first several rows of the next frame, reduntant
       lines can be eliminated with the num_lines_overlap parameter.
       This program is designed to be run before processing the
-      data in another software package as it removes the camera
-      information from the output <def link="Cube">cube</def>.
+      data in another software package and the output cube will not
+      produce a valid camera model for further processing in ISIS.
     </p>
     <p>
       When many push frame images are ingested into ISIS, their frames are separated
@@ -149,7 +149,7 @@
           </p>
           <p>
             If not entered, the program will assume the value 0. A value
-			of 2 or 4 works reasonably for LRO WAC images.
+            of 2 or 4 works reasonably for LRO WAC images.
           </p>
         </description>
         <internalDefault>0</internalDefault>

--- a/isis/tests/FunctionalTestsFrameStitch.cpp
+++ b/isis/tests/FunctionalTestsFrameStitch.cpp
@@ -7,6 +7,7 @@
 #include "LineManager.h"
 #include "SpecialPixel.h"
 #include "Statistics.h"
+#include "Table.h"
 
 #include "TestUtilities.h"
 #include "Fixtures.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Changed framestitch to keep the kernels group and tables so that we can use them in ALE to generate an ISD.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Related to #4945 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Currently, the stitched cube cannot be used in ALE by itself to generate an ISD. You have to use an unstitched cube to do that, but with the addition of line trimming we now need to work with the framestitch output.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Tested locally on a LRO WAC image and re-ran all framestitch tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
