### PR TITLE
Check if history blob buffer is null before executing memcpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ release.
 ### Removed
 
 ### Fixed
+- Updated History constructor to check for invalid BLOB before copying History BLOB to output cube [#4966](https://github.com/DOI-USGS/ISIS3/issues/4966)
 
 ## [8.0.0] - 2023-04-19
 

--- a/isis/src/base/objs/History/History.cpp
+++ b/isis/src/base/objs/History/History.cpp
@@ -34,7 +34,11 @@ namespace Isis {
     char *blob_buffer = blob.getBuffer();
     p_bufferSize = blob.Size();
     p_histBuffer = new char[p_bufferSize];
-    memcpy(p_histBuffer, blob_buffer, p_bufferSize);
+
+    if (blob_buffer != NULL) {
+      // Copy existing history
+      memcpy(p_histBuffer, blob_buffer, p_bufferSize);
+    }
   }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Adds a check in a `History` constructor to verify that the `Blob` param is valid (not a `NULL` value buffer). An instance that the `Blob` buffer value is `NULL` is when ISIS tries to read an unreadable History entry to transfer to the output cube that results in a segmentation fault from trying to `memcpy()` an invalid `Blob`. This is the case with https://github.com/DOI-USGS/ISIS3/issues/4966. 

Btw, if you want to reproduce the bug in https://github.com/DOI-USGS/ISIS3/issues/4966, the data files are extremely big and took a couple hours to copy over. I found that `rclone` sped up the process a ton. Contact me if you need the exact path to the data.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes https://github.com/DOI-USGS/ISIS3/issues/4966

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
