### PR TITLE
Better isNumeric and compareCsvLine in TestUtilities

### DIFF
--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -351,7 +351,7 @@ namespace Isis {
   void compareCsvLine(CSVReader::CSVAxis csvLine, QString headerStr, int initialIndex) {
     QStringList compareMe = headerStr.split(",");
     for (int i=initialIndex; i<compareMe.size(); i++) {
-      if (isNumeric(compareMe[i].trimmed())) {
+      if (isNumeric(compareMe[i].trimmed()) && isNumeric(QString(csvLine[i].trimmed()))) {
         EXPECT_NEAR(csvLine[i].toDouble(), compareMe[i].toDouble(), 0.000001);
       }
       else{
@@ -365,7 +365,7 @@ namespace Isis {
   void compareCsvLine(CSVReader::CSVAxis csvLine, CSVReader::CSVAxis csvLine2, int initialIndex,
                       double tolerance) {
     for (int i=initialIndex; i < csvLine.dim(); i++) {
-      if (isNumeric(QString(csvLine[i].trimmed()))) {
+      if (isNumeric(QString(csvLine[i].trimmed())) && isNumeric(QString(csvLine2[i].trimmed()))) {
         EXPECT_NEAR(csvLine[i].toDouble(), csvLine2[i].toDouble(), tolerance);
       }
       else{

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -355,7 +355,7 @@ namespace Isis {
         EXPECT_NEAR(csvLine[i].toDouble(), compareMe[i].toDouble(), 0.000001);
       }
       else{
-        EXPECT_EQ(QString(csvLine[i]).toStdString(), compareMe[i].toStdString());
+        EXPECT_EQ(QString(csvLine[i].trimmed()).toStdString(), compareMe[i].trimmed().toStdString());
       }
     }
   };
@@ -369,7 +369,7 @@ namespace Isis {
         EXPECT_NEAR(csvLine[i].toDouble(), csvLine2[i].toDouble(), tolerance);
       }
       else{
-        EXPECT_EQ(QString(csvLine[i]).toStdString(), csvLine2[i].toStdString());
+        EXPECT_EQ(QString(csvLine[i].trimmed()).toStdString(), csvLine2[i].trimmed().toStdString());
       }
     }
   };

--- a/isis/tests/TestUtilities.cpp
+++ b/isis/tests/TestUtilities.cpp
@@ -342,7 +342,7 @@ namespace Isis {
 
   // Check to see if a QString contains only numeric values.
   bool isNumeric(QString str){
-    QRegExp re("-*\\d*.*\\d*");
+    QRegExp re("^(?:[+-]?(?:\\d+|\\d*\\.(?=\\d)\\d*)(?:[eE][+-]?\\d+)?)$");
     return re.exactMatch(str);
   }
 

--- a/isis/tests/TestUtilitiesTests.cpp
+++ b/isis/tests/TestUtilitiesTests.cpp
@@ -54,6 +54,7 @@ TEST(TestUtilities, IsNumeric) {
     EXPECT_FALSE(isNumeric("2024.07.31")        ); // Decimal Date
     EXPECT_FALSE(isNumeric("2/3/2007")          ); // Date
     EXPECT_FALSE(isNumeric("6A1F")              ); // Hexadecimal
+    EXPECT_FALSE(isNumeric("89-e3")             );
 }
 
 TEST(TestUtilities, CompareCsvLine) {
@@ -63,7 +64,7 @@ TEST(TestUtilities, CompareCsvLine) {
     CSVReader::CSVAxis csvLine2;
     
 
-    // Standard line found in another test
+    // Sample line with many words
     csvLine = csv.getRow(0);
     compareCsvLine(csvLine, "3-d,3-d,3-d,Sigma,Sigma,Sigma,Correction,Correction,Correction,Coordinate,Coordinate,Coordinate");
 
@@ -123,5 +124,35 @@ TEST(TestUtilities, CompareCsvLine) {
         EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, csvLine2), "");
     }, "Actual: 6");
 
-    
+
+    // Sample line with lots of numbers
+    csvLine = csv.getRow(7);
+    compareCsvLine(csvLine, "AS15_000031957,FREE,3,0,0.33,24.25013429,6.15097050,1735.93990543,270.68671676,265.71819251,500.96944842,860.25781493,-1823.63228489,-677.74533463,1573.65050943,169.59077243,712.98695596");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "AS15_000031957,FREE,3,0,0.33,24.25013429,6.15097050,1742.85730233,270.68671676,265.71819251,500.96944842,860.25781493,-1823.63228489,-677.74533463,1573.65050943,169.59077243,712.98695596"), "");
+
+
+    // long numbers
+    csvLine = csv.getRow(8);
+    compareCsvLine(csvLine, "Long Numbers, 3.14159265358979323846264338327950288419716939937510");
+    compareCsvLine(csvLine, "Long Numbers, 3.14159265358979323846264338327950288419716939937510e0");
+    compareCsvLine(csvLine, "Long Numbers, 3.1415926535898");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Long Numbers, 3.1417"), "");
+
+
+    // plus and minus
+    csvLine = csv.getRow(9);
+    compareCsvLine(csvLine, "Plus and Minus, 0, -1, +302, 5.46e-3, -4.7e4, 3+4, 56-62, 89-e3");
+    compareCsvLine(csvLine, "Plus and Minus, 0, -1, 302, .00546, -4.7e4, 3+4, 56-62, 89-e3");
+    EXPECT_NONFATAL_FAILURE({
+        EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Plus and Minus, 0, -1, +302, 5.46e3, 4.7e4, 3+A, 56-62, 89-e3"), "");
+    }, "Actual: 3");
+
+
+    // very small
+    csvLine = csv.getRow(10);
+    csvLine2 = csv.getRow(11);
+    compareCsvLine(csvLine, "Very Small, 3.685e-38");
+    compareCsvLine(csvLine, "Very Small, 4.152e-36");
+    compareCsvLine(csvLine, csvLine, 1, 1e-42);
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, csvLine2, 1, 1e-39), "");
 }

--- a/isis/tests/TestUtilitiesTests.cpp
+++ b/isis/tests/TestUtilitiesTests.cpp
@@ -1,0 +1,127 @@
+#include <map>
+#include <cmath>
+
+#include <QtMath>
+#include <QFile>
+#include <QScopedPointer>
+
+// #include "Pvl.h"
+// #include "PvlGroup.h"
+// #include "Statistics.h"
+#include "CSVReader.h"
+// #include "Latitude.h"
+// #include "Longitude.h"
+// #include "ControlPoint.h"
+// #include "CSMCamera.h"
+// #include "LidarData.h"
+// #include "SerialNumber.h"
+
+#include "TestUtilities.h"
+#include "NetworkFixtures.h"
+#include "CsmFixtures.h"
+
+#include "gmock/gmock.h"
+#include "gtest/gtest-spi.h"
+
+using namespace Isis;
+using namespace testing;
+
+TEST(TestUtilities, IsNumeric) {
+    EXPECT_TRUE(isNumeric("0")           );
+    EXPECT_TRUE(isNumeric("1")           );
+    EXPECT_TRUE(isNumeric("3.14")        );
+    EXPECT_TRUE(isNumeric("347")         );
+    EXPECT_TRUE(isNumeric("194602754")   );
+    EXPECT_TRUE(isNumeric("-3")          );
+    EXPECT_TRUE(isNumeric("-4867")       );
+    EXPECT_TRUE(isNumeric("5e7")         ); // sci notation
+    EXPECT_TRUE(isNumeric("3.875e18")    ); // sci notation
+    EXPECT_TRUE(isNumeric("-4.55")       ); 
+    EXPECT_TRUE(isNumeric("34564.488564"));
+    EXPECT_TRUE(isNumeric(".99431")      );
+
+    EXPECT_FALSE(isNumeric("abcdef")            ); // alphabet (hex)
+    EXPECT_FALSE(isNumeric("kittenrainbowmagic")); // alphabet
+    EXPECT_FALSE(isNumeric("13466-234")         ); // hyphen
+    EXPECT_FALSE(isNumeric("e34e")              ); // Wrong e's
+    EXPECT_FALSE(isNumeric("e3")                );
+    EXPECT_FALSE(isNumeric("5.4e")              );
+    EXPECT_FALSE(isNumeric("Hello World")       ); // Words
+    EXPECT_FALSE(isNumeric("123 4 56")          ); // Spaces
+    EXPECT_FALSE(isNumeric("45..54")            ); // Double Decimal
+    EXPECT_FALSE(isNumeric("321.")              ); // Decimal Point with no digits
+    EXPECT_FALSE(isNumeric("22/7")              ); // Fractional Pi
+    EXPECT_FALSE(isNumeric("2024.07.31")        ); // Decimal Date
+    EXPECT_FALSE(isNumeric("2/3/2007")          ); // Date
+    EXPECT_FALSE(isNumeric("6A1F")              ); // Hexadecimal
+}
+
+TEST(TestUtilities, CompareCsvLine) {
+    CSVReader csv = CSVReader("data/testUtilities/testcsv1.csv",
+                                false, 0, ',', false, true);
+    CSVReader::CSVAxis csvLine;
+    CSVReader::CSVAxis csvLine2;
+    
+
+    // Standard line found in another test
+    csvLine = csv.getRow(0);
+    compareCsvLine(csvLine, "3-d,3-d,3-d,Sigma,Sigma,Sigma,Correction,Correction,Correction,Coordinate,Coordinate,Coordinate");
+
+    EXPECT_NONFATAL_FAILURE({
+        EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "3-c,3-e,3-f,Sigma,Alpha,Sigma,Correction,Correction,Correction,Coordinate,Coordinate,Coordinate"), "");
+    }, "Actual: 4"); // need double-layer expect for more than one expected failure with "Actual: 3" for 3 failures.
+
+
+    // Test for Near doubles, csv file has 3.141592653589793.  Default tolerance 0.000001
+    csvLine = csv.getRow(1);
+    compareCsvLine(csvLine, "Near Doubles, 3.1415926535898");
+    compareCsvLine(csvLine, "Near Doubles, 3.141593");
+
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Near Doubles, 3.14159"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Near Doubles, 3.141591"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Near Doubles, Pi"), "");
+
+
+    // Scientific Notation (csv has sci notation)
+    csvLine = csv.getRow(2);
+    compareCsvLine(csvLine, "Sci Notation, 4.78e3");
+    compareCsvLine(csvLine, "Sci Notation, 4780");
+
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Sci Notation, 478"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Sci Notation, 4783"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Sci Notation, Text"), "");
+
+
+    // Scientific Notation (csv has standard notation)
+    csvLine = csv.getRow(3);
+    compareCsvLine(csvLine, "Sci Notation, 4.78e3");
+    compareCsvLine(csvLine, "Sci Notation, 4780");
+
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Sci Notation, 478"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Sci Notation, 4783"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Sci Notation, Text"), "");
+
+    // Compare only second cell and onward
+    compareCsvLine(csvLine, "Pie Notation, 4780", 1);    
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Pie Notation, 4780"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Pie Notation, 4783", 1), "");
+
+    
+    // Text vs Numbers
+    csvLine = csv.getRow(4);
+    compareCsvLine(csvLine, "Zeroes and Strings, 0");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "0, 0"), "");
+    EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, "Zeroes and Strings, Zeroes and Strings"), "");
+
+    // Compare Multiple Lines
+    csvLine = csv.getRow(0);
+    csvLine2 = csv.getRow(5);
+    compareCsvLine(csvLine, csvLine2);
+    csvLine2 = csv.getRow(6);
+
+    EXPECT_NONFATAL_FAILURE({
+        EXPECT_NONFATAL_FAILURE(compareCsvLine(csvLine, csvLine2), "");
+    }, "Actual: 6");
+
+    
+}

