### PR TITLE
Embree Pin

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - cxx-compiler=1.1.2
   - doxygen
   - eigen < 3.4
-  - embree
+  - embree>=2.17,<3
   - ffmpeg
   - geos>=3.7,<3.8
   - geotiff

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -60,7 +60,9 @@ requirements:
    - curl
    - doxygen
    - eigen<3.4
-   - embree
+   # versioned due to major release of embree 3 on conda-forge
+   # it is not compatible without changes to ISIS
+   - embree>=2.17, <3
    - ffmpeg
    - geos>=3.7,<3.8
    - geotiff
@@ -123,7 +125,7 @@ requirements:
   - cspice
   - curl
   - eigen
-  - embree
+  - {{ pin_compatible('embree', min_pin='x.x', max_pin='x.x') }}
   - {{ pin_compatible('ffmpeg', min_pin='x.x') }}
   - {{ pin_compatible('geos', min_pin='x.x', max_pin='x.x') }}
   - {{ pin_compatible('geotiff', max_pin='x.x') }}


### PR DESCRIPTION
Pinned embree in env and recipe due to new major version tick in conda-forge

## Description
Due to the release of embree3, we have to pin to embree 2 as ISIS (currently) cannot be built on embree3. This is due to the embree 3 changes being API breaking.

## Related Issue
#5127 

## How Has This Been Validated?
Attempted to create new ISIS build environment from environment.yml file and got embree3 rather than embree2

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
