### PR TITLE
Fixed noproj bug where missing shapemodel-related keywords (RayTraceEngine, BulletParts, Tolerance) are dropped when the output label is created.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ release.
 ### Added
 - Added new csm plugins path to IsisPreferences [#5397](https://github.com/DOI-USGS/ISIS3/pull/5397)
 
+### Fixed
+- Fixed <i>noproj</i> bug where missing shapemodel-related keywords (RayTraceEngine, BulletParts, Tolerance) are dropped when the output label is created. This resulted in the Bullet collision detection engine not being used. Issue: [#5377](https://github.com/USGS-Astrogeology/ISIS3/issues/5377)
+
 ## [8.1.0] - 2023-12-05
 
 ### Changed
@@ -73,7 +76,6 @@ release.
 ### Removed
 
 ### Fixed
-- Fixed <i>noproj</i> bug where missing shapemodel-related keywords (RayTraceEngine, BulletParts, Tolerance) are dropped when the output label is created. This resulted in the Bullet collision detection engine not being used. Issue: [#5377](https://github.com/USGS-Astrogeology/ISIS3/issues/5377)
 - Bug fix for Cnetthinner app resolving divide by zero in CnetManager.cpp. Issue: [#5354](https://github.com/USGS-Astrogeology/ISIS3/issues/5354) 
 - Updated photomet MinnaertEmpirical model to support photemplate-style PVL format [#3621](https://github.com/DOI-USGS/ISIS3/issues/3621)
 - Fix matrix inversion errors in <i>findfeatures</i> due to bad FASTGEOM matrix transforms using a more robust implementation to detect these errors and throw exceptions. Images with these errors are captured and logged to the <b>TONOTMATCHED</b> file. Fixes [#4639](https://github.com/DOI-USGS/ISIS3/issues/4639)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,8 @@ release.
 ### Removed
 
 ### Fixed
-- Bug fix for Cnetthinner app resolving divide by zero in CnetManager.cpp. Issue: [#5354](https://github.com/USGS-Astrogeology/ISIS3/issues/5354), 
+- Fixed <i>noproj</i> bug where missing shapemodel-related keywords (RayTraceEngine, BulletParts, Tolerance) are dropped when the output label is created. This resulted in the Bullet collision detection engine not being used. Issue: [#5377](https://github.com/USGS-Astrogeology/ISIS3/issues/5377)
+- Bug fix for Cnetthinner app resolving divide by zero in CnetManager.cpp. Issue: [#5354](https://github.com/USGS-Astrogeology/ISIS3/issues/5354) 
 - Updated photomet MinnaertEmpirical model to support photemplate-style PVL format [#3621](https://github.com/DOI-USGS/ISIS3/issues/3621)
 - Fix matrix inversion errors in <i>findfeatures</i> due to bad FASTGEOM matrix transforms using a more robust implementation to detect these errors and throw exceptions. Images with these errors are captured and logged to the <b>TONOTMATCHED</b> file. Fixes [#4639](https://github.com/DOI-USGS/ISIS3/issues/4639)
 - Fixed <i>findfeatures</i> use of projected mosaics with correct check for <b>TargetName</b> in the Mapping labels. [#4772](https://github.com/DOI-USGS/ISIS3/issues/4772)

--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -260,7 +260,10 @@ namespace Isis {
         bool isTable = false;
         bool isFrameCode = kernelsKeyword.isNamed("NaifFrameCode") ||
                            kernelsKeyword.isNamed("NaifIkCode");
-        bool isShapeModel = kernelsKeyword.isNamed("ShapeModel");
+        bool isShapeModel = kernelsKeyword.isNamed("ShapeModel") ||
+                            kernelsKeyword.isNamed("RayTraceEngine") ||
+                            kernelsKeyword.isNamed("BulletParts") ||
+                            kernelsKeyword.isNamed("Tolerance");
 
         for (int keyValueIndex = 0; keyValueIndex < kernelsKeyword.size(); keyValueIndex++) {
           if (kernelsKeyword[keyValueIndex] == "Table") {

--- a/isis/src/base/apps/noproj/noproj.xml
+++ b/isis/src/base/apps/noproj/noproj.xml
@@ -67,6 +67,15 @@
     <change name="Kaitlyn Lee" date="2021-03-31">
       Refactored app to be callable and converted its tests to GTests.
     </change>
+    <change name="Kris Becker" date="2021-05-06">
+          Added checks for ray tracing options in UofA OSIRIS-REx ISIS code base.
+          The keywords needed for Bullet to operate properly are RayTraceEngine,
+          BulletParts, and Tolerance. These parameters must be included in the
+          output label in order for cam2cam to run and subsequent use is consistent.
+    </change>
+    <change name="Ken Edmundson" date="2023-12-14">
+          Incorporated Kris Becker's 2021-05-06 bug fix above into USGS code base.
+    </change>
   </history>
 
   <category>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->In OSIRIS-REx processing a bug was discovered in the noproj application. Missing keywords (RayTraceEngine, BulletParts, Tolerance) related to the shapemodel are dropped when noproj creates the output label. This causes problems for Bullet engine configurations that use the .conf or .obj formats. In fact, Bullet was never used. The NAIF DSK toolkit was used by default for geometry calculations. This has been resolved in the UofA OSIRIS-REx ISIS code base.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/DOI-USGS/ISIS3/issues/5377

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->Existing gtests have been confirmed.

Results of test suite...

kledmundson:/Users/kledmundson/ISISDev/noproj/Dec082023noproj/ISIS3/build$ ctest -R Noproj --output-on-failure
Test project /Users/kledmundson/ISISDev/noproj/Dec082023noproj/ISIS3/build
    Start 1473: DefaultCube.FunctionalTestNoprojDefault
1/6 Test #1473: DefaultCube.FunctionalTestNoprojDefault ...........   Passed    4.39 sec
    Start 1474: DefaultCube.FunctionalTestNoprojExpand
2/6 Test #1474: DefaultCube.FunctionalTestNoprojExpand ............   Passed    4.68 sec
    Start 1475: DefaultCube.FunctionalTestNoprojFromInput
3/6 Test #1475: DefaultCube.FunctionalTestNoprojFromInput .........   Passed    4.40 sec
    Start 1476: DefaultCube.FunctionalTestNoprojFromUser
4/6 Test #1476: DefaultCube.FunctionalTestNoprojFromUser ..........   Passed    2.90 sec
    Start 1477: DefaultCube.FunctionalTestNoprojSpecs
5/6 Test #1477: DefaultCube.FunctionalTestNoprojSpecs .............   Passed    4.18 sec
    Start 1505: LineScannerCube.FunctionalTestNoprojLineScanner
6/6 Test #1505: LineScannerCube.FunctionalTestNoprojLineScanner ...   Passed    2.88 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =  23.63 sec

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added any user impacting changes to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
