### PR TITLE
Added Qview Lat/Lon Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
 ### Changed
 
 ### Added
+- Added LatLonGrid Tool to Qview to view latitude and longitude lines if camera model information is present.
 
 ### Deprecated
 

--- a/isis/src/qisis/apps/qview/main.cpp
+++ b/isis/src/qisis/apps/qview/main.cpp
@@ -25,6 +25,7 @@ find files of those names at the top level of this repository. **/
 #include "BandTool.h"
 #include "BlinkTool.h"
 #include "EditTool.h"
+#include "LatLonGridTool.h"
 #include "FeatureNomenclatureTool.h"
 #include "FileName.h"
 #include "FileTool.h"
@@ -175,6 +176,8 @@ int main(int argc, char *argv[]) {
 
   Tool *editTool = createTool<EditTool>(vw, &tools);
 
+  Tool *latLonGridTool = createTool<LatLonGridTool>(vw, &tools);
+
   Tool *windowTool = createTool<WindowTool>(vw, &tools);
 
   Tool *measureTool = createTool<MeasureTool>(vw, &tools);
@@ -276,6 +279,7 @@ int main(int argc, char *argv[]) {
   delete statsTool;
   delete helpTool;
   delete matchTool;
+  delete latLonGridTool;
   delete stereoTool;
   delete histTool;
   delete spatialPlotTool;

--- a/isis/src/qisis/apps/qview/qview.xml
+++ b/isis/src/qisis/apps/qview/qview.xml
@@ -266,5 +266,8 @@
     <change name="Summer Stapleton" date="2018-03-14">
       Included documentation for Spatial Plot Tool in this .xml. References #5281.
     </change>
+    <change name="Amy Stamile" date="2022-08-26">
+      Added latitude and longtitude grid display.
+    </change>
   </history>
 </application>

--- a/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
+++ b/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
@@ -1,0 +1,98 @@
+/** This is free and unencumbered software released into the public domain.
+
+The authors of ISIS do not claim copyright on the contents of this file.
+For more details about the LICENSE terms and the AUTHORS, you will
+find files of those names at the top level of this repository. **/
+
+/* SPDX-License-Identifier: CC0-1.0 */
+
+#include "LatLonGridTool.h"
+
+#include <QAction>
+#include <QApplication>
+#include <QPixmap>
+#include <QStackedWidget>
+#include <QPainter>
+
+#include "MdiCubeViewport.h"
+#include "ToolPad.h"
+#include "Workspace.h"
+
+
+namespace Isis {
+  /**
+   * Constructs an LatLonGridTool object.
+   *
+   * @param parent Parent widget
+   *
+   *
+   */
+  LatLonGridTool::LatLonGridTool(QWidget *parent) : Tool(parent) {
+  }
+
+  /**
+   * Adds the LatLonGridTool to the tool pad.
+   *
+   * @param pad input - The tool pad that LatLonGridTool is to be added to
+   *
+   * @return QAction*
+   */
+  QAction *LatLonGridTool::toolPadAction(ToolPad *pad) {
+    QAction *action = new QAction(pad);
+    action->setIcon(QPixmap(toolIconDir() + "/grid.png"));
+    action->setToolTip("Lat Lon Grid Tool (G)");
+    action->setShortcut(Qt::Key_G);
+
+    QString text  =
+      "<b>Function:</b>  View lat lon grid \
+      <p><b>Shortcut:</b> G</p> ";
+    action->setWhatsThis(text);
+
+    return action;
+  }
+
+  /**
+   * Draws grid onto cube viewport
+   * This is overiding the parents paintViewport member.
+   *
+   * @param vp Pointer to Viewport to be painted
+   * @param painter
+   */
+  void LatLonGridTool::paintViewport(MdiCubeViewport *mvp, QPainter *painter) {
+      drawLatLonGrid (mvp, painter);
+  }
+
+  /**
+   * Draws grid
+   * @param vp Viewport whose measurements will be drawn
+   * @param painter
+   */
+  void LatLonGridTool::drawLatLonGrid(MdiCubeViewport *mvp, QPainter *painter) {
+    double samp = 100;
+    double line = 100;
+    int x, y;
+    mvp->cubeToViewport(samp, line, x, y);
+    QBrush brush(Qt::gray);
+    QPen pen(brush, 2);
+
+    painter->setPen(pen);
+    // TODO: draw grid lines based on lat lons
+    painter->drawLine(20, 120, 250, 120);
+  }
+
+  /**
+   * Creates the toolbar containing the lat-lon grid tool widgets
+   *
+   * @param active  input  The widget that will contain the lat-lon grid tool
+   *                       specific widgets
+   *
+   * @return QWidget*
+   */
+  QWidget *LatLonGridTool::createToolBarWidget(QStackedWidget *active) {
+    QWidget *container = new QWidget(active);
+    container->setObjectName("LatLonGridToolActiveToolBarWidget");
+
+    m_container = container;
+    return container;
+  }
+}

--- a/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
+++ b/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
@@ -61,6 +61,7 @@ namespace Isis {
   QWidget *LatLonGridTool::createToolBarWidget(QStackedWidget *active) {
     QWidget *container = new QWidget(active);
     container->setObjectName("LatLonGridToolActiveToolBarWidget");
+
     m_gridCheckBox = new QCheckBox;
     m_gridCheckBox->setText("Show Grid");
 
@@ -123,6 +124,20 @@ namespace Isis {
             painter->drawText(x2, y1, toString(lat));
         }
       }
+    }
+    else {
+      mvp = cubeViewport();
+    }
+  }
+
+  void LatLonGridTool::updateTool() {
+    MdiCubeViewport *vp = cubeViewport();
+
+    if (vp->camera() == NULL) {
+        m_gridCheckBox->setEnabled(false);
+    }
+    else {
+        m_gridCheckBox->setEnabled(true);
     }
   }
 }

