### PR TITLE
Allow error fix

### DIFF
--- a/isis/src/base/objs/CameraPointInfo/CameraPointInfo.cpp
+++ b/isis/src/base/objs/CameraPointInfo/CameraPointInfo.cpp
@@ -349,23 +349,21 @@ namespace Isis {
     }
 
     if (!noErrors) {
-      if (!allowErrors) {
-        for (int i = 0; i < gp->keywords(); i++) {
-          QString name = (*gp)[i].name();
-          // These three keywords have 3 values, so they must have 3 NULLs
-          if (name == "BodyFixedCoordinate" || name == "SpacecraftPosition" ||
-              name == "SunPosition") {
-            (*gp)[i].addValue("NULL");
-            (*gp)[i].addValue("NULL");
-            (*gp)[i].addValue("NULL");
-          }
-          else {
-            (*gp)[i].setValue("NULL");
-          }
+      for (int i = 0; i < gp->keywords(); i++) {
+        QString name = (*gp)[i].name();
+        // These three keywords have 3 values, so they must have 3 NULLs
+        if (name == "BodyFixedCoordinate" || name == "SpacecraftPosition" ||
+            name == "SunPosition") {
+          (*gp)[i].addValue("NULL");
+          (*gp)[i].addValue("NULL");
+          (*gp)[i].addValue("NULL");
+        }
+        else {
+          (*gp)[i].setValue("NULL");
         }
       }
-      else {
-        double pB[3], spB[3], sB[3];
+      if (!allowErrors) {
+        double spB[3], sB[3];
 
         m_camera->instrumentPosition(spB);
         gp->findKeyword("SpacecraftPosition").addValue(toString(spB[0]), "km");
@@ -413,7 +411,6 @@ namespace Isis {
           gp->findKeyword("LookDirectionCamera").addValue("Null");
           gp->findKeyword("LookDirectionCamera").addValue("Null");
         }
-
       }
 
       // Set all keywords that still have valid information


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Ensures that all keywords from CameraPointInfo will be populated when `allowError` is set to true. Change prompted by failing cnettable test (cnettable_app_test_allowErrors).

## Related Issue
#5393

## How Has This Been Validated?
Validated through existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
