### PR TITLE
Campt attribute fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ release.
 - Fixed a bug in the <i>cnetwinnow</i> test that did not clean/remove it during test runs.
 - Fixed <i>findfeatures</i> instantiation and use of projection classes to correctly return geometry data from projected images and mosaics. [#4772](https://github.com/DOI-USGS/ISIS3/issues/4772)
 - Fixed `cubeit` attribute error to allow attribute specification on the output cube filename [#5234](https://github.com/DOI-USGS/ISIS3/issues/5234)
+- `campt` handles input band selection attribute correctly [#5234](https://github.com/DOI-USGS/ISIS3/issues/5235)
 
 ## [8.0.0] - 2023-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ release.
 - Fixed a bug in the <i>cnetwinnow</i> test that did not clean/remove it during test runs.
 - Fixed <i>findfeatures</i> instantiation and use of projection classes to correctly return geometry data from projected images and mosaics. [#4772](https://github.com/DOI-USGS/ISIS3/issues/4772)
 - Fixed `cubeit` attribute error to allow attribute specification on the output cube filename [#5234](https://github.com/DOI-USGS/ISIS3/issues/5234)
-- `campt` handles input band selection attribute correctly [#5234](https://github.com/DOI-USGS/ISIS3/issues/5235)
+- Fixed `campt` to handle input band selection attribute correctly [#5234](https://github.com/DOI-USGS/ISIS3/issues/5235)
 
 ## [8.0.0] - 2023-04-19
 

--- a/isis/src/base/apps/campt/campt.cpp
+++ b/isis/src/base/apps/campt/campt.cpp
@@ -42,7 +42,14 @@ namespace Isis{
     else
         campt.SetCSVOutput(true);
 
-    campt.SetCube(cube->fileName());
+    QString inputCubePath = "";
+    try {
+      inputCubePath = ui.GetCubeName("FROM");
+    }
+    catch (IException &e) {
+      inputCubePath = cube->fileName();
+    }
+    campt.SetCube(inputCubePath);
 
     // Grab the provided points (coordinates)
     QList< QPair<double, double> > points = getPoints(ui, ui.WasEntered("COORDLIST"));

--- a/isis/src/base/objs/CubeManager/CubeManager.cpp
+++ b/isis/src/base/objs/CubeManager/CubeManager.cpp
@@ -109,8 +109,6 @@ namespace Isis {
     if (searchResult == p_cubes.end()) {
       p_cubes.insert(fileName, new Cube());
       searchResult = p_cubes.find(fileName);
-      // Bands are the only thing input attributes can affect
-      (*searchResult)->setVirtualBands(attIn.bands());
 
       // Need to clean up memory if there is a problem opening a cube
       // This allows the CubeManager class to clean up the dynamically alloc'd


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the band selection attribute in campt. It was being removed when getting the file name from the cube. It would likely be better if we just passed the filename through the API instead of the cube.

## Related Issue
Closes #5235 

## How Has This Been Validated?
Validated locally and maintains current API through jenkins tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
