### PR TITLE
Updated trimfilter to correctly use high/low filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ release.
   override the timestamp style naming convention of the output cube with their
   own name; if not specified retains existing behavior [#5125](https://github.com/USGS-Astrogeology/ISIS3/issues/5162)
 - Added new parameters <b>ONERROR</b>, <b>ERRORLOG</b>, and <b>ERRORLIST</b> to <i>mosrange</i> to provide better control over error behavior and provide diagnostics when problems are encountered processing the input file list.[#3606](https://github.com/DOI-USGS/ISIS3/issues/3606)
+- Added high/low filter functionality to trimfilter using existing parameters [#5311](https://github.com/DOI-USGS/ISIS3/issues/5311)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ release.
   override the timestamp style naming convention of the output cube with their
   own name; if not specified retains existing behavior [#5125](https://github.com/USGS-Astrogeology/ISIS3/issues/5162)
 - Added new parameters <b>ONERROR</b>, <b>ERRORLOG</b>, and <b>ERRORLIST</b> to <i>mosrange</i> to provide better control over error behavior and provide diagnostics when problems are encountered processing the input file list.[#3606](https://github.com/DOI-USGS/ISIS3/issues/3606)
-- Added high/low filter functionality to trimfilter using existing parameters [#5311](https://github.com/DOI-USGS/ISIS3/issues/5311)
 
 ### Deprecated
 
@@ -71,7 +70,7 @@ release.
 - Fixed target name translation for any dawn images with target "4 CERES" [#5294](https://github.com/DOI-USGS/ISIS3/pull/5294)
 - Fixed exception pop ups in qview when viewing images created using the CSM Camera [#5259](https://github.com/DOI-USGS/ISIS3/pull/5295/files)
 - Fixed shadowtau input file parseing errors when using example file [#5316](https://github.com/DOI-USGS/ISIS3/pull/5316)
-
+- Fixed high/low filter functionality in trimfilter [#5311](https://github.com/DOI-USGS/ISIS3/issues/5311)
 ## [8.0.1] - 2023-08-23
 
 ### Fixed

--- a/isis/src/base/apps/trimfilter/main.cpp
+++ b/isis/src/base/apps/trimfilter/main.cpp
@@ -27,6 +27,13 @@ void IsisMain() {
   double low = -DBL_MAX;
   double high = DBL_MAX;
   int minimum;
+
+  if(ui.WasEntered("LOW")) {
+    low = ui.GetDouble("LOW");
+  }
+  if(ui.WasEntered("HIGH")) {
+    high = ui.GetDouble("HIGH");
+  }
   if(ui.GetString("MINOPT") == "PERCENTAGE") {
     int size = lines * samples;
     double perc = ui.GetDouble("MINIMUM") / 100;
@@ -35,6 +42,7 @@ void IsisMain() {
   else {
     minimum = (int) ui.GetDouble("MINIMUM");
   }
+
   p.SetFilterParameters(samples, lines, low, high, minimum);
 
   // Process each line


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
High / low parameters were included in the xml file, but the values were hard coded instead of actually using user input. This PR fixes the behavior so that the filters are correctly applied.

## Related Issue
Closes #5311 

## How Has This Been Validated?
Ran the  commands in the original issue and verified that the results are as expected.
<img width="537" alt="Screen Shot 2023-11-16 at 7 52 21 PM" src="https://github.com/DOI-USGS/ISIS3/assets/3751180/90fa0c0c-f3e6-46e5-89ea-29625f0370d8">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
