### PR TITLE
Fix autoseed SeedDomain = SampleLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ file. Slightly modified the FunctionalTestJigsawBundleXYZ ctest accordingly. Iss
 - Fixed XmlToJson namespaced key conversion [#5652](https://github.com/DOI-USGS/ISIS3/pull/5652)
 - Fixed PHOTOMET not accepting backplanes [#5281](https://github.com/DOI-USGS/ISIS3/issues/5281)
 - Fixed dstripe parallel test failing by converting tests to gtests [#5613](https://github.com/DOI-USGS/ISIS3/issues/5613)
+- Fixed autoseed SeedDomain = SampleLine only working for first overlap [#5673](https://github.com/DOI-USGS/ISIS3/issues/5673)
 
 ## [8.3.0] - 2024-09-30
 

--- a/isis/src/control/apps/autoseed/autoseed.cpp
+++ b/isis/src/control/apps/autoseed/autoseed.cpp
@@ -289,7 +289,7 @@ namespace Isis {
           mp = PolygonTools::LatLonToXY(*polygonOverlaps, proj);
         }
         else if (seedDomain == SampleLine) {
-          mp = PolygonTools::LatLonToSampleLine(*polygonOverlaps, ugmap);
+          mp = PolygonTools::LatLonToSampleLine(*polygonOverlaps, gMaps[(*overlaps[ov])[0]]);
         }
         points = seeder->Seed(mp);
       }
@@ -340,10 +340,10 @@ namespace Isis {
       else if (seedDomain == SampleLine) {
         // Convert the Sample/Line points back to Lat/Lon points
         for (unsigned int pt = 0; pt < points.size(); pt ++) {
-          if (ugmap->SetImage(points[pt]->getX(), points[pt]->getY())) {
+          if (gMaps[(*overlaps[ov])[0]]->SetImage(points[pt]->getX(), points[pt]->getY())) {
             seed.push_back(Isis::globalFactory->createPoint(
-                             geos::geom::Coordinate(ugmap->UniversalLongitude(),
-                                                    ugmap->UniversalLatitude())).release());
+                             geos::geom::Coordinate(gMaps[(*overlaps[ov])[0]]->UniversalLongitude(),
+                                                    gMaps[(*overlaps[ov])[0]]->UniversalLatitude())).release());
           }
           else {
             IString msg = "Unable to convert from Sample/Line to a (lon,lat)";

--- a/isis/src/control/apps/autoseed/autoseed.cpp
+++ b/isis/src/control/apps/autoseed/autoseed.cpp
@@ -174,15 +174,9 @@ namespace Isis {
     //PolygonSeeder *seeder = PolygonSeederFactory::Create(seedDef);
 
     TProjection *proj = NULL;
-    UniversalGroundMap *ugmap = NULL;
     mapGroup = Target::radiiGroup(cubeLab, mapGroup);
     if (seedDomain == XY) {
       proj = (TProjection *) ProjectionFactory::Create(maplab);
-    }
-    else if (seedDomain == SampleLine) {
-      Cube cube;
-      cube.open(serialNumbers.fileName(0));
-      ugmap = new UniversalGroundMap(cube);
     }
 
     // Create the control net to store the points in.
@@ -514,10 +508,6 @@ namespace Isis {
     if (seedDomain == XY) {
       delete proj;
       proj = NULL;
-    }
-    else if (seedDomain == SampleLine) {
-      delete ugmap;
-      ugmap = NULL;
     }
 
     delete seeder;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Autoseed SeedDomain = SampleLine only used the UniversalGroundMap of the first cube to access sample/line information.  This resulted in a cnet that only included overlaps from the first cube, and ```Unable to convert polygon from Lat/Lon to Sample/Line.``` for all other polygons.

For context, `ugmap` is the UniversalGroundMap of the first image, and `gMaps[(*overlaps[ov])[0]]` is the UniversalGroundMap corresponding to the image we're working with within the loop.

## Related Issue
Closes #5673 
Related to #5193 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Ran autoseed on the test data included in #5193 .  

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
