### PR TITLE
Fixed Underscore Env Var Expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ release.
 
 ### Fixed
 - Fixed <i>noproj</i> bug where missing shapemodel-related keywords (RayTraceEngine, BulletParts, Tolerance) are dropped when the output label is created. This resulted in the Bullet collision detection engine not being used. Issue: [#5377](https://github.com/USGS-Astrogeology/ISIS3/issues/5377)
+- Fixed ISIS failing to expand env variables with an "_" in them. [#5402](https://github.com/DOI-USGS/ISIS3/pull/5402)
 
 ## [8.1.0] - 2023-12-05
 

--- a/isis/src/base/objs/FileName/FileName.cpp
+++ b/isis/src/base/objs/FileName/FileName.cpp
@@ -846,7 +846,7 @@ namespace Isis {
     // Loop while there are any "$" at the current position or after
     // Some "$" might be skipped if no translation can be found
     while((varStartPos = expandedStr.indexOf("$", varSearchStartPos)) != -1) {
-      int varEndPos = expandedStr.indexOf(QRegExp("[^a-zA-Z{}0-9]"), varStartPos + 1);
+      int varEndPos = expandedStr.indexOf(QRegExp("[^a-zA-Z{}0-9_]"), varStartPos + 1);
       if (varEndPos == -1)
         varEndPos = expandedStr.length();
 

--- a/isis/tests/FileNameTests.cpp
+++ b/isis/tests/FileNameTests.cpp
@@ -84,14 +84,14 @@ TEST(FileName, Extension) {
   EXPECT_EQ("cub", file.extension());
 }
 
-TEST(FileName, Expanded1) {
+TEST(FileName, ExpandedDefault) {
   QString relativeFileName("test.cub");
   FileName file("$ISISROOT/" + relativeFileName);
   QString isisRoot(getenv("ISISROOT"));
   EXPECT_EQ(isisRoot + "/" + relativeFileName, file.expanded());
 }
 
-TEST(FileName, Expanded2) {
+TEST(FileName, ExpandedUnderscore) {
   QString relativeFileName("test.cub");
   setenv("SOME_FILE_PATH", getenv("ISISROOT"), 1);
   FileName file("$SOME_FILE_PATH/" + relativeFileName);

--- a/isis/tests/FileNameTests.cpp
+++ b/isis/tests/FileNameTests.cpp
@@ -84,11 +84,19 @@ TEST(FileName, Extension) {
   EXPECT_EQ("cub", file.extension());
 }
 
-TEST(FileName, Expanded) {
+TEST(FileName, Expanded1) {
   QString relativeFileName("test.cub");
   FileName file("$ISISROOT/" + relativeFileName);
   QString isisRoot(getenv("ISISROOT"));
   EXPECT_EQ(isisRoot + "/" + relativeFileName, file.expanded());
+}
+
+TEST(FileName, Expanded2) {
+  QString relativeFileName("test.cub");
+  setenv("SOME_FILE_PATH", getenv("ISISROOT"), 1);
+  FileName file("$SOME_FILE_PATH/" + relativeFileName);
+  QString someFilePath(getenv("ISISROOT"));
+  EXPECT_EQ(someFilePath + "/" + relativeFileName, file.expanded());
 }
 
 TEST(FileName, Original) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
ISIS was failing to expand `$CONDA_PREFIX`, when I dug into it I found that the "_" was considered an ending token for environment variables. This PR fixes this.

## Related Issue
N/A

## How Has This Been Validated?
Added test to cover change

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
