### PR TITLE
Added comparison for JSONs within a tolerance

### DIFF
--- a/isis/tests/ComparisonTests.cpp
+++ b/isis/tests/ComparisonTests.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+
+#include "TestUtilities.h"
+
+using json = nlohmann::json;
+using namespace Isis;
+using namespace std;
+
+TEST(AssertJsonsNear, BasicComparisons) {
+  json testJson1 = {
+      {"pi", 3.14},
+      {"array", {1, 0, 2}},
+      {"nested_array", {{1, 2}, {3, 4}, {5, 6}}},
+      {"object", {
+        {"one", 1},
+        {"two", "2"}
+      }}
+  };
+  EXPECT_PRED_FORMAT3(AssertJsonsNear, testJson1, testJson1, 1);
+
+  json testJson2 = testJson1;
+  testJson2["new_value"] = "new";
+  EXPECT_FALSE(AssertJsonsNear("json1", "json2", "tolerance", testJson1, testJson2, 1));
+  EXPECT_FALSE(AssertJsonsNear("json2", "json1", "tolerance", testJson2, testJson1, 1));
+
+  json testJson3 = testJson1;
+  testJson3["pi"] = "3.14";
+  EXPECT_FALSE(AssertJsonsNear("json1", "json3", "tolerance", testJson1, testJson3, 1));
+
+  json testJson4 = testJson1;
+  testJson4["array"].push_back(3);
+  EXPECT_FALSE(AssertJsonsNear("json1", "json4", "tolerance", testJson1, testJson4, 1));
+
+  json testJson5 = testJson1;
+  testJson5["object"]["one"] = "1";
+  EXPECT_FALSE(AssertJsonsNear("json1", "json5", "tolerance", testJson1, testJson5, 1));
+
+  json testJson6 = testJson1;
+  testJson6["nested_array"][1].push_back(-1);
+  EXPECT_FALSE(AssertJsonsNear("json1", "json6", "tolerance", testJson1, testJson6, 1));
+}
+
+
+TEST(AssertJsonsNear, Tolerance) {
+  json testJson1 = {
+      {"pi", 3.14},
+      {"array", {1, 0, 2}},
+      {"nested_array", {{1, 2}, {3, 4}, {5, 6}}},
+      {"object", {
+        {"one", 1},
+        {"two", "2"}
+      }}
+  };
+
+  json testJson2 = testJson1;
+  testJson2["pi"] = 3;
+  EXPECT_TRUE(AssertJsonsNear("json1", "json2", "1", testJson1, testJson2, 1));
+  EXPECT_FALSE(AssertJsonsNear("json1", "json2", "0.1", testJson1, testJson2, 0.1));
+
+  json testJson3 = testJson1;
+  testJson3["nested_array"][2][1] = 5.5;
+  EXPECT_TRUE(AssertJsonsNear("json1", "json3", "1", testJson1, testJson3, 1));
+  EXPECT_FALSE(AssertJsonsNear("json1", "json3", "0.1", testJson1, testJson3, 0.1));
+
+  json testJson4 = testJson1;
+  testJson4["object"]["one"] = 0.5;
+  EXPECT_TRUE(AssertJsonsNear("json1", "json3", "1", testJson1, testJson4, 1));
+  EXPECT_FALSE(AssertJsonsNear("json1", "json3", "0.1", testJson1, testJson4, 0.1));
+}

