### PR TITLE
Bandtrim has been refactored to be callable; old Makefile tests have been converted to gtests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release.
 - Added backplane options for SunIllumination and SurfaceObliqueDetectorResolution to phocube [#5467](https://github.com/DOI-USGS/ISIS3/issues/5467)
 
 ### Changed
+- Bandtrim has been refactored to be callable; old Makefile tests have been removed and replaced by gtests. Issue: [#5571](https://github.com/USGS-Astrogeology/ISIS3/issues/5571)
 - Added jigsaw error message for csminit'd images without csm parameters[#5486](https://github.com/DOI-USGS/ISIS3/issues/5486)
 - Changed `qwt` dependency version to 6.2.0 or below [#5498](https://github.com/DOI-USGS/ISIS3/issues/5498)
 - Pinned `suitesparse` dependency version to maximum not including 7.7.0 [#5496](https://github.com/DOI-USGS/ISIS3/issues/5496)

--- a/isis/src/base/apps/bandtrim/bandtrim.cpp
+++ b/isis/src/base/apps/bandtrim/bandtrim.cpp
@@ -1,0 +1,74 @@
+/** This is free and unencumbered software released into the public domain.
+
+The authors of ISIS do not claim copyright on the contents of this file.
+For more details about the LICENSE terms and the AUTHORS, you will
+find files of those names at the top level of this repository. **/
+
+/* SPDX-License-Identifier: CC0-1.0 */
+
+#include "bandtrim.h"
+
+#include "Cube.h"
+#include "ProcessByBrick.h"
+#include "SpecialPixel.h"
+
+namespace Isis {
+
+  // Process to trim spectral pixels if any are null
+  void BandTrimSpectral(Buffer &in, Buffer &out);
+
+  /**
+   * Bandtrim searches for NULL pixels in all bands of a cube.
+   * When a NULL pixel is found the corresponding pixel is set
+   * to NULL in all other bands.
+   *
+   * @param ui User Interface with application parameters
+   */
+  void bandtrim(UserInterface &ui) {
+  
+    // open cube
+    Cube icube;
+    icube.open(ui.GetCubeName("FROM"));
+
+    bandtrim(&icube, ui);
+  }
+
+
+  /**
+   * Bandtrim searches for NULL pixels in all bands of a cube.
+   * When a NULL pixel is found the corresponding pixel is set
+   * to NULL in all other bands.
+   *
+   * @param icube Input cube
+   * @param ui User Interface with application parameters
+   */
+  void bandtrim(Cube *icube, UserInterface &ui) {
+    ProcessByBrick p;
+    p.SetInputCube(icube);
+    p.SetBrickSize(1, 1, icube->bandCount());
+
+    QString fname = ui.GetCubeName("TO");
+    CubeAttributeOutput &atts = ui.GetOutputAttribute("TO");
+    p.SetOutputCube(fname, atts);
+
+    p.StartProcess(BandTrimSpectral);
+    p.EndProcess();
+  }
+
+  // Process to trim spectral pixels if any are null
+  void BandTrimSpectral(Buffer &in, Buffer &out) {
+    // Copy input to output and check to see if we should null
+    bool nullPixels = false;
+    for(int i = 0; i < in.size(); i++) {
+      out[i] = in[i];
+      if(in[i] == Isis::Null) nullPixels = true;
+    }
+
+    // Null all pixels in the spectra if necessary
+    if(nullPixels) {
+      for(int i = 0; i < in.size(); i++) {
+        out[i] = Isis::Null;
+      }
+    }
+  }
+}

--- a/isis/src/base/apps/bandtrim/bandtrim.h
+++ b/isis/src/base/apps/bandtrim/bandtrim.h
@@ -6,15 +6,14 @@ find files of those names at the top level of this repository. **/
 
 /* SPDX-License-Identifier: CC0-1.0 */
 
-#include "Isis.h"
+#ifndef bandtrim_h
+#define bandtrim_h
 
-#include "bandtrim.h"
+#include "UserInterface.h"
 
-#include "Application.h"
-
-using namespace Isis;
-
-void IsisMain() {
-  UserInterface &ui = Application::GetUserInterface();
-  bandtrim(ui);
+namespace Isis{  
+  extern void bandtrim(UserInterface &ui);
+  extern void bandtrim(Cube *iCube, UserInterface &ui);
 }
+
+#endif

--- a/isis/src/base/apps/bandtrim/bandtrim.xml
+++ b/isis/src/base/apps/bandtrim/bandtrim.xml
@@ -35,6 +35,9 @@
     <change name="Steven Lambright" date="2008-05-12">
       Removed references to CubeInfo 
     </change>
+    <change name="Ken Edmundson" date="2024-07-31">
+      Converted to callable app and converted Makefile tests to gtests. 
+    </change>
   </history>
 
   <groups>

--- a/isis/src/base/apps/bandtrim/tsts/Makefile
+++ b/isis/src/base/apps/bandtrim/tsts/Makefile
@@ -1,4 +1,0 @@
-BLANKS = "%-6s"    
-LENGTH = "%-40s"
-
-include $(ISISROOT)/make/isismake.tststree

--- a/isis/src/base/apps/bandtrim/tsts/default/Makefile
+++ b/isis/src/base/apps/bandtrim/tsts/default/Makefile
@@ -1,6 +1,0 @@
-APPNAME = bandtrim
-
-include $(ISISROOT)/make/isismake.tsts
-
-commands:
-	$(APPNAME) FROM=$(INPUT)/input.cub TO=$(OUTPUT)/truth.cub > /dev/null;

--- a/isis/src/base/apps/bandtrim/tsts/oneband/Makefile
+++ b/isis/src/base/apps/bandtrim/tsts/oneband/Makefile
@@ -1,6 +1,0 @@
-APPNAME = bandtrim
-
-include $(ISISROOT)/make/isismake.tsts
-
-commands:
-	$(APPNAME) FROM=$(INPUT)/input.cub TO=$(OUTPUT)/truth.cub > /dev/null;

--- a/isis/tests/FunctionalTestsBandtrim.cpp
+++ b/isis/tests/FunctionalTestsBandtrim.cpp
@@ -126,7 +126,7 @@ TEST_F(DefaultCube, FunctionalTestBandtrimDefault) {
 /**
    * BandtrimOneBand Test
    * 
-   * BandtrimDefault test given a single 5x5 input cube with 1 band.
+   * BandtrimOneBand test given a single 5x5 input cube with 1 band.
    * The four pixels in the upper left corner are set to Isis::Null
    * as below. N implies a Null pixel.
    * 
@@ -148,7 +148,7 @@ TEST_F(DefaultCube, FunctionalTestBandtrimOneBand) {
   resizeCube(5, 5, 1);
 
   // set 4 pixel block in upper left corner to Isis::Null
-  Brick b(1, 1, 1, testCube->pixelType()); // create buffer of size 4 pixels
+  Brick b(1, 1, 1, testCube->pixelType()); // create buffer of size 1 pixels
   b.SetBasePosition(1, 1, 1);
   b[0] = Isis::Null;
   testCube->write(b);

--- a/isis/tests/FunctionalTestsBandtrim.cpp
+++ b/isis/tests/FunctionalTestsBandtrim.cpp
@@ -1,0 +1,192 @@
+
+#include <QString>
+#include <QVector>
+
+#include "Brick.h"
+#include "CameraFixtures.h"
+#include "Histogram.h"
+#include "bandtrim.h"
+
+#include "gtest/gtest.h"
+
+using namespace Isis;
+
+static QString APP_XML = FileName("$ISISROOT/bin/xml/bandtrim.xml").expanded();
+
+/**
+   * BandtrimDefault Test
+   * 
+   * BandtrimDefault test given a single 5x5 input cube with 7 bands.
+   * One pixel in each band is set to Isis::Null as below.
+   * N implies a Null pixel, N1 is band 1, N2 is band 2, etc.
+   * All Null pixels should be duplicated across each band in the
+   * output Cube.
+   * 
+   * The output cube is verified by checking the histogram statistics
+   * for each band.
+   * 
+   * |  |N1|  |N2|  | 
+   * |  |  |  |  |  |
+   * |N3|  |N4|  |N5|
+   * |  |  |  |  |  |
+   * |  |N6|  |N7|  |
+   * 
+   * INPUT: testCube from DefaultCube fixture modified as above.
+   * 
+   * OUTPUT: bandtrimDefaultOut.cub
+   * 
+   */
+TEST_F(DefaultCube, FunctionalTestBandtrimDefault) {
+
+  // reduce test cube size, create seven bands
+  resizeCube(5, 5, 7);
+
+  // set one pixel in each of the seven bands to Isis::Null
+  // following the pattern in the comment block above
+
+  Brick b(1, 1, 1, testCube->pixelType()); // create buffer of size 1 pixel
+
+  b.SetBasePosition(2, 1, 1);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(4, 1, 2);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(1, 3, 3);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(3, 3, 4);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(5, 3, 5);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(2, 5, 6);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(4, 5, 7);
+  b[0] = Isis::Null;
+  testCube->write(b);
+  
+  // run bandtrim
+  QVector<QString> args = {"to=" + tempDir.path() + "/bandtrimDefaultOut.cub"};
+  UserInterface ui(APP_XML, args);
+
+  try {
+     bandtrim(testCube, ui);
+  }
+  catch(IException &e) {
+    FAIL() << e.toString().toStdString().c_str() << std::endl;
+  }
+
+  // Open output cube
+  Cube outCube(tempDir.path() + "/bandtrimDefaultOut.cub");
+
+  // validate histogram statistics for each band in output cube
+  std::unique_ptr<Histogram> band1Hist (outCube.histogram(1));
+  std::unique_ptr<Histogram> band2Hist (outCube.histogram(2));
+  std::unique_ptr<Histogram> band3Hist (outCube.histogram(3));
+  std::unique_ptr<Histogram> band4Hist (outCube.histogram(4));
+  std::unique_ptr<Histogram> band5Hist (outCube.histogram(5));
+  std::unique_ptr<Histogram> band6Hist (outCube.histogram(6));
+  std::unique_ptr<Histogram> band7Hist (outCube.histogram(7));
+
+  EXPECT_EQ(band1Hist->ValidPixels(), 18);
+  EXPECT_EQ(band1Hist->Average(), 13);
+  EXPECT_EQ(band1Hist->Sum(), 234);
+  EXPECT_EQ(band2Hist->ValidPixels(), 18);
+  EXPECT_EQ(band2Hist->Average(), 38);
+  EXPECT_EQ(band2Hist->Sum(), 684);
+  EXPECT_EQ(band3Hist->ValidPixels(), 18);
+  EXPECT_EQ(band3Hist->Average(), 63);
+  EXPECT_EQ(band3Hist->Sum(), 1134);
+  EXPECT_EQ(band4Hist->ValidPixels(), 18);
+  EXPECT_EQ(band4Hist->Average(), 88);
+  EXPECT_EQ(band4Hist->Sum(), 1584);
+  EXPECT_EQ(band5Hist->ValidPixels(), 18);
+  EXPECT_EQ(band5Hist->Average(), 113);
+  EXPECT_EQ(band5Hist->Sum(), 2034);
+  EXPECT_EQ(band6Hist->ValidPixels(), 18);
+  EXPECT_EQ(band6Hist->Average(), 138);
+  EXPECT_EQ(band6Hist->Sum(), 2484);
+  EXPECT_EQ(band7Hist->ValidPixels(), 18);
+  EXPECT_EQ(band7Hist->Average(), 163);
+  EXPECT_EQ(band7Hist->Sum(), 2934);
+
+  outCube.close();
+}
+
+
+/**
+   * BandtrimOneBand Test
+   * 
+   * BandtrimDefault test given a single 5x5 input cube with 1 band.
+   * The four pixels in the upper left corner are set to Isis::Null
+   * as below. N implies a Null pixel.
+   * 
+   * The output cube is verified by checking histogram statistics.
+   * 
+   * |N|N| | | | 
+   * |N|N| | | |
+   * | | | | | |
+   * | | | | | |
+   * | | | | | |
+   * 
+   * INPUT: testCube from DefaultCube fixture
+   * 
+   * OUTPUT: bandtrimOneBandOut.cub
+   */
+TEST_F(DefaultCube, FunctionalTestBandtrimOneBand) {
+  
+  // reduce test cube size
+  resizeCube(5, 5, 1);
+
+  // set 4 pixel block in upper left corner to Isis::Null
+  Brick b(1, 1, 1, testCube->pixelType()); // create buffer of size 4 pixels
+  b.SetBasePosition(1, 1, 1);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(2, 1, 1);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(1, 2, 1);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  b.SetBasePosition(2, 2, 1);
+  b[0] = Isis::Null;
+  testCube->write(b);
+
+  // run bandtrim
+  QVector<QString> args = {"to=" + tempDir.path() + "/bandtrimOneBandOut.cub"};
+
+  UserInterface ui(APP_XML, args);
+
+  try {
+    bandtrim(testCube, ui);
+  }
+  catch(IException &e) {
+    FAIL() << e.toString().toStdString().c_str() << std::endl;
+  }
+
+  // Open output cube
+  Cube outCube(tempDir.path() + "/bandtrimOneBandOut.cub");
+
+  // validate histogram statistics for each band in output cube
+  std::unique_ptr<Histogram> band1Hist (outCube.histogram(1));
+
+  EXPECT_EQ(band1Hist->ValidPixels(), 21);
+  EXPECT_EQ(band1Hist->Average(), 14.714285714285714);
+  EXPECT_EQ(band1Hist->Sum(), 309);
+
+  outCube.close();
+}
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
The bandtrim application has been refactored to be callable. The two Makefile tests have been converted to gtests. Makefile tests have been removed.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DOI-USGS/ISIS3/issues/5571

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Results of ctest suite...

ctest -R FunctionalTestBandtrim --output-on-failure
Test project /Users/kledmundson/ISISDev/bandtrim/Jul192024a/ISIS3/build
    Start 1405: DefaultCube.FunctionalTestBandtrimDefault
1/2 Test #1405: DefaultCube.FunctionalTestBandtrimDefault ...   Passed    1.56 sec
    Start 1406: DefaultCube.FunctionalTestBandtrimOneBand
2/2 Test #1406: DefaultCube.FunctionalTestBandtrimOneBand ...   Passed    1.56 sec

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation and I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
