### PR TITLE
Fix Strip and Grid PolygonSeeder memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed embree shapemodel intersection calculation [#5592](https://github.com/DOI-USGS/ISIS3/issues/5592)
 - Fixed findFeaturesSegment.py errors from issues [#5725](https://github.com/DOI-USGS/ISIS3/issues/5725) and [#5702](https://github.com/DOI-USGS/ISIS3/issues/5702)
 - Fixed jigsaw save/apply bug by adding back missing metadata to Instrument Position/Pointing tables [#5701](https://github.com/DOI-USGS/ISIS3/issues/5701)
+- Fixed `StripPolygonSeeder` and `GridPolygonSeeder` memory leaks [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
 
 ## [9.0.0] - 09-25-2024
 

--- a/isis/src/base/objs/GridPolygonSeeder/GridPolygonSeeder.cpp
+++ b/isis/src/base/objs/GridPolygonSeeder/GridPolygonSeeder.cpp
@@ -102,8 +102,7 @@ namespace Isis {
         if(p->within(multiPoly)) {
           points.push_back(Isis::globalFactory->createPoint(c).release());
         }
-          delete p;
-        }
+        delete p;
       }
     }
 
@@ -362,7 +361,7 @@ namespace Isis {
         if(p->within(&xymp)) {
           result = p->clone().release();
         }
-          delete p;
+        delete p;
       }
     }
 

--- a/isis/src/base/objs/GridPolygonSeeder/GridPolygonSeeder.cpp
+++ b/isis/src/base/objs/GridPolygonSeeder/GridPolygonSeeder.cpp
@@ -102,7 +102,6 @@ namespace Isis {
         if(p->within(multiPoly)) {
           points.push_back(Isis::globalFactory->createPoint(c).release());
         }
-        else {
           delete p;
         }
       }
@@ -363,9 +362,7 @@ namespace Isis {
         if(p->within(&xymp)) {
           result = p->clone().release();
         }
-        else {
           delete p;
-        }
       }
     }
 

--- a/isis/src/base/objs/StripPolygonSeeder/StripPolygonSeeder.cpp
+++ b/isis/src/base/objs/StripPolygonSeeder/StripPolygonSeeder.cpp
@@ -87,15 +87,14 @@ namespace Isis {
         if(p->within(multiPoly)) {
           points.push_back(Isis::globalFactory->createPoint(c).release());
         }
-          delete p;
+        delete p;
 
         geos::geom::Coordinate c2(x - dDeltaXToReal, y - dDeltaYToReal);
         p = Isis::globalFactory->createPoint(c2).release();
         if(p->within(multiPoly)) {
           points.push_back(Isis::globalFactory->createPoint(c2).release());
-          }
-          delete p;
         }
+        delete p;
       }
     }
 

--- a/isis/src/base/objs/StripPolygonSeeder/StripPolygonSeeder.cpp
+++ b/isis/src/base/objs/StripPolygonSeeder/StripPolygonSeeder.cpp
@@ -87,11 +87,14 @@ namespace Isis {
         if(p->within(multiPoly)) {
           points.push_back(Isis::globalFactory->createPoint(c).release());
         }
+          delete p;
 
         geos::geom::Coordinate c2(x - dDeltaXToReal, y - dDeltaYToReal);
         p = Isis::globalFactory->createPoint(c2).release();
         if(p->within(multiPoly)) {
           points.push_back(Isis::globalFactory->createPoint(c2).release());
+          }
+          delete p;
         }
       }
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes memory leaks in the `StripPolygonSeeder` and `GridPolygonSeeder` resulting in significantly large memory footprints when seeding images that cross the prime meridian

## Related Issue
Fixes #5193 

## How Has This Been Validated?
Validated locally using the image set provided on the issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
