### PR TITLE
Updated meta.yaml to reflect 8.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release.
 - Removed the `.py` extention from the _isisdataeval_ tool `isisdata_mockup` for consistency and install it in $ISISROOT/bin; added the `--tojson` and `--hasher` option to _isisdata_mockup_ tool improve utility; updated the tool `README.md` documentation to reflect this change, removed help output and trimmed example results;  fixed paths to test data in `make_isisdata_mockup.sh`. [#5163](https://github.com/DOI-USGS/ISIS3/pull/5163)
 
 ### Added
+- Added rclone to run dependencies in meta.yaml [#5183](https://github.com/DOI-USGS/ISIS3/issues/5183)
 
 ### Deprecated
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@
 #       A Public Release for ISIS3.6.1:                        {% set version = "3.6.1" %}
 #       A Release Candidate for ISIS3.6.1:                     {% set version = "3.6.1_RC" %}
 #       A custom build of ISIS3.6.1 for the CaSSIS mission:    {% set version = "3.6.1_cassis" %}
-{% set version = "7.2.0_RC1" %}
+{% set version = "8.0.0_RC1" %}
 
 # This is the build number for the current version you are building. If this is the first build of
 # this version, the build number will be 0. It is incremented by 1 with every consecutive build of
@@ -46,7 +46,6 @@ build:
 requirements:
   build:
    - ale=0.8.6
-   - aom
    - armadillo
    - boost=1.72
    - boost-cpp=1.72
@@ -58,17 +57,16 @@ requirements:
    - cspice=67
    - csm>=3.0.3,<3.0.4
    - curl
+   - cxx-compiler=1.1.2
    - doxygen
    - eigen<3.4
-   # versioned due to major release of embree 3 on conda-forge
-   # it is not compatible without changes to ISIS
-   - embree>=2.17, <3
+   - embree>=2.17,<3
    - ffmpeg
-   - geos>=3.7,<3.8
+   - geos>=3.9,<3.10
    - geotiff
    - gmp
    - graphviz
-   - gsl>=2.6,<2.7
+   - gsl>=2.6
    - hdf5
    - icu
    - inja
@@ -89,12 +87,12 @@ requirements:
    - nlohmann_json
    - ninja==1.7.2
    - nn
-   - numpy=1.23
    - opencv>=4.5.2
    - openssl>=1.1.1k
    - pcl>=1.10.0
    - protobuf<3.20
    - python>=3.7.11
+   - pytest
    - rclone
    - qhull
    - qt>=5.9.6,<5.15.0
@@ -106,7 +104,6 @@ requirements:
    - texlive-core
    - tnt
    - x264
-   - x265
    - xalan-c
    - xerces-c=3
    - xorg-kbproto
@@ -160,6 +157,7 @@ requirements:
   - qhull
   - {{ pin_compatible('qt', max_pin='x.x') }}
   - {{ pin_compatible('qwt', max_pin='x.x') }}
+  - rclone
   - superlu
   - tnt
   - x264


### PR DESCRIPTION
Push meta.yaml changes made in 8.0.0 branch back to dev

## Description
rclone was missing from run dependencies.  This was updated in 8.0.0 release but changes were not pushed back to dev.

## Related Issue
#5183

## How Has This Been Validated?
8.0.0 recipe includes rclone in run dependencies.  Tested by conda installing 8.0.0 rc and using rclone / downloadIsisData

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
