### PR TITLE
Added depreciation notice to PvlObject::addLogGroup for ISIS3 v9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ release.
 - Added new parameters <b>ONERROR</b>, <b>ERRORLOG</b>, and <b>ERRORLIST</b> to <i>mosrange</i> to provide better control over error behavior and provide diagnostics when problems are encountered processing the input file list.[#3606](https://github.com/DOI-USGS/ISIS3/issues/3606)
 - Added ability to delegate calculation of nadir pointing to ALE [#5117](https://github.com/USGS-Astrogeology/ISIS3/issues/5117)
 - Added --no-kernels flag to downloadIsisData [#5264](https://github.com/DOI-USGS/ISIS3/issues/5264)
+- Added notice for depreciation to PvlObject::addLogGroup function which will be depreciated in favor of Application::appendAndLog(https://github.com/DOI-USGS/ISIS3/issues/5310)
 
 ### Deprecated
 

--- a/isis/src/base/objs/PvlObject/PvlObject.cpp
+++ b/isis/src/base/objs/PvlObject/PvlObject.cpp
@@ -159,6 +159,9 @@ namespace Isis {
   void PvlObject::addLogGroup(Isis::PvlGroup &group) {
     addGroup(group);
     Application::Log(group);
+    QString msg = "This function(PvlObject::addLogGroup) will be depreciated in ISIS3 v9.0 in "
+                  "favor of Application::appendLogGroup";
+    std::cout << msg << std::endl;
   };
 
   /**

--- a/isis/src/base/objs/PvlObject/PvlObject.cpp
+++ b/isis/src/base/objs/PvlObject/PvlObject.cpp
@@ -161,7 +161,7 @@ namespace Isis {
     Application::Log(group);
     QString msg = "This function(PvlObject::addLogGroup) will be depreciated in ISIS3 v9.0 in "
                   "favor of Application::appendLogGroup";
-    std::cout << msg << std::endl;
+    std::cerr << msg << std::endl;
   };
 
   /**


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail including motivation and any context -->
Added depreciation notice message to PvlObject::addLogGroup for ISIS v9.0 that notes it will be depreciated in favor of Application:appendAndLog

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DOI-USGS/ISIS3/issues/5310

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Only adds a logging message and contains no breaking changes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
