### PR TITLE
ALE Related ISIS Fixes

### DIFF
--- a/isis/src/base/apps/copylabel/copylabel.xml
+++ b/isis/src/base/apps/copylabel/copylabel.xml
@@ -208,6 +208,18 @@
         </description>
       </parameter>
 
+      <parameter name="OBJECTS">
+        <type>string</type>
+        <internalDefault>none</internalDefault> 
+        <brief>
+          Copy the given objects, in CSV format
+        </brief>
+        <description>
+          Copy and given objects over to the FROM cube, groups must be specified 
+          with exact spelling, and be comma separated.
+        </description>
+      </parameter>
+
       <parameter name="BLOBS">
         <type>string</type>
         <internalDefault>none</internalDefault> 

--- a/isis/src/base/apps/copylabel/copylabel.xml
+++ b/isis/src/base/apps/copylabel/copylabel.xml
@@ -66,6 +66,11 @@
    <change name="Mackenzie Boyd" date="2011-04-27">
      Original version.  
    </change>
+   <change name="Adam Paquette" date="2022-08-02">
+     Added the ability to directly request objects from a cubes
+     label to be copied to the new cube. Similarly to how the
+     GROUPS argument functions.
+   </change>
   </history>
 
   <category>

--- a/isis/src/base/apps/copylabel/copylabel.xml
+++ b/isis/src/base/apps/copylabel/copylabel.xml
@@ -207,7 +207,7 @@
           Copy the given groups, in CSV format
         </brief>
         <description>
-          Copy and given groups over to the FROM cube, groups must exist in the
+          Copy any given groups over to the FROM cube, groups must exist in the
           IsisCube Object to be copied, and must be specified with exact spelling,
           comma separated.
         </description>
@@ -220,7 +220,7 @@
           Copy the given objects, in CSV format
         </brief>
         <description>
-          Copy and given objects over to the FROM cube, groups must be specified 
+          Copy any given objects over to the FROM cube, groups must be specified 
           with exact spelling, and be comma separated.
         </description>
       </parameter>

--- a/isis/src/base/objs/PvlObject/PvlObject.cpp
+++ b/isis/src/base/objs/PvlObject/PvlObject.cpp
@@ -66,7 +66,7 @@ namespace Isis {
         if (it.value().is_array()) {
           keyword.setName(QString::fromStdString(it.key()));
           for(auto ar = it.value().begin(); ar!=it.value().end();ar++) {
-            keyword += QString::number(ar->get<double>());
+            keyword += QString::number(ar->get<double>(), 'g', 16);
           }
         }
         else if(it.value().is_number()) {

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -213,9 +213,7 @@ namespace Isis {
         }
 
         json aleNaifKeywords = isd["naif_keywords"];
-        std::cout << aleNaifKeywords << std::endl;
         m_naifKeywords = new PvlObject("NaifKeywords", aleNaifKeywords);
-        std::cout << m_naifKeywords << std::endl;
 
         // Still need to load clock kernels for now
         load(kernels["LeapSecond"], noTables);
@@ -446,7 +444,7 @@ namespace Isis {
     }
     else if (m_usingAle) {
      m_instrumentRotation->LoadCache(isd["instrument_pointing"]);
-     m_instrumentRotation->MinimizeCache(SpiceRotation::DownsizeStatus::No);
+     m_instrumentRotation->MinimizeCache(SpiceRotation::DownsizeStatus::Yes);
      if (m_instrumentRotation->cacheSize() > 5) {
        m_instrumentRotation->LoadTimeCache();
      }

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -703,8 +703,9 @@ namespace Isis {
     }
     else if (m_instrumentPosition->GetSource() == SpicePosition::Memcache) {
       int aleCacheSize = m_instrumentPosition->cacheSize();
-      if (aleCacheSize > 3)
+      if (aleCacheSize > 3) {
         m_instrumentPosition->Memcache2HermiteCache(tol);
+      }
     }
     
 


### PR DESCRIPTION
Small ISIS fixes that relate to ALE and how the caches are reduced when ephemeris data is loaded from ALE

## Description
Moves the cache reduction for ephemeris data loaded via an ALE isd into the `createCache` function on the Spice object originally part of the `init` function. This adjusts the tolerance on the function from an arbitrarily defined `0.01` to the tolerance that is computed in the `createCache` function.

This PR also captures a previous functionality to the `copylabel` app, allowing users to specify copying `PvlObjects` outside of the `IsisCube` object to copy into a new cube. This was largely for the `NaifKeywords` object which should probably be propagated if the kernels are set to be propagated.

Finally, there is a fix to the precision that doubles would come in from ALE json isds. Where the default precision was 10 and this is not sufficient to properly translate doubles. This has been updated to handle 16 decimal points of precision rather than 10.

## Related Issue
N/A or Unknown

## Motivation and Context
ALE driver accuracy when compared to ISIS

## How Has This Been Tested?
Tested locally and will be tested with existing ISIS spiceinit tests

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
