### PR TITLE
Remove the need to specify model and plugin in csminit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
 ### Added
 
 ### Changed
+- Enhanced csminit by removing the need to specify model and plugin [#5585](https://github.com/DOI-USGS/ISIS3/issues/5585)
 
 ### Fixed
 - Fixed kaguyatc2isis invalid BandBin values [#5629](https://github.com/DOI-USGS/ISIS3/issues/5629)

--- a/isis/tests/FunctionalTestsCsminit.cpp
+++ b/isis/tests/FunctionalTestsCsminit.cpp
@@ -428,31 +428,13 @@ TEST_F(CSMPluginFixture, CSMInitStateStringFails) {
     csminit(options);
   }
   catch (IException &e) {
-    EXPECT_THAT(e.what(), testing::HasSubstr("When using a State string, PLUGINNAME and MODELNAME must be specified"));
-  }
-
-  QVector<QString> argsWithModel = {
-    "from="+filename,
-    "state="+statePath,
-    "modelname=TestCsmModel",
-    "pluginname=TestCsmPlugin"};
-
-  UserInterface optionsWithModel(APP_XML, argsWithModel);
-
-  // Expect a failure due to a bad state string.
-  try {
-    csminit(optionsWithModel);
-  }
-  catch (IException &e) {
-    EXPECT_THAT(e.what(), testing::HasSubstr("Could not construct sensor model using STATE string and MODELNAME"));
+    EXPECT_THAT(e.what(), testing::HasSubstr("No loaded model could be created from the State"));
   }
 
   QVector<QString> argsWithIsdAndState = {
     "from="+filename,
     "isd=fakePath",
-    "state="+statePath,
-    "modelname=TestCsmModel",
-    "pluginname=TestCsmPlugin"};
+    "state="+statePath};
 
   UserInterface optionsWithIsdAndState(APP_XML, argsWithIsdAndState);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Removes the need to provide MODELNAME and PLUGINNAME when running csminit with state. for example:

`csminit FROM=mycube.cub STATE=mystate.json`

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

closes #5585 and closes #5391 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Through tests and running csminit without specifying model and plugin names.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
