### PR TITLE
Caminfo Logic Fix

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,7 @@ dependencies:
   - krb5
   - libopencv>=4.5.2
   - libpng>=1.6.34
-  - libprotobuf
+  - libprotobuf<3.20
   - libtiff>=4.0
   - libxml2
   - make
@@ -47,7 +47,7 @@ dependencies:
   - opencv>=4.5.2
   - openssl>=1.1.1k
   - pcl >= 1.10.0
-  - protobuf
+  - protobuf<3.20
   - python>=3.7.11
   - qhull
   - qt>=5.9.6

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -290,7 +290,7 @@ namespace Isis{
         // Run camstats on the entire image (all bands)
         // another camstats will be run for each band and output
         // for each band.
-        else if (ui.GetBoolean("CAMSTATS") && !incube->hasTable("CameraStatistics")) {
+        else if (ui.GetBoolean("CAMSTATS")) {
           camstats = new QList< QPair<QString, QString> >;
 
           QString filename = incube->fileName();

--- a/isis/src/base/apps/caminfo/caminfo.xml
+++ b/isis/src/base/apps/caminfo/caminfo.xml
@@ -464,6 +464,10 @@ End
       This corrects inconsistencies of footprint generation failing in caminfo
       but passing in footprintinit. Fixes #4651.
     </change>
+    <change name="Adam Paquette" date="2021-07-06">
+      Updated CAMSTATS parameter decision tree to allow users to extract
+      camstats even if the cube contains a camstats table. Fixes #4919.
+    </change>
   </history>
 
   <category>

--- a/isis/tests/FunctionalTestsCaminfo.cpp
+++ b/isis/tests/FunctionalTestsCaminfo.cpp
@@ -172,6 +172,38 @@ TEST_F(DefaultCube, FunctionalTestCaminfoCsv) {
 
 
 TEST_F(DefaultCube, FunctionalTestCaminfoDefault) {
+    CameraStatistics camStats(testCube->camera(), 100, 100, testCube->fileName());
+
+    Pvl statsPvl = camStats.toPvl();
+    TableField fname("Name", Isis::TableField::Text, 45);
+    TableField fmin("Minimum", Isis::TableField::Double);
+    TableField fmax("Maximum", Isis::TableField::Double);
+    TableField favg("Average", Isis::TableField::Double);
+    TableField fstd("StandardDeviation", Isis::TableField::Double);
+
+    TableRecord record;
+    record += fname;
+    record += fmin;
+    record += fmax;
+    record += favg;
+    record += fstd;
+
+    Table table("CameraStatistics", record);
+
+    for (int i = 1; i < statsPvl.groups(); i++) {
+      PvlGroup &group = statsPvl.group(i);
+
+      int entry = 0;
+      record[entry] = group.name();
+      entry++;
+      for (int j = 0; j < group.keywords(); j++) {
+        record[entry] = toDouble(group[j][0]);
+        entry++;
+      }
+      table += record;
+    }
+    testCube->write(table);
+
     QString outFileName = tempDir.path() + "/outTemp.csv";
     QVector<QString> args = {"to="+outFileName,
         "ISISLABEL=true", "ORIGINAL=true", "STATISTICS=true", "CAMSTATS=true",


### PR DESCRIPTION
Updated CAMSTATS parameter decision tree to allow users to extract camstats even if the cube already contains a camstats table

## Description
Removed a conditional that prevented caminfo from computing camstats from the cube if the cube contained a camstats table.

## Related Issue
Closes #4919 

## Motivation and Context
Support Sprint

## How Has This Been Tested?
Tested locally and all expected keywords are coming back. Will be tested through CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