--- a/isis/tests/FunctionalTestsLrolola2isis.cpp
+++ b/isis/tests/FunctionalTestsLrolola2isis.cpp
@@ -15,16 +15,16 @@ static QString APP_XML = FileName("$ISISROOT/bin/xml/lrolola2isis.xml").expanded
 
 TEST_F(LidarObservationPair, FunctionalTestLrolola2isisTwoImage) {
   QString testFilePath = tempDir.path() + "/LidarTest_TwoImage";
-  
+
   QVector<QString> args = {"from=" + csvPath,
                            "cubes=" + cubeListFile,
                            "to=" + testFilePath,
-                           "outputtype=test", 
+                           "outputtype=test",
                            "threshold=10",
                            "point_range_sigma=10",
                            "point_latitude_sigma=10",
                            "point_longitude_sigma=10",
-                           "point_radius_sigma=10", 
+                           "point_radius_sigma=10",
                            "pointid=Lidar????"};
   UserInterface options(APP_XML, args);
 
@@ -38,7 +38,7 @@ TEST_F(LidarObservationPair, FunctionalTestLrolola2isisTwoImage) {
   QString otestFilePath = testFilePath + ".json";
   nlohmann::json testJson;
   nlohmann::json truthJson;
-  
+
   std::ifstream ifs;
   ifs.open(otestFilePath.toStdString());
   ifs >> testJson;
@@ -47,9 +47,10 @@ TEST_F(LidarObservationPair, FunctionalTestLrolola2isisTwoImage) {
   ifs.open("data/lrolola2isis/Lrolola2isisTruth.json");
   ifs >> truthJson;
   ifs.close();
-  
 
-  ASSERT_EQ(testJson, truthJson);
+  // If the model changes slightly, then the back-projected image coordinate
+  // can change slightly so use a 0.01 pixel tolerance
+  EXPECT_PRED_FORMAT3(AssertJsonsNear, testJson, truthJson, 0.01);
 }
 
 TEST_F(LidarObservationPair, FunctionalTestLrolola2isisMultipleCsv) {
@@ -58,12 +59,12 @@ TEST_F(LidarObservationPair, FunctionalTestLrolola2isisMultipleCsv) {
   QVector<QString> args = {"fromlist=data/lrolola2isis/multipleCsv.lis",
                            "cubes=" + cubeListFile,
                            "to=" + testFilePath,
-                           "outputtype=test", 
+                           "outputtype=test",
                            "threshold=10",
                            "point_range_sigma=10",
                            "point_latitude_sigma=10",
                            "point_longitude_sigma=10",
-                           "point_radius_sigma=10", 
+                           "point_radius_sigma=10",
                            "pointid=Lidar????"};
   UserInterface options(APP_XML, args);
 
@@ -77,7 +78,7 @@ TEST_F(LidarObservationPair, FunctionalTestLrolola2isisMultipleCsv) {
   QString otestFilePath = testFilePath + ".json";
   nlohmann::json testJson;
   nlohmann::json truthJson;
-  
+
   std::ifstream ifs;
   ifs.open(otestFilePath.toStdString());
   ifs >> testJson;
@@ -86,7 +87,8 @@ TEST_F(LidarObservationPair, FunctionalTestLrolola2isisMultipleCsv) {
   ifs.open("data/lrolola2isis/Lrolola2isisTruth.json");
   ifs >> truthJson;
   ifs.close();
-  
 
-  ASSERT_EQ(testJson, truthJson);
+  // If the model changes slightly, then the back-projected image coordinate
+  // can change slightly so use a 0.01 pixel tolerance
+  EXPECT_PRED_FORMAT3(AssertJsonsNear, testJson, truthJson, 0.01);
 }

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -1,5 +1,8 @@
 #include "TestUtilities.h"
 
+#include <cmath>
+#include <string>
+
 namespace Isis {
 
   /**
@@ -196,6 +199,145 @@ namespace Isis {
           << vec1[index] << " and " << vec2[index] << ".\n";
     }
     return failure;
+  }
+
+  /**
+   * Helper recursive comparison function for two JSON objects
+   * Logic is modified from nlohmann::json::diff function
+   */
+  std::vector<std::string> compareJsons(
+      const nlohmann::json &json1,
+      const nlohmann::json &json2,
+      std::string jsonPointer,
+      double tolerance) {
+    std::vector<std::string> differences;
+    // Basic check for equality to short-circuit behavior
+    if (json1 == json2) {
+      return differences;
+    }
+
+    // Check types
+    // If both are numeric, then don't check the type so we can compare ints to floats
+    if (!(json1.is_number() && json2.is_number()) && json1.type() != json2.type()) {
+      differences.push_back("JSONs have different types at [" + jsonPointer + "]");
+      return differences;
+    }
+
+    switch (json1.type()) {
+      // Handle arrays
+      case nlohmann::detail::value_t::array: {
+        // Check for same size
+        if (json1.size() != json2.size()) {
+          differences.push_back(
+              "JSONs have different sized arrays [" + std::to_string(json1.size())
+              + "] and [" + std::to_string(json2.size()) + "] at [" + jsonPointer + "]");
+          return differences;
+        }
+
+        // Check values
+        for (size_t i = 0; i < json1.size(); i++) {
+          std::string newPointer = jsonPointer + "/" + std::to_string(i);
+          std::vector<std::string> tempDiffs = compareJsons(json1[i], json2[i], newPointer, tolerance);
+          differences.insert(differences.end(), tempDiffs.begin(), tempDiffs.end());
+        }
+
+        break;
+      }
+
+      // Handle objects
+      case nlohmann::detail::value_t::object: {
+        // Check for keys from the first JSON
+        for (auto it = json1.cbegin(); it != json1.cend(); ++it) {
+          // Check for presence
+          if (json2.contains(it.key())) {
+            // Check values
+            std::string newPointer = jsonPointer + "/" + it.key();
+            std::vector<std::string> tempDiffs = compareJsons(it.value(), json2[it.key()], newPointer, tolerance);
+            differences.insert(differences.end(), tempDiffs.begin(), tempDiffs.end());
+          }
+          else {
+            differences.push_back(
+                "Key [" + it.key() + "] is present in the first JSON but not the second at ["
+                + jsonPointer + "]");
+          }
+        }
+
+        // Check for keys from the second JSON
+        // This time only check for presence because if they are present in the first JSON
+        // we have already checked their value
+        for (auto it = json2.cbegin(); it != json2.cend(); ++it) {
+          if (!json1.contains(it.key())) {
+            differences.push_back(
+                "Key [" + it.key() + "] is present in the second JSON but not the first at ["
+                + jsonPointer + "]");
+          }
+        }
+
+        break;
+      }
+
+      // Handle numeric types
+      case nlohmann::detail::value_t::number_integer:
+      case nlohmann::detail::value_t::number_unsigned:
+      case nlohmann::detail::value_t::number_float: {
+        double numDiff = abs(json1.get<double>() - json2.get<double>());
+        if (numDiff > tolerance) {
+          differences.push_back(
+                "Values [" + json1.dump() + "] and [" + json2.dump() + "] differ by ["
+                + std::to_string(numDiff) + "] which is greater than tolerance ["
+                + std::to_string(tolerance) + "] at [" + jsonPointer + "]");
+        }
+
+        break;
+      }
+
+      // Handle the rest
+      case nlohmann::detail::value_t::null:
+      case nlohmann::detail::value_t::string:
+      case nlohmann::detail::value_t::boolean:
+      case nlohmann::detail::value_t::binary:
+      case nlohmann::detail::value_t::discarded:
+      default: {
+        // This "if" is redundant with the short-circuit check but is included for clarity/safety
+        if (json1 != json2) {
+          differences.push_back(
+                "Values [" + json1.dump() + "] and [" + json2.dump() + "] differ at ["
+                + jsonPointer + "]");
+        }
+
+        break;
+      }
+    }
+
+    return differences;
+  }
+
+
+  /**
+   * Asserts that two JSON objects are the same except for numerical values are within
+   * a given tolerance.
+   */
+  ::testing::AssertionResult AssertJsonsNear(
+      const char* json1_expr,
+      const char* json2_expr,
+      const char* tolerance_expr,
+      const nlohmann::json &json1,
+      const nlohmann::json &json2,
+      double tolerance) {
+
+    std::vector<std::string> differences = compareJsons(json1, json2, std::string(""), tolerance);
+
+    if (differences.size() > 0) {
+      ::testing::AssertionResult failure = ::testing::AssertionFailure()
+          << "JSONs " << json1_expr << " and " << json2_expr << " are different within a tolerance of "
+          << tolerance_expr << std::endl;
+      for (size_t i = 0; i < differences.size(); i++) {
+        failure << differences[i] << std::endl;
+      }
+      return failure;
+    }
+
+    return ::testing::AssertionSuccess();
   }
 
   // Check to see if a QString contains only numeric values.

--- a/isis/tests/TestUtilities.h
+++ b/isis/tests/TestUtilities.h
@@ -11,6 +11,8 @@
 
 #include "csm.h"
 
+#include <nlohmann/json.hpp>
+
 #include "FileName.h"
 #include "IException.h"
 #include "PvlGroup.h"
@@ -57,6 +59,20 @@ namespace Isis {
       const char* tolerance_expr,
       const std::vector<double> &vec1,
       const std::vector<double> &vec2,
+      double tolerance);
+
+  std::vector<std::string> compareJsons(
+      const nlohmann::json &json1,
+      const nlohmann::json &json2,
+      std::string jsonPointer,
+      double tolerance);
+
+  ::testing::AssertionResult AssertJsonsNear(
+      const char* json1_expr,
+      const char* json2_expr,
+      const char* tolerance_expr,
+      const nlohmann::json &json1,
+      const nlohmann::json &json2,
       double tolerance);
 
   bool isNumeric(QString str);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Added a new predicate formatter for comparing JSON values with a numeric tolerance.

We are seeing very slight variations in some JSON values between OSs so this allows us to just test within a given tolerance when working with JSON values.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

The issue was identified in #5039 and #5021

The tests with the small differences were originally added in #4878

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

I added a simple test suite in the ComparisonTests file to check that the predicate formatter is working correctly.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
