### PR TITLE
Pinned suitesparse to below 7.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ release.
 
 ### Changed
 - Changed `qwt` dependency version to 6.2.0 or below [#5498](https://github.com/DOI-USGS/ISIS3/issues/5498)
+- Pinned `suitesparse` dependency version to maximum not including 7.7.0 [#5496](https://github.com/DOI-USGS/ISIS3/issues/5496)
+
 
 ### Fixed
 - Fixed a bug in QVIEW's Stretch tool where the default min/max type was not an available option [#5289](https://github.com/DOI-USGS/ISIS3/issues/5289)

--- a/environment.yml
+++ b/environment.yml
@@ -60,7 +60,7 @@ dependencies:
   - qwt<6.3.0
   - rclone
   - sqlite>=3.43.0,<4.0a0
-  - suitesparse
+  - suitesparse<7.7.0
   - superlu
   - swig
   - texlive-core

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -103,7 +103,7 @@ requirements:
    - qt-main
    - qwt <6.3.0
    - sqlite >=3.43.0,<4.0a0
-   - suitesparse
+   - suitesparse <7.7.0
    - superlu
    - swig
    - texlive-core


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Build fails on Linux with `suitesparse` version 7.7.0, pinned to <7.7.0.

Will cherry-pick this into the 8.2.0_RC2 release after it's merged into `dev`.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Addresses https://github.com/DOI-USGS/ISIS3/issues/5496

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
