### PR TITLE
Fix detached label support for kaguyasp2ascii

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -337,6 +337,10 @@
       "name": "Miller-Ribelin, Elizabeth"
     },
     {
+      "affiliation": "Japan Aerospace Exploration Agency, Institute of Space and Astronautical Science",
+      "name": "Murakami, Shin-ya",
+      "orcid": "0000-0002-7137-4849"
+    {
       "affiliation": "United States Geological Survey, Astro Geology Science Center",
       "name": "Nelson, Gavin"
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed a bug in kaguyasp2isis that doesn't work for data with a detached label.
+
 ## [8.3.0] - 2024-08-16
 
 ### Added

--- a/isis/src/kaguya/apps/kaguyasp2ascii/main.cpp
+++ b/isis/src/kaguya/apps/kaguyasp2ascii/main.cpp
@@ -11,6 +11,7 @@ find files of those names at the top level of this repository. **/
 #include <bitset>
 #include <cstdio>
 #include <QString>
+#include <QDir>
 
 #include "ProcessImportPds.h"
 
@@ -32,12 +33,20 @@ void IsisMain() {
   // Detached labels use format keyword = "dataFile" value <unit>
   int keywordIndex = 1;
 
-  if (FileName(inFile).baseName() == FileName(dataFile).baseName()){
-    // data files usually do not include path information.  If input basename matches datafile basename, include path information
-    // this allows users to specify data that is not in the current directory.
+  // Determine label for inFile is attached label or detached label
+  if (FileName(inFile).name() == FileName(dataFile).name()){
+    // If input filename matches datafile filename without path information,
+    // one assumes label file for inFile is attached label, otherwise
+    // detached label.
     dataFile = inFile;
     // Attached labels use format keyword = value <units>
     keywordIndex = 0;
+  } else {
+     // data files specification in label usually do not include path
+     // information. If label is detached label, data file is located at
+     // the same directory as label file. 
+     // this allows users to specify data that is not in the current directory.
+     dataFile = FileName(inFile).dir().path() + "/" + dataFile;
   }
 
   ofstream os;


### PR DESCRIPTION
Recently detached label for kaguyasp2ascii was supported by #5568, however, kaguyasp2ascii recognizes detached label as attached label. This PR will fix the support to detached label.

## Description
Whether input file is attached label or detached label can be discriminate input filename given to kaguyasp2ascii and value of FILE_NAME in the label. If value of FILE_NAME is same as the input filename which can be derived by the input file path, the input file is attached label.

Current code compares `baseName()`s of input file and value of FILE_NAME which doesn't include extensions of the filenames although it should include the extensions.

As already written as the comment in the code, value of FILE_NAME usually doesn't have path information, so one needs to calculate path of data file for detached label case. Current code doesn't calculate path of data file for detached label case, so assuming data file is placed at the same directory with the label, data file path is derived from the label file path.

Without the fix in this PR, detached label will output an error as follows:

> $ kaguyasp2ascii from=SP_2C_03_00295_N148_E2403.lbl to=SP_2C_02_02509_S336_E1946.txt 
> **ERROR** Failed to convert string [SP_2C_03_00295_N148_E2403.spc] to an integer.

## Related Issue
#5568

## How Has This Been Validated?
Tested for detached label at the same directory with the current directory.
`kaguyasp2ascii from=SP_2C_03_00295_N148_E2403.lbl to=SP_2C_03_00295_N148_E2403.txt`

Tested for detached label at outside of the current directory.
`kaguyasp2ascii from=kaguya/SP_2C_03_00295_N148_E2403.lbl to=SP_2C_03_00295_N148_E2403.txt`

Tested for attached label at the same directory with the current directory.
`kaguyasp2ascii from=SP_2C_02_02509_S336_E1946.spc to=SP_2C_02_02509_S336_E1946.txt`

Tested for attached label at outside of the current directory.
`kaguyasp2ascii from=isistestdata/isis/src/kaguya/apps/kaguyasp2ascii/tsts/jan2015Format/input/SP_2C_02_02509_S336_E1946.spc to=SP_2C_02_02509_S336_E1946.txt`

Note that SP_2C_03_00295_N148_E2403.lbl and SP_2C_03_00295_N148_E2403.spc are available at 
https://data.darts.isas.jaxa.jp/pub/pds3/sln-l-sp-4-level2c-v3.0/20071102/data/SP_2C_03_00295_N148_E2403.lbl
and https://data.darts.isas.jaxa.jp/pub/pds3/sln-l-sp-4-level2c-v3.0/20071102/data/SP_2C_03_00295_N148_E2403.spc, respectively.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
