### PR TITLE
Removed IrregularBodyCameraGroundMap.truth file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ release.
 - Skypt has been refactored to be callable; old Makefile tests have been removed and replaced by gtests. Issue: [#5443](https://github.com/USGS-Astrogeology/ISIS3/issues/5443)
 
 ### Fixed
+- Fixed a bug in which the IrregularBodyCameraGroundMap unit test was removed but not the associated truth file. [#5461](https://github.com/DOI-USGS/ISIS3/issues/5461)
 - Fixed a bug in which the histogram tool used the entire image to calculate bin size, which caused an issue with high dynamic range images. [#5371](https://github.com/DOI-USGS/ISIS3/issues/5371)
 - Fixed a bug in which 'version' file was compiled as source and prevented subsequent ISIS recompilation [#5374](https://github.com/DOI-USGS/ISIS3/issues/5374)
 - Fixed <i>noproj</i> bug where some temporary files were not deleted after call to cam2cam.  Issue: [#4813](https://github.com/USGS-Astrogeology/ISIS3/issues/4813)

--- a/isis/src/base/objs/IrregularBodyCameraGroundMap/IrregularBodyCameraGroundMap.truth
+++ b/isis/src/base/objs/IrregularBodyCameraGroundMap/IrregularBodyCameraGroundMap.truth
@@ -1,1 +1,0 @@
-This class will be tested by the applications and the individual Camera models.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->In the Tagcams Instrument Import PR #5427, the unit test for the IrregularBodyCameraGroundMap class was removed but not the associated truth file. This caused build errors and failing tests on linux. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DOI-USGS/ISIS3/issues/5461

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

Reran Osiris-REx ctest suite

ctest -R OsirisRex --output-on-failure
Test project /Users/kledmundson/ISISDev/tagcams2isis/Apr122024/ISIS3/build
    Start 1776: TempTestingFiles.UnitTestOsirisRexTagCamsNAVCam
1/8 Test #1776: TempTestingFiles.UnitTestOsirisRexTagCamsNAVCam ........   Passed    2.31 sec
    Start 1777: TempTestingFiles.UnitTestOsirisRexTagCamsNFTCam
2/8 Test #1777: TempTestingFiles.UnitTestOsirisRexTagCamsNFTCam ........   Passed    0.84 sec
    Start 2227: OsirisRexOcamsCube.PolyMath
3/8 Test #2227: OsirisRexOcamsCube.PolyMath ............................   Passed    2.14 sec
    Start 2228: OsirisRexOcamsCube.MappingCam
4/8 Test #2228: OsirisRexOcamsCube.MappingCam ..........................   Passed    1.53 sec
    Start 2229: OsirisRexOcamsCube.SamplingCam
5/8 Test #2229: OsirisRexOcamsCube.SamplingCam .........................   Passed    1.53 sec
    Start 2230: OsirisRexOcamsCube.PolyCamUpdatedIkCodes
6/8 Test #2230: OsirisRexOcamsCube.PolyCamUpdatedIkCodes ...............   Passed    1.53 sec
    Start 2231: OsirisRexTagcamsNAVCamCube.NavigationCam
7/8 Test #2231: OsirisRexTagcamsNAVCamCube.NavigationCam ...............   Passed   15.34 sec
    Start 2232: OsirisRexTagcamsNFTCamCube.NaturalFeatureTrackingCam
8/8 Test #2232: OsirisRexTagcamsNFTCamCube.NaturalFeatureTrackingCam ...   Passed    2.94 sec

100% tests passed, 0 tests failed out of 8

ctest -R FunctionalTestTagcams --output-on-failure
Test project /Users/kledmundson/ISISDev/tagcams2isis/Apr122024/ISIS3/build
    Start 1762: TempTestingFiles.FunctionalTestTagcams2IsisNavCam
1/4 Test #1762: TempTestingFiles.FunctionalTestTagcams2IsisNavCam ...............   Passed    0.98 sec
    Start 1763: TempTestingFiles.FunctionalTestTagcams2IsisNavCamRemCalPixOff
2/4 Test #1763: TempTestingFiles.FunctionalTestTagcams2IsisNavCamRemCalPixOff ...   Passed    1.00 sec
    Start 1764: TempTestingFiles.FunctionalTestTagcams2IsisNftCam
3/4 Test #1764: TempTestingFiles.FunctionalTestTagcams2IsisNftCam ...............   Passed    0.99 sec
    Start 1765: TempTestingFiles.FunctionalTestTagcams2IsisStowCam
4/4 Test #1765: TempTestingFiles.FunctionalTestTagcams2IsisStowCam ..............   Passed    0.97 sec

100% tests passed, 0 tests failed out of 4


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
