### PR TITLE
CNetCombinePt: only log merged points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,10 @@ release.
 ### Deprecated
 
 ### Fixed
-- Fixed CNetCombinePt logging functionality such that only merged points are included in the log.
 - Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
 - Fixed the Mars Express HRSC SRC camera and serial number to use the StartTime instead of the StartClockCount  [#4803](https://github.com/USGS-Astrogeology/ISIS3/issues/4803)
 - Fixed algorithm for applying rolling shutter jitter. Matches implementation in USGSCSM.
-
+- Fixed CNetCombinePt logging functionality such that only merged points are included in the log. [#4973](https://github.com/USGS-Astrogeology/ISIS3/issues/4973)
 
 ## [7.0.0] - 2022-02-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ release.
 ### Deprecated
 
 ### Fixed
+- Fixed CNetCombinePt logging functionality such that only merged points are included in the log.
 - Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
 - Fixed the Mars Express HRSC SRC camera and serial number to use the StartTime instead of the StartClockCount  [#4803](https://github.com/USGS-Astrogeology/ISIS3/issues/4803)
 - Fixed algorithm for applying rolling shutter jitter. Matches implementation in USGSCSM.

--- a/isis/src/control/apps/cnetcombinept/cnetcombinept.cpp
+++ b/isis/src/control/apps/cnetcombinept/cnetcombinept.cpp
@@ -278,6 +278,7 @@ namespace Isis{
     BigInt nfound(0);
     BigInt nMerged(0);
     BOOST_FOREACH ( ControlPoint *point, all_points ) {
+      BigInt localFound(0);
       // Don't consider ignored or edit locked points
       if ( isWorthy( point ) ) {
 
@@ -298,10 +299,11 @@ namespace Isis{
             QList<PointType> m_points = m_cloud->radius_query(m_p, search_radius_sq);
             ControlPointMerger merger(image_tolerance);
             p_merged += merger.apply(point, m_points);
-            nfound   += merger.size();
+            localFound = merger.size();
+            nfound   += localFound;
 
             // Log any points that were merged
-            if (logMerges && nfound > 0) {
+            if (logMerges && localFound > 0) {
               QHash<QString, QSet<QString>>::iterator logIt = mergeLog.find(point->GetId());
               // point hasn't had any points merged into it yet
               if (logIt == mergeLog.end()) {

--- a/isis/tests/FunctionalTestsCnetcombinept.cpp
+++ b/isis/tests/FunctionalTestsCnetcombinept.cpp
@@ -251,7 +251,9 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptLog) {
   QHash<QString, QSet<QString>> merges;
   QHash<QString, int> startSizes;
   QHash<QString, int> endSizes;
+  short nLines = 0;
   while (!logFileHandle.atEnd()) {
+    nLines++;
     QStringList splitLine = QString(logFileHandle.readLine()).trimmed().split(',');
     ASSERT_EQ(splitLine.size(), 4);
     startSizes.insert(splitLine[0], splitLine[1].toInt());
@@ -282,6 +284,7 @@ TEST_F(CombineNetworks, FunctionalTestCnetcombineptLog) {
   EXPECT_TRUE(merges["1b"].contains("3a"));
   EXPECT_TRUE(merges["1b"].contains("2b"));
   EXPECT_TRUE(merges["1b"].contains("3b"));
+  EXPECT_EQ(nLines, 2);
 }
 
 TEST_F(CombineNetworks, FunctionalTestCnetcombineptList) {


### PR DESCRIPTION
## Description
Adjusted logging functionality such that only merged points are included

## Related Issue
#4973 

## Motivation and Context
CNetCombinePt currently includes all points in the log, but it should only include merged points.  

## How Has This Been Tested?
ctest -VV -R "Cnetcombinept" all tests pass.
## Screenshots (if appropriate):
<img width="837" alt="Screen Shot 2022-07-06 at 1 18 00 PM" src="https://user-images.githubusercontent.com/3751180/177627693-1be97329-3d70-4230-ab38-0eea404c5897.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
