### PR TITLE
Updated Qmos to load planetographic projections without loading planetocentric first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ release.
 ### Deprecated
 
 ### Fixed
+- Fixed users not being able to modify planetographic projections in qmos
 
 ## [7.2.0] - 2022-12-07
 

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicGridTool.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicGridTool.cpp
@@ -569,7 +569,7 @@ namespace Isis {
 
       if (obj["BaseLatitude"][0] != "Null")
         m_baseLat = Latitude(toDouble(obj["BaseLatitude"][0]), equatorialRadius, polarRadius,
-                             Latitude::Planetocentric, Angle::Degrees);
+            Latitude::Planetocentric, Angle::Degrees);
 
       if (obj["BaseLongitude"][0] != "Null")
         m_baseLon = Longitude(toDouble(obj["BaseLongitude"][0]), Angle::Degrees);
@@ -810,20 +810,25 @@ namespace Isis {
   void MosaicGridTool::onProjectionChanged() {
     TProjection * tproj = (TProjection *)getWidget()->getProjection();
     
+    PvlGroup mappingGroup(tproj->Mapping());
+
     // If Projection changed from a file, force extents to come from 
     // the new map file
     m_latExtents = Map;
     m_lonExtents = Map; 
 
-    Latitude minLat = Latitude(tproj->MinimumLatitude(), Angle::Degrees);
-    Latitude maxLat = Latitude(tproj->MaximumLatitude(), Angle::Degrees);
+    Latitude minLat = Latitude(tproj->MinimumLatitude(), mappingGroup, Angle::Degrees);
+    Latitude maxLat = Latitude(tproj->MaximumLatitude(), mappingGroup, Angle::Degrees);
     
     setLatExtents(m_latExtents, minLat, maxLat);
   
-    Longitude minLon = Longitude(tproj->MinimumLongitude(), Angle::Degrees);
-    Longitude maxLon = Longitude(tproj->MaximumLongitude(), Angle::Degrees);
+    Longitude minLon = Longitude(tproj->MinimumLongitude(), mappingGroup, Angle::Degrees);
+    Longitude maxLon = Longitude(tproj->MaximumLongitude(), mappingGroup, Angle::Degrees);
   
     setLonExtents(m_lonExtents, minLon, maxLon);
+
+    setBaseLat(Latitude(baseLat().angle(Angle::Degrees), mappingGroup, Angle::Degrees));
+    setBaseLon(Longitude(baseLon().angle(Angle::Degrees), mappingGroup, Angle::Degrees));
   }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The internal state of the latitudes and longitudes in the GridTool now track radii given from a mapping group.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #4754.

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Manually Validated via GUI.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
