### PR TITLE
Compile fix with clang16 on Arm

### DIFF
--- a/isis/src/base/apps/camtrim/main.cpp
+++ b/isis/src/base/apps/camtrim/main.cpp
@@ -11,7 +11,7 @@ using namespace Isis;
 // Global variables
 Cube *icube;
 Camera *cam;
-TProjection *proj;
+TProjection *tproj;
 double minlat;
 double maxlat;
 double minlon;
@@ -53,14 +53,14 @@ void IsisMain() {
   if(ui.WasEntered("MAP")) {
     Pvl lab;
     lab.read(ui.GetFileName("MAP"));
-    proj = (TProjection *) ProjectionFactory::Create(lab);
+    tproj = (TProjection *) ProjectionFactory::Create(lab);
 
     // add mapping to print.prt
-    PvlGroup mapping = proj->Mapping();
+    PvlGroup mapping = tproj->Mapping();
     Application::Log(mapping);
   }
   else {
-    proj = NULL;
+    tproj = NULL;
   }
 
   // Start the processing
@@ -86,10 +86,10 @@ void camtrim(Buffer &in, Buffer &out) {
     if(cam->HasSurfaceIntersection()) {
       lat = cam->UniversalLatitude();
       lon = cam->UniversalLongitude();
-      if(proj != NULL) {
-        proj->SetUniversalGround(lat, lon);
-        lat = proj->Latitude();
-        lon = proj->Longitude();
+      if(tproj != NULL) {
+        tproj->SetUniversalGround(lat, lon);
+        lat = tproj->Latitude();
+        lon = tproj->Longitude();
       }
       // Pixel is outside range
       if((lat < minlat) || (lat > maxlat) ||

--- a/isis/src/dev/apps/camdev/main.cpp
+++ b/isis/src/dev/apps/camdev/main.cpp
@@ -32,7 +32,7 @@ using namespace Isis;
 
 // Global variables
 Camera *cam;
-TProjection *proj;
+TProjection *tproj;
 int nbands;
 bool noCamera;
 
@@ -132,7 +132,7 @@ void IsisMain() {
 
   if(noCamera) {
     try {
-      proj = (TProjection *) icube->projection();
+      tproj = (TProjection *) icube->projection();
     }
     catch(IException &e) {
       QString msg = "Mosaic files must contain mapping labels";
@@ -423,7 +423,7 @@ void camdev(Buffer &out) {
 
       bool isGood=false;
       if (noCamera) {
-        isGood = proj->SetWorld(samp, line);
+        isGood = tproj->SetWorld(samp, line);
       }
       else {
         isGood = cam->SetImage(samp, line);
@@ -440,7 +440,7 @@ void camdev(Buffer &out) {
         }
         if(planetocentricLatitude) {
           if(noCamera) {
-            out[index] = proj->UniversalLatitude();
+            out[index] = tproj->UniversalLatitude();
           }
           else {
             out[index] = cam->UniversalLatitude();
@@ -461,7 +461,7 @@ void camdev(Buffer &out) {
         double pe360Lon, pw360Lon;
         if (positiveEast360Longitude) {
           if(noCamera) {
-            pe360Lon = proj->UniversalLongitude();
+            pe360Lon = tproj->UniversalLongitude();
           }
           else {
             pe360Lon = cam->UniversalLongitude();
@@ -502,7 +502,7 @@ void camdev(Buffer &out) {
         }
         if (pixelResolution) {
           if (noCamera) {
-            out[index] = proj->Resolution();
+            out[index] = tproj->Resolution();
           }
           else {
             out[index] = cam->PixelResolution();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When compiling ISIS on Arm with clang 16.0.6 I get this error:

```
ISIS3/isis/src/base/apps/camtrim/main.cpp:56:5: error: reference to 'proj' is ambiguous
    proj = (TProjection *) ProjectionFactory::Create(lab);
    ^
ISIS3/isis/src/base/apps/camtrim/main.cpp:14:14: note: candidate found by name lookup is 'proj'
TProjection *proj;
             ^
../include/c++/v1/complex:1054:1: note: candidate found by name lookup is 'std::proj'
proj(_Tp __re)

```

Apparently there is such a thing as std::proj (https://en.cppreference.com/w/cpp/numeric/complex/proj).

Because of "using namespace std", looks like there's a conflict, even though std::proj is a function, not a variable.

The fix seems to be to rename the local variable.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
