### PR TITLE
logs now report as pvgroups are added to pvl logs (fixes #4914)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ release.
 
 ### Changed
 - Updated the LRO calibration application Lrowaccal to add a units label to the RadiometricType keyword of the Radiometry group in the output cube label if the RadiometricType parameter is Radiance. No functionality is changed if the RadiometricType parameter is IOF. Lrowaccal has also been refactored to be callable for testing purposes. Issue: [#4939](https://github.com/USGS-Astrogeology/ISIS3/issues/4939), PR: [#4940](https://github.com/USGS-Astrogeology/ISIS3/pull/4940)
+- Changed how logs are reported so they no longer only printing at the end of the applications execution. [#4914](https://github.com/USGS-Astrogeology/ISIS3/issues/4914)
+
 
 ### Added
 - Improved functionality of msi2isis and MsiCamera model to support new Eros dataset, including support for Gaskell's SUMSPICE files that adjust timing, pointing and spacecraft position ephemeris. [#4886](https://github.com/USGS-Astrogeology/ISIS3/issues/4886)

--- a/isis/src/base/apps/automos/automos.cpp
+++ b/isis/src/base/apps/automos/automos.cpp
@@ -78,7 +78,7 @@ namespace Isis {
         PvlGroup outsiders("Outside");
         outsiders += PvlKeyword("File", list[i].toString());
         if (log) {
-          log->addGroup(outsiders);
+          log->addLogGroup(outsiders);
         }
       }
       else {
@@ -95,7 +95,7 @@ namespace Isis {
     // Logs the input file location in the mosaic
     for (int i = 0; i < m.imagePositions().groups(); i++) {
       if (log) {
-        log->addGroup(m.imagePositions().group(i));
+        log->addLogGroup(m.imagePositions().group(i));
       }
     }
 

--- a/isis/src/base/apps/automos/main.cpp
+++ b/isis/src/base/apps/automos/main.cpp
@@ -25,19 +25,7 @@ map <QString, void *> GuiHelpers() {
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    automos(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  automos(ui, &appLog);
 }
 
 // Function to calculate the ground range from multiple inputs (list of images)

--- a/isis/src/base/apps/cam2map/cam2map.cpp
+++ b/isis/src/base/apps/cam2map/cam2map.cpp
@@ -433,7 +433,7 @@ namespace Isis {
 
     // add mapping to print.prt
     if(log) {
-      log->addGroup(cleanMapping);
+      log->addLogGroup(cleanMapping);
     }
 
     // Cleanup

--- a/isis/src/base/apps/cam2map/main.cpp
+++ b/isis/src/base/apps/cam2map/main.cpp
@@ -35,19 +35,7 @@ map <QString, void *> GuiHelpers() {
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    cam2map(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  cam2map(ui, &appLog);
 }
 
 // Helper function to print out mapfile to session log

--- a/isis/src/base/apps/campt/campt.cpp
+++ b/isis/src/base/apps/campt/campt.cpp
@@ -259,7 +259,7 @@ namespace Isis{
       }
 
       // we still want to output the results
-      log->addGroup((*point));
+      log->addLogGroup((*point));
       delete point;
       point = NULL;
     }

--- a/isis/src/base/apps/campt/main.cpp
+++ b/isis/src/base/apps/campt/main.cpp
@@ -3,7 +3,6 @@
 #include "campt.h"
 
 #include "Application.h"
-#include "PvlLog.h"
 
 using namespace std;
 using namespace Isis;

--- a/isis/src/base/apps/campt/main.cpp
+++ b/isis/src/base/apps/campt/main.cpp
@@ -3,7 +3,7 @@
 #include "campt.h"
 
 #include "Application.h"
-#include "Pvl.h"
+#include "PvlLog.h"
 
 using namespace std;
 using namespace Isis;
@@ -11,17 +11,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    campt(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-  
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  campt(ui, &appLog);
 }

--- a/isis/src/base/apps/camrange/camrange.cpp
+++ b/isis/src/base/apps/camrange/camrange.cpp
@@ -98,13 +98,13 @@ namespace Isis {
     neg180 += PvlKeyword("MinimumLongitude", toString(minlon));
     neg180 += PvlKeyword("MaximumLongitude", toString(maxlon));
 
-    log->addGroup(target);
-    log->addGroup(res);
-    log->addGroup(ugr);
-    log->addGroup(ogr);
-    log->addGroup(pos360);
-    log->addGroup(pos180);
-    log->addGroup(neg180);
+    log->addLogGroup(target);
+    log->addLogGroup(res);
+    log->addLogGroup(ugr);
+    log->addLogGroup(ogr);
+    log->addLogGroup(pos360);
+    log->addLogGroup(pos180);
+    log->addLogGroup(neg180);
 
     // Write the log->file if requested
     if(ui.WasEntered("TO")) {

--- a/isis/src/base/apps/camrange/main.cpp
+++ b/isis/src/base/apps/camrange/main.cpp
@@ -12,17 +12,5 @@ void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    camrange(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  camrange(ui, &appLog);
 }

--- a/isis/src/base/apps/camstats/camstats.cpp
+++ b/isis/src/base/apps/camstats/camstats.cpp
@@ -51,7 +51,7 @@ namespace Isis {
     // Send the Output to the log area
     Pvl statsPvl = camStats.toPvl();
     for (int i = 0; i < statsPvl.groups(); i++) {
-      log->addGroup(statsPvl.group(i));
+      log->addLogGroup(statsPvl.group(i));
     }
 
     if(ui.WasEntered("TO")) {

--- a/isis/src/base/apps/camstats/main.cpp
+++ b/isis/src/base/apps/camstats/main.cpp
@@ -11,17 +11,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    camstats(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  camstats(ui, &appLog);
 }

--- a/isis/src/base/apps/ckwriter/ckwriter.cpp
+++ b/isis/src/base/apps/ckwriter/ckwriter.cpp
@@ -51,7 +51,7 @@ namespace Isis {
         overlap.setName("Overlaps");
         overlap.addKeyword(PvlKeyword("Class", "WARNING"), PvlContainer::Replace);
         if (log) {
-          log->addGroup(overlap);
+          log->addLogGroup(overlap);
         }
       }
     }

--- a/isis/src/base/apps/ckwriter/main.cpp
+++ b/isis/src/base/apps/ckwriter/main.cpp
@@ -11,17 +11,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    ckwriter(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  ckwriter(ui, &appLog);
 }

--- a/isis/src/base/apps/csminit/main.cpp
+++ b/isis/src/base/apps/csminit/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    csminit(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  csminit(ui, &appLog);
 }

--- a/isis/src/base/apps/cubeit/cubeit.cpp
+++ b/isis/src/base/apps/cubeit/cubeit.cpp
@@ -116,7 +116,7 @@ namespace Isis {
       //Only write out results group if we added something to it.
       if (results.hasKeyword("UnpropagatedBand")) {
         if (log){
-          log->addGroup(results);
+          log->addLogGroup(results);
         }
       }
     }

--- a/isis/src/base/apps/cubeit/main.cpp
+++ b/isis/src/base/apps/cubeit/main.cpp
@@ -21,19 +21,7 @@ map <QString, void *> GuiHelpers() {
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    cubeit(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  cubeit(ui, &appLog);
 }
 
 //Helper function to output the input file to log.

--- a/isis/src/base/apps/demprep/demprep.cpp
+++ b/isis/src/base/apps/demprep/demprep.cpp
@@ -68,7 +68,7 @@ namespace Isis{
       demRange += PvlKeyword("MinimumRadius", toString(inCubeStats.Minimum()), "meters");
       demRange += PvlKeyword("MaximumRadius", toString(inCubeStats.Maximum()), "meters");
       if (log){
-        log->addGroup(demRange);
+        log->addLogGroup(demRange);
       }
 
       // Store min/max radii values in new ShapeModelStatistics table
@@ -268,7 +268,7 @@ namespace Isis{
     demRange += PvlKeyword("MinimumRadius", toString(outCubeStats.Minimum()), "meters");
     demRange += PvlKeyword("MaximumRadius", toString(outCubeStats.Maximum()), "meters");
     if (log){
-      log->addGroup(demRange);
+      log->addLogGroup(demRange);
     }
 
     // Store min/max radii values in new ShapeModelStatistics table

--- a/isis/src/base/apps/demprep/main.cpp
+++ b/isis/src/base/apps/demprep/main.cpp
@@ -9,17 +9,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    demprep(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
-}
+  demprep(ui, &appLog);
+ }

--- a/isis/src/base/apps/enlarge/enlarge_app.cpp
+++ b/isis/src/base/apps/enlarge/enlarge_app.cpp
@@ -94,7 +94,7 @@ namespace Isis{
     delete interp;
 
     // Write the results to the log
-    log->addGroup(resultsGrp);
+    log->addLogGroup(resultsGrp);
   }
 }
 

--- a/isis/src/base/apps/enlarge/main.cpp
+++ b/isis/src/base/apps/enlarge/main.cpp
@@ -11,17 +11,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    enlarge(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-  
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  enlarge(ui, &appLog); 
 }

--- a/isis/src/base/apps/fillgap/fillgap.cpp
+++ b/isis/src/base/apps/fillgap/fillgap.cpp
@@ -77,7 +77,7 @@ namespace Isis {
       PvlGroup mLog("Messages");
       mLog += PvlKeyword("Warning",
                         "Unable to fill " + toString(numSpecPixKept) + " special pixels.");
-      log->addGroup(mLog);
+      log->addLogGroup(mLog);
     }
     return;
   }

--- a/isis/src/base/apps/fillgap/main.cpp
+++ b/isis/src/base/apps/fillgap/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    fillgap(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  fillgap(ui, &appLog); 
 }

--- a/isis/src/base/apps/findimageoverlaps/findimageoverlaps.cpp
+++ b/isis/src/base/apps/findimageoverlaps/findimageoverlaps.cpp
@@ -87,7 +87,7 @@ namespace Isis {
     results += PvlKeyword("ErrorCount", toString((BigInt)overlaps.Errors().size()));
 
     if (log) {
-      log->addGroup(results);
+      log->addLogGroup(results);
     }
   }
 }

--- a/isis/src/base/apps/findimageoverlaps/main.cpp
+++ b/isis/src/base/apps/findimageoverlaps/main.cpp
@@ -11,17 +11,5 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
 
-  try {
-    findimageoverlaps(ui, true, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  findimageoverlaps(ui, true, &appLog); 
 }

--- a/isis/src/base/apps/footprintinit/footprintinit.cpp
+++ b/isis/src/base/apps/footprintinit/footprintinit.cpp
@@ -144,7 +144,7 @@ namespace Isis {
       PvlGroup results("Results");
       results.addKeyword(PvlKeyword("SINC", toString(sinc)));
       results.addKeyword(PvlKeyword("LINC", toString(linc)));
-      log->addGroup(results);
+      log->addLogGroup(results);
     }
 
     Process p;

--- a/isis/src/base/apps/footprintinit/main.cpp
+++ b/isis/src/base/apps/footprintinit/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    footprintinit(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
-}
+  footprintinit(ui, &appLog);
+ }

--- a/isis/src/base/apps/getsn/getsn.cpp
+++ b/isis/src/base/apps/getsn/getsn.cpp
@@ -89,6 +89,6 @@ namespace Isis {
       }
     }
 
-    log->addGroup(sn);    
+    log->addLogGroup(sn);    
   }
 }

--- a/isis/src/base/apps/isis2pds/isis2pds.cpp
+++ b/isis/src/base/apps/isis2pds/isis2pds.cpp
@@ -120,7 +120,7 @@ namespace Isis{
       results += PvlKeyword("ValidMin", toString(min));
       results += PvlKeyword("ValidMax", toString(max));
       if (log){
-        log->addGroup(results);
+        log->addLogGroup(results);
       }
     }
     else {
@@ -196,7 +196,7 @@ namespace Isis{
       results += PvlKeyword("ValidMin", toString(min));
       results += PvlKeyword("ValidMax", toString(max));
       if (log){
-        log->addGroup(results);
+        log->addLogGroup(results);
       }
 
       process.StandardPds4Label();

--- a/isis/src/base/apps/isis2pds/main.cpp
+++ b/isis/src/base/apps/isis2pds/main.cpp
@@ -9,17 +9,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    isis2pds(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  isis2pds(ui, &appLog); 
 }

--- a/isis/src/base/apps/isisexport/isisexport.cpp
+++ b/isis/src/base/apps/isisexport/isisexport.cpp
@@ -127,7 +127,7 @@ namespace Isis {
                               + "Previous value [" + QString::fromStdString(dataSource["ExtraPvl"][element.key()].dump())
                               + "] will be overwritten.";
               duplicateWarnings += PvlKeyword("Duplicate", message);
-              log->addGroup(duplicateWarnings);
+              log->addLogGroup(duplicateWarnings);
             }
           }
         }
@@ -150,7 +150,7 @@ namespace Isis {
                               + "Previous value [" + QString::fromStdString(dataSource["ExtraXml"][element.key()].dump())
                               + "] will be overwritten.";
               duplicateWarnings += PvlKeyword("Duplicate", message);
-              log->addGroup(duplicateWarnings);
+              log->addLogGroup(duplicateWarnings);
             }
           }
         }
@@ -174,7 +174,7 @@ namespace Isis {
                               + "Previous value [" + QString::fromStdString(dataSource["ExtraJson"][element.key()].dump())
                               + "] will be overwritten.";
               duplicateWarnings += PvlKeyword("Duplicate", message);
-              log->addGroup(duplicateWarnings);
+              log->addLogGroup(duplicateWarnings);
             }
           }
         }

--- a/isis/src/base/apps/isisexport/main.cpp
+++ b/isis/src/base/apps/isisexport/main.cpp
@@ -9,17 +9,5 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
 
-  try {
-    isisexport(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  isisexport(ui, &appLog); 
 }

--- a/isis/src/base/apps/isisimport/main.cpp
+++ b/isis/src/base/apps/isisimport/main.cpp
@@ -9,17 +9,5 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
 
-  try {
-    isisimport(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  isisimport(ui, &appLog); 
 }

--- a/isis/src/base/apps/map2map/main.cpp
+++ b/isis/src/base/apps/map2map/main.cpp
@@ -20,19 +20,7 @@ map <QString, void *> GuiHelpers() {
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    map2map(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  map2map(ui, &appLog); 
 }
 
 // Helper function to print out mapfile to session log

--- a/isis/src/base/apps/map2map/map2map.cpp
+++ b/isis/src/base/apps/map2map/map2map.cpp
@@ -370,7 +370,7 @@ namespace Isis {
     p.EndProcess();
 
     if (log){
-      log->addGroup(cleanOutGrp);
+      log->addLogGroup(cleanOutGrp);
     }
 
     // Cleanup

--- a/isis/src/base/apps/mapmos/main.cpp
+++ b/isis/src/base/apps/mapmos/main.cpp
@@ -12,17 +12,5 @@ void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    mapmos(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  mapmos(ui, &appLog); 
 }

--- a/isis/src/base/apps/mapmos/mapmos.cpp
+++ b/isis/src/base/apps/mapmos/mapmos.cpp
@@ -100,12 +100,12 @@ namespace Isis {
       // Logs the cube if it falls outside of the given mosaic
       PvlGroup outsiders("Outside");
       outsiders += PvlKeyword("File", sInputFile);
-      log->addGroup(outsiders);
+      log->addLogGroup(outsiders);
     }
     else {
       // Logs the input file location in the mosaic
       for (int i = 0; i < m.imagePositions().groups(); i++) {
-        log->addGroup(m.imagePositions().group(i));
+        log->addLogGroup(m.imagePositions().group(i));
       }
     }
 

--- a/isis/src/base/apps/mappt/main.cpp
+++ b/isis/src/base/apps/mappt/main.cpp
@@ -22,19 +22,7 @@ map <QString, void *> GuiHelpers() {
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    mappt(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-  
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  mappt(ui, &appLog);
 }
 
 

--- a/isis/src/base/apps/mappt/mappt.cpp
+++ b/isis/src/base/apps/mappt/mappt.cpp
@@ -40,7 +40,8 @@ void mappt(Cube *icube, UserInterface &ui, Pvl *log, CubeAttributeInput* inAtt) 
    
   if(log) {
     for(int i = 0; i < points.size(); i++) {
-      log->addLogGroup(getProjPointInfo(icube, points[i], ui, log));
+      PvlGroup g = getProjPointInfo(icube, points[i], ui, log);
+      log->addLogGroup(g);
     } 
   }
 

--- a/isis/src/base/apps/mappt/mappt.cpp
+++ b/isis/src/base/apps/mappt/mappt.cpp
@@ -40,7 +40,7 @@ void mappt(Cube *icube, UserInterface &ui, Pvl *log, CubeAttributeInput* inAtt) 
    
   if(log) {
     for(int i = 0; i < points.size(); i++) {
-      log->addGroup(getProjPointInfo(icube, points[i], ui, log));
+      log->addLogGroup(getProjPointInfo(icube, points[i], ui, log));
     } 
   }
 

--- a/isis/src/base/apps/maptrim/main.cpp
+++ b/isis/src/base/apps/maptrim/main.cpp
@@ -9,17 +9,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    maptrim(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  maptrim(ui, &appLog); 
 }

--- a/isis/src/base/apps/maptrim/maptrim.cpp
+++ b/isis/src/base/apps/maptrim/maptrim.cpp
@@ -116,7 +116,7 @@ namespace Isis{
     // Add mapping to print.prt
     PvlGroup mapping = proj->Mapping();
     if (log){
-      log->addGroup(mapping);
+      log->addLogGroup(mapping);
     }
 
     delete proj;

--- a/isis/src/base/apps/mosrange/main.cpp
+++ b/isis/src/base/apps/mosrange/main.cpp
@@ -16,17 +16,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    mosrange(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  mosrange(ui, &appLog); 
 }

--- a/isis/src/base/apps/mosrange/mosrange.cpp
+++ b/isis/src/base/apps/mosrange/mosrange.cpp
@@ -294,7 +294,7 @@ namespace Isis {
     mapping += PvlKeyword("PreciseMaximumLongitude", toString(longitudeStat.Maximum()));
 
     if (log){
-      log->addGroup(mapping);
+      log->addLogGroup(mapping);
     }
     
     // Write the output file if requested

--- a/isis/src/base/apps/nocam2map/main.cpp
+++ b/isis/src/base/apps/nocam2map/main.cpp
@@ -51,21 +51,9 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
 
-  try {
-    nocam2map(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
- 
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  nocam2map(ui, &appLog); 
 
-    // in this case, output data are in a "Results" group.
+  // in this case, output data are in a "Results" group.
   PvlGroup results = appLog.findGroup("Mapping");
   if( ui.WasEntered("TO") && ui.IsInteractive() ) {
     Application::GuiLog(results);

--- a/isis/src/base/apps/nocam2map/nocam2map.cpp
+++ b/isis/src/base/apps/nocam2map/nocam2map.cpp
@@ -186,7 +186,7 @@ namespace Isis {
     error += PvlKeyword("LineStdDeviationError", toString(lineErr.StandardDeviation()));
     
     if (log) {
-        log->addGroup(error);
+        log->addLogGroup(error);
     }
 
     //Close the input cubes for cleanup
@@ -465,7 +465,7 @@ namespace Isis {
       PvlGroup mapping = outmap->Mapping();
       
       if (log) {
-        log->addGroup(mapping);
+        log->addLogGroup(mapping);
       }
 
       //Clean up

--- a/isis/src/base/apps/overlapstats/main.cpp
+++ b/isis/src/base/apps/overlapstats/main.cpp
@@ -12,17 +12,5 @@ void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    overlapstats(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  overlapstats(ui, &appLog); 
 }

--- a/isis/src/base/apps/overlapstats/overlapstats.cpp
+++ b/isis/src/base/apps/overlapstats/overlapstats.cpp
@@ -244,7 +244,7 @@ namespace Isis {
       }
     }
 
-    log->addGroup(brief);
+    log->addLogGroup(brief);
 
     //Log the ERRORS file
     if (ui.WasEntered("ERRORS")) {
@@ -260,7 +260,7 @@ namespace Isis {
       PvlGroup grp("OverlapStats");
       PvlKeyword key("ErrorNumber", toString(errorNum));
       grp.addKeyword(key);
-      log->addGroup(grp);
+      log->addLogGroup(grp);
     }
 
     // Display FULL output
@@ -276,7 +276,7 @@ namespace Isis {
       }
     }
 
-    log->addGroup(brief);
+    log->addLogGroup(brief);
   }
 
 

--- a/isis/src/base/apps/pds2isis/main.cpp
+++ b/isis/src/base/apps/pds2isis/main.cpp
@@ -12,17 +12,5 @@ void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    pds2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  pds2isis(ui, &appLog); 
 }

--- a/isis/src/base/apps/pds2isis/pds2isis.cpp
+++ b/isis/src/base/apps/pds2isis/pds2isis.cpp
@@ -73,7 +73,7 @@ namespace Isis {
       results.setName("Results");
       results[0].addComment("Projection offsets and multipliers have been changed from");
       results[0].addComment("defaults. New values are below.");
-      log->addGroup(results);
+      log->addLogGroup(results);
     }
 
     p.EndProcess();

--- a/isis/src/base/apps/reduce/main.cpp
+++ b/isis/src/base/apps/reduce/main.cpp
@@ -9,17 +9,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    reduce(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  reduce(ui, &appLog); 
 }

--- a/isis/src/base/apps/reduce/reduce_app.cpp
+++ b/isis/src/base/apps/reduce/reduce_app.cpp
@@ -86,7 +86,7 @@ namespace Isis{
 
       // Write the results to the log
       if (log){
-        log->addGroup(results);
+        log->addLogGroup(results);
       }
     } // REFORMAT THESE ERRORS INTO ISIS TYPES AND RETHROW
     catch (IException &) {

--- a/isis/src/base/apps/ringsautomos/main.cpp
+++ b/isis/src/base/apps/ringsautomos/main.cpp
@@ -26,19 +26,7 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
 
-  try {
-    ringsautomos(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
- 
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  ringsautomos(ui, &appLog); 
 }
 
 

--- a/isis/src/base/apps/ringsautomos/ringsautomos.cpp
+++ b/isis/src/base/apps/ringsautomos/ringsautomos.cpp
@@ -80,7 +80,7 @@ namespace Isis {
         PvlGroup outsiders("Outside");
         outsiders += PvlKeyword("File", list[i].toString());
         if(log) {
-          log->addGroup(outsiders);
+          log->addLogGroup(outsiders);
         }
       }
       else {
@@ -97,7 +97,7 @@ namespace Isis {
     // Logs the input file location in the mosaic
     for (int i = 0; i < m.imagePositions().groups(); i++) {
       if(log) {
-        log->addGroup(m.imagePositions().group(i));
+        log->addLogGroup(m.imagePositions().group(i));
       }
     }
 

--- a/isis/src/base/apps/shadow/main.cpp
+++ b/isis/src/base/apps/shadow/main.cpp
@@ -11,17 +11,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    shadow(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  shadow(ui, &appLog); 
 }

--- a/isis/src/base/apps/shadow/shadow.cpp
+++ b/isis/src/base/apps/shadow/shadow.cpp
@@ -129,7 +129,7 @@ namespace Isis {
     }
 
     if (log) {
-      log->addGroup(functorLogData);
+      log->addLogGroup(functorLogData);
     }
 
     // Look for shape model object and remove it from output

--- a/isis/src/base/apps/spiceinit/main.cpp
+++ b/isis/src/base/apps/spiceinit/main.cpp
@@ -12,17 +12,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    spiceinit(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  spiceinit(ui, &appLog); 
 }

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -474,7 +474,7 @@ namespace Isis {
         currentKernels += source;
         icube->putGroup(currentKernels);
         if (log){
-          log->addGroup(currentKernels);
+          log->addLogGroup(currentKernels);
         }
 
       }
@@ -485,7 +485,7 @@ namespace Isis {
           currentKernels += PvlKeyword("Error", errPvl.group(errPvl.groups() - 1)["Message"][0]);
         }
         if (log) {
-          log->addGroup(currentKernels);
+          log->addLogGroup(currentKernels);
         }
         icube->putGroup(originalKernels);
 
@@ -681,7 +681,7 @@ namespace Isis {
     icube->putGroup(kernelsGroup);
 
     if (log) {
-      log->addGroup(kernelsGroup);
+      log->addLogGroup(kernelsGroup);
     }
 
     Pvl *icubeLabel = icube->label();

--- a/isis/src/base/apps/spiceserver/main.cpp
+++ b/isis/src/base/apps/spiceserver/main.cpp
@@ -12,17 +12,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    spiceserver(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  spiceserver(ui, &appLog); 
 }

--- a/isis/src/base/apps/spiceserver/spiceserver.cpp
+++ b/isis/src/base/apps/spiceserver/spiceserver.cpp
@@ -439,7 +439,7 @@ namespace Isis {
           currentKernels += PvlKeyword("Error", errPvl.group(errPvl.groups() - 1)["Message"][0]);
 
         if (log) {
-          log->addGroup(currentKernels);
+          log->addLogGroup(currentKernels);
         }
         throw e;
       }

--- a/isis/src/base/apps/spkwriter/main.cpp
+++ b/isis/src/base/apps/spkwriter/main.cpp
@@ -11,17 +11,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    spkwriter(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  spkwriter(ui, &appLog); 
 }

--- a/isis/src/base/apps/spkwriter/spkwriter.cpp
+++ b/isis/src/base/apps/spkwriter/spkwriter.cpp
@@ -91,7 +91,7 @@ namespace Isis {
         PvlGroup overlap = overrors.group(i);
         overlap.setName("Overlaps");
         overlap.addKeyword(PvlKeyword("Class", "WARNING"), PvlContainer::Replace);
-        log->addGroup(overlap);
+        log->addLogGroup(overlap);
       }
     }
 

--- a/isis/src/base/apps/stretch/main.cpp
+++ b/isis/src/base/apps/stretch/main.cpp
@@ -2,25 +2,14 @@
 
 #include "Application.h"
 #include "UserInterface.h"
-
+#include "PvlLog.h"
 #include "stretch_app.h"
-
+ 
 using namespace std;
 using namespace Isis;
 
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl results;
-  try{
-      stretch(ui, &results);
-  }
-  catch(...){
-      for (int resultIndex = 0; resultIndex < results.groups(); resultIndex++) {
-          Application::Log(results.group(resultIndex));
-      }
-      throw;
-  }
-  for (int resultIndex = 0; resultIndex < results.groups(); resultIndex++) {
-      Application::Log(results.group(resultIndex));
-  }
+  stretch(ui, &results);
 }

--- a/isis/src/base/apps/stretch/main.cpp
+++ b/isis/src/base/apps/stretch/main.cpp
@@ -2,7 +2,6 @@
 
 #include "Application.h"
 #include "UserInterface.h"
-#include "PvlLog.h"
 #include "stretch_app.h"
  
 using namespace std;

--- a/isis/src/base/apps/stretch/stretch_app.cpp
+++ b/isis/src/base/apps/stretch/stretch_app.cpp
@@ -46,6 +46,7 @@ namespace Isis {
     stretch(cubeFile, pairs, ui, log);
   }
 
+
   void stretch(Cube *inCube, QString &pairs, UserInterface &ui, Pvl *log) {
     ProcessByLine p;
     p.SetInputCube(inCube);
@@ -53,8 +54,9 @@ namespace Isis {
     if(ui.GetBoolean("USEPERCENTAGES")) {
       str.Parse(pairs, inCube->histogram());
     }
-    else
+    else {
       str.Parse(pairs);
+    }
 
     // Setup new mappings for special pixels if necessary
     if(ui.WasEntered("NULL"))
@@ -81,7 +83,7 @@ namespace Isis {
     results.addKeyword(dnPairs);
 
     if (log){
-      log->addGroup(results);
+      log->addLogGroup(results);
     }
   }
 

--- a/isis/src/base/apps/stretch/stretch_app.h
+++ b/isis/src/base/apps/stretch/stretch_app.h
@@ -4,7 +4,6 @@
 #include "PvlGroup.h"
 #include "PvlKeyword.h"
 #include "UserInterface.h"
-#include "PvlLog.h"
 
 namespace Isis {
   extern void stretch(UserInterface &ui, Pvl *log=nullptr);

--- a/isis/src/base/apps/stretch/stretch_app.h
+++ b/isis/src/base/apps/stretch/stretch_app.h
@@ -4,6 +4,7 @@
 #include "PvlGroup.h"
 #include "PvlKeyword.h"
 #include "UserInterface.h"
+#include "PvlLog.h"
 
 namespace Isis {
   extern void stretch(UserInterface &ui, Pvl *log=nullptr);

--- a/isis/src/base/objs/Application/Application.cpp
+++ b/isis/src/base/objs/Application/Application.cpp
@@ -353,16 +353,17 @@ namespace Isis {
   void Application::Log(PvlGroup &results) {
     // Add it to the log file
     static bool blankLine = false;
-
-    SessionLog::TheLog().AddResults(results);
+    if (iApp) {
+      SessionLog::TheLog().AddResults(results);
+    }
 
     // See if the log file will be written to the terminal/gui
     // The results group of the Sessoion::Log will be written later
     // in Application::FunctionCleanup if TerminalOutput is on
-    if (SessionLog::TheLog().TerminalOutput()) return;
+    if (iApp && SessionLog::TheLog().TerminalOutput()) return;
 
     // See if we should write the info to our parents gui
-    if (HasParent()) {
+    if (iApp && HasParent()) {
       ostringstream ostr;
       if (blankLine) ostr << endl;
       ostr << results << endl;
@@ -371,7 +372,7 @@ namespace Isis {
     }
 
     // Otherwise see if we need to write to our gui
-    else if (iApp->GetUserInterface().IsInteractive()) {
+    else if (iApp && iApp->GetUserInterface().IsInteractive()) {
       ostringstream ostr;
       if (blankLine) ostr << endl;
       ostr << results << endl;

--- a/isis/src/base/objs/Application/Application.h
+++ b/isis/src/base/objs/Application/Application.h
@@ -31,7 +31,6 @@ namespace Isis {
   class Gui;
   class IException;
   class Progress;
-  class PvlObject; 
 
   /**
    *  @author ????-??-?? Unknown

--- a/isis/src/base/objs/Application/Application.h
+++ b/isis/src/base/objs/Application/Application.h
@@ -31,6 +31,7 @@ namespace Isis {
   class Gui;
   class IException;
   class Progress;
+  class PvlObject; 
 
   /**
    *  @author ????-??-?? Unknown

--- a/isis/src/base/objs/PvlObject/PvlObject.cpp
+++ b/isis/src/base/objs/PvlObject/PvlObject.cpp
@@ -12,6 +12,7 @@ find files of those names at the top level of this repository. **/
 #include "IString.h"
 #include "Message.h"
 #include "PvlFormat.h"
+#include "Application.h"
 
 #include <QList>
 
@@ -157,6 +158,15 @@ namespace Isis {
     throw IException(IException::Unknown, msg, _FILEINFO_);
   }
 
+  /**
+   * Add a group to the object and report it to the log/terminal. 
+   *
+   * @param group The PvlGroup object to add.
+   */
+  void PvlObject::addLogGroup(Isis::PvlGroup &group) {
+    addGroup(group);
+    Application::Log(group);
+  };
 
   /**
    * Finds a keyword in the current PvlObject, or deeper inside

--- a/isis/src/base/objs/PvlObject/PvlObject.h
+++ b/isis/src/base/objs/PvlObject/PvlObject.h
@@ -188,6 +188,8 @@ namespace Isis {
         //m_groups[m_groups.size()-1].SetFileName(FileName());
       };
 
+      void addLogGroup(Isis::PvlGroup &group);
+
       using PvlContainer::operator+=;
       void operator+= (const Isis::PvlGroup &group) {
         addGroup(group);

--- a/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
+++ b/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
@@ -362,7 +362,7 @@ namespace Isis{
       PvlGroup msgGrp("Warnings");
       msgGrp += PvlKeyword("CameraAngleLookup", "Failed! No Camera information for filter combination: " + filter);
       if (log) {
-        log->addGroup(msgGrp);
+        log->addLogGroup(msgGrp);
       }
       bandBin += PvlKeyword("Center", "None found for filter combination.");
       bandBin += PvlKeyword("Width", "None found for filter combination.");

--- a/isis/src/cassini/apps/ciss2isis/main.cpp
+++ b/isis/src/cassini/apps/ciss2isis/main.cpp
@@ -17,18 +17,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    ciss2isis(ui, &appLog);
-
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  ciss2isis(ui, &appLog);
 }

--- a/isis/src/chandrayaan1/apps/chan1m32isis/main.cpp
+++ b/isis/src/chandrayaan1/apps/chan1m32isis/main.cpp
@@ -15,7 +15,4 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl results = chan1m32isis(ui);
-  for (int resultIndex = 0; resultIndex < results.groups(); resultIndex++) {
-    Application::Log(results.group(resultIndex));
-  }
 }

--- a/isis/src/control/apps/autoseed/autoseed.cpp
+++ b/isis/src/control/apps/autoseed/autoseed.cpp
@@ -487,7 +487,7 @@ namespace Isis {
     pluginInfo.addKeyword(PvlKeyword("MaxIncidence", toString(maxIncidence)));
     pluginInfo.addKeyword(PvlKeyword("MaxEmission", toString(maxEmission)));
     if (log) {
-      log->addGroup(pluginInfo);
+      log->addLogGroup(pluginInfo);
     }
 
     // inform user of any unused (invalid) keywords found in the def file
@@ -495,7 +495,7 @@ namespace Isis {
       PvlGroup unusedKeywords(unusedDefKeywords);
       unusedKeywords.setName("InvalidKeyordsFoundInDefFile");
       if (log) {
-        log->addGroup(unusedKeywords);
+        log->addLogGroup(unusedKeywords);
       }
     }
 
@@ -518,7 +518,7 @@ namespace Isis {
     resultsGrp.addKeyword(cpIgnoredCountKeyword);
     resultsGrp.addKeyword(cmIgnoredCountKeyword);
     if (log) {
-      log->addGroup(resultsGrp);
+      log->addLogGroup(resultsGrp);
     }
 
     if (seedDomain == XY) {

--- a/isis/src/control/apps/autoseed/main.cpp
+++ b/isis/src/control/apps/autoseed/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    autoseed(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  autoseed(ui, &appLog); 
 }

--- a/isis/src/control/apps/cnetcheck/cnetcheck.cpp
+++ b/isis/src/control/apps/cnetcheck/cnetcheck.cpp
@@ -459,7 +459,7 @@ namespace Isis {
     QString logstr = ss.str().c_str();
 
     if (log){
-      log->addGroup(results);
+      log->addLogGroup(results);
     }
 
     if (!ui.IsInteractive()) {

--- a/isis/src/control/apps/cnetcheck/main.cpp
+++ b/isis/src/control/apps/cnetcheck/main.cpp
@@ -21,21 +21,9 @@ void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
 
-  try {
-    QString results = cnetcheck(ui, &appLog);
+  QString results = cnetcheck(ui, &appLog);
 
-    if (ui.IsInteractive()){
-      Application::GuiLog(results);
-    }
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
+  if (ui.IsInteractive()){
+    Application::GuiLog(results);
   }
 }

--- a/isis/src/control/apps/cnetcombinept/cnetcombinept.cpp
+++ b/isis/src/control/apps/cnetcombinept/cnetcombinept.cpp
@@ -497,7 +497,7 @@ namespace Isis{
       summary += PvlKeyword("MeasuresMerged",    toString(nMerged));
       summary += PvlKeyword("MeasuresDeleted",   toString(nRemoved));
       summary += PvlKeyword("MinimumMeasures",   toString(nMinMeasures));
-      log->addGroup(summary);
+      log->addLogGroup(summary);
     }
 
     pbl.EndProcess();

--- a/isis/src/control/apps/cnetcombinept/main.cpp
+++ b/isis/src/control/apps/cnetcombinept/main.cpp
@@ -18,17 +18,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    cnetcombinept(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  cnetcombinept(ui, &appLog); 
 }

--- a/isis/src/control/apps/cnetextract/cnetextract.cpp
+++ b/isis/src/control/apps/cnetextract/cnetextract.cpp
@@ -398,7 +398,7 @@ namespace Isis {
 
     // Log Control Net results
     if (log){
-      log->addGroup(summary);
+      log->addLogGroup(summary);
     }
 
     outProgress.CheckStatus();
@@ -504,7 +504,7 @@ namespace Isis {
                            "Check the documentation for specific keyword descriptions.");
       }
       if(log) {
-        log->addGroup(results);
+        log->addLogGroup(results);
       }
 
       resultsProgress.CheckStatus();

--- a/isis/src/control/apps/cnetextract/main.cpp
+++ b/isis/src/control/apps/cnetextract/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    cnetextract(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  cnetextract(ui, &appLog); 
 }

--- a/isis/src/control/apps/cnetstats/cnetstats.cpp
+++ b/isis/src/control/apps/cnetstats/cnetstats.cpp
@@ -68,7 +68,7 @@ namespace Isis{
         for (int i=0; i<pvlDefFile.objects(); i++) {
           PvlObject pvlObj = pvlDefFile.object(i);
           for (int j=0; j<pvlObj.groups(); j++) {
-            log->addGroup(pvlObj.group(j));
+            log->addLogGroup(pvlObj.group(j));
           }
         }
 
@@ -80,7 +80,7 @@ namespace Isis{
           for (int i=0; i<pvlResults.objects(); i++) {
             PvlObject pvlObj = pvlResults.object(i);
             for (int j=0; j<pvlObj.groups(); j++) {
-              log->addGroup(pvlObj.group(j));
+              log->addLogGroup(pvlObj.group(j));
             }
           }
           QString sErrMsg = "Invalid Deffile\n";
@@ -110,7 +110,7 @@ namespace Isis{
       // Log the summary of the input Control Network
       PvlGroup statsGrp;
       cNetFilter.GenerateControlNetStats(statsGrp);
-      log->addGroup(statsGrp);
+      log->addLogGroup(statsGrp);
 
       // Run Filters using Deffile
       if (ui.WasEntered("DEFFILE")) {

--- a/isis/src/control/apps/cnetstats/main.cpp
+++ b/isis/src/control/apps/cnetstats/main.cpp
@@ -18,17 +18,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    cnetstats(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  cnetstats(ui, &appLog); 
 }

--- a/isis/src/control/apps/findfeatures/findfeatures.cpp
+++ b/isis/src/control/apps/findfeatures/findfeatures.cpp
@@ -313,7 +313,7 @@ namespace Isis{
     }
 
     if(log){
-      log->addGroup(bestinfo);
+      log->addLogGroup(bestinfo);
     }
 
 
@@ -353,7 +353,7 @@ namespace Isis{
       // Write out control network
       cnet.Write( ui.GetFileName("ONET") );
       if(log){
-        log->addGroup(cnetinfo);
+        log->addLogGroup(cnetinfo);
       }
     }
 

--- a/isis/src/control/apps/findfeatures/main.cpp
+++ b/isis/src/control/apps/findfeatures/main.cpp
@@ -19,19 +19,7 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    findfeatures(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  findfeatures(ui, &appLog);
 
   Pvl results;
   if( (ui.GetBoolean("LISTALL") || ui.GetBoolean("LISTSPEC")) && ui.IsInteractive() ) {

--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -72,7 +72,7 @@ namespace Isis {
                                                    in addition error in the bundle adjust. \
                                                    We recommend that you do not solve for radii at this moment."));
          if(log) {
-           log->PvlObject::addGroup(radiusSolveWarning);
+           log->addLogGroup(radiusSolveWarning);
          }
       }
     }
@@ -183,10 +183,10 @@ namespace Isis {
         iss >> summary;
 
         for (auto grpIt = summary.beginGroup(); grpIt!= summary.endGroup(); grpIt++) {
-          log->addGroup(*grpIt);
+          log->addLogGroup(*grpIt);
         }
 
-        log->addGroup(gp);
+        log->addLogGroup(gp);
       }
       delete bundleSolution;
     }

--- a/isis/src/control/apps/jigsaw/main.cpp
+++ b/isis/src/control/apps/jigsaw/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    jigsaw(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  jigsaw(ui, &appLog);
 }

--- a/isis/src/control/apps/pointreg/main.cpp
+++ b/isis/src/control/apps/pointreg/main.cpp
@@ -20,17 +20,5 @@ void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    pointreg(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  pointreg(ui, &appLog); 
 }

--- a/isis/src/control/apps/pointreg/pointreg.cpp
+++ b/isis/src/control/apps/pointreg/pointreg.cpp
@@ -469,25 +469,25 @@ namespace Isis {
     PvlGroup pLog("Points");
     pLog += PvlKeyword("Total", toString(outNet.GetNumPoints()));
     pLog += PvlKeyword("Ignored", toString(ignored));
-    appLog->addGroup(pLog);
+    applog->addLogGroup(pLog);
 
     PvlGroup mLog("Measures");
     mLog += PvlKeyword("Locked", toString(locked));
     mLog += PvlKeyword("Registered", toString(registered));
     mLog += PvlKeyword("NotIntersected", toString(notintersected));
     mLog += PvlKeyword("Unregistered", toString(unregistered));
-    appLog->addGroup(mLog);
+    applog->addLogGroup(mLog);
 
     // Log Registration Statistics
     Pvl arPvl = ar->RegistrationStatistics();
 
     for (int i = 0; i < arPvl.groups(); i++) {
-      appLog->addGroup(arPvl.group(i));
+      applog->addLogGroup(arPvl.group(i));
     }
 
     // add the auto registration information to print.prt
     PvlGroup autoRegTemplate = ar->RegTemplate();
-    appLog->addGroup(autoRegTemplate);
+    applog->addLogGroup(autoRegTemplate);
 
     if (validator) {
       PvlGroup validationGroup("ValidationStatistics");
@@ -502,11 +502,11 @@ namespace Isis {
         }
       }
 
-      appLog->addGroup(validationGroup);
+      applog->addLogGroup(validationGroup);
 
       PvlGroup validationTemplate = validator->UpdatedTemplate();
       validationTemplate.setName("ValidationTemplate");
-      appLog->addGroup(validationTemplate);
+      applog->addLogGroup(validationTemplate);
     }
 
     outNet.Write(ui.GetFileName("ONET"));

--- a/isis/src/control/apps/pointreg/pointreg.cpp
+++ b/isis/src/control/apps/pointreg/pointreg.cpp
@@ -469,25 +469,25 @@ namespace Isis {
     PvlGroup pLog("Points");
     pLog += PvlKeyword("Total", toString(outNet.GetNumPoints()));
     pLog += PvlKeyword("Ignored", toString(ignored));
-    applog->addLogGroup(pLog);
+    appLog->addLogGroup(pLog);
 
     PvlGroup mLog("Measures");
     mLog += PvlKeyword("Locked", toString(locked));
     mLog += PvlKeyword("Registered", toString(registered));
     mLog += PvlKeyword("NotIntersected", toString(notintersected));
     mLog += PvlKeyword("Unregistered", toString(unregistered));
-    applog->addLogGroup(mLog);
+    appLog->addLogGroup(mLog);
 
     // Log Registration Statistics
     Pvl arPvl = ar->RegistrationStatistics();
 
     for (int i = 0; i < arPvl.groups(); i++) {
-      applog->addLogGroup(arPvl.group(i));
+      appLog->addLogGroup(arPvl.group(i));
     }
 
     // add the auto registration information to print.prt
     PvlGroup autoRegTemplate = ar->RegTemplate();
-    applog->addLogGroup(autoRegTemplate);
+    appLog->addLogGroup(autoRegTemplate);
 
     if (validator) {
       PvlGroup validationGroup("ValidationStatistics");
@@ -502,11 +502,11 @@ namespace Isis {
         }
       }
 
-      applog->addLogGroup(validationGroup);
+      appLog->addLogGroup(validationGroup);
 
       PvlGroup validationTemplate = validator->UpdatedTemplate();
       validationTemplate.setName("ValidationTemplate");
-      applog->addLogGroup(validationTemplate);
+      appLog->addLogGroup(validationTemplate);
     }
 
     outNet.Write(ui.GetFileName("ONET"));

--- a/isis/src/control/apps/sumspice/main.cpp
+++ b/isis/src/control/apps/sumspice/main.cpp
@@ -17,17 +17,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    sumspice(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  sumspice(ui, &appLog); 
 }

--- a/isis/src/control/apps/sumspice/sumspice.cpp
+++ b/isis/src/control/apps/sumspice/sumspice.cpp
@@ -121,7 +121,7 @@ namespace Isis {
     }
 
     if (duplicates.keywords() != 0 && log) {
-      log->addGroup(duplicates);
+      log->addLogGroup(duplicates);
     }
 
     // Determine the update mode
@@ -197,7 +197,7 @@ namespace Isis {
       PvlGroup loggrp("Warnings");
       loggrp.addKeyword(message);
       if (log){
-        log->addGroup(loggrp);
+        log->addLogGroup(loggrp);
       }
     }
 

--- a/isis/src/galileo/apps/gllssical/gllssical.cpp
+++ b/isis/src/galileo/apps/gllssical/gllssical.cpp
@@ -147,7 +147,7 @@ namespace Isis {
     ocube->putGroup(calibrationLog);
     
     if(log){
-      log->addGroup(calibrationLog);
+      log->addLogGroup(calibrationLog);
     }
     
     p.EndProcess();

--- a/isis/src/galileo/apps/gllssical/main.cpp
+++ b/isis/src/galileo/apps/gllssical/main.cpp
@@ -10,17 +10,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    gllssical(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
- 
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  gllssical(ui, &appLog); 
 }

--- a/isis/src/kaguya/apps/kaguyatc2isis/main.cpp
+++ b/isis/src/kaguya/apps/kaguyatc2isis/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    kaguyatc2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt != appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt != appLog.endGroup(); grpIt++){
-    Application::Log(*grpIt);
-  }
+  kaguyatc2isis(ui, &appLog); 
 }

--- a/isis/src/kaguya/apps/mimap2isis/main.cpp
+++ b/isis/src/kaguya/apps/mimap2isis/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    mimap2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  mimap2isis(ui, &appLog); 
 }

--- a/isis/src/kaguya/apps/mimap2isis/mimap2isis.cpp
+++ b/isis/src/kaguya/apps/mimap2isis/mimap2isis.cpp
@@ -121,7 +121,7 @@ namespace Isis {
     results.setName("Results");
     results[0].addComment("Projection offsets and multipliers have been changed from");
     results[0].addComment("defaults. New values are below.");
-    log->addGroup(results);
+    log->addLogGroup(results);
   }
 
   p.EndProcess();

--- a/isis/src/lro/apps/lronacpho/lronacpho.cpp
+++ b/isis/src/lro/apps/lronacpho/lronacpho.cpp
@@ -142,7 +142,7 @@ namespace Isis{
     oCube->putGroup(photo);
     
     if(log){
-      log->addGroup(photo);
+      log->addLogGroup(photo);
     }
     //Application::Log(photo);
 

--- a/isis/src/lro/apps/lronacpho/main.cpp
+++ b/isis/src/lro/apps/lronacpho/main.cpp
@@ -32,18 +32,6 @@ void IsisMain (){
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
   
-  try {
-    lronacpho(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
- 
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  lronacpho(ui, &appLog); 
 }
 

--- a/isis/src/lro/apps/lrowacphomap/main.cpp
+++ b/isis/src/lro/apps/lrowacphomap/main.cpp
@@ -14,8 +14,5 @@ using namespace Isis;
 
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
-  Pvl results = lrowacphomap(ui);
-  for (int resultIndex = 0; resultIndex < results.groups(); resultIndex++) {
-    Application::Log(results.group(resultIndex));
-  }
+  lrowacphomap(ui);
 }

--- a/isis/src/mro/apps/crism2isis/crism2isis.cpp
+++ b/isis/src/mro/apps/crism2isis/crism2isis.cpp
@@ -174,7 +174,7 @@ namespace Isis{
                           "using the nearest-neighbor algorithm due to gimble "
                           "jitter of the MRO CRISM instrument.");
     if (log){
-      log->addGroup(results);
+      log->addLogGroup(results);
     }
     return;
   }

--- a/isis/src/mro/apps/crism2isis/main.cpp
+++ b/isis/src/mro/apps/crism2isis/main.cpp
@@ -17,17 +17,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    crism2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  crism2isis(ui, &appLog); 
 }

--- a/isis/src/mro/apps/hi2isis/hi2isis.cpp
+++ b/isis/src/mro/apps/hi2isis/hi2isis.cpp
@@ -230,7 +230,7 @@ namespace Isis {
 
     // Write the results to the log
     if(log){
-      log->addGroup(results);
+      log->addLogGroup(results);
     }
 
     return;

--- a/isis/src/mro/apps/hi2isis/main.cpp
+++ b/isis/src/mro/apps/hi2isis/main.cpp
@@ -17,17 +17,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    hi2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  hi2isis(ui, &appLog); 
 }

--- a/isis/src/mro/apps/hical/main.cpp
+++ b/isis/src/mro/apps/hical/main.cpp
@@ -21,17 +21,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    hical(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  hical(ui, &appLog); 
 }

--- a/isis/src/mro/apps/hicrop/hicrop.cpp
+++ b/isis/src/mro/apps/hicrop/hicrop.cpp
@@ -372,7 +372,7 @@ namespace Isis {
 
       // Write the results to the log
       if(log) {
-        log->addGroup(results);
+        log->addLogGroup(results);
       }
 
       // Unfurnishes kernel files to prevent file table overflow

--- a/isis/src/mro/apps/hicrop/main.cpp
+++ b/isis/src/mro/apps/hicrop/main.cpp
@@ -18,17 +18,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    hicrop(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  hicrop(ui, &appLog); 
 }

--- a/isis/src/mro/apps/marci2isis/main.cpp
+++ b/isis/src/mro/apps/marci2isis/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    marci2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  marci2isis(ui, &appLog); 
 }

--- a/isis/src/mro/apps/marci2isis/marci2isis.cpp
+++ b/isis/src/mro/apps/marci2isis/marci2isis.cpp
@@ -226,7 +226,7 @@ namespace Isis{
                                     " Assuming exposure time is fixed for [" + inFile.toString() +  "]" );
       missing.addKeyword(message);
       missing.addKeyword(PvlKeyword("FileNotFoundInVarexpFile", prodId), Pvl::Replace);
-      log->addGroup(missing);
+      log->addLogGroup(missing);
     }
 
     // Translate labels to every image and close output cubes before calling EndProcess

--- a/isis/src/near/apps/msi2isis/main.cpp
+++ b/isis/src/near/apps/msi2isis/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    msi2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  msi2isis(ui, &appLog); 
 }

--- a/isis/src/newhorizons/apps/leisa2isis/main.cpp
+++ b/isis/src/newhorizons/apps/leisa2isis/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    leisa2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  leisa2isis(ui, &appLog); 
 }

--- a/isis/src/newhorizons/apps/mvic2isis/main.cpp
+++ b/isis/src/newhorizons/apps/mvic2isis/main.cpp
@@ -19,17 +19,5 @@ using namespace Isis;
 void IsisMain() {
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
-  try {
-    mvic2isis(ui, &appLog);
-  }
-  catch (...) {
-    for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-      Application::Log(*grpIt);
-    }
-    throw;
-  }
-
-  for (auto grpIt = appLog.beginGroup(); grpIt!= appLog.endGroup(); grpIt++) {
-    Application::Log(*grpIt);
-  }
+  mvic2isis(ui, &appLog); 
 }

--- a/isis/tests/FunctionalTestsStretch.cpp
+++ b/isis/tests/FunctionalTestsStretch.cpp
@@ -47,7 +47,7 @@ TEST_F(SpecialSmallCube, FunctionalTestStretchSwitchSpecial) {
   QString pairs = "0:255 255:0";
 
   UserInterface options(STRETCH_XML, args);
-  PvlLog log;
+  Log log;
   try {
     stretch(testCube, pairs, options, &log);
   }

--- a/isis/tests/FunctionalTestsStretch.cpp
+++ b/isis/tests/FunctionalTestsStretch.cpp
@@ -47,7 +47,7 @@ TEST_F(SpecialSmallCube, FunctionalTestStretchSwitchSpecial) {
   QString pairs = "0:255 255:0";
 
   UserInterface options(STRETCH_XML, args);
-  Pvl log;
+  PvlLog log;
   try {
     stretch(testCube, pairs, options, &log);
   }

--- a/isis/tests/FunctionalTestsStretch.cpp
+++ b/isis/tests/FunctionalTestsStretch.cpp
@@ -47,7 +47,7 @@ TEST_F(SpecialSmallCube, FunctionalTestStretchSwitchSpecial) {
   QString pairs = "0:255 255:0";
 
   UserInterface options(STRETCH_XML, args);
-  Log log;
+  Pvl log;
   try {
     stretch(testCube, pairs, options, &log);
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Pvl logs were being reported at the end of the programs execution which is a problem for apps that run for a long time. This changes the apps to report as groups are added.

This changes Application::Log to work with or without an iApp instance. Plus, a new function `addLogGroup` that adds the PVL group as usual but also calls Application::Log on the object. 

Tried to catch all the converted apps using a recursive grep for `Pvl appLog`, `Pvl results`, `Pvl log` in `main.cpp`s. I think I got all or at least a vast majority of them. 

`Application::Log` calls were removed in `main.cpp`s of converted tests as they're no longer needed. Left `Application::GuiLog` calls were left alone. Getsn was also left alone since it had very specific logging code in both the main and callable. 


## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

fixes #4914

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

Long running apps like jigsaw were not getting realtime updates. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Jenkins tests, if nothing broke no new test failures should appear. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
