### PR TITLE
Fix ISIS Version Parseing

### DIFF
--- a/isis/cmake/Utilities.cmake
+++ b/isis/cmake/Utilities.cmake
@@ -169,7 +169,7 @@ function(get_os_version text)
                     ERROR_VARIABLE result)
 
     # Format the string
-    string(REGEX MATCH "[0-9]+.[0-9]+.[0-9]+" version "${result}")
+    string(REGEX MATCH "[0-9]+\.[0-9]+\.?[0-9]*" version "${result}")
     string(REGEX MATCH "^[0-9]+.[0-9]+" version "${version}")
     string(REPLACE "." "_" version "${version}")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The ISIS OS version parsing in Cmake was wrong for Macs. This resulted in weird version parsing if we couldn't find a three element OS version. This occurred for MacOS 12.7 where there is no bug fix version and ISIS couldn't parse the OS version.

## Related Issue
Nothing specific, likely related to #5219

## How Has This Been Validated?
Validated locally on my Mac 12.7 machine, will be further validated through Jenkins Ubuntu machine

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
