### PR TITLE
fixes for apollopaninit argument type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,15 @@ release.
 ## [Unreleased]
 
 ### Changed
-- Removed the `.py` extention from the _isisdataeval_ tool `isisdata_mockup` for consistency and install it in $ISISROOT/bin; added the `--tojson` and `--hasher` option to _isisdata_mockup_ tool improve utility; updated the tool `README.md` documentation to reflect this change, removed help output and trimmed example results;  fixed paths to test data in `make_isisdata_mockup.sh`. [#5163](https://github.com/DOI-USGS/ISIS3/pull/5163)
+- Removed the `.py` extention from the _isisdataeval_ tool `isisdata_mockup` for
+  consistency and install it in $ISISROOT/bin; added the `--tojson` and
+  `--hasher` option to _isisdata_mockup_ tool improve utility; updated the tool
+  `README.md` documentation to reflect this change, removed help output and
+  trimmed example results;  fixed paths to test data in
+  `make_isisdata_mockup.sh`. [#5163](https://github.com/DOI-USGS/ISIS3/pull/5163)
+  
+- Changed apollopaninit FROM argument type from cube to filename as a TIFF image
+  is expected rather than a cube.
 
 ### Added
 - Added rclone to run dependencies in meta.yaml [#5183](https://github.com/DOI-USGS/ISIS3/issues/5183)

--- a/isis/src/apollo/apps/apollopaninit/apollopaninit.xml
+++ b/isis/src/apollo/apps/apollopaninit/apollopaninit.xml
@@ -27,6 +27,9 @@
     <change name="Jacob Cain" date="2022-11-22">
         Changed FROM type to cube. Fixes #4780.
     </change>
+    <change name="Anton Hibl" date="2023-06-26">
+      Changed FROM type back to filename as apollopaninit doesn't utilize cubes.
+    </change>
   </history>
 
   <category>
@@ -42,13 +45,13 @@
   <groups>
     <group name="Files">
       <parameter name="FROM">
-        <type>cube</type>
+        <type>filename</type>
         <fileMode>input</fileMode>
         <brief>
           Input Cube
         </brief>
         <description>
-          Use this parameter to select the cube filename to import.
+          Use this parameter to select the filename to import; expects a TIFF image.
         </description>
         <filter>
           *.cub

--- a/isis/src/apollo/apps/apollopaninit/main.cpp
+++ b/isis/src/apollo/apps/apollopaninit/main.cpp
@@ -117,11 +117,11 @@ void IsisMain() {
   insCode = scFrameCode - 230;
 
   try {
-    panCube.open(ui.GetCubeName("FROM"),"rw");
+    panCube.open(ui.GetFileName("FROM"),"rw");
   }
   catch (IException &e) {
     throw IException(IException::User,
-                     "Unable to open the file [" + ui.GetCubeName("FROM") + "] as a cube.",
+                     "Unable to open the file [" + ui.GetFileName("FROM") + "] as a cube.",
                      _FILEINFO_);
   }
 
@@ -639,7 +639,7 @@ void IsisMain() {
   CentroidApolloPan centroid(resolution);
   Chip inputChip,selectionChip;
   inputChip.SetSize(int(ceil(200*5.0/resolution)), int(ceil(200*5.0/resolution)));
-  fileName = ui.GetCubeName("FROM");
+  fileName = ui.GetFileName("FROM");
   if( panCube.pixelType() == 1)  //UnsignedByte
     centroid.setDNRange(12, 1e99);  //8 bit bright target
   else
@@ -768,7 +768,7 @@ void IsisMain() {
   panCube.write(tableFid);
   //close the new cube
   panCube.close(false);
-  panCube.open(ui.GetCubeName("FROM"),"rw");
+  panCube.open(ui.GetFileName("FROM"),"rw");
 
   delete spPos;
   delete spRot;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
changes the FROM arguemnt type from cube to filename as a tiff image is expected rather than a cube.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Tested ingestion of apollo panoramic images locally into ISIS.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
