### PR TITLE
Ciss2isis fix

### DIFF
--- a/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
+++ b/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
@@ -77,6 +77,7 @@ namespace Isis{
 
     //SET PROGRESS TEXT, VALID MAXIMUM PIXEL VALUE, AND CREATE STRETCH IF NEEDED
     if(dataConversionType != "Table") {   //Conversion Type is 12Bit or 8LSB, only save off overclocked pixels
+      validMax = 255;
       if(dataConversionType == "12Bit") {
         p.Progress()->SetText("Image was 12 bit. No conversion needed. \nSaving line prefix data...");
       }
@@ -85,6 +86,7 @@ namespace Isis{
       }
     }
     else {  //if ConversionType == Table, Use LUT to create stretch pairs for conversion
+      validMax = 4095;
       CreateStretchPairs();
       // Pvl outputLabels;
       Pvl *outputLabel = ocube->label();
@@ -94,6 +96,14 @@ namespace Isis{
       inst.findKeyword("BiasStripMean").setValue(toString(stretch.Map(biasStripMean)));
       inst.findKeyword("BiasStripMean").addComment("BiasStripMean value converted back to 12 bit.");
       p.Progress()->SetText("Image was converted using 12-to-8 bit table. \nConverting prefix pixels back to 12 bit and saving line prefix data...");
+    }
+
+    Pvl inputLabel(in.expanded());
+    if (inputLabel.hasKeyword"VALID_MAXIMUM"()) {
+      PvlKeyword labelValidMax = inputLabel.findKeyword("VALID_MAXIMUM");
+      if (labelValidMax[1] != "UNK") {
+        validMax = toInt(labelValidMax[1]);
+      }
     }
 
     p.StartProcess();
@@ -294,7 +304,6 @@ namespace Isis{
 
     //  initialize global variables
     dataConversionType = (QString) inst.findKeyword("DataConversionType");
-    validMax = inputLabel.findKeyword("ValidMaximum")[1].toInt();
     sumMode = inst.findKeyword("SummingMode");
     compressionType = (QString) inst.findKeyword("CompressionType");
     IString fsw((QString) inst.findKeyword("FlightSoftwareVersionId"));

--- a/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
+++ b/isis/src/cassini/apps/ciss2isis/ciss2isis.cpp
@@ -99,7 +99,7 @@ namespace Isis{
     }
 
     Pvl inputLabel(in.expanded());
-    if (inputLabel.hasKeyword"VALID_MAXIMUM"()) {
+    if (inputLabel.hasKeyword("VALID_MAXIMUM")) {
       PvlKeyword labelValidMax = inputLabel.findKeyword("VALID_MAXIMUM");
       if (labelValidMax[1] != "UNK") {
         validMax = toInt(labelValidMax[1]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes ingesting CassiniIss images that do not specify the VALID_MAX keyword.

## Related Issue
Fixes #5454

## How Has This Been Validated?
Validated with an image that has VALID_MAX set to `(UNK, UNK)`. This should get a test. I am making the PR so the change doesn't get lost

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
