### PR TITLE
Fixed Hillshade being off by 2 pixels. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ release.
 ### Fixed
 
 - Fixed bugs in downloadIsisData script [#5024](https://github.com/USGS-Astrogeology/ISIS3/issues/5024) 
+- Fixed shadow shifting image by 2 pixels to the upper left corner. [#5035](https://github.com/USGS-Astrogeology/ISIS3/issues/5035)
 
 ## [7.1.0] - 2022-07-27
 

--- a/isis/src/base/apps/shadow/ShadowFunctor.cpp
+++ b/isis/src/base/apps/shadow/ShadowFunctor.cpp
@@ -224,6 +224,7 @@ namespace Isis {
 
         // We need to calculate the direction of the light source (sun) relative to the surface
         //   point.
+        std::cout << "l/s: " << line << ", " << sample << std::endl;
         if (elevationModelProjection->SetWorld(sample + 1, line + 1)) {
           SurfacePoint startSurfacePoint(
               Latitude(elevationModelProjection->UniversalLatitude(), Angle::Degrees),
@@ -393,10 +394,13 @@ namespace Isis {
 
           Hillshade hillshade(azimuth, elevation, elevationModelProjection->Resolution());
 
+          // int sizex = 
+
           Portal portal(3, 3, m_inputDem->pixelType(), -1.5, -1.5);
-          portal.SetPosition(sample + 1, line + 1, input.Band());
+          portal.SetPosition(sample, line, input.Band());
 
           if (!portal.CopyOverlapFrom(input)) {
+            std::cout << "oof" << std::endl;
             m_inputDem->read(portal);
           }
 
@@ -419,6 +423,7 @@ namespace Isis {
             }
           }
           else {
+            std::cout << "else shadow" << std::endl;
             m_shadowedByRayStats->AddData(0.0);
             output[bufferIndex] = Lrs;
           }

--- a/isis/src/base/apps/shadow/ShadowFunctor.cpp
+++ b/isis/src/base/apps/shadow/ShadowFunctor.cpp
@@ -394,7 +394,7 @@ namespace Isis {
           Hillshade hillshade(azimuth, elevation, elevationModelProjection->Resolution());
 
 
-          Portal portal(3, 3, m_inputDem->pixelType(), 0, 0);
+          Portal portal(3, 3, m_inputDem->pixelType(), -0.5, -0.5);
           portal.SetPosition(sample, line, input.Band());
 
           if (!portal.CopyOverlapFrom(input)) {

--- a/isis/src/base/apps/shadow/ShadowFunctor.cpp
+++ b/isis/src/base/apps/shadow/ShadowFunctor.cpp
@@ -224,7 +224,6 @@ namespace Isis {
 
         // We need to calculate the direction of the light source (sun) relative to the surface
         //   point.
-        std::cout << "l/s: " << line << ", " << sample << std::endl;
         if (elevationModelProjection->SetWorld(sample + 1, line + 1)) {
           SurfacePoint startSurfacePoint(
               Latitude(elevationModelProjection->UniversalLatitude(), Angle::Degrees),
@@ -394,18 +393,15 @@ namespace Isis {
 
           Hillshade hillshade(azimuth, elevation, elevationModelProjection->Resolution());
 
-          // int sizex = 
 
-          Portal portal(3, 3, m_inputDem->pixelType(), -1.5, -1.5);
+          Portal portal(3, 3, m_inputDem->pixelType(), 0, 0);
           portal.SetPosition(sample, line, input.Band());
 
           if (!portal.CopyOverlapFrom(input)) {
-            std::cout << "oof" << std::endl;
             m_inputDem->read(portal);
           }
 
           double shadedValue = hillshade.shadedValue(portal);
-
           if (shadedValue > 0) {
             bool shadowed = m_enableShadowCalculations && couldBeShadowed &&
                 isShadowed(rayStartPointInBodyFixed, sample + 1, line + 1,
@@ -423,7 +419,6 @@ namespace Isis {
             }
           }
           else {
-            std::cout << "else shadow" << std::endl;
             m_shadowedByRayStats->AddData(0.0);
             output[bufferIndex] = Lrs;
           }

--- a/isis/src/base/apps/shadow/shadow.cpp
+++ b/isis/src/base/apps/shadow/shadow.cpp
@@ -118,6 +118,7 @@ namespace Isis {
     int ns = demCube->sampleCount();
     int nl = demCube->lineCount();
     int nb = demCube->bandCount();
+    std::cout << ns << ", " << nl << ", "<< nb << std::endl;
     Cube *outputCube = p.SetOutputCube(ui.GetCubeName("TO"), atts, ns, nl, nb);
 
     p.ProcessCube(functor, false);

--- a/isis/src/base/apps/shadow/shadow.cpp
+++ b/isis/src/base/apps/shadow/shadow.cpp
@@ -118,7 +118,6 @@ namespace Isis {
     int ns = demCube->sampleCount();
     int nl = demCube->lineCount();
     int nb = demCube->bandCount();
-    std::cout << ns << ", " << nl << ", "<< nb << std::endl;
     Cube *outputCube = p.SetOutputCube(ui.GetCubeName("TO"), atts, ns, nl, nb);
 
     p.ProcessCube(functor, false);

--- a/isis/src/base/objs/Hillshade/Hillshade.cpp
+++ b/isis/src/base/objs/Hillshade/Hillshade.cpp
@@ -7,7 +7,6 @@ find files of those names at the top level of this repository. **/
 #include "Hillshade.h"
 
 #include <algorithm>
-#include <iostream>
 
 #include <QDebug>
 #include <QObject>
@@ -231,7 +230,6 @@ namespace Isis {
     bool anySpecialPixels = false;
     for(int i = 0; i < input.size(); ++i) {
       if(IsSpecial(input[i])) {
-        std::cout << "special pixel " << input[i] << std::endl;
         anySpecialPixels = true;
       }
     }

--- a/isis/src/base/objs/Hillshade/Hillshade.cpp
+++ b/isis/src/base/objs/Hillshade/Hillshade.cpp
@@ -7,6 +7,7 @@ find files of those names at the top level of this repository. **/
 #include "Hillshade.h"
 
 #include <algorithm>
+#include <iostream>
 
 #include <QDebug>
 #include <QObject>
@@ -230,6 +231,7 @@ namespace Isis {
     bool anySpecialPixels = false;
     for(int i = 0; i < input.size(); ++i) {
       if(IsSpecial(input[i])) {
+        std::cout << "special pixel " << input[i] << std::endl;
         anySpecialPixels = true;
       }
     }
@@ -280,7 +282,6 @@ namespace Isis {
       double numerator = 1.0 + p0 * p + q0 * q;
 
       double denominator = sqrt(1 + p * p + q * q) * sqrt(1 + p0 * p0 + q0 * q0);
-
       result = numerator / denominator;
     }
 

--- a/isis/tests/FunctionalTestsShadow.cpp
+++ b/isis/tests/FunctionalTestsShadow.cpp
@@ -37,10 +37,10 @@ TEST_F(DemCube, FunctionalTestShadowMatch) {
   EXPECT_DOUBLE_EQ(double(shadowStats["MinimumElevation"]), 90.0);
   EXPECT_DOUBLE_EQ(double(shadowStats["MaximumElevation"]), 90.0);
 
-  EXPECT_EQ(int(shadowStats["NumRays"]), 5388);
-  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 5388);
+  EXPECT_EQ(int(shadowStats["NumRays"]), 5551);
+  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 5551);
   EXPECT_DOUBLE_EQ(double(shadowStats["AverageRayDemIntersectionsPerRay"]), 1.0);
-  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5388);
+  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5551);
   EXPECT_EQ(int(shadowStats["NumShadowedPixels"]), 0);
   EXPECT_EQ(int(shadowStats["NumSpecialPixels"]), 2800);
   EXPECT_EQ(int(shadowStats["NumPixelsShadowedByRays"]), 0);
@@ -49,10 +49,10 @@ TEST_F(DemCube, FunctionalTestShadowMatch) {
 
   std::unique_ptr<Histogram> hist (shadowCube.histogram());
 
-  EXPECT_NEAR(hist->Average(), 0.000870468438, 1e-11);
-  EXPECT_NEAR(hist->Sum(), 4.6900839445906222, 1e-11);
-  ASSERT_EQ(hist->ValidPixels(), 5388);
-  EXPECT_NEAR(hist->StandardDeviation(), 0.0010127599253911463, 1e-11);
+  EXPECT_NEAR(hist->Average(), 0.00084506527240706553, 1e-11);
+  EXPECT_NEAR(hist->Sum(), 4.6909573271316205, 1e-11);
+  ASSERT_EQ(hist->ValidPixels(), 5551);
+  EXPECT_NEAR(hist->StandardDeviation(), 0.0010084740620921499, 1e-11);
 }
 
 TEST_F(DemCube, FunctionalTestShadowTime) {
@@ -76,10 +76,10 @@ TEST_F(DemCube, FunctionalTestShadowTime) {
   EXPECT_DOUBLE_EQ(double(shadowStats["MinimumElevation"]), 54.185416336220001);
   EXPECT_DOUBLE_EQ(double(shadowStats["MaximumElevation"]), 55.260883777776002);
 
-  EXPECT_EQ(int(shadowStats["NumRays"]), 9409);
-  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 9926);
-  EXPECT_DOUBLE_EQ(double(shadowStats["AverageRayDemIntersectionsPerRay"]), 1.0549473907960001);
-  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 9305);
+  EXPECT_EQ(int(shadowStats["NumRays"]), 9604);
+  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 10177);
+  EXPECT_DOUBLE_EQ(double(shadowStats["AverageRayDemIntersectionsPerRay"]), 1.0596626405664);
+  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 9500);
   EXPECT_EQ(int(shadowStats["NumShadowedPixels"]), 104);
   EXPECT_EQ(int(shadowStats["NumSpecialPixels"]), 2800);
   EXPECT_EQ(int(shadowStats["NumPixelsShadowedByRays"]), 104);
@@ -88,10 +88,10 @@ TEST_F(DemCube, FunctionalTestShadowTime) {
 
   std::unique_ptr<Histogram> hist (shadowCube.histogram());
 
-  EXPECT_NEAR(hist->Average(), 0.57758065374995482, 1e-11);
-  EXPECT_NEAR(hist->Sum(), 5374.3879831433296, 1e-11);
-  ASSERT_EQ(hist->ValidPixels(), 9305);
-  EXPECT_NEAR(hist->StandardDeviation(), 0.0026649128709642098, 1e-11);
+  EXPECT_NEAR(hist->Average(), 0.57755590112585775, 1e-11);
+  EXPECT_NEAR(hist->Sum(), 5486.7810606956482, 1e-11);
+  ASSERT_EQ(hist->ValidPixels(), 9500);
+  EXPECT_NEAR(hist->StandardDeviation(), 0.0027122379225963896, 1e-11);
 }
 
 TEST_F(DemCube, FunctionalTestShadowNoShadow) {
@@ -116,7 +116,7 @@ TEST_F(DemCube, FunctionalTestShadowNoShadow) {
 
   EXPECT_EQ(int(shadowStats["NumRays"]), 0);
   EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 0);
-  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5388);
+  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5551);
   EXPECT_EQ(int(shadowStats["NumShadowedPixels"]), 0);
   EXPECT_EQ(int(shadowStats["NumSpecialPixels"]), 2800);
   EXPECT_EQ(int(shadowStats["NumPixelsShadowedByRays"]), 0);
@@ -125,10 +125,10 @@ TEST_F(DemCube, FunctionalTestShadowNoShadow) {
 
   std::unique_ptr<Histogram> hist (shadowCube.histogram());
 
-  EXPECT_NEAR(hist->Average(), 0.000870468438, 1e-11);
-  EXPECT_NEAR(hist->Sum(), 4.6900839445906222, 1e-11);
-  EXPECT_EQ(hist->ValidPixels(), 5388);
-  EXPECT_NEAR(hist->StandardDeviation(), 0.0010127599253911463, 1e-11);
+  EXPECT_NEAR(hist->Average(), 0.00084506527240706553, 1e-11);
+  EXPECT_NEAR(hist->Sum(), 4.6909573271316205, 1e-11);
+  EXPECT_EQ(hist->ValidPixels(), 5551);
+  EXPECT_NEAR(hist->StandardDeviation(), 0.0010084740620921499, 1e-11);
 }
 
 TEST_F(DemCube, FunctionalTestShadowAccurate) {
@@ -149,10 +149,10 @@ TEST_F(DemCube, FunctionalTestShadowAccurate) {
   EXPECT_DOUBLE_EQ(double(shadowStats["MinimumElevation"]), 90.0);
   EXPECT_DOUBLE_EQ(double(shadowStats["MaximumElevation"]), 90.0);
 
-  EXPECT_EQ(int(shadowStats["NumRays"]), 5388);
-  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 5388);
+  EXPECT_EQ(int(shadowStats["NumRays"]), 5551);
+  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 5551);
   EXPECT_DOUBLE_EQ(double(shadowStats["AverageRayDemIntersectionsPerRay"]), 1.0);
-  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5388);
+  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5551);
   EXPECT_EQ(int(shadowStats["NumShadowedPixels"]), 0);
   EXPECT_EQ(int(shadowStats["NumSpecialPixels"]), 2800);
   EXPECT_EQ(int(shadowStats["NumPixelsShadowedByRays"]), 0);
@@ -161,10 +161,10 @@ TEST_F(DemCube, FunctionalTestShadowAccurate) {
 
   std::unique_ptr<Histogram> hist (shadowCube.histogram());
 
-  EXPECT_NEAR(hist->Average(), 0.000870468438, 1e-11);
-  EXPECT_NEAR(hist->Sum(), 4.6900839445906222, 1e-11);
-  ASSERT_EQ(hist->ValidPixels(), 5388);
-  EXPECT_NEAR(hist->StandardDeviation(), 0.0010127599253911463, 1e-11);
+  EXPECT_NEAR(hist->Average(), 0.00084506527240706553, 1e-11);
+  EXPECT_NEAR(hist->Sum(), 4.6909573271316205, 1e-11);
+  ASSERT_EQ(hist->ValidPixels(), 5551);
+  EXPECT_NEAR(hist->StandardDeviation(), 0.0010084740620921499, 1e-11);
 }
 
 TEST_F(DemCube, FunctionalTestShadowCustom) {
@@ -185,10 +185,10 @@ TEST_F(DemCube, FunctionalTestShadowCustom) {
   EXPECT_DOUBLE_EQ(double(shadowStats["MinimumElevation"]), 90.0);
   EXPECT_DOUBLE_EQ(double(shadowStats["MaximumElevation"]), 90.0);
 
-  EXPECT_EQ(int(shadowStats["NumRays"]), 5388);
-  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 5388);
+  EXPECT_EQ(int(shadowStats["NumRays"]), 5551);
+  EXPECT_EQ(int(shadowStats["NumRayDemIntersections"]), 5551);
   EXPECT_DOUBLE_EQ(double(shadowStats["AverageRayDemIntersectionsPerRay"]), 1.0);
-  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5388);
+  EXPECT_EQ(int(shadowStats["NumLightedPixels"]), 5551);
   EXPECT_EQ(int(shadowStats["NumShadowedPixels"]), 0);
   EXPECT_EQ(int(shadowStats["NumSpecialPixels"]), 2800);
   EXPECT_EQ(int(shadowStats["NumPixelsShadowedByRays"]), 0);
@@ -197,10 +197,10 @@ TEST_F(DemCube, FunctionalTestShadowCustom) {
 
   std::unique_ptr<Histogram> hist (shadowCube.histogram());
 
-  EXPECT_NEAR(hist->Average(), 0.000870468438, 1e-11);
-  EXPECT_NEAR(hist->Sum(), 4.6900839445906222, 1e-11);
-  ASSERT_EQ(hist->ValidPixels(), 5388);
-  EXPECT_NEAR(hist->StandardDeviation(), 0.0010127599253911463, 1e-11);
+  EXPECT_NEAR(hist->Average(), 0.00084506527240706553, 1e-11);
+  EXPECT_NEAR(hist->Sum(), 4.6909573271316205, 1e-11);
+  ASSERT_EQ(hist->ValidPixels(), 5551);
+  EXPECT_NEAR(hist->StandardDeviation(), 0.0010084740620921499, 1e-11);
 }
 
 TEST_F(DemCube, FunctionalTestShadowErrors) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

The the way the Portal used for computing the final DN in Hillshade was shifting everything over about 2 pixels. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://github.com/USGS-Astrogeology/ISIS3/issues/5035

The issue describes that it moves more as resolution was reduced, but I think the lower pixel density was simply making the shift more obvious. 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

Visually using qview. 

Using the script `for x in 1 2 3 4 5; do reduce from=dtm.cub to=t$x.cub lsc=$x ssc=$x; shadow from=t$x.cub match= M1146718551L.shift.cub to=s$x-og.cub; done` and viewing the results in qview:

## Before

![shadow-original](https://user-images.githubusercontent.com/13245976/187806323-85b11957-8a92-4c82-9109-401d11d72aa0.gif)

## After
![shadow-fix](https://user-images.githubusercontent.com/13245976/187806276-7c259ebe-155d-48ee-9ecf-23094bde9599.gif)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
