### PR TITLE
Fix gaussstretch segfault

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ release.
 - Fixes embree shape models not being from .BDS extension files [5064](https://github.com/USGS-Astrogeology/ISIS3/issues/5064)
 - Fixed failing shapemodel parameters when bullet was the preferred ray tracing engine but could not be created. [#5062](https://github.com/USGS-Astrogeology/ISIS3/issues/5062)
 - Fixed version for Qt to prevent depreciations. [#5070](https://github.com/USGS-Astrogeology/ISIS3/issues/5070)
+- Fixed gaussstretch segmentation fault error and refactored gaussstretch files/tests to use gtest. [#5240](https://github.com/DOI-USGS/ISIS3/issues/5240)
 
 ## [7.1.0] - 2022-07-27
 

--- a/isis/src/base/apps/gaussstretch/gaussstretch.cpp
+++ b/isis/src/base/apps/gaussstretch/gaussstretch.cpp
@@ -7,9 +7,6 @@ using namespace std;
 using namespace Isis;
 
 namespace Isis {
-  void gauss(Buffer &in, Buffer &out);
-
-  vector<GaussianStretch *> stretch;
 
   void gaussstretch(UserInterface &ui) {
     Cube icube;
@@ -30,6 +27,7 @@ namespace Isis {
                     icube->sampleCount(), icube->lineCount(), icube->bandCount());
     double gsigma = ui.GetDouble("GSIGMA");
 
+    vector<GaussianStretch *> stretch;
     for(int i = 0; i < icube->bandCount(); i++) {
       Histogram *hist = icube->histogram(i + 1);
       double mean = (hist->Maximum() + hist->Minimum()) / 2.0;

--- a/isis/src/base/apps/gaussstretch/gaussstretch.cpp
+++ b/isis/src/base/apps/gaussstretch/gaussstretch.cpp
@@ -1,0 +1,57 @@
+#include "ProcessByLine.h"
+#include "Statistics.h"
+#include "GaussianStretch.h"
+#include "gaussstretch.h"
+
+using namespace std;
+using namespace Isis;
+
+namespace Isis {
+  void gauss(Buffer &in, Buffer &out);
+
+  vector<GaussianStretch *> stretch;
+
+  void gaussstretch(UserInterface &ui) {
+    Cube icube;
+    CubeAttributeInput inAtt = ui.GetInputAttribute("FROM");
+    if (inAtt.bands().size() != 0) {
+      icube.setVirtualBands(inAtt.bands());
+    }
+    icube.open(ui.GetCubeName("FROM"));
+    gaussstretch(&icube, ui);
+  }
+
+  void gaussstretch(Cube *icube, UserInterface &ui) {
+    ProcessByLine p;
+    p.SetInputCube(icube);
+    QString outputFileName = ui.GetCubeName("TO");
+    CubeAttributeOutput outputAttributes= ui.GetOutputAttribute("TO");
+    p.SetOutputCube(outputFileName, outputAttributes, 
+                    icube->sampleCount(), icube->lineCount(), icube->bandCount());
+    double gsigma = ui.GetDouble("GSIGMA");
+
+    for(int i = 0; i < icube->bandCount(); i++) {
+      Histogram *hist = icube->histogram(i + 1);
+      double mean = (hist->Maximum() + hist->Minimum()) / 2.0;
+      double stdev = (hist->Maximum() - hist->Minimum()) / (2.0 * gsigma);
+      stretch.push_back(new GaussianStretch(*hist, mean, stdev));
+    }
+
+    p.StartProcess(gauss);
+    for(int i = icube->bandCount()-1; i >= 0 ; i--) {
+      delete stretch[i];
+      stretch.pop_back();
+    }
+    p.EndProcess();
+
+    stretch.clear();
+  }
+
+  // Processing routine for the pca with one input cube
+  void gauss(Buffer &in, Buffer &out) {
+    for(int i = 0; i < in.size(); i++) {
+      if(IsSpecial(in[i])) out[i] = in[i];
+      out[i] = stretch[in.Band(i)-1]->Map(in[i]);
+    }
+  }
+}

--- a/isis/src/base/apps/gaussstretch/gaussstretch.cpp
+++ b/isis/src/base/apps/gaussstretch/gaussstretch.cpp
@@ -37,7 +37,15 @@ namespace Isis {
       stretch.push_back(new GaussianStretch(*hist, mean, stdev));
     }
 
-    p.StartProcess(gauss);
+    // Processing routine for the pca with one input cube
+    auto gaussProcess = [&](Buffer &in, Buffer &out)->void {
+      for(int i = 0; i < in.size(); i++) {
+        if(IsSpecial(in[i])) out[i] = in[i];
+        out[i] = stretch[in.Band(i)-1]->Map(in[i]);
+      }
+    };
+
+    p.StartProcess(gaussProcess);
     for(int i = icube->bandCount()-1; i >= 0 ; i--) {
       delete stretch[i];
       stretch.pop_back();
@@ -45,13 +53,5 @@ namespace Isis {
     p.EndProcess();
 
     stretch.clear();
-  }
-
-  // Processing routine for the pca with one input cube
-  void gauss(Buffer &in, Buffer &out) {
-    for(int i = 0; i < in.size(); i++) {
-      if(IsSpecial(in[i])) out[i] = in[i];
-      out[i] = stretch[in.Band(i)-1]->Map(in[i]);
-    }
   }
 }

--- a/isis/src/base/apps/gaussstretch/gaussstretch.h
+++ b/isis/src/base/apps/gaussstretch/gaussstretch.h
@@ -1,0 +1,12 @@
+#ifndef gaussstretch_h
+#define gaussstretch_h
+
+#include "Cube.h"
+#include "UserInterface.h"
+
+namespace Isis {
+    extern void gaussstretch(Cube *icube, UserInterface &ui);
+    extern void gaussstretch(UserInterface &ui);
+}
+
+#endif

--- a/isis/src/base/apps/gaussstretch/main.cpp
+++ b/isis/src/base/apps/gaussstretch/main.cpp
@@ -1,44 +1,12 @@
 #include "Isis.h"
-#include "ProcessByLine.h"
-#include "Statistics.h"
-#include "GaussianStretch.h"
+
+#include "gaussstretch.h"
+#include "Application.h"
 
 using namespace std;
 using namespace Isis;
 
-void gauss(Buffer &in, Buffer &out);
-
-vector<GaussianStretch *> stretch;
-
 void IsisMain() {
-  ProcessByLine p;
-  Cube *icube = p.SetInputCube("FROM");
-  p.SetOutputCube("TO");
-  double gsigma = Isis::Application::GetUserInterface().GetDouble("GSIGMA");
-
-  for(int i = 0; i < icube->bandCount(); i++) {
-    Histogram *hist = icube->histogram(i + 1);
-    double mean = (hist->Maximum() + hist->Minimum()) / 2.0;
-    double stdev = (hist->Maximum() - hist->Minimum()) / (2.0 * gsigma);
-    stretch.push_back(new GaussianStretch(*hist, mean, stdev));
-  }
-
-  p.StartProcess(gauss);
-  for(int i = 0; i < icube->bandCount(); i++) delete stretch[i];
-  p.EndProcess();
-
-  while(!stretch.empty()) {
-      delete stretch.back();
-      stretch.pop_back();
-  }
-
-  stretch.clear();
-}
-
-// Processing routine for the pca with one input cube
-void gauss(Buffer &in, Buffer &out) {
-  for(int i = 0; i < in.size(); i++) {
-    if(IsSpecial(in[i])) out[i] = in[i];
-    out[i] = stretch[in.Band(i)-1]->Map(in[i]);
-  }
+  UserInterface &ui = Application::GetUserInterface();
+  gaussstretch(ui);
 }

--- a/isis/src/base/apps/gaussstretch/tsts/Makefile
+++ b/isis/src/base/apps/gaussstretch/tsts/Makefile
@@ -1,4 +1,0 @@
-BLANKS = "%-6s"    
-LENGTH = "%-40s"
-
-include $(ISISROOT)/make/isismake.tststree

--- a/isis/src/base/apps/gaussstretch/tsts/default/Makefile
+++ b/isis/src/base/apps/gaussstretch/tsts/default/Makefile
@@ -1,7 +1,0 @@
-APPNAME = gaussstretch
-
-include $(ISISROOT)/make/isismake.tsts
-
-commands:
-	$(APPNAME) from= $(INPUT)//ab102401.cub \
-	  to= $(OUTPUT)/gaussstretchTruth.cub > /dev/null;

--- a/isis/tests/FunctionalTestsGaussstretch.cpp
+++ b/isis/tests/FunctionalTestsGaussstretch.cpp
@@ -1,0 +1,29 @@
+#include <iostream>
+
+#include "Cube.h"
+#include "CameraFixtures.h"
+#include "Histogram.h"
+#include "ImageHistogram.h"
+
+#include "gaussstretch.h"
+#include "gmock/gmock.h"
+
+using namespace Isis;
+
+static QString APP_XML = FileName("$ISISROOT/bin/xml/gaussstretch.xml").expanded();
+
+TEST_F(DefaultCube, FunctionalTestGaussstretch) {
+  QString outputCubePath = tempDir.path() + "/tempGaussStretchOut.cub";
+  double gsigma = 3.0;
+  QVector<QString> args = {"from=" + testCube->fileName(), "to=" + outputCubePath, "gsigma=" + QString::number(gsigma)};
+  UserInterface options(APP_XML, args);
+  try {
+    gaussstretch(options);
+  }
+  catch (IException &e) {
+    FAIL() << "Unable to open image: " << e.what() << std::endl;
+  }
+  Cube outputCube(outputCubePath);
+
+  EXPECT_FLOAT_EQ(outputCube.histogram()->Median(), -1.79769e+308);
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Addresses the `gaussstretch` segfault issue that occurs even when producing a valid output. The related issue below mentions that this issue exists throughout versions 4.1.0-7.2.0. This PR only targets 7.2. How to address the other affected versions?

Also refactors code and converts tests into gtest.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Only fixes version `7.2` in https://github.com/DOI-USGS/ISIS3/issues/5240

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Ran `gaussstretch from=<test.cub> to=<test.output.cub> gsigma=3.0` and confirmed segfault error does not output.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
