### PR TITLE
findFeaturesSegment.py script fixes

### DIFF
--- a/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
+++ b/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
@@ -322,6 +322,7 @@ def findFeaturesSegment(ui):
     pool.join()
     output = output.get()
     match_segments = segment(ui.GetCubeName("match"), ui.GetInteger("NL"))
+    
     if len(img_list) > 1:
         from_segments = reduce(lambda d1,d2: {k: merge(d1, d2, k) for k in set(d1)|set(d2)}, output)
     else:
@@ -331,6 +332,7 @@ def findFeaturesSegment(ui):
             og_value = value
             from_segments[seg] = [og_value]
 
+    print("FROM_SEGMENTS = " + str(from_segments))
     segment_paths = [s["Path"] for sublist in list(from_segments.values()) for s in sublist]
     segment_paths = segment_paths + [s["Path"] for s in list(match_segments.values())]
 
@@ -342,6 +344,7 @@ def findFeaturesSegment(ui):
     output = output.get()
     log.debug(f"{output}")
     
+    # Remove redundant overlapping pairs
     image_sets = list(itertools.product(match_segments.values(), from_segments.values()))
     x = match_segments.values()
     y = from_segments.values()

--- a/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
+++ b/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
@@ -345,7 +345,6 @@ def findFeaturesSegment(ui):
     log.debug(f"{output}")
     
     # Remove redundant overlapping pairs
-    image_sets = list(itertools.product(match_segments.values(), from_segments.values()))
     x = match_segments.values()
     y = from_segments.values()
     x,y = (x,y) if len(x) > len(y) else (y,x)

--- a/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
+++ b/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
@@ -196,7 +196,7 @@ def generate_cnet(params, images):
     
     log.debug(new_params)
 
-    overlapfromlist = workdir / f"{workdir / og_tolist.stem}_{match_segment_n}_{from_stem}_overlap_fromlist.lis"
+    overlapfromlist = workdir / f"{og_tolist.stem}_{match_segment_n}_{from_stem}_overlap_fromlist.lis"
     overlaptolist = workdir / f"{og_tolist.stem}_{match_segment_n}_{from_stem}.overlaps"
     
     # check for overlaps
@@ -341,7 +341,6 @@ def findFeaturesSegment(ui, workdir):
     pool = ThreadPool(nthreads)
     starmap_args = []
     for image in img_list: 
-        print(image)
         starmap_args.append([image, workdir, ui.GetInteger("NL")])
     output = pool.starmap_async(segment, starmap_args)
     pool.close()
@@ -427,7 +426,7 @@ def findFeaturesSegment(ui, workdir):
 
     log.debug(f"merged images: {final_images}")
     kisis.fromlist.make(final_images, Path(ui.GetFileName("tolist")))
-     
+    
     if len(onets) > 1: 
         try:
             kisis.cnetmerge(clist = onet_list, onet=ui.GetFileName("onet"), networkid=ui.GetAsString("networkid"), description=f"{ui.GetString('description')}")
@@ -454,8 +453,8 @@ if __name__ == "__main__":
             shutil.rmtree(workdir) 
         raise e 
     
-    log.info(f"COMPLETE, wrote: {ui.GetFileName("onet")}")
+    # log.info(f"COMPLETE, wrote: {ui.GetFileName("onet")}")
     if is_workdir_temp: 
         shutil.rmtree(workdir)
     else:
-        log.info(f"Intermediate files written to: {workdir}")
+        log.info("Intermediate files written to")

--- a/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
+++ b/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.py
@@ -134,7 +134,10 @@ def segment(img_path : Path, nlines : int = MAX_LEN):
 
 def generate_cnet(params, images):
 
-    match_segment_n = images["match"][0]["Segment"]
+    if isinstance(images["match"], list):
+        match_segment_n = images["match"][0]["Segment"]
+    else:
+        match_segment_n = images["match"]["Segment"]
     from_segment_n = images["from"][0]["Segment"]
 
     new_params = deepcopy(params)
@@ -332,7 +335,6 @@ def findFeaturesSegment(ui):
             og_value = value
             from_segments[seg] = [og_value]
 
-    print("FROM_SEGMENTS = " + str(from_segments))
     segment_paths = [s["Path"] for sublist in list(from_segments.values()) for s in sublist]
     segment_paths = segment_paths + [s["Path"] for s in list(match_segments.values())]
 

--- a/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.xml
+++ b/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.xml
@@ -145,7 +145,9 @@
           <brief>Directory to output intermediate files to</brief>
           <description>
              This directory is where any intermediate and temp files are saved to. 
-             If this is set to None (default), these files go into the temp directory.  
+             If this is set to None (default), these files go into the temp directory 
+             which is deleted when the program is terminated. Set this if you want to debug 
+             a network. 
           </description>
           <internalDefault>None</internalDefault>
         </parameter>

--- a/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.xml
+++ b/isis/python_bindings/apps/findFeaturesSegment/findFeaturesSegment.xml
@@ -139,6 +139,17 @@
           <filter>*.lis</filter>
         </parameter>
 
+        <parameter name="WORKDIR">
+          <type>filename</type>
+          <fileMode>output</fileMode>
+          <brief>Directory to output intermediate files to</brief>
+          <description>
+             This directory is where any intermediate and temp files are saved to. 
+             If this is set to None (default), these files go into the temp directory.  
+          </description>
+          <internalDefault>None</internalDefault>
+        </parameter>
+
         <parameter name="NL">
           <type>integer</type>
           <fileMode>output</fileMode>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
The process to retrieve the `from_segments` in this line 
```
from_segments = reduce(lambda d1,d2: {k: merge(d1, d2, k) for k in set(d1)|set(d2)}, output)
```
from a `FROMLIST` that contains only one cube outputs this format:
```
{ 'seg1': PVLGroup([...]), 'seg2': PVLGroup([...])}
```
so accessing each segment as a list caused a `TypeError`. 

Added an if/else statement to account for `img_list = 1` so `from_segments` ultimately outputs this:
```
{ 'seg1': [PVLGroup([...])], 'seg2': [PVLGroup([...])]}
```

To reduce redundant overlapping image pairs, I implemented an iteration of @Kelvinrr's [generic code](https://github.com/DOI-USGS/ISIS3/issues/5540#issuecomment-2243235916) with the change in the way the segments are accessed. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Addresses https://github.com/DOI-USGS/ISIS3/issues/5489 & https://github.com/DOI-USGS/ISIS3/issues/5540

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
