### PR TITLE
corrected calibration inclusion filter (needed ,)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ release.
 - Fixed shadowtau input file parseing errors when using example file [#5316](https://github.com/DOI-USGS/ISIS3/pull/5316)
 - Fixed ProgramLauncher failing while reporting errors from launched programs [#5331](https://github.com/DOI-USGS/ISIS3/pull/5331)
 - Fixed high/low filter functionality in trimfilter [#5311](https://github.com/DOI-USGS/ISIS3/issues/5311)
+- Fixed downloadIsisData script excluding needed files in the calibration folder [#5272](https://github.com/DOI-USGS/ISIS3/issues/5272)
 
 ## [8.0.1] - 2023-08-23
 

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -17,7 +17,7 @@ import re
 
 # priority is: lowest index is highest priority 
 filter_list = [
-        '+ calibration/**' # we generally want everything in calibration 
+        '+ calibration/**', # we generally want everything in calibration 
         '- source/',
         '- /a_older_versions/',
         '- /former_versions/',


### PR DESCRIPTION
Fixed an issue with the downloadIsisData script that caused some wanted files to be skipped.

## Description
<!--- Describe your changes in detail including motivation and any context -->
A user was having difficulty performing radiometric calibration on EDR images from PDS.  The hical application required .csv files containing additional information, but the downloadIsisData script was not downloading them.  A suggested workaround was to remove the `'- *.csv'` filter from the script.

The script is supposed to download everything in the calibration folder, but did not due to a missing comma after the first string in filter_list.  When the comma is added, the script includes everything in the calibration folder as intended.

## Related Issue
Fixes #5272 

## How Has This Been Validated?
The script was run with the command
    python downloadIsisData mro ~/data --include='calibration/**'
and it was manually verified that .csv files were downloaded to the appropriate subdirectories.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
