### PR TITLE
Initial version bump action

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -1,0 +1,26 @@
+name: versionbump
+on:
+  pull_request:
+    branches:
+      - lts
+    types:
+      - closed
+
+jobs:
+  version_bump:
+    if: github.event.pull_request.merged && ${{ github.event.label.name == 'bug' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version
+        run: |
+          git config --global user.name 'ProjectBot'
+          git config --global user.email 'bot@users.noreply.github.com'
+          CURRENTVERSION=$(sed -n '0,/^{%[[:space:]]*set[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)"[[:space:]]*%}/s//\1/p' ${{github.workspace}}/recipe/meta.yaml)
+          CURRENTVERSION=`echo $CURRENTVERSION | awk -F. '/[0-9]+\./{$NF;print}' OFS=.`
+          NEWVERSION=`echo $CURRENTVERSION | awk -F. '/[0-9]+\./{$NF++;print}' OFS=.`
+          sed -i "0,/^{%.*version.*\"\([^\"]*\)\".*/s//{% set version = "\"${NEWVERSION}"\" %}/" ${{github.workspace}}/recipe/meta.yaml
+          sed -i "0,/set(VERSION.*/s//set(VERSION \""${NEWVERSION}"\")/" ${{github.workspace}}/isis/CMakeLists.txt          
+          git add ${{github.workspace}}/isis/CMakeLists.txt ${{github.workspace}}/recipe/meta.yaml
+          git commit -m 'auto bump version'
+          git push


### PR DESCRIPTION
Creates a bot to bump version on specified branch.  Currently set to fake "lts" branch.  Will need to be updated when LTS branches are released.

## Description
Bumps patch version specified in meta.yaml and cmakelists.txt.

I'm a noob at awk/sed, so there's probably a better way to hit this regex.  It was a difficult for me to balance generality and specificity.

## Related Issue
LTS Release + CI/CD work

## How Has This Been Validated?
Bot commit visible at https://github.com/AustinSanders/ISIS3/commit/29f55d1dd4a47333e230d140229a4ddf73f7e153

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
