### PR TITLE
Update LTS Pipeline

### DIFF
--- a/.github/workflows/gitlab-lts.yml
+++ b/.github/workflows/gitlab-lts.yml
@@ -1,4 +1,9 @@
-name: Cherrypick bugfixes to release branch
+name: Github to Gitlab CI - Run CodeBuild (LTS)
+
+env:
+  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
+
 on:
   push:
     branches:
@@ -37,32 +42,30 @@ jobs:
     # Print the result to the log
     - name: See result
       run: echo "${{ steps.execute_py_script.outputs.result }}"
-  release_pull_request:
+  build:
     needs: check_labels
     # Only run this step if the code was a bugfix
     if: contains(needs.check_labels.outputs.result, 'true')
     runs-on: ubuntu-latest
-    name: release_pull_request
     steps:
-    - name: checkout
-      uses: actions/checkout@v2.2.0
-      # Fetch all info including branches + tags
-      with:
-        fetch-depth: 0
-    - name: 'Get Previous tag'
-      id: get_latest_tag
-      uses: "WyriHaximus/github-action-get-previous-tag@v1"
-    - id: get_short_version
-      # Get the major / minor version without patch info i.e. 6.0 from 6.0.1
-      run: |
-        major_minor=$(echo ${{steps.get_latest_tag.outputs.tag}} | cut -d '.' -f 1,2)
-        echo "::set-output name=major_minor::$major_minor"
-    - name: Create PR to branch
-      uses: adamtharani/github-action-cherry-pick@master
-      # PR to the latest feature release.  Merges are enabled
-      with:
-        pr_branch: ${{steps.get_short_version.outputs.major_minor}}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        DRY_RUN: false
-
+      - uses: actions/checkout@v4
+      - name: Run script
+        env:
+          LTS_VERSION: 8.0.5_LTS  # formatted as x.x.x_LTS
+          BASE_LTS: 8.0
+          GITHUB_SHA: ${{ secrets.GITHUB_SHA }}
+        run: |
+          git config --global user.name "Github_CI"
+          git config --global user.email "project_14468_bot_3f7d8e1a392afd88ead5f3f3154e809d@noreply.gitlab.com"
+          git clone https://isis-codebuild-ci:$GITLAB_TOKEN@code.usgs.gov/astrogeology/isis-codebuild-ci.git
+          echo $LTS_VERSION
+          cd isis-codebuild-ci
+          if [[ "git ls-remote --exit-code origin $LTS_VERSION" == 2 ]]; then
+            git checkout -b $LTS_VERSION
+          else
+            git checkout $LTS_VERSION
+            git reset --hard origin/main
+          fi
+          echo -e "\nenv: \n  shell: bash \n  variables: \n    LTS_VERSION: $LTS_VERSION \n    BASE_LTS: $BASE_LTS \n    ANACONDA_API_TOKEN: $ANACONDA_TOKEN \n    GITHUB_SHA: $GITHUB_SHA" >> buildspec-lts.yml
+          git commit -a -m "$LTS_VERSION"
+          git push origin $LTS_VERSION --force

--- a/.github/workflows/gitlab-lts.yml
+++ b/.github/workflows/gitlab-lts.yml
@@ -51,8 +51,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Run script
         env:
-          LTS_VERSION: 8.0.5_LTS  # formatted as x.x.x_LTS
-          BASE_LTS: 8.0
+          LTS_VERSION: 9.0.0_LTS  # formatted as x.x.x_LTS
+          BASE_LTS: 9.0
           GITHUB_SHA: ${{ secrets.GITHUB_SHA }}
         run: |
           git config --global user.name "Github_CI"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Re-introduces the bugfix cherry-picking with the addition of the ISIS Codebuild pipeline.

Workflow:
1. When a bugfix is merged into `dev`, a GitHub workflow (gitlab-lts.yml) will be triggered.
2. The LTS workflow will check for the `bug` label on the PR or append labels if related issues exist under the **Related Issue** header in the PR body. 
3. If the PR is a bugfix, the workflow triggers a Codebuild build.
   1. `LTS_VERSION` and `BASE_LTS` are environment variables. `LTS_VERSION` is the upcoming LTS version (i.e., 8.0.5_LTS) and should be bumped after every LTS release. `BASE_LTS` is the major version of the LTS that is being supported for the remainder of the LTS period (i.e., 8.0).
   2. The `build` job checks if the `LTS_VERSION` branch already exists (since bugfixes are cherry-picked into the same LTS version until it is released) and overwrites the branch with the latest `main` isis-codebuild-ci changes. This is an easier way to support writing a new `GITHUB_SHA` to the buildspec-lts.yml each time.
   3. The Codebuild process will cherry-pick, build, and test the bugfix against the LTS branch. If either the merge or tests fail, this will have to be manually addressed by a developer.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
