### PR TITLE
Fix gdal driver registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed jigsaw save/apply bug by adding back missing metadata to Instrument Position/Pointing tables [#5701](https://github.com/DOI-USGS/ISIS3/issues/5701)
 - Fixed `StripPolygonSeeder` and `GridPolygonSeeder` memory leaks [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
 - Fixed `pointreg` helper function to display deffile to application log [#5806](https://github.com/DOI-USGS/ISIS3/pull/5806)
+- Fixed ISIS Q Applications crashing when opening more than one cube at once. [#5805](https://github.com/DOI-USGS/ISIS3/pull/5805)
 
 ## [9.0.0] - 09-25-2024
 

--- a/isis/src/base/objs/Application/Application.cpp
+++ b/isis/src/base/objs/Application/Application.cpp
@@ -25,6 +25,8 @@ extern int errno;
 #include <QString>
 #include <QTime>
 
+#include "gdal_priv.h"
+
 #include "Application.h"
 #include "FileName.h"
 #include "IException.h"
@@ -90,6 +92,16 @@ namespace Isis {
     p_startDirectIO = DirectIO();
     p_startPageFaults = PageFaults();
     p_startProcessSwaps = ProcessSwaps();
+
+    // Setup gdal drivers and error handler
+    try {
+      GDALAllRegister();
+      CPLSetErrorHandler(CPLQuietErrorHandler);
+    }
+    catch(exception &e) {
+      QString msg = "Failed to load GDAL Drivers, with error [" + QString(e.what()) + "]";
+      throw IException(IException::Unknown, msg, _FILEINFO_);
+    }
 
     // Create user interface and log
     try {

--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -48,8 +48,6 @@ using namespace std;
 namespace Isis {
   //! Constructs a Cube object.
   Cube::Cube() {
-    GDALAllRegister();
-    CPLSetErrorHandler(CPLQuietErrorHandler);
     construct();
   }
 
@@ -62,8 +60,6 @@ namespace Isis {
    *     "r" or read-write "rw".
    */
   Cube::Cube(const FileName &fileName, QString access) {
-    GDALAllRegister();
-    CPLSetErrorHandler(CPLQuietErrorHandler);
     construct();
     open(fileName.toString(), access);
   }
@@ -78,8 +74,6 @@ namespace Isis {
    *     "r" or read-write "rw".
    */
   void Cube::fromLabel(const FileName &fileName, Pvl &label, QString access) {
-    GDALAllRegister();
-    CPLSetErrorHandler(CPLQuietErrorHandler);
     initCoreFromLabel(label);
     create(fileName.expanded());
 
@@ -103,8 +97,6 @@ namespace Isis {
    *     "r" or read-write "rw".
    */
   void Cube::fromIsd(const FileName &fileName, Pvl &label, nlohmann::json &isd, QString access) {
-    GDALAllRegister();
-    CPLSetErrorHandler(CPLQuietErrorHandler);
     fromLabel(fileName, label, access);
 
     PvlGroup &instGrp = label.findGroup("Instrument", Pvl::Traverse);
@@ -670,8 +662,6 @@ namespace Isis {
   }
 
   void Cube::createGdal(QString &dataFileName, QString &driverName, char **papszOptions) {
-    GDALAllRegister();
-    CPLSetErrorHandler(CPLQuietErrorHandler);
     GDALDriver* driver = GetGDALDriverManager()->GetDriverByName(driverName.toStdString().c_str());
     if (driver) {
       double noDataValue;

--- a/isis/src/base/objs/CubeManager/unitTest.cpp
+++ b/isis/src/base/objs/CubeManager/unitTest.cpp
@@ -18,6 +18,8 @@ using namespace Isis;
 
 int main(int argc, char *argv[]) {
   Isis::Preference::Preferences(true);
+  GDALAllRegister();
+  CPLSetErrorHandler(CPLQuietErrorHandler);
 
   cout << "CubeManager Unit Test" << endl;
   QVector<Cube *> cubes;

--- a/isis/src/base/objs/ImageIoHandler/GdalIoHandler.cpp
+++ b/isis/src/base/objs/ImageIoHandler/GdalIoHandler.cpp
@@ -19,7 +19,6 @@ using namespace std;
 namespace Isis {
   GdalIoHandler::GdalIoHandler(QString &dataFilePath, const QList<int> *virtualBandList, GDALDataType pixelType, GDALAccess eAccess) : 
                  ImageIoHandler(virtualBandList) {
-    GDALAllRegister();
     m_geodataSetPath = dataFilePath.toUtf8().constData();
     m_geodataSet = GDALDataset::FromHandle(GDALOpen(m_geodataSetPath.c_str(), eAccess));
     m_datasetOwner = true;

--- a/isis/src/base/objs/ShapeModelFactory/unitTest.cpp
+++ b/isis/src/base/objs/ShapeModelFactory/unitTest.cpp
@@ -47,6 +47,9 @@ using namespace Isis;
  }
 
 int main() {
+  GDALAllRegister();
+  CPLSetErrorHandler(CPLQuietErrorHandler);
+
   try {
     Isis::Preference::Preferences(true);
 

--- a/isis/src/base/objs/SpectralDefinitionFactory/unitTest.cpp
+++ b/isis/src/base/objs/SpectralDefinitionFactory/unitTest.cpp
@@ -18,6 +18,8 @@ using namespace Isis;
 
 int main(int argc, char *argv[]) {
   Preference::Preferences(true);
+  GDALAllRegister();
+  CPLSetErrorHandler(CPLQuietErrorHandler);
 
   cerr.precision(14);
 

--- a/isis/src/qisis/objs/QIsisApplication/QIsisApplication.cpp
+++ b/isis/src/qisis/objs/QIsisApplication/QIsisApplication.cpp
@@ -8,6 +8,8 @@
 #include <QMessageBox>
 #include <QUrl>
 
+#include <gdal_priv.h>
+
 #include "FileName.h"
 #include "Preference.h"
 #include "IException.h"
@@ -29,6 +31,16 @@ namespace Isis {
     QApplication(argc, argv) {
     // try to use US locale for numbers so we don't end up printing "," instead
     //   of "." where it might count.
+
+    // Setup gdal drivers and error handler
+    try {
+      GDALAllRegister();
+      CPLSetErrorHandler(CPLQuietErrorHandler);
+    }
+    catch(std::exception &e) {
+      QString msg = "Failed to load GDAL Drivers, with error [" + QString(e.what()) + "]";
+      throw IException(IException::Unknown, msg, _FILEINFO_);
+    }
 
     for (int i = 1; i < argc; i++) {
         QString arg(argv[i]);

--- a/isis/tests/GTiffTests.cpp
+++ b/isis/tests/GTiffTests.cpp
@@ -58,6 +58,9 @@ void check_tiff(Cube &cube,
 
 
 TEST_F(TempTestingFiles, TestGTiffCreateWriteCopy) {
+  GDALAllRegister();
+  CPLSetErrorHandler(CPLQuietErrorHandler);
+
   Cube out;
   QString file = "";
   check_tiff(out, file, 0, 0, 0, 0, 1, 7, 0, 1, 0, 0, 0, 65536);
@@ -121,6 +124,9 @@ INSTANTIATE_TEST_SUITE_P (GdalDnPixelTypes,
                                             Isis::Double));
 
 TEST_P(GdalDnTypeGenerator, TestGTiffCreateWrite) {
+  GDALAllRegister();
+  CPLSetErrorHandler(CPLQuietErrorHandler);
+  
   Cube out;
   QString file = "";
   check_tiff(out, file, 0, 0, 0, 0, 1, 7, 0, 1, 0, 0, 0, 65536);
@@ -176,6 +182,9 @@ TEST_P(GdalDnTypeGenerator, TestGTiffCreateWrite) {
 }
 
 TEST_F(TempTestingFiles, TestGTiffTableWriteRead) {
+  GDALAllRegister();
+  CPLSetErrorHandler(CPLQuietErrorHandler);
+
   TableField f1("Column1", TableField::Integer);
   TableField f2("Column2", TableField::Double);
   TableField f3("Column3", TableField::Text, 10);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Moves `GDALAllRegister` calls and error handler setup into the ISIS `Application` and `QIsisApplication` classes. This fixes a race condition in ISIS QApplications when opening multiple cubes at once.

## Related Issue
N/A

## How Has This Been Validated?
Validated locally using Qmos

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
