### PR TITLE
QView Stretch tool min/max type selection feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ release.
 - CSMCamera can now read and use the body rotation from ALE produced ISDs [#5072](https://github.com/DOI-USGS/ISIS3/pull/5072)
 - CSMSkyMap added to CSMCamera for use with local rover projections in ISIS [#5072](https://github.com/DOI-USGS/ISIS3/pull/5072)
 - OSIRIS-REx Tagcams instrument support, tests, and test data added [#5424](https://github.com/DOI-USGS/ISIS3/issues/5424)
+- Added min/max type drop-down selection option in QView's Stretch tool [#5289](https://github.com/DOI-USGS/ISIS3/issues/5289)
 
 
 ## [8.1.0] - 2024-01-08

--- a/isis/src/qisis/objs/StretchTool/StretchTool.h
+++ b/isis/src/qisis/objs/StretchTool/StretchTool.h
@@ -177,6 +177,7 @@ namespace Isis {
 
     private:
       void stretchRect(CubeViewport *cvp, QRect rect);
+      void stretchMinMaxType(CubeViewport *cvp);
 
     private:
       AdvancedStretchDialog *m_advancedStretch; //!< The advanced dialog
@@ -192,6 +193,7 @@ namespace Isis {
       QAction *m_copyBands;              //!< Copy band stretch action
 
       QComboBox *m_stretchBandComboBox;  //!< Stretch combo box
+      QComboBox *p_minMaxTypeSelection;  //!< Min/Max type combo box
 
       QLineEdit *m_stretchMinEdit;       //!< Min. line edit
       QLineEdit *m_stretchMaxEdit;       //!< Max. line edit


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
The related issue linked below explains how the min/max values in the QView Stretch tool does not show the entire dynamic range of the min/max values in comparison to the `stats` output. The `stats` app outputs the absolute min/max values while the Stretch tool uses the best min/max values which is the better value of either the absolute or Chebyshev values. This could lead to confusion as to why there are two min/max types showing and may require a second tool to confirm the min/max values as OP states.

This added feature gives the user the option to set the min/max types given three presets (Best, Absolute, & Chebyshev) from which the stretch view will change accordingly. The user still has the freedom to input their own min/max values in the text box and change other params as they choose.

Also added a "What's This" note as well, so if you open the Stretch Tool within QView then select the "What's This" feature (cursor with question mark icon), you can then select the drop-down (default "Best") and there is more info regarding this feature. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Addresses https://github.com/DOI-USGS/ISIS3/issues/5289

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
