### PR TITLE
Add filters for old files in ISISDATA area

### DIFF
--- a/isis/config/exclude_list.txt
+++ b/isis/config/exclude_list.txt
@@ -10,4 +10,3 @@
 - chandrayaan1/kernels/spk/SAVE_SCS_2017-11-22
 - */kernels/fk/release.*/*
 - cassini/kernels/fk/Archive
-

--- a/isis/config/exclude_list.txt
+++ b/isis/config/exclude_list.txt
@@ -1,0 +1,13 @@
+- /a_older_versions/*
+- /kernels/*/former_versions/
+- /corrupt_files/*
+- /zzarchive/**
+- /kernels/*/original
+- gallileo/kernels/ck/prime_mission/*/extended_mission/*
+- gallileo/kernels/*/prime_mission/
+- galileo/kernels/ck/GEM/
+- clementine1/kernels/ck/save
+- chandrayaan1/kernels/spk/SAVE_SCS_2017-11-22
+- */kernels/fk/release.*/*
+- cassini/kernels/fk/Archive
+

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -219,4 +219,3 @@ if __name__ == '__main__':
     log.debug("Additional Args:", kwargs)
 
     main(args.mission, args.dest, os.path.expanduser(args.config), args.num_transfers, kwargs)
-

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -11,9 +11,9 @@ import tempfile
 from shutil import which
 from os import path
 from collections import OrderedDict
+from pathlib import Path
 
 def find_conf():
-    from pathlib import Path
     local_path = Path("rclone.conf")
     # this should be installed in scripts folder, so config is one directory up in etc 
     install_path = Path(os.path.dirname(__file__)) / '..' / "etc" / "isis" / 'rclone.conf'
@@ -110,7 +110,10 @@ def create_rclone_arguments(destination, mission_name, ntransfers=10, rclone_kwa
     if source_type == "naifKernels":
         destination = os.path.join(destination, "kernels")
 
-    extra_args=[f"{mission_name}",f"{destination}", "--progress", f"--checkers={ntransfers}", f"--transfers={ntransfers}", "--track-renames", f"--log-level={log.getLevelName(log.getLogger().getEffectiveLevel())}"]
+    exclude_paths = Path(os.path.dirname(__file__)) / '..' / 'config' / 'exclude_list.txt'
+
+
+    extra_args=[f"{mission_name}",f"{destination}", "--progress", f"--checkers={ntransfers}", f"--transfers={ntransfers}", "--track-renames", f"--log-level={log.getLevelName(log.getLogger().getEffectiveLevel())}", f"--exclude-from={exclude_paths}"]
 
     extra_args.extend(rclone_kwargs)
     log.debug(f"Args created: {extra_args}")


### PR DESCRIPTION
## Description
added filters for the following files in the ISISDATA download script, these are being imminently removed:

- /a_older_versions/*
- /kernels/*/former_versions/
- /corrupt_files/*
- /zzarchive/**
- /kernels/*/original
- gallileo/kernels/ck/prime_mission/*/extended_mission/*
- gallileo/kernels/*/prime_mission/
- galileo/kernels/ck/GEM/
- clementine1/kernels/ck/save
- chandrayaan1/kernels/spk/SAVE_SCS_2017-11-22
- */kernels/fk/release.*/*
- cassini/kernels/fk/Archive


## Related Issue
Storage concerns for the ISISDATA area

## How Has This Been Validated?
Tested reinstalling all data into my ISISDATA area, seems to work as this was a very minor change.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:

- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