--- a/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
+++ b/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
@@ -85,6 +85,7 @@ namespace Isis {
   void LatLonGridTool::paintViewport(MdiCubeViewport *mvp, QPainter *painter) {
     int x1, x2, y1, y2;
     double lat, lon;
+
     QFont font;
     QBrush brush(Qt::gray);
     QPen pen(brush, 1);
@@ -96,8 +97,9 @@ namespace Isis {
       painter->setFont(font);
 
       // Draws Longitude Lines
-      for (int i = 0; i < mvp->cubeSamples(); i += mvp->cubeSamples() / 12) {
-        if (mvp->camera() != NULL && mvp->camera()->SetImage(i, 0)) {
+      for (int i = mvp->cubeSamples(); i > 0; i -= mvp->cubeSamples() / 12) {
+        if (mvp->camera() != NULL) {
+            mvp->camera()->SetImage(i, 0);
             lon = mvp->camera()->UniversalLongitude();
 
             lon = ceil(lon * 100.0) / 100.0;
@@ -106,13 +108,14 @@ namespace Isis {
             mvp->cubeToViewport(0, mvp->cubeLines(), x2, y2);
             painter->drawLine(x1, y1, x1, y2);
 
-            painter->drawText(x1, y2, toString(lon));
+            painter->drawText(x1, y2 + 10, toString(lon));
         }
       }
 
       // Draws Latitude Lines
-      for (int i = 0; i < mvp->cubeLines(); i += mvp->cubeLines() / 12) {
-        if (mvp->camera() != NULL && mvp->camera()->SetImage(0, i)) {
+      for (int i = mvp->cubeLines(); i > 0; i -= mvp->cubeLines() / 12) {
+        if (mvp->camera() != NULL) {
+            mvp->camera()->SetImage(0, i);
             lat = mvp->camera()->UniversalLatitude();
 
             lat = ceil(lat * 100.0) / 100.0;
@@ -121,15 +124,19 @@ namespace Isis {
             mvp->cubeToViewport(mvp->cubeSamples(), 0, x2, y2);
             painter->drawLine(x1, y1, x2, y1);
 
-            painter->drawText(x2, y1, toString(lat));
+            painter->drawText(x2 + 5, y1, toString(lat));
         }
       }
     }
+    // remove grid by updating viewport to original cubeViewport
     else {
       mvp = cubeViewport();
     }
   }
 
+  /**
+   * Enables/Disable grid option tool based on camera model
+   */
   void LatLonGridTool::updateTool() {
     MdiCubeViewport *vp = cubeViewport();
 

--- a/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
+++ b/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.cpp
@@ -140,11 +140,13 @@ namespace Isis {
   void LatLonGridTool::updateTool() {
     MdiCubeViewport *vp = cubeViewport();
 
-    if (vp->camera() == NULL) {
+    if (vp != NULL) {
+      if (vp->camera() == NULL) {
         m_gridCheckBox->setEnabled(false);
-    }
-    else {
-        m_gridCheckBox->setEnabled(true);
+      }
+      else {
+          m_gridCheckBox->setEnabled(true);
+      }
     }
   }
 }

--- a/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.h
+++ b/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.h
@@ -40,12 +40,12 @@ namespace Isis {
 
     public:
       LatLonGridTool(QWidget *parent);
-      void addTo(ToolPad *toolpad);
       void paintViewport(MdiCubeViewport *mvp, QPainter *painter);
 
     protected:
       QAction *toolPadAction(ToolPad *pad);
       QWidget *createToolBarWidget(QStackedWidget *active);
+      void updateTool();
 
     private:
       QWidget *m_container;

--- a/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.h
+++ b/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.h
@@ -14,10 +14,12 @@ find files of those names at the top level of this repository. **/
 
 #include <QMap>
 #include <QStack>
+#include <QPointer>
 
 
 class QToolButton;
 class QPainter;
+class QCheckBox;
 
 namespace Isis {
   class MdiCubeViewport;
@@ -47,7 +49,7 @@ namespace Isis {
 
     private:
       QWidget *m_container;
-      void drawLatLonGrid (MdiCubeViewport *mvp,QPainter *painter);
+      QPointer<QCheckBox> m_gridCheckBox;
   };
 };
 

--- a/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.h
+++ b/isis/src/qisis/objs/LatLonGridTool/LatLonGridTool.h
@@ -1,0 +1,54 @@
+#ifndef LatLonGridTool_h
+#define LatLonGridTool_h
+
+/** This is free and unencumbered software released into the public domain.
+
+The authors of ISIS do not claim copyright on the contents of this file.
+For more details about the LICENSE terms and the AUTHORS, you will
+find files of those names at the top level of this repository. **/
+
+/* SPDX-License-Identifier: CC0-1.0 */
+
+#include "Tool.h"
+
+
+#include <QMap>
+#include <QStack>
+
+
+class QToolButton;
+class QPainter;
+
+namespace Isis {
+  class MdiCubeViewport;
+
+
+  /**
+   * @brief Lat Lon Grid View Tool
+   *
+   * This tool is part of the Qisis namespace and allows visualizes latitude and
+   * longitude lines on cube.
+   *
+   * @ingroup Visualization Tools
+   *
+   * @author  2022-08-08  Amy Stamile
+   */
+  class LatLonGridTool : public Tool {
+      Q_OBJECT
+
+    public:
+      LatLonGridTool(QWidget *parent);
+      void addTo(ToolPad *toolpad);
+      void paintViewport(MdiCubeViewport *mvp, QPainter *painter);
+
+    protected:
+      QAction *toolPadAction(ToolPad *pad);
+      QWidget *createToolBarWidget(QStackedWidget *active);
+
+    private:
+      QWidget *m_container;
+      void drawLatLonGrid (MdiCubeViewport *mvp,QPainter *painter);
+  };
+};
+
+#endif

--- a/isis/src/qisis/objs/LatLonGridTool/Makefile
+++ b/isis/src/qisis/objs/LatLonGridTool/Makefile
@@ -1,0 +1,7 @@
+ifeq ($(ISISROOT), $(BLANK))
+.SILENT:
+error:
+	echo "Please set ISISROOT";
+else
+	include $(ISISROOT)/make/isismake.objs
+endif


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds option for displaying lat/lon grid when lat/lon info is present.

## Related Issue
<!--- This project only accepts pull requests related to open issues (GitIssues) -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
LROC Sprint


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Hand tested in qview

## Screenshots (if appropriate):
<img width="1282" alt="Screen Shot 2022-08-26 at 2 56 48 PM" src="https://user-images.githubusercontent.com/74275278/186996237-c82b489b-4d6a-4a5e-9fd5-f7285c46c973.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