--- a/isis/tests/TestUtilitiesTests.cpp
+++ b/isis/tests/TestUtilitiesTests.cpp
@@ -1,25 +1,4 @@
-#include <map>
-#include <cmath>
-
-#include <QtMath>
-#include <QFile>
-#include <QScopedPointer>
-
-// #include "Pvl.h"
-// #include "PvlGroup.h"
-// #include "Statistics.h"
-#include "CSVReader.h"
-// #include "Latitude.h"
-// #include "Longitude.h"
-// #include "ControlPoint.h"
-// #include "CSMCamera.h"
-// #include "LidarData.h"
-// #include "SerialNumber.h"
-
 #include "TestUtilities.h"
-#include "NetworkFixtures.h"
-#include "CsmFixtures.h"
-
 #include "gmock/gmock.h"
 #include "gtest/gtest-spi.h"
 

--- a/isis/tests/data/testUtilities/testcsv1.csv
+++ b/isis/tests/data/testUtilities/testcsv1.csv
@@ -5,3 +5,8 @@ Sci Notation, 4780
 Zeroes and Strings, 0
 3-d,3-d,3-d,Sigma,Sigma,Sigma,Correction,Correction,Correction,Coordinate,Coordinate,Coordinate
 3-d,3-d,3-d,Sigma,Sigma,Sigma,Coordinate,Coordinate,Coordinate,Correction,Correction,Correction
