### PR TITLE
Propagate "Cube" Format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 
 ### Changed
 - Enhanced csminit by removing the need to specify model and plugin [#5585](https://github.com/DOI-USGS/ISIS3/issues/5585)
+- Changed file format to propagate from the input image format to the output image format [#5737](https://github.com/DOI-USGS/ISIS3/pull/5737)
 
 ### Fixed
 - Fixed kaguyatc2isis invalid BandBin values [#5629](https://github.com/DOI-USGS/ISIS3/issues/5629)

--- a/isis/src/base/objs/CubeAttribute/CubeAttribute.cpp
+++ b/isis/src/base/objs/CubeAttribute/CubeAttribute.cpp
@@ -179,6 +179,18 @@ namespace Isis {
   }
 
 
+  bool CubeAttributeOutput::propagateFileFormat() const {
+    bool result = false;
+
+    QStringList fileFormatAtts = attributeList(&CubeAttributeOutput::isFileFormat);
+
+    if (fileFormatAtts.isEmpty() || fileFormatAtts.last() == "PROPAGATE")
+      result = true;
+
+    return result;
+  }
+
+
 //   void CubeAttributeOutput::Set(const FileName &fileName) {
 //     Reset();
 //

--- a/isis/src/base/objs/CubeAttribute/CubeAttribute.h
+++ b/isis/src/base/objs/CubeAttribute/CubeAttribute.h
@@ -481,6 +481,9 @@ namespace Isis {
       //! Return true if the min/max are to be propagated from an input cube
       bool propagateMinimumMaximum() const;
 
+      //! Return true if the file format is to be propagated from an input cube
+      bool propagateFileFormat() const;
+
       //! Return the file format an Cube::Format
       Cube::Format fileFormat() const;
 

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -329,7 +329,19 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     try {
       cube->setDimensions(ns, nl, nb);
       cube->setByteOrder(att.byteOrder());
-      cube->setFormat(att.fileFormat());
+      if (att.propagateFileFormat()) {
+        if(InputCubes.size() > 0) {
+          cube->setFormat(InputCubes[0]->format());
+        }
+        else {
+          QString msg = "You told me to propagate file format from input to output";
+          msg += " cube but there are no input cubes loaded";
+          throw IException(IException::Programmer, msg, _FILEINFO_);
+        }
+      }
+      else {
+        cube->setFormat(att.fileFormat());
+      }
       cube->setLabelsAttached(att.labelAttachment());
       if(att.propagatePixelType()) {
         if(InputCubes.size() > 0) {

--- a/isis/src/base/objs/Process/Process.cpp
+++ b/isis/src/base/objs/Process/Process.cpp
@@ -329,21 +329,18 @@ Isis::Cube *Process::SetOutputCubeStretch(const QString &parameter, const int ns
     try {
       cube->setDimensions(ns, nl, nb);
       cube->setByteOrder(att.byteOrder());
-      if (att.propagateFileFormat()) {
-        if(InputCubes.size() > 0) {
-          cube->setFormat(InputCubes[0]->format());
-        }
-        else {
-          QString msg = "You told me to propagate file format from input to output";
-          msg += " cube but there are no input cubes loaded";
-          throw IException(IException::Programmer, msg, _FILEINFO_);
-        }
+
+      // If we have an input cube and the user did not specify an output format
+      // propagate the input cubes format to the output cube
+      if(InputCubes.size() > 0 && att.propagateFileFormat()) {
+        cube->setFormat(InputCubes[0]->format());
       }
       else {
         cube->setFormat(att.fileFormat());
       }
+
       cube->setLabelsAttached(att.labelAttachment());
-      if(att.propagatePixelType()) {
+      if (att.propagatePixelType()) {
         if(InputCubes.size() > 0) {
           cube->setPixelType(InputCubes[0]->pixelType());
         }

--- a/isis/src/cassini/apps/vimscal/tsts/defaultsolarcoef/Makefile
+++ b/isis/src/cassini/apps/vimscal/tsts/defaultsolarcoef/Makefile
@@ -12,27 +12,27 @@ include $(ISISROOT)/make/isismake.tsts
 #   the standard points for testing work correctly.
 commands:
 	$(APPNAME) from=$(INPUT)/V1515948001_1.ir.cub \
-	  to=$(OUTPUT)/V1515948001_1.ir.cal1.cub UNITS=IOF \
+	  to=$(OUTPUT)/V1515948001_1.ir.cal1.cub+Tile UNITS=IOF \
 	  IRORIGDARK=false DARK=true > /dev/null;
 	catlab from=$(OUTPUT)/V1515948001_1.ir.cal1.cub \
 	  TO=$(OUTPUT)/V1515948001_1.ir.cal1.pvl > /dev/null;
 	$(APPNAME) from=$(INPUT)/V1515948001_1.ir.cub \
-	  to=$(OUTPUT)/V1515948001_1.ir.cal2.cub UNITS=SPECENERGY \
+	  to=$(OUTPUT)/V1515948001_1.ir.cal2.cub+Tile UNITS=SPECENERGY \
 	  IRORIGDARK=false DARK=true > /dev/null;
 	catlab from=$(OUTPUT)/V1515948001_1.ir.cal2.cub \
 	  TO=$(OUTPUT)/V1515948001_1.ir.cal2.pvl > /dev/null;
 	$(APPNAME) from=$(INPUT)/V1515948001_1.ir.cub \
-	  to=$(OUTPUT)/V1515948001_1.ir.cal3.cub UNITS=IOF \
+	  to=$(OUTPUT)/V1515948001_1.ir.cal3.cub+Tile  UNITS=IOF \
 	  IRORIGDARK=true DARK=true > /dev/null;
 	catlab from=$(OUTPUT)/V1515948001_1.ir.cal3.cub \
 	  TO=$(OUTPUT)/V1515948001_1.ir.cal3.pvl > /dev/null;
 	$(APPNAME) from=$(INPUT)/V1515948001_1.ir.cub \
-	  to=$(OUTPUT)/V1515948001_1.ir.cal4.cub UNITS=IOF \
+	  to=$(OUTPUT)/V1515948001_1.ir.cal4.cub+Tile  UNITS=IOF \
 	  IRORIGDARK=true DARK=false > /dev/null;
 	catlab from=$(OUTPUT)/V1515948001_1.ir.cal4.cub \
 	  TO=$(OUTPUT)/V1515948001_1.ir.cal4.pvl > /dev/null;
 	$(APPNAME) from=$(INPUT)/V1515948001_1.ir.cub \
-	  to=$(OUTPUT)/V1515948001_1.ir.cal5.cub UNITS=IOF \
+	  to=$(OUTPUT)/V1515948001_1.ir.cal5.cub+Tile  UNITS=IOF \
 	  IRORIGDARK=false DARK=false > /dev/null;
 	catlab from=$(OUTPUT)/V1515948001_1.ir.cal5.cub \
 	  TO=$(OUTPUT)/V1515948001_1.ir.cal5.pvl > /dev/null;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Defaulted process classes to propagate the file format from the input cube to the output cube. Makes running something like:
```
ctxcal from=ingest.tiff to=ingest.cal.tiff+GTiff
```
into
```
ctxcal from=ingest.tiff to=ingest.cal.tiff
```

Biggest win is that users won't have to constantly remember to run each step in a process with `+GTiff`

## Related Issue
IAA

## How Has This Been Validated?
Validated from current test suite

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
