### PR TITLE
Added --no-kernels flag to downoadIsisData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,8 @@ release.
   override the timestamp style naming convention of the output cube with their
   own name; if not specified retains existing behavior [#5125](https://github.com/USGS-Astrogeology/ISIS3/issues/5162)
 - Added new parameters <b>ONERROR</b>, <b>ERRORLOG</b>, and <b>ERRORLIST</b> to <i>mosrange</i> to provide better control over error behavior and provide diagnostics when problems are encountered processing the input file list.[#3606](https://github.com/DOI-USGS/ISIS3/issues/3606)
-<<<<<<< HEAD
 - Added ability to delegate calculation of nadir pointing to ALE [#5117](https://github.com/USGS-Astrogeology/ISIS3/issues/5117)
-=======
 - Added --no-kernels flag to downloadIsisData [#5264](https://github.com/DOI-USGS/ISIS3/issues/5264)
->>>>>>> c23f57395 (Updated changelog)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,11 @@ release.
   override the timestamp style naming convention of the output cube with their
   own name; if not specified retains existing behavior [#5125](https://github.com/USGS-Astrogeology/ISIS3/issues/5162)
 - Added new parameters <b>ONERROR</b>, <b>ERRORLOG</b>, and <b>ERRORLIST</b> to <i>mosrange</i> to provide better control over error behavior and provide diagnostics when problems are encountered processing the input file list.[#3606](https://github.com/DOI-USGS/ISIS3/issues/3606)
+<<<<<<< HEAD
 - Added ability to delegate calculation of nadir pointing to ALE [#5117](https://github.com/USGS-Astrogeology/ISIS3/issues/5117)
+=======
+- Added --no-kernels flag to downloadIsisData [#5264](https://github.com/DOI-USGS/ISIS3/issues/5264)
+>>>>>>> c23f57395 (Updated changelog)
 
 ### Deprecated
 

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -40,7 +40,10 @@ filter_list = [
         '- document/',
         '- *.csv',
         '- toolkit/',
-        '- kernels_ORG/'
+        '- kernels_ORG/',
+        '- orbnum/**',
+        '- old/**',
+        '- SpecialProducts/**'
     ]
 
 def find_conf():

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -146,7 +146,7 @@ def create_rclone_arguments(destination, mission_name, parsedArgs, rclone_kwargs
         filter_list.extend(excludes)    
 
     if args.no_kernels:
-        excludes = [f"- {arg}" for arg in ['ck/**','ek/**','fk/**','ik/**','iak/**','lsk/**','mk/**','pck/**','sclk/**','spk/**']]
+        excludes = [f"- {arg}" for arg in ['ck/**','ek/**','fk/**','ik/**','iak/**','lsk/**','mk/**','pck/**','sclk/**','spk/**','tspk/**','dsk/**']]
         filter_list.extend(excludes)
         
 
@@ -243,7 +243,7 @@ if __name__ == '__main__':
     parser.add_argument('--filter', help='Additional filters for files', nargs='*')
     parser.add_argument('--include', help='files and patterns to include while downloading', nargs='*')
     parser.add_argument('--exclude', help='files and patterns to ignore while downloading', nargs='*')
-    parser.add_argument('--no-kernels', help='Exclude all kernel files from download.  Analogous to --exclude="{ck/**,ek/**,fk/**,ik/**,iak/**,lsk/**,mk/**,pck/**,sclk/**,spk/**}"', default=False, action='store_true')
+    parser.add_argument('--no-kernels', help='Exclude all kernel files from download.  Analogous to --exclude="{ck/**,ek/**,fk/**,ik/**,iak/**,lsk/**,mk/**,pck/**,sclk/**,spk/**,tspk/**,dsk/**}"', default=False, action='store_true')
     parser.add_argument('-c', '--command', choices=["copy", "sync", "ls", "lsd", "size"], help='files and patterns to ignore while downloading', default="copy")
 
     args, kwargs = parser.parse_known_args()

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -145,6 +145,11 @@ def create_rclone_arguments(destination, mission_name, parsedArgs, rclone_kwargs
         excludes = [f"- {arg}" for arg in args.exclude]
         filter_list.extend(excludes)    
 
+    if args.no_kernels:
+        excludes = [f"- {arg}" for arg in ['ck/**','ek/**','fk/**','ik/**','iak/**','lsk/**','mk/**','pck/**','sclk/**','spk/**']]
+        filter_list.extend(excludes)
+        
+
     # we need to add this to the end  
     if args.include: 
         filter_list.append("- *")
@@ -238,6 +243,7 @@ if __name__ == '__main__':
     parser.add_argument('--filter', help='Additional filters for files', nargs='*')
     parser.add_argument('--include', help='files and patterns to include while downloading', nargs='*')
     parser.add_argument('--exclude', help='files and patterns to ignore while downloading', nargs='*')
+    parser.add_argument('--no-kernels', help='Exclude all kernel files from download.  Analogous to --exclude="{ck/**,ek/**,fk/**,ik/**,iak/**,lsk/**,mk/**,pck/**,sclk/**,spk/**}"', default=False, action='store_true')
     parser.add_argument('-c', '--command', choices=["copy", "sync", "ls", "lsd", "size"], help='files and patterns to ignore while downloading', default="copy")
 
     args, kwargs = parser.parse_known_args()

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -229,7 +229,7 @@ if __name__ == '__main__':
         $ downloadIsisData tgo $ISISDATA
     
         # download everything except kernels with debug output
-        $ downloadIsisData all $ISISDATA --dry-run --exclude="kernels/**" -vv
+        $ downloadIsisData all $ISISDATA --dry-run --no-kernels -vv
         
         # download only cks and fks
         $ downloadIsisData all $ISISDATA --include="{ck/**,fk/**}" 


### PR DESCRIPTION
## Description
The "filter" and "exclude" syntax does not provide a convenient means of excluding kernels since the /kernels/ directory is part of the remote specification in the rclone configuration file.  This adds a  --no-kernels flag as syntax sugar to exclude any common kernel subdirectories like /ck, /fk, etc.

## Related Issue
Closes #5264 

## How Has This Been Validated?
Ran `downloadIsisData mro ~/data/testdata --no-kernels` and verified that only calibration files were downloaded

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
