### PR TITLE
Cleans Build Warnings

### DIFF
--- a/isis/src/base/objs/CSMCamera/CSMCamera.h
+++ b/isis/src/base/objs/CSMCamera/CSMCamera.h
@@ -147,9 +147,6 @@ namespace Isis {
 
       csm::RasterGM *m_model; //! CSM sensor model
       iTime m_refTime; //! The reference time that all model image times are relative to
-      SpiceRotation *m_bodyRotation = NULL; //!< Body spice rotation
-      SpiceRotation *m_instrumentRotation = NULL; //!< Instrument spice rotation
-      Longitude *m_solarLongitude = NULL;
 
       void isisToCsmPixel(double line, double sample, csm::ImageCoord &csmPixel) const;
       void csmToIsisPixel(csm::ImageCoord csmPixel, double &line, double &sample) const;

--- a/isis/src/base/objs/EmbreeTargetShape/EmbreeTargetShape.cpp
+++ b/isis/src/base/objs/EmbreeTargetShape/EmbreeTargetShape.cpp
@@ -471,7 +471,6 @@ namespace Isis {
     if (!isValid()) {
       return;
     }
-    int tri = 0;
     Triangle *triangles = (Triangle *)rtcSetNewGeometryBuffer(rtcMesh, RTC_BUFFER_TYPE_INDEX, 0, RTC_FORMAT_UINT3, sizeof(Triangle), numberOfPolygons());
     // Add the body's face (vertex indices) to the Embree device's index buffer
     for (int t = 0; t < numberOfPolygons(); ++t) {

--- a/isis/src/base/objs/ProcessByBrick/ProcessByBrick.h
+++ b/isis/src/base/objs/ProcessByBrick/ProcessByBrick.h
@@ -748,12 +748,17 @@ namespace Isis {
        *
        * @internal
        */
-      class ProcessIterator : public std::iterator<
-          std::forward_iterator_tag, int> {
+      class ProcessIterator {
         public:
           ProcessIterator(int position);
           ProcessIterator(const ProcessIterator &other);
           virtual ~ProcessIterator();
+
+          using value_type = int;
+          using iterator_category = std::forward_iterator_tag;
+          using difference_type = std::ptrdiff_t;
+          using pointer = int*;
+          using reference = int&;
 
           ProcessIterator &operator++();
 

--- a/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
+++ b/isis/src/tgo/apps/tgocassisstitch/tgocassisstitch.cpp
@@ -52,7 +52,7 @@ namespace Isis {
 
   void tgocassisstitch(UserInterface &ui) {
 
-    QMap<QString, FileName> frameMap;
+    QMultiMap<QString, FileName> frameMap;
 
     try {
       // Open up the list of framelet files
@@ -128,7 +128,7 @@ namespace Isis {
                             frameletList.fileName(i) );
     }
 
-    return frameMap;
+    return std::move(frameMap);
   }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Clean up warnings that pop up with building isis. These include unused variables and LIBCPP_DEPRECATED_IN_CXX17 warnings. Also handles one straggler QT warning.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#closes 5456

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
