### PR TITLE
Fixed bug in noproj where some temporary files were not deleted after completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release.
 - Added new csm plugins path to IsisPreferences [#5397](https://github.com/DOI-USGS/ISIS3/pull/5397)
 
 ### Fixed
+- Fixed <i>noproj</i> bug where some temporary files were not deleted after call to cam2cam.  Issue: [#4813](https://github.com/USGS-Astrogeology/ISIS3/issues/4813)
 - Fixed <i>noproj</i> bug where missing shapemodel-related keywords (RayTraceEngine, BulletParts, Tolerance) are dropped when the output label is created. This resulted in the Bullet collision detection engine not being used. Issue: [#5377](https://github.com/USGS-Astrogeology/ISIS3/issues/5377)
 
 ## [8.1.0] - 2023-12-05

--- a/isis/src/base/apps/noproj/main.cpp
+++ b/isis/src/base/apps/noproj/main.cpp
@@ -1,3 +1,10 @@
+/** This is free and unencumbered software released into the public domain.
+
+The authors of ISIS do not claim copyright on the contents of this file.
+For more details about the LICENSE terms and the AUTHORS, you will
+find files of those names at the top level of this repository. **/
+
+/* SPDX-License-Identifier: CC0-1.0 */
 #define GUIHELPERS
 #include "Isis.h"
 

--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -3,17 +3,14 @@
 #include <iostream>
 #include <sstream>
 #include <QString>
+#include <QStringList>
 
 #include "AlphaCube.h"
-#include "Application.h"
-#include "Blob.h"
 #include "cam2cam.h"
 #include "CameraDetectorMap.h"
 #include "CameraFocalPlaneMap.h"
-#include "History.h"
 #include "iTime.h"
 #include "Process.h"
-#include "ProgramLauncher.h"
 #include "Pvl.h"
 #include "PvlObject.h"
 
@@ -26,6 +23,8 @@ namespace Isis {
   static void storeSpice(PvlGroup *instrumentGroup, PvlObject *naifKeywordsObject,
                   QString oldName, QString spiceName,
                   double constantCoeff, double multiplierCoeff, bool putMultiplierInX);
+
+  QStringList findAllDetachedFiles(const PvlObject &object);
 
   /**
    * Remove camera distortions in a raw level 1 cube.
@@ -44,7 +43,7 @@ namespace Isis {
     if((ui.WasEntered("MATCH"))) {
       mcube.open(ui.GetCubeName("MATCH"));
     }
-
+    
     noproj(&icube, &mcube, ui);
   }
 
@@ -191,6 +190,7 @@ namespace Isis {
     //   1) the idealInstrument pvl if there or
     //   2) the input size expanded by user specified percentage
     Cube *ocube = p.SetOutputCube(matchCubeFile.expanded(), cao, 1, 1, 1);
+    
     // Extract the times and the target from the instrument group
     QString startTime = inst["StartTime"];
     QString stopTime;
@@ -352,40 +352,39 @@ namespace Isis {
 
     p.EndProcess();
 
-  // Now adjust the label to fake the true size of the image to match without
-  // taking all the space it would require for the image data
+    // Now adjust the label to fake the true size of the image to match without
+    // taking all the space it would require for the image data
     Pvl label;
-    label.read(matchCubeFileNoExt + ".lbl");
+    QString matchLbl = matchCubeFileNoExt + ".lbl";
+    label.read(matchLbl);
     PvlGroup &dims = label.findGroup("Dimensions", Pvl::Traverse);
     dims["Lines"] = toString(numberLines);
     dims["Samples"] = toString(detectorSamples);
     dims["Bands"] = toString(numberBands);
-    label.write(matchCubeFileNoExt + ".lbl");
+    label.write(matchLbl);
 
-  // And run cam2cam to apply the transformation
+    // And run cam2cam to apply the transformation
     QVector<QString> args = {"to=" + ui.GetCubeName("TO"), "INTERP=" + ui.GetString("INTERP")};
     UserInterface cam2camUI(FileName("$ISISROOT/bin/xml/cam2cam.xml").expanded(), args);
     Cube matchCube;
     matchCube.open(matchCubeFile.expanded(), "rw");
     cam2cam(icube, &matchCube, cam2camUI);
 
-  //  Cleanup by deleting the match files
-    remove((matchCubeFileNoExt + ".History.IsisCube").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".lbl").toStdString().c_str());
-    remove(matchCubeFile.expanded().toStdString().c_str());
-    remove((matchCubeFileNoExt + ".OriginalLabel.IsisCube").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".Table.BodyRotation").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".Table.HiRISE Ancillary").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".Table.HiRISE Calibration Ancillary").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".Table.HiRISE Calibration Image").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".Table.InstrumentPointing").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".Table.InstrumentPosition").toStdString().c_str());
-    remove((matchCubeFileNoExt + ".Table.SunPosition").toStdString().c_str());
+    // Cleanup by deleting the match files
+    QStringList detfiles = findAllDetachedFiles( label );
+    detfiles.append(matchLbl);
 
-  // Finally finish by adding the OriginalInstrument group to the TO cube
+    // Now actually remove the files
+    foreach (const QString &dfile, detfiles ) {
+      std::string  dtf = dfile.toStdString();
+      remove ( dtf.c_str() );
+    }
+
+    // Finally finish by adding the OriginalInstrument group to the TO cube
     Cube toCube;
     toCube.open(ui.GetCubeName("TO"), "rw");
-  // Extract label and create cube object
+  
+    // Extract label and create cube object
     Pvl *toLabel = toCube.label();
     PvlObject &o = toLabel->findObject("IsisCube");
     o.deleteGroup("OriginalInstrument");
@@ -396,6 +395,7 @@ namespace Isis {
     if (o.hasGroup("AlphaCube")) {
       o.deleteGroup("AlphaCube");
     }
+
     toCube.close();
   }
 
@@ -421,4 +421,27 @@ namespace Isis {
       naifKeywordsObject->addKeyword(spiceKeyword, Pvl::Replace);
     }
   }
+
+  // Find all detached filenames specified in objects in the label
+  QStringList findAllDetachedFiles(const PvlObject &object) {
+
+    // Check this object for a detached file spec
+    QStringList detfiles;
+    QString dfilename = "^" + object.name();
+    if ( object.hasKeyword(dfilename) ) {
+      QString detname = object[dfilename];
+      detfiles.append(detname);
+    }
+
+    // Now check all objects contain in this object
+    for (int i_obj = 0; i_obj <  object.objects(); i_obj++) {
+      const PvlObject &obj = object.object(i_obj);
+      QStringList files = findAllDetachedFiles(obj);
+      if ( files.size() > 0 ) {
+        detfiles.append(files);
+      }    
+    }
+  
+    return ( detfiles );
+  }  
 }

--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -1,3 +1,10 @@
+/** This is free and unencumbered software released into the public domain.
+The authors of ISIS do not claim copyright on the contents of this file.
+For more details about the LICENSE terms and the AUTHORS, you will
+find files of those names at the top level of this repository. **/
+
+/* SPDX-License-Identifier: CC0-1.0 */
+
 #include "noproj.h"
 
 #include <iostream>

--- a/isis/src/base/apps/noproj/noproj.h
+++ b/isis/src/base/apps/noproj/noproj.h
@@ -5,8 +5,8 @@
 #include "UserInterface.h"
 
 namespace Isis{
-  extern void noproj(Cube *icube, Cube *mcube, UserInterface &ui);
   extern void noproj(UserInterface &ui);
+  extern void noproj(Cube *icube, Cube *mcube, UserInterface &ui);
 }
 
 #endif

--- a/isis/src/base/apps/noproj/noproj.h
+++ b/isis/src/base/apps/noproj/noproj.h
@@ -1,3 +1,10 @@
+/** This is free and unencumbered software released into the public domain.
+
+The authors of ISIS do not claim copyright on the contents of this file.
+For more details about the LICENSE terms and the AUTHORS, you will
+find files of those names at the top level of this repository. **/
+
+/* SPDX-License-Identifier: CC0-1.0 */
 #ifndef noproj_h
 #define noproj_h
 

--- a/isis/src/base/apps/noproj/noproj.xml
+++ b/isis/src/base/apps/noproj/noproj.xml
@@ -73,8 +73,16 @@
           BulletParts, and Tolerance. These parameters must be included in the
           output label in order for cam2cam to run and subsequent use is consistent.
     </change>
+    <change name="Kris Becker" date="2021-09-22">
+          Rework how temporary external files are identified in UofA OSIRIS-REx
+          ISIS code base after use by cam2cam and ensure they are all deleted. Fixes
+          #4813.
+    </change>
     <change name="Ken Edmundson" date="2023-12-14">
           Incorporated Kris Becker's 2021-05-06 bug fix above into USGS code base.
+    </change>
+    <change name="Ken Edmundson" date="2024-01-09">
+          Incorporated Kris Becker's 2021-09-22 bug fix above into USGS code base.
     </change>
   </history>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->As stated in https://github.com/DOI-USGS/ISIS3/issues/4813, "...there are various files that the noproj application doesn't clean up after completion. This is likely due to not every file being accounted for when we go to remove various files that are created." The fix for this was initially implemented in the University of Arizona's ISIS OSIRIS-REx codebase.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->https://github.com/DOI-USGS/ISIS3/issues/4813

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Results of ctest suite...

ctest -R Noproj --output-on-failure
Test project /Users/kledmundson/ISISDev/noproj/Dec172023/ISIS3/build
    Start 1473: DefaultCube.FunctionalTestNoprojDefault
1/6 Test #1473: DefaultCube.FunctionalTestNoprojDefault ...........   Passed    4.32 sec
    Start 1474: DefaultCube.FunctionalTestNoprojExpand
2/6 Test #1474: DefaultCube.FunctionalTestNoprojExpand ............   Passed    4.58 sec
    Start 1475: DefaultCube.FunctionalTestNoprojFromInput
3/6 Test #1475: DefaultCube.FunctionalTestNoprojFromInput .........   Passed    4.32 sec
    Start 1476: DefaultCube.FunctionalTestNoprojFromUser
4/6 Test #1476: DefaultCube.FunctionalTestNoprojFromUser ..........   Passed    2.92 sec
    Start 1477: DefaultCube.FunctionalTestNoprojSpecs
5/6 Test #1477: DefaultCube.FunctionalTestNoprojSpecs .............   Passed    4.09 sec
    Start 1505: LineScannerCube.FunctionalTestNoprojLineScanner
6/6 Test #1505: LineScannerCube.FunctionalTestNoprojLineScanner ...   Passed    2.79 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =  23.21 sec

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
