### PR TITLE
Disable doc building on Mac Arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Added ShowDeprecated option to show or hide warnings in IsisPreferences. [#5611](https://github.com/DOI-USGS/ISIS3/issues/5611)
 
 ### Changed
+- Removed Arm dependency on xalan-c, as it does not build for now on conda-forge. This requires turning off doc building on Arm. Also changed some variables to avoid name clashes on Arm with clang 16. [#5802])(https://github.com/DOI-USGS/ISIS3/pull/5802)
 - Update OSIRIS-REx OCams instrument (Map, Poly, & SamCam) support to current state in UofA code base [#5426](https://github.com/DOI-USGS/ISIS3/issues/5426)
 - Enhanced csminit by removing the need to specify model and plugin [#5585](https://github.com/DOI-USGS/ISIS3/issues/5585)
 - Changed file format to propagate from the input image format to the output image format [#5737](https://github.com/DOI-USGS/ISIS3/pull/5737)

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -73,8 +73,9 @@ option(buildCore       "Build the core ISIS modules"                    ON  )
 option(buildMissions   "Build the mission specific modules"             ON  )
 option(buildStaticCore "Build libisis static as well as dynamic"        OFF )
 option(buildTests      "Set up unit, application, and module tests."    ON  )
+option(buildDocs       "Build the docs."                                ON  )
 option(JP2KFLAG        "Whether or not to build using JPEG2000 support" OFF )
-option(pybindings      "Turn on to build Python bindings"               ON )
+option(pybindings      "Turn on to build Python bindings"               ON  )
 
 # if cmake install prefix is not set, and conda env is activated, use the
 # conda env as the install directory.
@@ -91,6 +92,12 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
   message(STATUS "Support for JPEG2000 is not available on Mac Arm.")
   set(JP2KFLAG OFF)
+endif()
+
+# No docs support on Mac Arm. The xalan-c Arm package is not available on conda-forge.
+if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+  message(STATUS "Building documentation is not available on Mac Arm.")
+  set(buildDocs OFF)
 endif()
 
 # Prioritize passed in variables over env vars, probably a better way to do this
@@ -132,6 +139,7 @@ add_definitions( -DISISBUILDDIR="${CMAKE_BINARY_DIR}" )
 message("CONFIGURATION")
 message("\tBUILD STATIC CORE: ${buildStaticCore}")
 message("\tBUILD TESTS: ${buildTests}")
+message("\tBUILD DOCS: ${buildDocs}")
 message("\tBUILD CORE: ${buildCore}")
 message("\tBUILD MISSIONS: ${buildMissions}")
 message("\tJP2K SUPPORT: ${JP2KFLAG}")
@@ -214,7 +222,10 @@ else()
 endif()
 
 # Paths to required executables
-find_program(XALAN Xalan REQUIRED)
+if (buildDocs)
+  find_program(XALAN Xalan REQUIRED)
+endif()
+
 find_program(LATEX latex)
 find_program(DOXYGEN NAME doxygen PATH_SUFFIXES doxygen REQUIRED)
 find_program(UIC uic REQUIRED)
@@ -479,13 +490,15 @@ endif()
 # Set up documentation build target.
 # - This script is called by running "ninja docs".
 # - This long call passes all desired variables to the script.
-add_custom_target(docs COMMAND ${CMAKE_COMMAND}
-                  -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
-                  -DDOXYGEN=${DOXYGEN}  -DXALAN=${XALAN}
-                  -DLATEX=${LATEX}
-                  -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
-                  -DPACKAGE_VERSION=${PACKAGE_VERSION}
-                  -P ${CMAKE_MODULE_PATH}/BuildDocs.cmake)
+if (buildDocs)
+  add_custom_target(docs COMMAND ${CMAKE_COMMAND}
+                    -DPROJECT_SOURCE_DIR=${PROJECT_SOURCE_DIR}
+                    -DDOXYGEN=${DOXYGEN}  -DXALAN=${XALAN}
+                    -DLATEX=${LATEX}
+                    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+                    -DPACKAGE_VERSION=${PACKAGE_VERSION}
+                    -P ${CMAKE_MODULE_PATH}/BuildDocs.cmake)
+endif()
 
 # Add custom build target to copy modified header files to the build/incs directory.
 # ALL is specified so that the target is added to the default build target, i.e. the copy command

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -73,7 +73,7 @@ option(buildCore       "Build the core ISIS modules"                    ON  )
 option(buildMissions   "Build the mission specific modules"             ON  )
 option(buildStaticCore "Build libisis static as well as dynamic"        OFF )
 option(buildTests      "Set up unit, application, and module tests."    ON  )
-option(buildDocs       "Build the docs."                                ON  )
+option(buildDocs       "Build the docs."                                OFF )
 option(JP2KFLAG        "Whether or not to build using JPEG2000 support" OFF )
 option(pybindings      "Turn on to build Python bindings"               ON  )
 

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -73,7 +73,7 @@ option(buildCore       "Build the core ISIS modules"                    ON  )
 option(buildMissions   "Build the mission specific modules"             ON  )
 option(buildStaticCore "Build libisis static as well as dynamic"        OFF )
 option(buildTests      "Set up unit, application, and module tests."    ON  )
-option(buildDocs       "Build the docs."                                OFF )
+option(buildDocs       "Build the docs."                                ON  )
 option(JP2KFLAG        "Whether or not to build using JPEG2000 support" OFF )
 option(pybindings      "Turn on to build Python bindings"               ON  )
 

--- a/isis/cmake/RunMakeFileTest.cmake
+++ b/isis/cmake/RunMakeFileTest.cmake
@@ -4,7 +4,7 @@
 #============================================================================
 
 # Minimum version 3.5 required to avoid cmake warnings
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.15)
 list(APPEND CMAKE_MODULE_PATH "${CODE_ROOT}/cmake")
 list(APPEND CMAKE_PREFIX_PATH "${CODE_ROOT}/cmake")
 include(Utilities)

--- a/isis/src/base/apps/camtrim/main.cpp
+++ b/isis/src/base/apps/camtrim/main.cpp
@@ -11,7 +11,7 @@ using namespace Isis;
 // Global variables
 Cube *icube;
 Camera *cam;
-TProjection *proj;
+TProjection *tproj;
 double minlat;
 double maxlat;
 double minlon;
@@ -53,14 +53,14 @@ void IsisMain() {
   if(ui.WasEntered("MAP")) {
     Pvl lab;
     lab.read(ui.GetFileName("MAP"));
-    proj = (TProjection *) ProjectionFactory::Create(lab);
+    tproj = (TProjection *) ProjectionFactory::Create(lab);
 
     // add mapping to print.prt
-    PvlGroup mapping = proj->Mapping();
+    PvlGroup mapping = tproj->Mapping();
     Application::Log(mapping);
   }
   else {
-    proj = NULL;
+    tproj = NULL;
   }
 
   // Start the processing
@@ -86,10 +86,10 @@ void camtrim(Buffer &in, Buffer &out) {
     if(cam->HasSurfaceIntersection()) {
       lat = cam->UniversalLatitude();
       lon = cam->UniversalLongitude();
-      if(proj != NULL) {
-        proj->SetUniversalGround(lat, lon);
-        lat = proj->Latitude();
-        lon = proj->Longitude();
+      if(tproj != NULL) {
+        tproj->SetUniversalGround(lat, lon);
+        lat = tproj->Latitude();
+        lon = tproj->Longitude();
       }
       // Pixel is outside range
       if((lat < minlat) || (lat > maxlat) ||

--- a/isis/src/dev/apps/camdev/main.cpp
+++ b/isis/src/dev/apps/camdev/main.cpp
@@ -32,7 +32,7 @@ using namespace Isis;
 
 // Global variables
 Camera *cam;
-TProjection *proj;
+TProjection *tproj;
 int nbands;
 bool noCamera;
 
@@ -132,7 +132,7 @@ void IsisMain() {
 
   if(noCamera) {
     try {
-      proj = (TProjection *) icube->projection();
+      tproj = (TProjection *) icube->projection();
     }
     catch(IException &e) {
       QString msg = "Mosaic files must contain mapping labels";
@@ -423,7 +423,7 @@ void camdev(Buffer &out) {
 
       bool isGood=false;
       if (noCamera) {
-        isGood = proj->SetWorld(samp, line);
+        isGood = tproj->SetWorld(samp, line);
       }
       else {
         isGood = cam->SetImage(samp, line);
@@ -440,7 +440,7 @@ void camdev(Buffer &out) {
         }
         if(planetocentricLatitude) {
           if(noCamera) {
-            out[index] = proj->UniversalLatitude();
+            out[index] = tproj->UniversalLatitude();
           }
           else {
             out[index] = cam->UniversalLatitude();
@@ -461,7 +461,7 @@ void camdev(Buffer &out) {
         double pe360Lon, pw360Lon;
         if (positiveEast360Longitude) {
           if(noCamera) {
-            pe360Lon = proj->UniversalLongitude();
+            pe360Lon = tproj->UniversalLongitude();
           }
           else {
             pe360Lon = cam->UniversalLongitude();
@@ -502,7 +502,7 @@ void camdev(Buffer &out) {
         }
         if (pixelResolution) {
           if (noCamera) {
-            out[index] = proj->Resolution();
+            out[index] = tproj->Resolution();
           }
           else {
             out[index] = cam->PixelResolution();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

 Removed Arm dependency on xalan-c, as it does not build for now on conda-forge. See: https://github.com/conda-forge/xalan-c-feedstock/pull/5

This requires turning off doc building on Arm. Also changed some variables to avoid name clashes on Arm with clang 16. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->

## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
