### PR TITLE
Bug fix in noproj to remove persistent temporary lbl file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ release.
 - Pinned `suitesparse` dependency version to maximum not including 7.7.0 [#5496](https://github.com/DOI-USGS/ISIS3/issues/5496)
 
 ### Fixed
+- Fixed a bug in noproj.cpp which left a persisent lbl file after running noproj. [#5577] (https://github.com/DOI-USGS/ISIS3/issues/5577)
 - Fixed a bug in QVIEW's FindTool in which camera was prioritized over projction [#5508](https://github.com/DOI-USGS/ISIS3/issues/5508)
 - Fixed a bug in PolygonTools in which the program exited before attempting to fix an invalid Polygon [#5520](https://github.com/DOI-USGS/ISIS3/issues/5520)
 - Fixed a bug in QVIEW's Stretch tool where the default min/max type was not an available option [#5289](https://github.com/DOI-USGS/ISIS3/issues/5289)

--- a/isis/src/base/apps/noproj/noproj.cpp
+++ b/isis/src/base/apps/noproj/noproj.cpp
@@ -378,7 +378,8 @@ namespace Isis {
     Cube matchCube;
     matchCube.open(matchCubeFile.expanded(), "rw");
     cam2cam(icube, &matchCube, cam2camUI);
-
+    matchCube.close();
+    
     // Cleanup by deleting the match files
     QStringList detfiles = findAllDetachedFiles( label );
     detfiles.append(matchLbl);

--- a/isis/src/base/apps/noproj/noproj.xml
+++ b/isis/src/base/apps/noproj/noproj.xml
@@ -84,6 +84,10 @@
     <change name="Ken Edmundson" date="2024-01-09">
           Incorporated Kris Becker's 2021-09-22 bug fix above into USGS code base.
     </change>
+    <change name="Ken Edmundson" date="2024-08-07">
+          Additional bug fix to address persistent temporary lbl file after
+          running noproj. Fixes #5577.
+    </change>
   </history>
 
   <category>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
In testing the noproj app for upcoming modifications, Sarah Sutton (@artmathgirl) discovered that there was still a persistent temporary match file (extension lbl; e.g. matchXXXX.lbl) remaining after running noproj. This results from not closing the match cube after returning from the call to cam2cam (and sadly, I didn't catch it) e.g. ...

Code snippet from noproj.cpp (~line 375)...
// And run cam2cam to apply the transformation
QVector args = {"to=" + ui.GetCubeName("TO"), "INTERP=" + ui.GetString("INTERP")};
UserInterface cam2camUI(FileName("$ISISROOT/bin/xml/cam2cam.xml").expanded(), args);
Cube matchCube;
matchCube.open(matchCubeFile.expanded(), "rw");
cam2cam(icube, &matchCube, cam2camUI);
matchCube.close(); THE MISSING LINE

## Description
<!--- Describe your changes in detail including motivation and any context -->
Added the line to close the matchCube in noproj.cpp.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DOI-USGS/ISIS3/issues/5577
https://github.com/DOI-USGS/ISIS3/issues/4813

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
noproj tests were rerun, all pass on Mac except for DefaultCube.FunctionalTestNoprojFromUser.

Note that this test seems to be failing in the current ISIS dev but was passing after the last two noproj PRs. 

There are very subtle differences in
hist->Average()
hist->Sum()

Having some trouble explaining that, but sure that this isn't a result of this bug fix.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
