### PR TITLE
Fixes Jigsaw NaN InstrumentPosition Velocities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ release.
 - Fixes embree shape models not being from .BDS extension files [5064](https://github.com/USGS-Astrogeology/ISIS3/issues/5064)
 - Fixed failing shapemodel parameters when bullet was the preferred ray tracing engine but could not be created. [#5062](https://github.com/USGS-Astrogeology/ISIS3/issues/5062)
 - Fixed version for Qt to prevent depreciations. [#5070](https://github.com/USGS-Astrogeology/ISIS3/issues/5070)
+- Fixed NaN velocities in spkwriter as a result of jigsaw position solves. [#4942](https://github.com/USGS-Astrogeology/ISIS3/issues/4942)
 
 ## [7.1.0] - 2022-07-27
 

--- a/isis/src/base/objs/SpicePosition/SpicePosition.cpp
+++ b/isis/src/base/objs/SpicePosition/SpicePosition.cpp
@@ -744,7 +744,7 @@ namespace Isis {
     // Load the time cache first
     LoadTimeCache();
 
-    if (p_fullCacheSize > 1) {
+    if (p_hasVelocity) {
       // Load the positions and velocity caches
       p_et = -DBL_MAX;   // Forces recalculation in SetEphemerisTime
       std::vector<ale::State> stateCache;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Jigsaw successfully runs the calculations for InstrumentPosition but when it gets to updating the InstrumentPosition table in the label, it fails to grab the cached velocities. In SpicePosition::ReloadCache, there is a check if `p_fullCacheSize > 1` to determine whether or not to include velocity in the cached states. But p_fullCacheSize is obtained from the label's `SpkTableOriginalSize` variable which does not indicate whether or not the velocity is included. Therefore, updating the check to just see if `p_hasVelocity` instead allowed jigsaw to pick up the cached velocity data and include it in the updated InstrumentPosition Table.


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#4942
We were seeing errors in campt because spkwriter was picking up the NaN values of the InstrumentPosition table of the jigsawed cubes. Any image spiceinited with this new spk kernel would then pick up the NaN velocities and campt is the first application to complain with a SPICE error of a zero vector. 


## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
We tested this with Galileo images that also have `SpkTableOriginalSize=1` in the label and tried solving for position, and confirmed that the label was updated with NaN velocity for InstrumentPosition. This fix also handled the NaN issues for these Galileo images.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
