### PR TITLE
Allow CSMinit to pull body rotations

### DIFF
--- a/isis/src/base/objs/Camera/Camera.h
+++ b/isis/src/base/objs/Camera/Camera.h
@@ -251,7 +251,7 @@ namespace Isis {
                                       const double radius);
       virtual bool SetGround(Latitude latitude, Longitude longitude);
       virtual bool SetGround(const SurfacePoint & surfacePt);
-      bool SetRightAscensionDeclination(const double ra, const double dec);
+      virtual bool SetRightAscensionDeclination(const double ra, const double dec);
 
       void LocalPhotometricAngles(Angle & phase, Angle & incidence,
                                   Angle & emission, bool &success);

--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -8,6 +8,7 @@
 #include "TestCsmPlugin.h"
 #include "TempFixtures.h"
 #include "CameraFixtures.h"
+#include "Table.h"
 #include "TestUtilities.h"
 #include "TestCsmModel.h"
 #include "FileName.h"
@@ -28,6 +29,7 @@ class CSMPluginFixture : public TempTestingFiles {
     Pvl label;
     QString isdPath;
     QString altIsdPath;
+    QString bodyRotationIsdPath;
     QString filename;
     TestCsmModel model;
     AlternativeTestCsmModel altModel;
@@ -48,6 +50,35 @@ class CSMPluginFixture : public TempTestingFiles {
       std::ofstream file(isdPath.toStdString());
       file << isd;
       file.flush();
+
+      // Taken from msl mastcsm ISD (shouldn't matter though)
+      isd["body_rotation"] = {
+        {"time_dependent_frames", {
+          10014,
+          1
+        }},
+        {"ck_table_start_time", 598481006.3095651},
+        {"ck_table_end_time", 598481006.3095651},
+        {"ck_table_original_size", 1},
+        {"ephemeris_times", {598481006.3095651}},
+        {"quaternions", {{
+          -0.6980532256833364,
+          0.3170871114443887,
+          0.02820811335664892,
+          0.6413904896471425
+        }}},
+        {"angular_velocities" , {{
+          3.1623010866149816e-05,
+          -2.881378556904996e-05,
+          5.65157890696139e-05
+        }}},
+        {"reference_frame", 1}
+      };
+      bodyRotationIsdPath = tempDir.path() + "/body_rotation.json";
+      std::ofstream bodyRotationFile(bodyRotationIsdPath.toStdString());
+      bodyRotationFile << isd;
+      bodyRotationFile.flush();
+      isd.erase("body_rotation");
 
       json altIsd;
       altIsd["test_param_one"] = 1.0;
@@ -139,6 +170,77 @@ TEST_F(CSMPluginFixture, CSMInitDefault) {
   ASSERT_TRUE(testCube->hasGroup("Kernels"));
   PvlGroup &kernGroup = testCube->group("Kernels");
   EXPECT_TRUE(kernGroup.hasKeyword("ShapeModel"));
+
+  // Check that the BodyRotation table does not exist
+  ASSERT_FALSE(testCube->hasTable("BodyRotation"));
+}
+
+TEST_F(CSMPluginFixture, CSMInitBodyRotation) {
+  // Run csminit with defaults for everything besides FROM and ISD
+  QVector<QString> args = {
+    "from="+filename,
+    "isd="+bodyRotationIsdPath
+  };
+
+  UserInterface options(APP_XML, args);
+  csminit(options);
+
+  testCube->open(filename);
+
+  // Most of this is copied from the Default test but
+  // we want to make sure we retain all functionality if
+  // a BodyRotation is present
+
+  // Get a model and a state string
+  Blob stateString("CSMState", "String");
+  testCube->read(stateString);
+
+  // Verify contents of the Blob's PVL label
+  PvlObject blobPvl = stateString.Label();
+
+  // Check that the plugin can create a model from the state string
+  std::string modelName = QString(blobPvl.findKeyword("ModelName")).toStdString();
+  std::string modelState(stateString.getBuffer(), stateString.Size());
+  EXPECT_TRUE(plugin->canModelBeConstructedFromState(modelName, modelState));
+
+  // Check blob label ModelName and Plugin Name
+  EXPECT_EQ(QString(blobPvl.findKeyword("PluginName")).toStdString(), plugin->getPluginName());
+  EXPECT_EQ(modelName, TestCsmModel::SENSOR_MODEL_NAME);
+
+  // Check the Instrument group
+  ASSERT_TRUE(testCube->hasGroup("Instrument"));
+  PvlGroup &instGroup = testCube->group("Instrument");
+  EXPECT_TRUE(instGroup.hasKeyword("TargetName"));
+
+  // Check the CsmInfo group
+  ASSERT_TRUE(testCube->hasGroup("CsmInfo"));
+  PvlGroup &infoGroup = testCube->group("CsmInfo");
+  ASSERT_TRUE(infoGroup.hasKeyword("CSMPlatformID"));
+  EXPECT_EQ(infoGroup["CSMPlatformID"][0].toStdString(), model.getPlatformIdentifier());
+  ASSERT_TRUE(infoGroup.hasKeyword("CSMInstrumentId"));
+  EXPECT_EQ(infoGroup["CSMInstrumentId"][0].toStdString(), model.getSensorIdentifier());
+  ASSERT_TRUE(infoGroup.hasKeyword("ReferenceTime"));
+  EXPECT_EQ(infoGroup["ReferenceTime"][0].toStdString(), model.getReferenceDateAndTime());
+  ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterNames"));
+  ASSERT_EQ(infoGroup["ModelParameterNames"].size(), 3);
+  EXPECT_EQ(infoGroup["ModelParameterNames"][0].toStdString(), TestCsmModel::PARAM_NAMES[0]);
+  EXPECT_EQ(infoGroup["ModelParameterNames"][1].toStdString(), TestCsmModel::PARAM_NAMES[1]);
+  ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterUnits"));
+  ASSERT_EQ(infoGroup["ModelParameterUnits"].size(), 3);
+  EXPECT_EQ(infoGroup["ModelParameterUnits"][0].toStdString(), TestCsmModel::PARAM_UNITS[0]);
+  EXPECT_EQ(infoGroup["ModelParameterUnits"][1].toStdString(), TestCsmModel::PARAM_UNITS[1]);
+  ASSERT_TRUE(infoGroup.hasKeyword("ModelParameterTypes"));
+  ASSERT_EQ(infoGroup["ModelParameterTypes"].size(), 3);
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][0].toStdString(), "REAL");
+  EXPECT_EQ(infoGroup["ModelParameterTypes"][1].toStdString(), "REAL");
+
+  // Check the Kernels group
+  ASSERT_TRUE(testCube->hasGroup("Kernels"));
+  PvlGroup &kernGroup = testCube->group("Kernels");
+  EXPECT_TRUE(kernGroup.hasKeyword("ShapeModel"));
+
+  // Check for BodyRotation table
+  ASSERT_TRUE(testCube->hasTable("BodyRotation"));
 }
 
 TEST_F(CSMPluginFixture, CSMInitRunTwice) {


### PR DESCRIPTION
Allows csminit to pull body rotations from ISDs that contain the `body_rotation` keyword

## Description
Uses some ISIS `SpiceRotation` object functionality to pull the `body_rotation` key from an ISD (if it exists) and adds it to the cube as a BodyRotation table similar to spiceinit. This allows the CSMCamera to access other elements of the ISIS camera model that need access to the body rotaiton.

## Related Issue
Ground based sensor work (See USGSCSM IAA Proposal)
Closes #5069
Closes #5057 

## How Has This Been Validated?
Validated through both hand testing and new gtest

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