+AS15_000031957,FREE,3,0,0.33,24.25013429,6.15097050,1735.93990543,270.68671676,265.71819251,500.96944842,860.25781493,-1823.63228489,-677.74533463,1573.65050943,169.59077243,712.98695596
+Long Numbers, 3.14159265358979323846264338327950288419716939937510
+Plus and Minus, 0, -1, +302, 5.46e-3, -4.7e4, 3+4, 56-62, 89-e3
+Very Small, 3.685e-38
+Very Small, 4.152e-36

--- a/isis/tests/data/testUtilities/testcsv1.csv
+++ b/isis/tests/data/testUtilities/testcsv1.csv
@@ -1,0 +1,7 @@
+3-d,3-d,3-d,Sigma,Sigma,Sigma,Correction,Correction,Correction,Coordinate,Coordinate,Coordinate
+Near Doubles, 3.141592653589793
+Sci Notation, 4.78e3
+Sci Notation, 4780
+Zeroes and Strings, 0
+3-d,3-d,3-d,Sigma,Sigma,Sigma,Correction,Correction,Correction,Coordinate,Coordinate,Coordinate
+3-d,3-d,3-d,Sigma,Sigma,Sigma,Coordinate,Coordinate,Coordinate,Correction,Correction,Correction


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
- `IsNumeric` had a narrow regex check that missed valid numbers, updated to catch scientific notation numbers (thanks to @kledmundson).
- `compareCsvLine` only checked if one side of the comparison was numeric and then tried to convert both sides to doubles (resulting in strings read as `0`).  It now checks both sides, and won't try to convert non-number strings to doubles.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Fixes #5527 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
- Tests have been added to check for expected behavior for `isNumeric` and `compareCsvLine`.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
