### PR TITLE
Fixes Onerror Continue for ISIS Raytracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ release.
 - Fixed shadow shifting image by 2 pixels to the upper left corner. [#5035](https://github.com/USGS-Astrogeology/ISIS3/issues/5035)
 - Fixed compiler warnings on ubuntu [#4911](https://github.com/USGS-Astrogeology/ISIS3/issues/4911)
 - Fixes embree shape models not being from .BDS extension files [5064](https://github.com/USGS-Astrogeology/ISIS3/issues/5064)
+- Fixed failing shapemodel parameters when bullet was the preferred ray tracing engine but could not be created. [#5062](https://github.com/USGS-Astrogeology/ISIS3/issues/5062)
 
 ## [7.1.0] - 2022-07-27
 

--- a/isis/src/base/objs/ShapeModelFactory/ShapeModelFactory.cpp
+++ b/isis/src/base/objs/ShapeModelFactory/ShapeModelFactory.cpp
@@ -166,7 +166,6 @@ namespace Isis {
 
             // Bullet failed to load the kernel...test failure conditions
             if ("cub" == ext) {
-              onerror = "fail";   // This is fatal no matter the condition
               QString mess = "Bullet could not initialize ISIS Cube DEM";
               throw IException(IException::Unknown, mess, _FILEINFO_);
             }
@@ -189,11 +188,14 @@ namespace Isis {
 
             return ( b_model );
           }
-        } catch (IException &ie) {
+        } 
+        catch (IException &ie) {
           fileError.append(ie);
           QString mess = "Unable to create preferred BulletShapeModel";
           fileError.append(IException(IException::Unknown, mess, _FILEINFO_));
-          if ("fail" == onerror) throw fileError;
+          if ("fail" == onerror) {
+            throw fileError;
+          }
         }
 
         // Don't have ShapeModel yet - invoke pre-exising behavior (2017-03-23)
@@ -227,7 +229,9 @@ namespace Isis {
           fileError.append(ie);
           QString mess = "Unable to create preferred EmbreeShapeModel";
           fileError.append(IException(IException::Unknown, mess, _FILEINFO_));
-          if ("fail" == onerror) throw fileError;
+          if ("fail" == onerror) {
+            throw fileError;
+          }
         }
       }
 


### PR DESCRIPTION
Removes line updating onerror after a failed attempt to generate a bullet shapemodel

## Description
Removes a line updating a value obtained from the IsisPreferences file. When this value was updated it would cause programs, like qnet, error on images that were trying to build a bullet shapemodel.

## Related Issue
Closes #5062

## How Has This Been Validated?
Tested locally with reproduction steps from the above issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
