### PR TITLE
Updated kaguyasp2ascii to support newer (detached) data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ release.
 ## [Unreleased]
 
 ### Changed
+- Modified kaguyasp2isis to work with new (detached) data [#5436](https://github.com/DOI-USGS/ISIS3/issues/5436)
 - Added jigsaw error message for csminit'd images without csm parameters[#5486](https://github.com/DOI-USGS/ISIS3/issues/5486)
 - Changed `qwt` dependency version to 6.2.0 or below [#5498](https://github.com/DOI-USGS/ISIS3/issues/5498)
 - Pinned `suitesparse` dependency version to maximum not including 7.7.0 [#5496](https://github.com/DOI-USGS/ISIS3/issues/5496)

--- a/isis/src/kaguya/apps/kaguyasp2ascii/kaguyasp2ascii.xml
+++ b/isis/src/kaguya/apps/kaguyasp2ascii/kaguyasp2ascii.xml
@@ -80,10 +80,10 @@
           Input Kaguya SP file
         </brief>
         <description>
-          This is the input Kaguya SP file
+          This is the input Kaguya SP file.  For an attached label, use the .spc file, or for a detached label, use the .lbl file.
         </description>
         <filter>
-          *.spc
+          *.lbl *.spc
         </filter>
       </parameter>
       <parameter name="TO">

--- a/isis/src/kaguya/apps/kaguyasp2ascii/main.cpp
+++ b/isis/src/kaguya/apps/kaguyasp2ascii/main.cpp
@@ -25,8 +25,17 @@ void IsisMain() {
   ProcessImportPds p;
   UserInterface &ui = Application::GetUserInterface();
 
-  FileName inFile = ui.GetFileName("FROM");
-  Pvl lab(inFile.expanded());
+  QString inFile = ui.GetFileName("FROM");
+  Pvl lab(inFile);
+  QString dataFile = lab.findKeyword("FILE_NAME")[0];
+
+  // Detached labels use format keyword = "dataFile" value <unit>
+  int keywordIndex = 1;
+
+  if (inFile == dataFile){
+    // Attached labels use format keyword = value <units>
+    keywordIndex = 0;
+  }
 
   ofstream os;
   QString outFile = FileName(ui.GetFileName("TO")).expanded();
@@ -59,32 +68,32 @@ void IsisMain() {
   int qaptr = 0;
 
   if (lab.hasKeyword("^SP_SPECTRUM_WAV")) {
-    wavptr = toInt(lab.findKeyword("^SP_SPECTRUM_WAV")[0]) - 1;
+    wavptr = toInt(lab.findKeyword("^SP_SPECTRUM_WAV")[keywordIndex]) - 1;
   }
   if (lab.hasKeyword("^SP_SPECTRUM_RAW")) {
-    rawptr = toInt(lab.findKeyword("^SP_SPECTRUM_RAW")[0]) - 1;
+    rawptr = toInt(lab.findKeyword("^SP_SPECTRUM_RAW")[keywordIndex]) - 1;
   }
   if (lab.hasKeyword("^SP_SPECTRUM_RAD")) {
-    radptr = toInt(lab.findKeyword("^SP_SPECTRUM_RAD")[0]) - 1;
+    radptr = toInt(lab.findKeyword("^SP_SPECTRUM_RAD")[keywordIndex]) - 1;
   }
   //older-format file without calibrated NIR2 data
   if (lab.hasKeyword("^SP_SPECTRUM_REF")) {
-    refptr1 = toInt(lab.findKeyword("^SP_SPECTRUM_REF")[0]) - 1;
+    refptr1 = toInt(lab.findKeyword("^SP_SPECTRUM_REF")[keywordIndex]) - 1;
   }
   //newer-format file with calibrated NIR2 data and 2 different Reflectances
   if (lab.hasKeyword("^SP_SPECTRUM_REF1")) {
-    refptr1 = toInt(lab.findKeyword("^SP_SPECTRUM_REF1")[0]) - 1;
+    refptr1 = toInt(lab.findKeyword("^SP_SPECTRUM_REF1")[keywordIndex]) - 1;
   }
   if (lab.hasKeyword("^SP_SPECTRUM_REF2")) {
-    refptr2 = toInt(lab.findKeyword("^SP_SPECTRUM_REF2")[0]) - 1;
+    refptr2 = toInt(lab.findKeyword("^SP_SPECTRUM_REF2")[keywordIndex]) - 1;
   }
   if (lab.hasKeyword("^SP_SPECTRUM_QA")) {
-    qaptr = toInt(lab.findKeyword("^SP_SPECTRUM_QA")[0]) - 1;
+    qaptr = toInt(lab.findKeyword("^SP_SPECTRUM_QA")[keywordIndex]) - 1;
   }
 
   FILE *spcptr;
-  if ((spcptr = fopen(inFile.expanded().toLatin1().data(),"rb")) == 0) {
-    QString msg = "Error opening input Kaguya SP file [" + inFile.expanded() + "]";
+  if ((spcptr = fopen(dataFile.toLatin1().data(),"rb")) == 0) {
+    QString msg = "Error opening input Kaguya SP file [" + dataFile + "]";
     throw IException(IException::User, msg, _FILEINFO_);
   }
 
@@ -101,7 +110,7 @@ void IsisMain() {
   if (!lab.hasObject("SP_SPECTRUM_WAV") || !lab.hasObject("SP_SPECTRUM_QA") ||
       !lab.hasObject("SP_SPECTRUM_RAD") || !(lab.hasObject("SP_SPECTRUM_REF") ||
       (lab.hasObject("SP_SPECTRUM_REF1") && lab.hasObject("SP_SPECTRUM_REF2")))) {
-    QString msg = "Input file [" + inFile.expanded() + "] is not a valid ";
+    QString msg = "Input file [" + inFile + "] is not a valid ";
     msg += "Kaguya Spectral Profiler file";
     throw IException(IException::User, msg, _FILEINFO_);
   }
@@ -261,6 +270,7 @@ void IsisMain() {
 
   PvlObject refobj;
   PvlObject refobj2;
+
   if (lab.hasKeyword("^SP_SPECTRUM_REF")) {
     refobj = lab.findObject("SP_SPECTRUM_REF");
   }

--- a/isis/src/kaguya/apps/kaguyasp2ascii/main.cpp
+++ b/isis/src/kaguya/apps/kaguyasp2ascii/main.cpp
@@ -32,7 +32,10 @@ void IsisMain() {
   // Detached labels use format keyword = "dataFile" value <unit>
   int keywordIndex = 1;
 
-  if (inFile == dataFile){
+  if (FileName(inFile).baseName() == FileName(dataFile).baseName()){
+    // data files usually do not include path information.  If input basename matches datafile basename, include path information
+    // this allows users to specify data that is not in the current directory.
+    dataFile = inFile;
     // Attached labels use format keyword = value <units>
     keywordIndex = 0;
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Update kaguyasp2ascii to support both attached and detached labels.

## Related Issue
Fixes #5436 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Tested with old (attached) and new (detached) labels.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
