### PR TITLE
Fixes Cassini position NAIF errors due to incorrect center body in spkwriter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ release.
 - Updated the LRO calibration application Lrowaccal to add a units label to the RadiometricType keyword of the Radiometry group in the output cube label if the RadiometricType parameter is Radiance. No functionality is changed if the RadiometricType parameter is IOF. Lrowaccal has also been refactored to be callable for testing purposes. Issue: [#4939](https://github.com/USGS-Astrogeology/ISIS3/issues/4939), PR: [#4940](https://github.com/USGS-Astrogeology/ISIS3/pull/4940)
 - Changed how logs are reported so they no longer only printing at the end of the applications execution. [#4914](https://github.com/USGS-Astrogeology/ISIS3/issues/4914)
 - Update marcical to include step 3 of the mission team's MARCI calibration process described [here](https://pds-imaging.jpl.nasa.gov/data/mro/mars_reconnaissance_orbiter/marci/mrom_1343/calib/marcical.txt). [#5004](https://github.com/USGS-Astrogeology/ISIS3/pull/5004)
+
+
 ### Added
 - Improved functionality of msi2isis and MsiCamera model to support new Eros dataset, including support for Gaskell's SUMSPICE files that adjust timing, pointing and spacecraft position ephemeris. [#4886](https://github.com/USGS-Astrogeology/ISIS3/issues/4886)
 - Added a new application, framestitch, for stitching even and odd push frame images back together prior to processing in other applications. [4924](https://github.com/USGS-Astrogeology/ISIS3/issues/4924)
@@ -55,6 +57,8 @@ release.
 - Fixed algorithm for applying rolling shutter jitter. Matches implementation in USGSCSM.
 - Fixed isis2std incorrectly outputing signed 16 bit tiff files. [#4897](https://github.com/USGS-Astrogeology/ISIS3/issues/4897)
 - Fixed CNetCombinePt logging functionality such that only merged points are included in the log. [#4973](https://github.com/USGS-Astrogeology/ISIS3/issues/4973)
+- Removed SpkCenterId functions in Cassini camera models due to spkwriter writing positions of Cassini relative to Titan but labeling
+it in the kernel as the position relative to the Saturn Barycenter. [#4942](https://github.com/USGS-Astrogeology/ISIS3/issues/4942)
 
 
 ## [7.0.0] - 2022-02-11

--- a/isis/src/cassini/objs/IssNACamera/IssNACamera.h
+++ b/isis/src/cassini/objs/IssNACamera/IssNACamera.h
@@ -59,6 +59,10 @@ namespace Isis {
    *   @history 2015-10-16 Ian Humphrey - Removed declarations of spacecraft and instrument
    *                           members and methods and removed implementation of these methods
    *                           since Camera now handles this. References #2335.
+   *   @history 2022-07-14 Amy Stamile - Removed SpkCenterId function due to spkwriter writing
+   *                           positions of Cassini relative to Titan (NAIF ID 606) but labeling
+   *                           it in the kernel as the position relative to the Saturn Barycenter
+   *                           (NAIF ID 6) Reference #4942.
    */
   class IssNACamera : public FramingCamera {
     public:
@@ -83,14 +87,6 @@ namespace Isis {
        *         Kernel Reference ID
        */
       virtual int CkReferenceId() const { return (1); }
-
-      /**
-       *  SPK Center ID - 6 (Saturn)
-       *
-       * @return @b int The appropriate instrument code for the Spacecraft
-       *         Kernel Center ID
-       */
-      virtual int SpkCenterId() const { return 6; }
 
       /**
        *  SPK Reference ID - J2000

--- a/isis/src/cassini/objs/IssWACamera/IssWACamera.h
+++ b/isis/src/cassini/objs/IssWACamera/IssWACamera.h
@@ -60,6 +60,10 @@ namespace Isis {
    *   @history 2015-10-16 Ian Humphrey - Removed declarations of spacecraft and instrument
    *                           members and methods and removed implementation of these methods
    *                           since Camera now handles this. References #2335.
+   *   @history 2022-07-14 Amy Stamile - Removed SpkCenterId function due to spkwriter writing
+   *                           positions of Cassini relative to Titan (NAIF ID 606) but labeling
+   *                           it in the kernel as the position relative to the Saturn Barycenter
+   *                           (NAIF ID 6) Reference #4942.
    */
   class IssWACamera : public FramingCamera {
     public:
@@ -84,14 +88,6 @@ namespace Isis {
        *         Kernel Reference ID
        */
       virtual int CkReferenceId() const { return (1); }
-
-      /**
-       *  SPK Center ID - 6 (Saturn)
-       *
-       * @return @b int The appropriate instrument code for the Spacecraft
-       *         Kernel Center ID
-       */
-      virtual int SpkCenterId() const { return 6; }
 
       /**
        *  SPK Reference ID - J2000

--- a/isis/src/cassini/objs/VimsCamera/VimsCamera.h
+++ b/isis/src/cassini/objs/VimsCamera/VimsCamera.h
@@ -72,6 +72,10 @@ namespace Isis {
    *   @history 2018-03-14 Adam Goins - Changed cache calculations with LoadCache() call.
    *                           This fixes an error where VimsCamera caused spiceinit to
    *                           fail when TargetName == SKY. Fixes #5353.
+   *   @history 2022-07-14 Amy Stamile - Removed SpkCenterId function due to spkwriter writing
+   *                           positions of Cassini relative to Titan (NAIF ID 606) but labeling
+   *                           it in the kernel as the position relative to the Saturn Barycenter
+   *                           (NAIF ID 6) Reference #4942.
    */
   class VimsCamera : public Camera {
     public:
@@ -108,14 +112,6 @@ namespace Isis {
        *         Kernel Reference ID
        */
       virtual int CkReferenceId() const { return (1); }
-
-      /**
-       *  SPK Center ID - 6 (Saturn)
-       *
-       * @return @b int The appropriate instrument code for the Spacecraft
-       *         Kernel Center ID
-       */
-      virtual int SpkCenterId() const { return 6; }
 
       /**
        *  SPK Reference ID - J2000


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

For Cassini Titan images spiceinited with spkwriter images were returning different positions than the same image spiceinited with a default cassini spk kernel.

The issue was that spkwriter was writing positions of Cassini relative to Titan but labeling
it in the kernel as the position relative to the Saturn Barycenter. This is due to the camera models hardcoding the center body as Saturn Barycenter.


 
## Description
This PR removes the hardcoded functions in the Cassini camera models. This is the results of campt from the two results:

Default spiceinited cube:
```
Group = GroundPoint
  Filename                   = /Users/astamile/testData/NAIFError/Finaltest_r-
                               egspice.cub
  Sample                     = 512.0
  Line                       = 512.0
  PixelValue                 = 1973
  RightAscension             = 116.13215283233 <DEGREE>
  Declination                = -1.1326024410936 <DEGREE>
  PlanetocentricLatitude     = -0.45931134252056 <DEGREE>
  PlanetographicLatitude     = -0.45931134252056 <DEGREE>
  PositiveEast360Longitude   = 213.42739550192 <DEGREE>
  PositiveEast180Longitude   = -146.57260449808 <DEGREE>
  PositiveWest360Longitude   = 146.57260449808 <DEGREE>
  PositiveWest180Longitude   = 146.57260449808 <DEGREE>
  BodyFixedCoordinate        = (-2148.986188821, -1418.4700411369,
                                -20.64225409362) <km>
  LocalRadius                = 2575000.0 <meters>
  SampleResolution           = 930.54010794526 <meters/pixel>
  LineResolution             = 930.54010794526 <meters/pixel>
  ObliqueDetectorResolution  = 930.54081760077 <meters>
  ObliquePixelResolution     = 930.54081760077 <meters/pix>
  ObliqueLineResolution      = 930.54081760077 <meters>
  ObliqueSampleResolution    = 930.54081760077 <meters>

  # Spacecraft Information
  SpacecraftPosition         = (-131745.51596537, -86981.58912533,
                                -1074.5876729846) <km>
  SpacecraftAzimuth          = 307.95635855922 <DEGREE>
  SlantDistance              = 155297.83861498 <km>
  TargetCenterDistance       = 157872.83668325 <km>
  SubSpacecraftLatitude      = -0.38999624702609 <DEGREE>
  SubSpacecraftLongitude     = 213.43376164131 <DEGREE>
  SpacecraftAltitude         = 155297.83668325 <km>
  OffNadirAngle              = 0.0011541531672208 <DEGREE>
  SubSpacecraftGroundAzimuth = 5.2474026169712 <DEGREE>

  # Sun Information
  SunPosition                = (-879514799.08957, -929599477.90723,
                                -460513070.24518) <km>
  SubSolarAzimuth            = 89.820124125382 <DEGREE>
  SolarDistance              = 9.0914496844703 <AU>
  SubSolarLatitude           = -19.791397298449 <DEGREE>
  SubSolarLongitude          = 226.58580801267 <DEGREE>
  SubSolarGroundAzimuth      = 147.11119332649 <DEGREE>

  # Illumination and Other
  Phase                      = 23.288232219596 <DEGREE>
  Incidence                  = 23.232536820009 <DEGREE>
  Emission                   = 0.070760962912729 <DEGREE>
  NorthAzimuth               = 302.70895137818 <DEGREE>

  # Time
  EphemerisTime              = 183716769.81247 <seconds>
  UTC                        = 2005-10-27T20:25:05.63
  LocalSolarTime             = 11.122772499283 <hour>
  SolarLongitude             = 309.34315015565 <DEGREE>

  # Look Direction Unit Vectors in Body Fixed, J2000, and Camera Coordinate Systems.
  LookDirectionBodyFixed     = (0.8345031130655, 0.55096142900174,
                                0.0067866071304697)
  LookDirectionJ2000         = (-0.44035699831055, 0.89760514998248,
                                -0.019766354338873)
  LookDirectionCamera        = (-2.99598538134119e-06, -2.99598538134119e-06,
                                0.99999999999102)
End_Group

```

spkwriter spiceinited cube:

```
Group = GroundPoint
  Filename                   = /Users/astamile/testData/NAIFError/Finaltest_s-
                               pkwriterspice.cub
  Sample                     = 512.0
  Line                       = 512.0
  PixelValue                 = 1973
  RightAscension             = 116.13215283233 <DEGREE>
  Declination                = -1.1326024410936 <DEGREE>
  PlanetocentricLatitude     = -0.45931134252055 <DEGREE>
  PlanetographicLatitude     = -0.45931134252055 <DEGREE>
  PositiveEast360Longitude   = 213.42739550192 <DEGREE>
  PositiveEast180Longitude   = -146.57260449808 <DEGREE>
  PositiveWest360Longitude   = 146.57260449808 <DEGREE>
  PositiveWest180Longitude   = 146.57260449808 <DEGREE>
  BodyFixedCoordinate        = (-2148.986188821, -1418.4700411369,
                                -20.64225409362) <km>
  LocalRadius                = 2575000.0 <meters>
  SampleResolution           = 930.54010794526 <meters/pixel>
  LineResolution             = 930.54010794526 <meters/pixel>
  ObliqueDetectorResolution  = 930.54081760077 <meters>
  ObliquePixelResolution     = 930.54081760077 <meters/pix>
  ObliqueLineResolution      = 930.54081760077 <meters>
  ObliqueSampleResolution    = 930.54081760077 <meters>

  # Spacecraft Information
  SpacecraftPosition         = (-131745.51596537, -86981.58912533,
                                -1074.5876729846) <km>
  SpacecraftAzimuth          = 307.95635855922 <DEGREE>
  SlantDistance              = 155297.83861498 <km>
  TargetCenterDistance       = 157872.83668325 <km>
  SubSpacecraftLatitude      = -0.38999624702609 <DEGREE>
  SubSpacecraftLongitude     = 213.43376164131 <DEGREE>
  SpacecraftAltitude         = 155297.83668325 <km>
  OffNadirAngle              = 0.0011541531672208 <DEGREE>
  SubSpacecraftGroundAzimuth = 5.2474026169712 <DEGREE>

  # Sun Information
  SunPosition                = (-879514799.08957, -929599477.90723,
                                -460513070.24518) <km>
  SubSolarAzimuth            = 89.820124125382 <DEGREE>
  SolarDistance              = 9.0914496844703 <AU>
  SubSolarLatitude           = -19.791397298449 <DEGREE>
  SubSolarLongitude          = 226.58580801267 <DEGREE>
  SubSolarGroundAzimuth      = 147.11119332649 <DEGREE>

  # Illumination and Other
  Phase                      = 23.288232219596 <DEGREE>
  Incidence                  = 23.232536820009 <DEGREE>
  Emission                   = 0.070760962912729 <DEGREE>
  NorthAzimuth               = 302.70895137818 <DEGREE>

  # Time
  EphemerisTime              = 183716769.81247 <seconds>
  UTC                        = 2005-10-27T20:25:05.63
  LocalSolarTime             = 11.122772499283 <hour>
  SolarLongitude             = 309.34315015565 <DEGREE>

  # Look Direction Unit Vectors in Body Fixed, J2000, and Camera Coordinate Systems.
  LookDirectionBodyFixed     = (0.8345031130655, 0.55096142900174,
                                0.0067866071304697)
  LookDirectionJ2000         = (-0.44035699831055, 0.89760514998248,
                                -0.019766354338873)
  LookDirectionCamera        = (-2.99598538134119e-06, -2.99598538134119e-06,
                                0.99999999999102)
End_Group
```


## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#4942 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Q4 ISIS Support Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Compared with campt. Check Jenkins for any potential broken tests.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
