### PR TITLE
Update spice::readValue to throw an exception is no values are read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ release.
 
 ### Fixed
 - Fixed users not being able to modify planetographic projections in qmos
+- Modified spice::readValue to add check for numValuesRead to stop reading garbase values [#4928](https://github.com/USGS-Astrogeology/ISIS3/issues/4928)
 
 ## [7.2.0] - 2022-12-07
 

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -1118,7 +1118,7 @@ namespace Isis {
         gdpool_c(key.toLatin1().data(), (SpiceInt)index, 1,
                  &numValuesRead, &kernelValue, &found);
 
-        if (found)
+        if (found && numValuesRead > 0)
           result = kernelValue;
       }
       else if (type == SpiceStringType) {
@@ -1126,7 +1126,7 @@ namespace Isis {
         gcpool_c(key.toLatin1().data(), (SpiceInt)index, 1, sizeof(kernelValue),
                  &numValuesRead, kernelValue, &found);
 
-        if (found)
+        if (found && numValuesRead > 0)
           result = kernelValue;
       }
       else if (type == SpiceIntType) {
@@ -1134,7 +1134,7 @@ namespace Isis {
         gipool_c(key.toLatin1().data(), (SpiceInt)index, 1, &numValuesRead,
                  &kernelValue, &found);
 
-        if (found)
+        if (found && numValuesRead > 0)
           result = (int)kernelValue;
       }
 

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -1142,6 +1142,10 @@ namespace Isis {
         QString msg = "Can not find [" + key + "] in text kernels";
         throw IException(IException::Io, msg, _FILEINFO_);
       }
+      else if (numValuesRead == 0){
+        QString msg = "Found " + key + "] in text kernels, but no values were identified and read.";
+        throw IException(IException::Io, msg, _FILEINFO_);
+      }
 
       storeValue(key, index, type, result);
       NaifStatus::CheckErrors();


### PR DESCRIPTION
Modified spice::readValue to add check for numValuesRead

## Description
Needs testing before merge.
Modified spice::readValue to add check for numValuesRead.

## Related Issue
Fixes #4928 

## How Has This Been Validated?
Needs testing before merge.  Not sure what testing is needed to ensure that existing camera models will not fail with new check.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
