### PR TITLE
Allow isis to delegate nadir pointing to ale drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ release.
   override the timestamp style naming convention of the output cube with their
   own name; if not specified retains existing behavior [#5125](https://github.com/USGS-Astrogeology/ISIS3/issues/5162)
 - Added new parameters <b>ONERROR</b>, <b>ERRORLOG</b>, and <b>ERRORLIST</b> to <i>mosrange</i> to provide better control over error behavior and provide diagnostics when problems are encountered processing the input file list.[#3606](https://github.com/DOI-USGS/ISIS3/issues/3606)
+- Added ability to delegate calculation of nadir pointing to ALE [#5117](https://github.com/USGS-Astrogeology/ISIS3/issues/5117)
 
 ### Deprecated
 

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -255,7 +255,6 @@ namespace Isis {
         kernelSuccess = tryKernels(icube, p, ui, log, lk, pck, targetSpk,
                                    realCkKernel, fk, ik, sclk, spk, iak, dem, exk);
       }
-
       if (!kernelSuccess) {
         throw IException(IException::Unknown,
                          "Unable to initialize camera model",

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -194,19 +194,16 @@ namespace Isis {
     //  ephemerides. (2008-02-27 (KJB))
     if (m_usingNaif) {
       try {
-        // At this time ALE does not compute pointing for the nadir option in spiceinit
-        // If NADIR is turned on fail here so ISIS can create nadir pointing
-        if (kernels["InstrumentPointing"][0].toUpper() == "NADIR") {
-          QString msg = "Falling back to ISIS generation of nadir pointing";
-          throw IException(IException::Programmer, msg, _FILEINFO_);
-        }
-
         if (isd == NULL){
           // try using ALE
           std::ostringstream kernel_pvl;
           kernel_pvl << kernels;
 
           json props;
+          if (kernels["InstrumentPointing"][0].toUpper() == "NADIR") {
+            props["nadir"] = true;
+          }
+
           props["kernels"] = kernel_pvl.str();
 
           isd = ale::load(lab.fileName().toStdString(), props.dump(), "ale", false, false, true);
@@ -440,7 +437,7 @@ namespace Isis {
 
     //  2009-03-18  Tracie Sucharski - Removed test for old keywords, any files
     // with the old keywords should be re-run through spiceinit.
-    if (kernels["InstrumentPointing"][0].toUpper() == "NADIR") {
+    if (kernels["InstrumentPointing"][0].toUpper() == "NADIR" && !isUsingAle()) {
       if (m_instrumentRotation) {
         delete m_instrumentRotation;
         m_instrumentRotation = NULL;


### PR DESCRIPTION
Remove the logic that blocks calculation of nadir pointing in ale drivers.  Nadir pointing in ALE was previously implemented and has been adjusted + tested as of [ALE PR 519](https://github.com/USGS-Astrogeology/ale/pull/519)

This should be merged alongside [ALE PR 519](https://github.com/USGS-Astrogeology/ale/pull/519)

## Description
Related to ALE driver sprint. Chandrayaan1_mrrfr data uses nadir pointing.  To date, nadir pointing has been disabled within ALE via logic in spice.cpp.  This modifies the logic to allow nadir pointing in ALE.

## Related Issue
Closes #5117 

## How Has This Been Validated?
Tested by spiceinit-ing cubs using isis + ale drivers with nadir pointing.  Ale driver and tests are included in the linked PR.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
