### PR TITLE
Remove restrictive validity check in caminfo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ release.
 
 
 ### Fixed
+- Fixed a bug in PolygonTools in which the program exited before attempting to fix an invalid Polygon [#5520](https://github.com/DOI-USGS/ISIS3/issues/5520)
 - Fixed a bug in QVIEW's Stretch tool where the default min/max type was not an available option [#5289](https://github.com/DOI-USGS/ISIS3/issues/5289)
 - Fixed a bug in QVIEW where images would double load if loaded from the commandline [#5505](https://github.com/DOI-USGS/ISIS3/pull/5505)
 

--- a/isis/src/base/objs/PolygonTools/PolygonTools.cpp
+++ b/isis/src/base/objs/PolygonTools/PolygonTools.cpp
@@ -21,6 +21,7 @@ find files of those names at the top level of this repository. **/
 #include "geos/operation/distance/DistanceOp.h"
 #include "geos/operation/overlay/snap/SnapOverlayOp.h"
 #include "geos/operation/overlay/snap/GeometrySnapper.h"
+#include "geos/operation/valid/isValidOp.h"
 
 #include "SpecialPixel.h"
 #include "PolygonTools.h"
@@ -104,7 +105,7 @@ namespace Isis {
         geos::geom::Polygon *newPoly = globalFactory->createPolygon(
                                          globalFactory->createLinearRing(*xycoords), std::move(holes)).release();
 
-        if(newPoly->isValid() && !newPoly->isEmpty() && newPoly->getArea() > 1.0e-14) {
+        if(!newPoly->isEmpty() && newPoly->getArea() > 1.0e-14) {
           xyPolys->push_back(newPoly);
         }
         else {
@@ -132,7 +133,6 @@ namespace Isis {
           throw IException(IException::Programmer, msg, _FILEINFO_);
         }
       }
-
     } // end else
   }
 

--- a/isis/src/base/objs/PolygonTools/PolygonTools.cpp
+++ b/isis/src/base/objs/PolygonTools/PolygonTools.cpp
@@ -21,7 +21,6 @@ find files of those names at the top level of this repository. **/
 #include "geos/operation/distance/DistanceOp.h"
 #include "geos/operation/overlay/snap/SnapOverlayOp.h"
 #include "geos/operation/overlay/snap/GeometrySnapper.h"
-#include "geos/operation/valid/isValidOp.h"
 
 #include "SpecialPixel.h"
 #include "PolygonTools.h"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes polygon->isValid check.  This check is unnecessary, and it does not allow the program to call FixGeometry on the polygon.  Multiple validity checks are performed later in Despike, which is part of the control flow of this process.

## Related Issue
Closes #5520

## How Has This Been Validated?
Program runs to completion on 8.2.0_RC2.  PVL was verified against a previous version (8.0.0).  All values are the same except emission/incidence angles (which is an expected difference between 8.2.x and 8.0.x, and the footprint values are shifted by 1, i.e. the Polygon values are identical, but the order is slightly different.

Polygons were verified through geos::geom::Polygon::normalize() -- the new values conform to the standard.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
