### PR TITLE
ShowDeprecated setting in IsisPreferences File

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Added GDAL SRS propagation for systems outside of ISIS to display projected GTiffs. [#5736](https://github.com/DOI-USGS/ISIS3/pull/5736)
 - Added ale version to history blob. [#5207](https://github.com/DOI-USGS/ISIS3/issues/5207)
 - Added CSM State output capability for jigsaw. [#5609](https://github.com/DOI-USGS/ISIS3/issues/5609)
+- Added ShowDeprecated option to show or hide warnings in IsisPreferences. [#5611](https://github.com/DOI-USGS/ISIS3/issues/5611)
 
 ### Changed
 - Update OSIRIS-REx OCams instrument (Map, Poly, & SamCam) support to current state in UofA code base [#5426](https://github.com/DOI-USGS/ISIS3/issues/5426)

--- a/isis/IsisPreferences
+++ b/isis/IsisPreferences
@@ -40,6 +40,7 @@ EndGroup
 #
 # FileLine = On | Off
 # Format = Standard | Pvl
+# ShowDeprecated = On | Off
 # StackTrace = On | Off
 ########################################################
 

--- a/isis/IsisPreferences
+++ b/isis/IsisPreferences
@@ -46,6 +46,7 @@ EndGroup
 Group = ErrorFacility
   FileLine = Off
   Format = Standard
+  ShowDeprecated = On
   StackTrace = Off
 EndGroup
 

--- a/isis/src/base/objs/Preference/Preference.cpp
+++ b/isis/src/base/objs/Preference/Preference.cpp
@@ -124,33 +124,47 @@ namespace Isis {
     return *p_preference;
   }
 
-  bool Preference::outputErrorAsPvl() {
-    bool usePvlFormat = false;
-    try {
-      PvlGroup &errorFacility = this->findGroup("ErrorFacility");
-      if (errorFacility.hasKeyword("Format")) {
-        QString format = errorFacility["Format"][0];
-        usePvlFormat = (format.toUpper() == "PVL");
+  bool Preference::checkIfPrefEquals(const QString &group, const QString &key, const QString &val) {
+    bool prefIsValue = true;
+    if (this->hasGroup(group)) {
+      PvlGroup &targetGroup = this->findGroup(group);
+      if (targetGroup.hasKeyword(key)) {
+        QString targetVal = targetGroup[key][0];
+        prefIsValue = (targetVal.toUpper() == val.toUpper());
       }
     }
-    catch (IException &e) {
-      // If we failed we likely don't have an ErrorFacility group
-    }
-    return usePvlFormat;
+    return prefIsValue;
   }
 
-  bool Preference::reportFileLine() {
-    bool reportFileLine = true;
-
-    if (this->hasGroup("ErrorFacility")) {
-      PvlGroup &errorFacility = this->findGroup("ErrorFacility");
-      if (errorFacility.hasKeyword("FileLine")) {
-        QString fileLine = errorFacility["FileLine"][0];
-        reportFileLine = (fileLine.toUpper() == "ON");
+  bool Preference::checkIfPrefEquals(const QString &group, const QString &key, const QString &val, const bool defaultReturn) {
+    bool prefIsValue = defaultReturn;
+    if (this->hasGroup(group)) {
+      PvlGroup &targetGroup = this->findGroup(group);
+      if (targetGroup.hasKeyword(key)) {
+        QString targetVal = targetGroup[key][0];
+        prefIsValue = (targetVal.toUpper() == val.toUpper());
       }
     }
+    return prefIsValue;
+  }
 
-    return reportFileLine;
+  // The following four methods check the boolean preferences 
+  // in the ErrorFacility Group.
+
+  bool Preference::reportFileLine() {
+    return checkIfPrefEquals("ErrorFacility", "FileLine", "On");
+  }
+
+  bool Preference::outputErrorAsPvl() {
+    return checkIfPrefEquals("ErrorFacility", "Format", "PVL", false);
+  }
+
+  bool Preference::getShowDeprecatedPref() {
+    return checkIfPrefEquals("ErrorFacility", "ShowDeprecated", "On");
+  }
+
+  bool Preference::getStackTracePref() {
+    return checkIfPrefEquals("ErrorFacility", "StackTrace", "Off");
   }
 
   void Preference::Shutdown() {

--- a/isis/src/base/objs/Preference/Preference.cpp
+++ b/isis/src/base/objs/Preference/Preference.cpp
@@ -124,18 +124,6 @@ namespace Isis {
     return *p_preference;
   }
 
-  bool Preference::checkIfPrefEquals(const QString &group, const QString &key, const QString &val) {
-    bool prefIsValue = true;
-    if (this->hasGroup(group)) {
-      PvlGroup &targetGroup = this->findGroup(group);
-      if (targetGroup.hasKeyword(key)) {
-        QString targetVal = targetGroup[key][0];
-        prefIsValue = (targetVal.toUpper() == val.toUpper());
-      }
-    }
-    return prefIsValue;
-  }
-
   bool Preference::checkIfPrefEquals(const QString &group, const QString &key, const QString &val, const bool defaultReturn) {
     bool prefIsValue = defaultReturn;
     if (this->hasGroup(group)) {

--- a/isis/src/base/objs/Preference/Preference.h
+++ b/isis/src/base/objs/Preference/Preference.h
@@ -71,8 +71,13 @@ namespace Isis {
         return p_unitTest;
       }
 
-      bool outputErrorAsPvl();
+      bool checkIfPrefEquals(const QString &group, const QString &key, const QString &val);
+      bool checkIfPrefEquals(const QString &group, const QString &key, const QString &val, const bool defaultReturn);
+
       bool reportFileLine();
+      bool outputErrorAsPvl();
+      bool getShowDeprecatedPref();
+      bool getStackTracePref();
 
       static Preference &Preferences(bool unitTest = false);
 

--- a/isis/src/base/objs/Preference/Preference.h
+++ b/isis/src/base/objs/Preference/Preference.h
@@ -71,8 +71,7 @@ namespace Isis {
         return p_unitTest;
       }
 
-      bool checkIfPrefEquals(const QString &group, const QString &key, const QString &val);
-      bool checkIfPrefEquals(const QString &group, const QString &key, const QString &val, const bool defaultReturn);
+      bool checkIfPrefEquals(const QString &group, const QString &key, const QString &val, const bool defaultReturn = true);
 
       bool reportFileLine();
       bool outputErrorAsPvl();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Added an entry to the IsisPreferences file to enable the showing/hiding of deprecation warnings in the future.

Default setting is On (aka, show the deprecation warnings.)

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

First, merge this PR, then merge the Sister PR to close the issue.
Sister PR: DOI-USGS/asc-public-docs#145

Linked issue: #5611 

Could close, though I'm tempted to leave open until I see the preference actually get used to check if a deprecation warning should be printed.

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Has not been validated per-se.  Decision factors investigated include c++ language deprecation features, user and team feedback, current practices in ISIS code.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
