### PR TITLE
Clean up for 7.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,9 +34,6 @@ release.
 -->
 
 ## [Unreleased]
-- Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
-- Updated the LRO photometry application Lronacpho, to use by default the current 2019 photometric model (LROC_Empirical). The model's coefficients are found in the PVL file that exists in the LRO data/mission/calibration directory. If the old parameter file is provided, the old algorithm(2014) will be used. This functionality is desired for calculation comparisons. Issue: [#4512](https://github.com/USGS-Astrogeology/ISIS3/issues/4512), PR: [#4519](https://github.com/USGS-Astrogeology/ISIS3/pull/4519)
-- Added a new application, framestitch, for stitching even and odd push frame images back together prior to processing in other applications. [4924](https://github.com/USGS-Astrogeology/ISIS3/issues/4924)
 
 ### Changed
 - Updated the LRO calibration application Lrowaccal to add a units label to the RadiometricType keyword of the Radiometry group in the output cube label if the RadiometricType parameter is Radiance. No functionality is changed if the RadiometricType parameter is IOF. Lrowaccal has also been refactored to be callable for testing purposes. Issue: [#4939](https://github.com/USGS-Astrogeology/ISIS3/issues/4939), PR: [#4940](https://github.com/USGS-Astrogeology/ISIS3/pull/4940)
@@ -44,8 +41,7 @@ release.
 ### Added
 - Improved functionality of msi2isis and MsiCamera model to support new Eros dataset, including support for Gaskell's SUMSPICE files that adjust timing, pointing and spacecraft position ephemeris. [#4886](https://github.com/USGS-Astrogeology/ISIS3/issues/4886)
 - Re-added and refactored the LRO photometry application lrowacphomap to be callable for testing purposes. Issue: [#4960](https://github.com/USGS-Astrogeology/ISIS3/issues/4960), PR: [#4961](https://github.com/USGS-Astrogeology/ISIS3/pull/4961)
-
-### Deprecated
+- Added a new application, framestitch, for stitching even and odd push frame images back together prior to processing in other applications. [4924](https://github.com/USGS-Astrogeology/ISIS3/issues/4924)
 
 ### Fixed
 - Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)

--- a/isis/src/lro/apps/lrowacphomap/HapkeLRO.h
+++ b/isis/src/lro/apps/lrowacphomap/HapkeLRO.h
@@ -49,7 +49,7 @@ namespace Isis {
    * Camera", published in Icaris v141, pg. 205-255 (1999).
    *
    * @author  2021-08-18 Cordell Michaud
-   * 
+   *
    * @internal
    *   @history 2021-07-19 Cordell Michaud - Code adapted from PhotometricFunction and HapkeLRO written by Kris Becker
    *
@@ -61,7 +61,7 @@ namespace Isis {
       bool normalized() const;
       double photometry(double i, double e, double g, int band = 1) const override;
       double photometry(double i, double e, double g, double lat, double lon, int band = 1) const;
-      void report(PvlContainer &pvl);
+      void report(PvlContainer &pvl) override;
       void setNormalized(bool normalized);
 
     private:
@@ -81,17 +81,17 @@ namespace Isis {
 
       /**
        * Container for band photometric correction parameters
-       * 
+       *
        * @author 2021-07-30 Cordell Michaud
-       * 
+       *
        * @internal
        *   @history 2021-07-19 Cordell Michaud - Code adapted from PhotoemtricFunction written by Kris Becker
        */
       class Parameters
       {
         public:
-          Parameters() 
-            : band(1), bandBinCenter(0.0), mapBands(), 
+          Parameters()
+            : band(1), bandBinCenter(0.0), mapBands(),
             names(), phoStd(0.0), values() {}
 
           ~Parameters() {}

--- a/isis/src/lro/apps/lrowacphomap/HapkeLROC.h
+++ b/isis/src/lro/apps/lrowacphomap/HapkeLROC.h
@@ -38,7 +38,7 @@ namespace Isis {
    * This class is based on the Hapke PhotoModel from Isis base code. Photometry method
    * was updated to match full Hapke (2012) model and some variable names were changed
    * to match reference formula.
-   * 
+   *
    * Reference:
    *    Hapke, B. (2012) Theory of Reflectance and Emittance Spectroscopy, Cambridge Univ. Press.
    *
@@ -56,7 +56,7 @@ namespace Isis {
       bool normalized() const;
       double photometry(double i, double e, double g, int band = 1) const override;
       double photometry(double i, double e, double g, double lat, double lon, int band = 1) const;
-      void report(PvlContainer &pvl);
+      void report(PvlContainer &pvl) override;
       void setNormalized(bool normalized);
 
     private:
@@ -78,7 +78,6 @@ namespace Isis {
       mutable double m_oldPhase;
       mutable double m_oldIncidence;
       mutable double m_oldEmission;
-      mutable double m_photoB0save;
       mutable double m_photoCot2t;
       mutable double m_photoCott;
       mutable double m_photoTant;
@@ -89,16 +88,16 @@ namespace Isis {
 
       /**
         * Container for band photometric correction parameters
-        * 
+        *
         * @author 2021-08-02 Cordell Michaud
-        * 
+        *
         * @internal
         *   @history 2021-07-19 Cordell Michaud - Code adapted from PhotometricFunction written by Kris Becker
         */
       class Parameters {
         public:
-          Parameters() 
-            : band(1), bandBinCenter(0.0), mapBands(), 
+          Parameters()
+            : band(1), bandBinCenter(0.0), mapBands(),
             names(), phoStd(0.0), values() {}
 
           ~Parameters() {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Fixed some build warnings from lrowacphomap. Cleaned up duplicate entries in CHANGELOG. Moved entries in CHANGELOG under appropriate headers.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No issue, 7.0.1. prep.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

1. The build warnings were from overrides, so this makes sure that if we modify the photometric function API, that these classes will also get modified, or the build will fail.
2. The CHANGELOG had duplicate entries and entries not under headers making it hard to read.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran a local build and the tests for lrowacphomap on my Mac system without issue.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
