### PR TITLE
Qview command line Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ release.
 
 ### Fixed
 - Fixed a bug in QVIEW's Stretch tool where the default min/max type was not an available option [#5289](https://github.com/DOI-USGS/ISIS3/issues/5289)
+- Fixed a bug in QVIEW where images would double load if loaded from the commandline [#5505](https://github.com/DOI-USGS/ISIS3/pull/5505)
 
 ## [8.2.0] - 2024-04-18
 

--- a/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
+++ b/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
@@ -200,7 +200,7 @@ namespace Isis {
 
     p_pixmapPaintRects = new QList<QRect *>();
     p_progressTimer = new QTimer();
-    p_progressTimer->setInterval(250);
+    p_progressTimer->setInterval(20);
 
     p_knownStretches = new QVector< Stretch * >();
     p_globalStretches = new QVector< Stretch * >();

--- a/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
+++ b/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
@@ -200,7 +200,7 @@ namespace Isis {
 
     p_pixmapPaintRects = new QList<QRect *>();
     p_progressTimer = new QTimer();
-    p_progressTimer->setInterval(20);
+    p_progressTimer->setInterval(250);
 
     p_knownStretches = new QVector< Stretch * >();
     p_globalStretches = new QVector< Stretch * >();

--- a/isis/src/qisis/objs/CubeViewport/ViewportBuffer.cpp
+++ b/isis/src/qisis/objs/CubeViewport/ViewportBuffer.cpp
@@ -754,7 +754,14 @@ namespace Isis {
    * @return bool
    */
   bool ViewportBuffer::working() {
-    return !p_actions->empty() || !p_bufferInitialized || !p_enabled;
+    bool hasFillAction = false;
+    for (auto action : *p_actions) {
+      if (action->getActionType() == ViewportBufferAction::fill) {
+        hasFillAction = true;
+        break;
+      }
+    }
+    return hasFillAction || !p_bufferInitialized || !p_enabled;
   }
 
 


### PR DESCRIPTION
## Description
Avoid double image load when opening cubes from command line in qview

## Related Issue
N/A

## How Has This Been Validated?
Tested locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
