### PR TITLE
Added failure for images with missing original label in caminfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ release.
 - Re-added and refactored the LRO photometry application lrowacphomap to be callable for testing purposes. Issue: [#4960](https://github.com/USGS-Astrogeology/ISIS3/issues/4960), PR: [#4961](https://github.com/USGS-Astrogeology/ISIS3/pull/4961)
 - Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
 - Added changes to lronaccal to use time-dependent dark files for dark correction and use of specific dark files for images with exp code of zero. Also added GTests for lronaccal and refactored code to make callable. Added 3 truth cubes to testing directory.  PR[#4520](https://github.com/USGS-Astrogeology/ISIS3/pull/4520)
+- Added failure for images with missing original label in caminfo. [#4817](https://github.com/USGS-Astrogeology/ISIS3/pull/4817)
 
 ### Deprecated
 

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -80,11 +80,18 @@ namespace Isis{
       }
 
       // Add the orginal label blob
-      if(ui.GetBoolean("ORIGINALLABEL") && incube->label()->hasObject("OriginalLabel")) {
-        OriginalLabel orig = incube->readOriginalLabel();
-        Pvl p = orig.ReturnLabels();
-        p.setName("OriginalLabel");
-        params.addObject(p);
+      if(ui.GetBoolean("ORIGINALLABEL")) {
+        if (incube->label()->hasObject("OriginalLabel")) {
+          OriginalLabel orig = incube->readOriginalLabel();
+          Pvl p = orig.ReturnLabels();
+          p.setName("OriginalLabel");
+          params.addObject(p);
+        }
+        else {
+          QString msg = "Could not find OriginalLabel "
+                        "in input file [" + incube->fileName() + "].";
+          throw IException(IException::User, msg, _FILEINFO_);
+        }
       }
 
       // Add the stats

--- a/isis/tests/FunctionalTestsCaminfo.cpp
+++ b/isis/tests/FunctionalTestsCaminfo.cpp
@@ -209,7 +209,7 @@ TEST_F(DefaultCube, FunctionalTestCaminfoDefault) {
 
     QString outFileName = tempDir.path() + "/outTemp.csv";
     QVector<QString> args = {"to="+outFileName,
-        "ISISLABEL=true", "ORIGINAL=true", "STATISTICS=true", "CAMSTATS=true",
+        "ISISLABEL=true", "STATISTICS=true", "CAMSTATS=true",
         "POLYGON=true", "polysinc=100", "polylinc=100"};
 
     UserInterface options(APP_XML, args);
@@ -367,7 +367,7 @@ TEST_F(DefaultCube, FunctionalTestCaminfoDefault) {
 TEST_F(DefaultCube, FunctionalTestCaminfoPoly) {
     QString outFileName = tempDir.path() + "/outTemp.pvl";
     QVector<QString> args = {"from="+ testCube->fileName(),  "to="+outFileName,
-        "ISISLABEL=false", "ORIGINAL=false", "STATISTICS=false", "CAMSTATS=false",
+        "ISISLABEL=false", "STATISTICS=false", "CAMSTATS=false",
         "POLYGON=true", "inctype=vertices", "numvertices=3"};
 
     UserInterface options(APP_XML, args);
@@ -398,7 +398,7 @@ TEST_F(DefaultCube, FunctionalTestCaminfoPoly) {
 TEST_F(DefaultCube, FunctionalTestCaminfoBoundary) {
     QString outFileName = tempDir.path() + "/outTemp.cub";
     QVector<QString> args = {"from="+ testCube->fileName(),  "to="+outFileName,
-        "ISISLABEL=false", "ORIGINAL=false", "STATISTICS=true", "CAMSTATS=true",
+        "ISISLABEL=false", "STATISTICS=true", "CAMSTATS=true",
         "POLYGON=true", "LINC=25", "SINC=25", "POLYSINC=100", "POLYLINC=100"};
 
     UserInterface options(APP_XML, args);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
When running caminfo with ORIGINALLABEL=true, the program will still run but just not include the original label. This should instead inform the user that the original label is missing and fail (similar to catoriglab).

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #4817 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Q4 Support Sprint

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
