### PR TITLE
Fixed rolling shutter applyJitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ release.
 ### Fixed
 - Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
 - Fixed the Mars Express HRSC SRC camera and serial number to use the StartTime instead of the StartClockCount  [#4803](https://github.com/USGS-Astrogeology/ISIS3/issues/4803)
+- Fixed algorithm for applying rolling shutter jitter. Matches implementation in USGSCSM.
 
 
 ## [7.0.0] - 2022-02-11

--- a/isis/tests/RollingShutterCameraDetectorMapTests.cpp
+++ b/isis/tests/RollingShutterCameraDetectorMapTests.cpp
@@ -8,15 +8,15 @@ TEST(RollingShutterCameraDetectorMapTests, ApplyAndRemoveJitter) {
   std::vector<double> times = {0.000329333333333,
                                0.010428888888889,
                                0.022284888888889};
-                             
+
   std::vector<double> lineCoeffs = {-1.1973143372677,
                                      1.4626764650998,
                                      0.9960730288934};
-                                    
+
   std::vector<double> sampleCoeffs = {-3.2335155748071,
                                        1.1186072652055,
                                        2.740121618258};
-                                  
+
   Isis::RollingShutterCameraDetectorMap detectorMap(NULL, times, sampleCoeffs, lineCoeffs);
 
   std::vector<double> lines;
@@ -26,8 +26,9 @@ TEST(RollingShutterCameraDetectorMapTests, ApplyAndRemoveJitter) {
     for (int sample = 1; sample <= 3; sample++) {
       std::pair<double, double> removed = detectorMap.removeJitter(sample, line);
       std::pair<double, double> applied = detectorMap.applyJitter(removed.first, removed.second);
-      EXPECT_NEAR(removed.second, applied.second, 0.1);
-      EXPECT_NEAR(removed.first, applied.first, 0.1);
+      // Test tolerances match iteration tolerance in RollingShutterCameraDetectorMap::applyJitter
+      EXPECT_NEAR(sample, applied.first, 1e-7);
+      EXPECT_NEAR(line, applied.second, 1e-7);
     }
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

The existing algorithm for applying rolling shutter jitter is incorrect. It does not properly invert the jitter and converges after a single iteration. The existing test is passing because the test tolerances (0.1 pixels) are significantly larger than the actual jitter (around 0.003 pixels).

This matches the implementation in USGSCSM
https://github.com/USGS-Astrogeology/usgscsm/blob/dev/src/Utilities.cpp#L132

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#2965

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This updates the sensor model to now properly invert.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This now passes when the test tolerances are tightened. The algorithm was also extensively tested when implementing in USGSCSM.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
