### PR TITLE
Update HistogramTool to better support high dynamic range images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ release.
 
 
 ### Fixed
+- Fixed a bug in which the histogram tool used the entire image to calculate bin size, which caused an issue with high dynamic range images. [#5371](https://github.com/DOI-USGS/ISIS3/issues/5371)
 - Fixed a bug in which 'version' file was compiled as source and prevented subsequent ISIS recompilation [#5374](https://github.com/DOI-USGS/ISIS3/issues/5374)
 - Fixed <i>noproj</i> bug where some temporary files were not deleted after call to cam2cam.  Issue: [#4813](https://github.com/USGS-Astrogeology/ISIS3/issues/4813)
 - Fixed <i>noproj</i> bug where missing shapemodel-related keywords (RayTraceEngine, BulletParts, Tolerance) are dropped when the output label is created. This resulted in the Bullet collision detection engine not being used. Issue: [#5377](https://github.com/USGS-Astrogeology/ISIS3/issues/5377)

--- a/isis/src/qisis/objs/HistogramTool/HistogramTool.cpp
+++ b/isis/src/qisis/objs/HistogramTool/HistogramTool.cpp
@@ -190,7 +190,7 @@ namespace Isis {
 
       Cube *cube = activeViewport->cube();
       int band = activeViewport->grayBand();
-      ImageHistogram hist(*cube, band);
+      std::unique_ptr<ImageHistogram> hist;
 
       //If the rubber band is a line
       if (rubberBandTool()->currentMode() == RubberBandTool::LineMode) {
@@ -272,6 +272,7 @@ namespace Isis {
           return;
         }
 
+        hist = std::make_unique<ImageHistogram>(ImageHistogram(*cube, band, NULL, ssamp, sline, esamp, eline));
         Brick *brick = new Brick(*cube, 1, 1, 1);
 
         //For each point read that value from the cube and add it to the histogram
@@ -281,7 +282,7 @@ namespace Isis {
           int il = pt->y();
           brick->SetBasePosition(is, il, band);
           cube->read(*brick);
-          hist.AddData(brick->DoubleBuffer(), 1);
+          hist->AddData(brick->DoubleBuffer(), 1);
         }
         delete brick;
 
@@ -304,6 +305,7 @@ namespace Isis {
         esamp = round(esamp);
         eline = round(eline);
 
+        hist = std::make_unique<ImageHistogram>(ImageHistogram(*cube, band, NULL, ssamp, sline, esamp, eline));
         int nsamps = (int)(std::fabs(esamp - ssamp) + 1);
 
         Brick *brick = new Brick(*cube, nsamps, 1, 1);
@@ -313,7 +315,7 @@ namespace Isis {
           int isamp = std::min(ssamp,esamp);
           brick->SetBasePosition(isamp, line, band);
           cube->read(*brick);
-          hist.AddData(brick->DoubleBuffer(), nsamps);
+          hist->AddData(brick->DoubleBuffer(), nsamps);
         }
         delete brick;
       }
@@ -333,6 +335,7 @@ namespace Isis {
                                          esamp, eline);
 
 
+          hist = std::make_unique<ImageHistogram>(ImageHistogram(*cube, band, NULL, ssamp, sline, esamp, eline));
           for(int y = (int)sline; y <= (int)eline; y++) {
             for(int x = (int)ssamp; x <= (int)esamp; x++) {
               int x1, y1;
@@ -357,7 +360,7 @@ namespace Isis {
           for(unsigned int j = 0; j < x_contained.size(); j++) {
             brick->SetBasePosition(x_contained[j], y_contained[j], band);
             cube->read(*brick);
-            hist.AddData(brick->DoubleBuffer(), 1);
+            hist->AddData(brick->DoubleBuffer(), 1);
           }
           delete brick;
         }
@@ -368,13 +371,13 @@ namespace Isis {
       QVector<QPointF> binCountData;
       QVector<QPointF> cumPctData;
       double cumpct = 0.0;
-      for(int i = 0; i < hist.Bins(); i++) {
-        if(hist.BinCount(i) > 0) {
-          binCountData.append(QPointF(hist.BinMiddle(i), hist.BinCount(i)));
+      for(int i = 0; i < hist->Bins(); i++) {
+        if(hist->BinCount(i) > 0) {
+          binCountData.append(QPointF(hist->BinMiddle(i), hist->BinCount(i)));
 
-          double pct = (double)hist.BinCount(i) / hist.ValidPixels() * 100.;
+          double pct = (double)hist->BinCount(i) / hist->ValidPixels() * 100.;
           cumpct += pct;
-          cumPctData.append(QPointF(hist.BinMiddle(i), cumpct));
+          cumPctData.append(QPointF(hist->BinMiddle(i), cumpct));
         }
       }
 
@@ -389,7 +392,7 @@ namespace Isis {
       // ---------------------------------------------
 
       for(int y = 0; y < binCountData.size(); y++) {
-        intervals[y].interval = QwtInterval(binCountData[y].x(), binCountData[y].x() + hist.BinSize());
+        intervals[y].interval = QwtInterval(binCountData[y].x(), binCountData[y].x() + hist->BinSize());
 
         intervals[y].value = binCountData[y].y();
         if(binCountData[y].y() > maxYValue) maxYValue = binCountData[y].y();
@@ -405,14 +408,14 @@ namespace Isis {
       }
 
 
-      QLabel *label = new QLabel("  Average = " + QString::number(hist.Average()) + '\n' +
-                                "\n  Minimum = " + QString::number(hist.Minimum()) + '\n' +
-                                "\n  Maximum = " + QString::number(hist.Maximum()) + '\n' +
-                                "\n  Stand. Dev.= " + QString::number(hist.StandardDeviation()) + '\n' +
-                                "\n  Variance = " + QString::number(hist.Variance()) + '\n' +
-                                "\n  Median = " + QString::number(hist.Median()) + '\n' +
-                                "\n  Mode = " + QString::number(hist.Mode()) + '\n' +
-                                "\n  Skew = " + QString::number(hist.Skew()), targetWindow);
+      QLabel *label = new QLabel("  Average = " + QString::number(hist->Average()) + '\n' +
+                                "\n  Minimum = " + QString::number(hist->Minimum()) + '\n' +
+                                "\n  Maximum = " + QString::number(hist->Maximum()) + '\n' +
+                                "\n  Stand. Dev.= " + QString::number(hist->StandardDeviation()) + '\n' +
+                                "\n  Variance = " + QString::number(hist->Variance()) + '\n' +
+                                "\n  Median = " + QString::number(hist->Median()) + '\n' +
+                                "\n  Mode = " + QString::number(hist->Mode()) + '\n' +
+                                "\n  Skew = " + QString::number(hist->Skew()), targetWindow);
 
 
       QVBoxLayout *dockLayout = new QVBoxLayout;


### PR DESCRIPTION
## Description

Updates the HistogramTool to better support high dynamic range images.  

Previously, the tool used the entire image to create the bin sizes, which did not work with high dynamic range images.  For example, if the image had a DN range of [-15000, 50000], but most of the data were in [0,1], the bins size would be roughly 1, so there would be a single, giant bin, and the stats were incorrect / misleading.  Using only the DNs in the window corrects this issue by only considering the DNs within the desired region.

Accomplished by passing the start-stop range inside conditionals.  Uses a smart pointer to automatically handle destructor on descope.

## Related Issue
Fixes #5371 

## How Has This Been Validated?
Manually tested in qview for both line/rectangle selection.  Automated tests will run on Jenkins.  Compare following screenshot to screenshot in original issue.

<img width="1088" alt="Screenshot 2024-03-27 at 1 44 55 PM" src="https://github.com/DOI-USGS/ISIS3/assets/3751180/921e08dc-e5f2-4980-a08f-693875a35fb9">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
