### PR TITLE
Update camstats PvlGroup "User Parameters" to UserParameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ release.
 - Updated pixel2map documentation
 - Changed PVL parsing to no longer allow valueless keywords [#5573](https://github.com/DOI-USGS/ISIS3/pull/5573)
 - Changed all `.trn` files with an `Auto`, `Debug` or `Optional` keyword with no value to have a value of `1` [#5573](https://github.com/DOI-USGS/ISIS3/pull/5573)
+- Changed 'User Parameters' group in camstats to UserParameters for PVL compliance [#5625](https://github.com/DOI-USGS/ISIS3/issues/5625).
 
 ### Fixed
 - Fixed noseam bug where a debugging output statement was inadvertently left in noseam.cpp.

--- a/isis/src/base/apps/caminfo/caminfo.cpp
+++ b/isis/src/base/apps/caminfo/caminfo.cpp
@@ -340,7 +340,7 @@ namespace Isis{
           camstats->append(MakePair("ObliqueResolutionMaximum", cg["ObliqueResolutionMaximum"][0]));
 
           // Add keywords for all camera values
-          // Skips first "User Parameters" group.
+          // Skips first "UserParameters" group.
           for (int i = 1; i < camPvl.groups(); i++) {
             PvlGroup &group = camPvl.group(i);
 

--- a/isis/src/base/apps/camstats/camstats.cpp
+++ b/isis/src/base/apps/camstats/camstats.cpp
@@ -187,7 +187,7 @@ namespace Isis {
       Table table(cam_name, record);
 
       // Place all the gathered camera statistics in a table and attach it to the
-      // cube. Skip "User Parameters" group.
+      // cube. Skip "UserParameters" group.
       for (int i = 1; i < statsPvl.groups(); i++) {
         PvlGroup &group = statsPvl.group(i);
 

--- a/isis/src/base/objs/CameraStatistics/CameraStatistics.cpp
+++ b/isis/src/base/objs/CameraStatistics/CameraStatistics.cpp
@@ -63,7 +63,7 @@ namespace Isis {
    * numbers can be used to improve performance.  The filename provided does
    * not serve a functional purpose during the statistics gathering process,
    * but will report the filename used to create the Camera instance in the
-   * "User Parameters" section of the PVL output from the "toPvl" method.
+   * "UserParameters" section of the PVL output from the "toPvl" method.
    *
    * @param cam Camera pointer upon which statistics will be gathered
    * @param sinc Sample increment for gathering statistics
@@ -294,7 +294,7 @@ namespace Isis {
    * The general format will look as follows:
    *
    * @code
-   *   Group = User Parameters
+   *   Group = UserParameters
    *     Filename (not provided for constructor w/ Camera but not filename)
    *     Linc
    *     Sinc
@@ -366,7 +366,7 @@ namespace Isis {
   Pvl CameraStatistics::toPvl() const {
     // Set up the Pvl groups and get min, max, avg, and sd for each statstics
     // object
-    PvlGroup pUser("User Parameters");
+    PvlGroup pUser("UserParameters");
     if (m_filename != "") pUser += PvlKeyword("Filename", m_filename);
     pUser += PvlKeyword("Linc", toString(m_linc));
     pUser += PvlKeyword("Sinc", toString(m_sinc));

--- a/isis/src/base/objs/CameraStatistics/CameraStatistics.truth
+++ b/isis/src/base/objs/CameraStatistics/CameraStatistics.truth
@@ -1,6 +1,6 @@
 UnitTest for Camera Statistics
 
-User Parameters:
+UserParameters:
   Linc = 1
   Sinc = 1
 

--- a/isis/tests/FunctionalTestsCamstats.cpp
+++ b/isis/tests/FunctionalTestsCamstats.cpp
@@ -20,7 +20,7 @@ TEST(CamStats, FunctionalTestCamstatsDefaultParameters) {
 
   camstats(options, &appLog);
 
-  PvlGroup group = appLog.findGroup("User Parameters");
+  PvlGroup group = appLog.findGroup("UserParameters");
   EXPECT_DOUBLE_EQ((double) group.findKeyword("Linc"), 1.0);
   EXPECT_DOUBLE_EQ((double) group.findKeyword("Sinc"), 1.0);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updated camstats PvlGroup "User Parameters" to UserParameters for PVL compliance.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Closes #5625 


## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Running camstats produces PVL with the following segment:
```
Group = UserParameters
  Filename = out.cub
  Linc     = 1
  Sinc     = 1
End_Group
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
