### PR TITLE
hist blob fix

### DIFF
--- a/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
+++ b/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
@@ -1585,10 +1585,9 @@ namespace Isis {
       }
     }
 
+    // check for extraneous data in the keyword ... ,2,3
     QRegularExpression regex("(,*[0-9]?)?");
-    QString temp = "";
-    temp += keyword;
-    QRegularExpressionMatch match = regex.match(temp);
+    QRegularExpressionMatch match = regex.match(keyword);
     if (!keyword.isEmpty() && match.hasMatch()) {
           keywordValues.at(0).first += keyword;
           keyword = "";

--- a/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
+++ b/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
@@ -7,7 +7,7 @@ find files of those names at the top level of this repository. **/
 
 #include <QDebug>
 #include <QString>
-
+#include <QRegularExpression>
 #include "PvlKeyword.h"
 #include "IException.h"
 #include "Message.h"
@@ -1583,6 +1583,15 @@ namespace Isis {
 
         keyword = "";
       }
+    }
+
+    QRegularExpression regex("(,)");
+    QString temp = "";
+    temp += keyword[0];
+    QRegularExpressionMatch match = regex.match(temp);
+    if (!keyword.isEmpty() && match.hasMatch()) {
+          keywordValues.at(0).first += keyword;
+          keyword = "";
     }
 
     /*

--- a/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
+++ b/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
@@ -1586,7 +1586,7 @@ namespace Isis {
     }
 
     // check for extraneous data in the keyword ... ,2,3
-    QRegularExpression regex("(,*[0-9]?)?");
+    QRegularExpression regex("^,");
     QRegularExpressionMatch match = regex.match(keyword);
     if (!keyword.isEmpty() && match.hasMatch()) {
           keywordValues.at(0).first += keyword;

--- a/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
+++ b/isis/src/base/objs/PvlKeyword/PvlKeyword.cpp
@@ -1585,9 +1585,9 @@ namespace Isis {
       }
     }
 
-    QRegularExpression regex("(,)");
+    QRegularExpression regex("(,*[0-9]?)?");
     QString temp = "";
-    temp += keyword[0];
+    temp += keyword;
     QRegularExpressionMatch match = regex.match(temp);
     if (!keyword.isEmpty() && match.hasMatch()) {
           keywordValues.at(0).first += keyword;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
There was an error with the history blobs on a cube, if the keyword `from` in the blob contained a `,` the application would throw an error.

## Description
<!--- Describe your changes in detail -->
Changed the PvlKeyword parser to handle keywords that contain a `,`.

## Related Issue
Solves #4337 
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested locally to verify that running an application like cathist on a cube that has a key with `1,2,3` in its value doesn't error out and the history is correctly displayed. 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
