### PR TITLE
Add qview stretch bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a bug in QVIEW's Stretch tool where the default min/max type was not an available option [#5289](https://github.com/DOI-USGS/ISIS3/issues/5289)
+
 ## [8.2.0] - 2024-04-18
 
 ### Changed

--- a/isis/src/qisis/objs/StretchTool/StretchTool.cpp
+++ b/isis/src/qisis/objs/StretchTool/StretchTool.cpp
@@ -188,21 +188,22 @@ namespace Isis {
     p_minMaxTypeSelection->setToolTip("Min/Max Type");
     text =
       "<b>Function:</b> Select the minimum & maximum value types to \
-      set the stretch to. The three options are: \
-      <p>- Best: (default) The better of the absolute min/max or the \
+      set the stretch to. The four options are: \
+      <p>- Default: Min and max values are set to the \
+        0.5 and 99.5 percentiles, respectively. \
+      <p>- Best: The better of the absolute min/max or the \
         Chebyshev min/max. The better value is considered the value \
         closest to the mean. \
       <p>- Absolute: The absolute min/max value of all valid pixels. \
       <p>- Chebyshev: The min/max value such that a certain percentage \
         of data will fall within K standard deviations of the average \
         (Chebyshev's Theorem). It can be used to obtain a value that \
-        does not include statistical outliers. \
-      <p><b>Hint:</b> Percentages are set to mininum of 0.5 and \
-      maximum of 99.5.";
+        does not include statistical outliers.";
     p_minMaxTypeSelection->setWhatsThis(text);
-    p_minMaxTypeSelection->addItem("Best",      0);
-    p_minMaxTypeSelection->addItem("Absolute",  1);
-    p_minMaxTypeSelection->addItem("Chebyshev", 2);
+    p_minMaxTypeSelection->addItem("Default",      0);
+    p_minMaxTypeSelection->addItem("Best",         1);
+    p_minMaxTypeSelection->addItem("Absolute",     2);
+    p_minMaxTypeSelection->addItem("Chebyshev",    3);
 
     connect(p_minMaxTypeSelection, SIGNAL(currentIndexChanged(int)), this, SLOT(changeStretch()));
 
@@ -1135,6 +1136,7 @@ namespace Isis {
 
     // Get current band statistics
     Statistics stats = statsFromCube(cvp->cube(), bandNum);
+    Histogram hist = histFromCube(cvp->cube(), bandNum, stats.BestMinimum(), stats.BestMaximum());
     
     // Set min/max given ComboBox selection
     int minMaxIndex = p_minMaxTypeSelection->currentIndex();
@@ -1142,14 +1144,17 @@ namespace Isis {
     double selectedMax = 0;
 
     if (minMaxIndex == 0) {
+      selectedMin = hist.Percent(0.5);
+      selectedMax = hist.Percent(99.5);
+    } else if (minMaxIndex == 1) {
       // Best
       selectedMin = stats.BestMinimum();
       selectedMax = stats.BestMaximum();
-    } else if (minMaxIndex == 1) {
+    } else if (minMaxIndex == 2) {
       // Absolute
       selectedMin = stats.Minimum();
       selectedMax = stats.Maximum();
-    } else if (minMaxIndex == 2) {
+    } else if (minMaxIndex == 3) {
       // Chebyshev
       selectedMin = stats.ChebyshevMinimum();
       selectedMax = stats.ChebyshevMaximum();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
There is a QVIEW bug in the Stretch tool from a recent PR that gave the user options for min/max type selection. More info on the bug in the original issue thread: https://github.com/DOI-USGS/ISIS3/issues/5289#issuecomment-2078193344. 

Found that the initial min and max values are set to the 0.5 and 99.5 percentiles. Added that preset as `Default` option in addition to the existing three options. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DOI-USGS/ISIS3/issues/5289

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Open a cube in QVIEW's Stretch window and switch between min/max types to verify that the values are appropriate with the type.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
