### PR TITLE
Marcical update to be fully congruent with calibration method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,19 +34,18 @@ release.
 -->
 
 ## [Unreleased]
-- Update marcical to include step 3 of the mission team's MARCI calibration process described [here](https://pds-imaging.jpl.nasa.gov/data/mro/mars_reconnaissance_orbiter/marci/mrom_1343/calib/marcical.txt). [#5004](https://github.com/USGS-Astrogeology/ISIS3/pull/5004)
-- Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
-- Updated the LRO photometry application Lronacpho, to use by default the current 2019 photometric model (LROC_Empirical). The model's coefficients are found in the PVL file that exists in the LRO data/mission/calibration directory. If the old parameter file is provided, the old algorithm(2014) will be used. This functionality is desired for calculation comparisons. Issue: [#4512](https://github.com/USGS-Astrogeology/ISIS3/issues/4512), PR: [#4519](https://github.com/USGS-Astrogeology/ISIS3/pull/4519)
-- Added a new application, framestitch, for stitching even and odd push frame images back together prior to processing in other applications. [4924](https://github.com/USGS-Astrogeology/ISIS3/issues/4924)
-- Added changes to lronaccal to use time-dependent dark files for dark correction and use of specific dark files for images with exp code of zero. Also added GTests for lronaccal and refactored code to make callable. Added 3 truth cubes to testing directory.  PR[#4520](https://github.com/USGS-Astrogeology/ISIS3/pull/4520)
+
 ### Changed
+- Updated the LRO photometry application Lronacpho, to use by default the current 2019 photometric model (LROC_Empirical). The model's coefficients are found in the PVL file that exists in the LRO data/mission/calibration directory. If the old parameter file is provided, the old algorithm(2014) will be used. This functionality is desired for calculation comparisons. Issue: [#4512](https://github.com/USGS-Astrogeology/ISIS3/issues/4512), PR: [#4519](https://github.com/USGS-Astrogeology/ISIS3/pull/4519)
 - Updated the LRO calibration application Lrowaccal to add a units label to the RadiometricType keyword of the Radiometry group in the output cube label if the RadiometricType parameter is Radiance. No functionality is changed if the RadiometricType parameter is IOF. Lrowaccal has also been refactored to be callable for testing purposes. Issue: [#4939](https://github.com/USGS-Astrogeology/ISIS3/issues/4939), PR: [#4940](https://github.com/USGS-Astrogeology/ISIS3/pull/4940)
 - Changed how logs are reported so they no longer only printing at the end of the applications execution. [#4914](https://github.com/USGS-Astrogeology/ISIS3/issues/4914)
-
-
+- Update marcical to include step 3 of the mission team's MARCI calibration process described [here](https://pds-imaging.jpl.nasa.gov/data/mro/mars_reconnaissance_orbiter/marci/mrom_1343/calib/marcical.txt). [#5004](https://github.com/USGS-Astrogeology/ISIS3/pull/5004)
 ### Added
 - Improved functionality of msi2isis and MsiCamera model to support new Eros dataset, including support for Gaskell's SUMSPICE files that adjust timing, pointing and spacecraft position ephemeris. [#4886](https://github.com/USGS-Astrogeology/ISIS3/issues/4886)
+- Added a new application, framestitch, for stitching even and odd push frame images back together prior to processing in other applications. [4924](https://github.com/USGS-Astrogeology/ISIS3/issues/4924)
 - Re-added and refactored the LRO photometry application lrowacphomap to be callable for testing purposes. Issue: [#4960](https://github.com/USGS-Astrogeology/ISIS3/issues/4960), PR: [#4961](https://github.com/USGS-Astrogeology/ISIS3/pull/4961)
+- Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
+- Added changes to lronaccal to use time-dependent dark files for dark correction and use of specific dark files for images with exp code of zero. Also added GTests for lronaccal and refactored code to make callable. Added 3 truth cubes to testing directory.  PR[#4520](https://github.com/USGS-Astrogeology/ISIS3/pull/4520)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ release.
 -->
 
 ## [Unreleased]
+- Update marcical to include step 3 of the mission team's MARCI calibration process described [here](https://pds-imaging.jpl.nasa.gov/data/mro/mars_reconnaissance_orbiter/marci/mrom_1343/calib/marcical.txt). [#5004](https://github.com/USGS-Astrogeology/ISIS3/pull/5004)
 - Added check to determine if poles were a valid projection point in ImagePolygon when generating footprint for a map projected image. [#4390](https://github.com/USGS-Astrogeology/ISIS3/issues/4390)
 - Updated the LRO photometry application Lronacpho, to use by default the current 2019 photometric model (LROC_Empirical). The model's coefficients are found in the PVL file that exists in the LRO data/mission/calibration directory. If the old parameter file is provided, the old algorithm(2014) will be used. This functionality is desired for calculation comparisons. Issue: [#4512](https://github.com/USGS-Astrogeology/ISIS3/issues/4512), PR: [#4519](https://github.com/USGS-Astrogeology/ISIS3/pull/4519)
 - Added a new application, framestitch, for stitching even and odd push frame images back together prior to processing in other applications. [4924](https://github.com/USGS-Astrogeology/ISIS3/issues/4924)

--- a/isis/src/mro/apps/marcical/marcical.xml
+++ b/isis/src/mro/apps/marcical/marcical.xml
@@ -11,14 +11,14 @@
     band's filter number. In order to output in I/F units, the cube must have spice
     data. This calibration problem follows the algorithms described the document titled:<br/><br/>
 
-Mars Reconnaissance Orbiter Mars Color Imager (MARCI): <br/>
-Instrument Description, Calibration, and Performance<br/><br/>
+    Mars Reconnaissance Orbiter Mars Color Imager (MARCI): <br/>
+    Instrument Description, Calibration, and Performance<br/><br/>
 
-J.F. Bell III, M.J. Wolff, M.C. Malin, W.M. Calvin, B.A. Cantor, 
-M.A. Caplinger, R.T. Clancy, K.S. Edgett3, L.J. Edwards5, J. Fahle, 
-F. Ghaemi, R.M. Haberle, A. Hale, P.B. James, S.W. Lee, 
-T. McConnochie, E. Noe Dobrea1, M.A. Ravine, D. Schaeffer, 
-K.D. Supulver, and P.C. Thomas
+    J.F. Bell III, M.J. Wolff, M.C. Malin, W.M. Calvin, B.A. Cantor, 
+    M.A. Caplinger, R.T. Clancy, K.S. Edgett3, L.J. Edwards5, J. Fahle, 
+    F. Ghaemi, R.M. Haberle, A. Hale, P.B. James, S.W. Lee, 
+    T. McConnochie, E. Noe Dobrea1, M.A. Ravine, D. Schaeffer, 
+    K.D. Supulver, and P.C. Thomas
   </description>
 
   <category>
@@ -47,6 +47,10 @@ K.D. Supulver, and P.C. Thomas
     <change name="Stuart Sides" date="2019-11-08">
       Modified to use the exposure duration from the new label keywords added by
       marci2isis. Related #2034
+    </change>
+    <change name="Lauren Adoram-Kershner" date="2022-07-15">
+    Implimented step 3 of marci calibration description, where if normalized flatfile DN value 
+    is less than 0.25, the output cube DN is set to 0. 
     </change>
   </history>
 

--- a/isis/tests/FunctionalTestsMarcical.cpp
+++ b/isis/tests/FunctionalTestsMarcical.cpp
@@ -34,10 +34,10 @@ TEST(Marcical, MarcicalTestDefault) {
   EXPECT_EQ( inst["VariableExposureDuration"][2].toStdString(), "17.5" );
 
   std::unique_ptr<Histogram> outHist (outCube.histogram());
-  EXPECT_NEAR( outHist->Average(), 0.034876, 1e-6 );
-  EXPECT_NEAR( outHist->Sum(), 1.39504, 1e-5 );
+  EXPECT_NEAR( outHist->Average(), 0.046682, 1e-6 );
+  EXPECT_NEAR( outHist->Sum(), 1.86728, 1e-5 );
   EXPECT_EQ( outHist->ValidPixels(), 40 );
-  EXPECT_NEAR( outHist->StandardDeviation(), 0.0110666, 1e-7 );
+  EXPECT_NEAR( outHist->StandardDeviation(), 0.0148127, 1e-7 );
 }
 
 TEST(Marcical, MarcicalTestDefaultNoIof) {
@@ -61,10 +61,10 @@ TEST(Marcical, MarcicalTestDefaultNoIof) {
   EXPECT_EQ( inst["VariableExposureDuration"][2].toStdString(), "17.5" );
 
   std::unique_ptr<Histogram> outHist (outCube.histogram());
-  EXPECT_NEAR( outHist->Average(), 8.80655,  1e-5);
-  EXPECT_NEAR( outHist->Sum(), 352.262, 1e-3 );
+  EXPECT_NEAR( outHist->Average(), 11.78765,  1e-5);
+  EXPECT_NEAR( outHist->Sum(), 471.5062, 1e-3 );
   EXPECT_EQ( outHist->ValidPixels(), 40 );
-  EXPECT_NEAR( outHist->StandardDeviation(), 2.79442, 1e-5 );
+  EXPECT_NEAR( outHist->StandardDeviation(), 3.74036, 1e-5 );
 }
 
 TEST(Marcical, MarcicalTestSingleDuration) {
@@ -86,10 +86,10 @@ TEST(Marcical, MarcicalTestSingleDuration) {
   EXPECT_EQ( inst["VariableExposureDuration"][0].toStdString(), "8.8" );
 
   std::unique_ptr<Histogram> outHist (outCube.histogram());
-  EXPECT_NEAR( outHist->Average(), 0.00656912, 1e-7 );
-  EXPECT_NEAR( outHist->Sum(), 0.131382, 1e-6 );
+  EXPECT_NEAR( outHist->Average(), 0.00879284, 1e-7 );
+  EXPECT_NEAR( outHist->Sum(), 0.175856, 1e-6 );
   EXPECT_EQ( outHist->ValidPixels(), 20 );
-  EXPECT_NEAR( outHist->StandardDeviation(), 0.000671733, 1e-8 );
+  EXPECT_NEAR( outHist->StandardDeviation(), 0.000899121, 1e-8 );
 }
 
 TEST(Marcical, MarcicalTestSingleDurationNoIof) {
@@ -111,8 +111,8 @@ TEST(Marcical, MarcicalTestSingleDurationNoIof) {
   EXPECT_EQ( inst["VariableExposureDuration"][0].toStdString(), "8.8" );
 
   std::unique_ptr<Histogram> outHist (outCube.histogram());
-  EXPECT_NEAR( outHist->Average(), 1.61438, 1e-4 );
-  EXPECT_NEAR( outHist->Sum(), 32.2875, 1e-4 );
+  EXPECT_NEAR( outHist->Average(), 2.16086, 1e-4 );
+  EXPECT_NEAR( outHist->Sum(), 43.2172, 1e-4 );
   EXPECT_EQ( outHist->ValidPixels(), 20 );
-  EXPECT_NEAR( outHist->StandardDeviation(), 0.16508, 1e-4 );
+  EXPECT_NEAR( outHist->StandardDeviation(), 0.22096, 1e-4 );
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
One small functional update to make sure we are fully implimenting the MARCI calibration method outlined [here](https://pds-imaging.jpl.nasa.gov/data/mro/mars_reconnaissance_orbiter/marci/mrom_1343/calib/marcical.txt). Specifically step 3 is being implemented in this PR.

## Description
<!--- Describe your changes in detail -->
In the MARCI calibration documentation output by the MRO mission team, after the flat file is taken through normalization and flattening there should be a check applied. If the flat file value is below 0.25 the equation in the follow step (step 4) should be set to zero. This was not reflected in the code. 

All other changes are syntax improvements.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to issue #4619

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Our MARCI calibration was not fully congruent to what the mission teams outlined for calibration of MARCI images.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Output from running tests locally
```
The following tests did not run:
	1732 - TempTestingFiles.FunctionalTestJitterfitDefault (Disabled)
	1763 - TempTestingFiles.UnitTestImageImporterTestJpeg (Disabled)

The following tests FAILED:
	128 - isis_unit_test_JP2Importer (Failed)
	811 - deltack_app_test_directOffTarget (Failed)
	905 - cassini_module_test_vims (Failed)
	951 - hayabusa_module_test_fullframe (Failed)
	952 - hayabusa_module_test_subframe (Failed)
	984 - lronaccal_app_test_nacl-full (Failed)
	985 - lronaccal_app_test_nacl-summed (Failed)
	986 - lronaccal_app_test_nacr-full (Failed)
	987 - lronaccal_app_test_nacr-summed (Failed)
	1042 - mex_unit_test_MexHrscSrcCamera (Failed)
	1109 - mro_module_test_hirise (Failed)
	1110 - near_module_test_msi (Failed)
	1759 - TempTestingFiles.FunctionalTestStd2isisJp2 (Failed)
	1765 - TempTestingFiles.UnitTestImageImporterStd2IsisJp2 (Failed)
	1912 - IsisTruthCube.FunctionalTestsIsis2StdJpeg2KGray (Failed)
	1913 - IsisTruthCube.FunctionalTestsIsis2StdJpeg2KU16 (Failed)
	1914 - IsisTruthCube.FunctionalTestsIsis2StdJpeg2KS16 (Failed)
	1924 - SmallARGBCube.FunctionalTestsIsis2StdJpeg2KRGB (Failed)
	1925 - SmallARGBCube.FunctionalTestsIsis2StdJpeg2KARGB (Failed)
	1997 - LronaccalDefault.FunctionalTestsLronaccal (Failed)
	1998 - LronaccalNear.FunctionalTestsLronaccal (Failed)
	1999 - LronaccalPair.FunctionalTestsLronaccal (Failed)
```

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
