### PR TITLE
Fix Pointreg Helper Function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed findFeaturesSegment.py errors from issues [#5725](https://github.com/DOI-USGS/ISIS3/issues/5725) and [#5702](https://github.com/DOI-USGS/ISIS3/issues/5702)
 - Fixed jigsaw save/apply bug by adding back missing metadata to Instrument Position/Pointing tables [#5701](https://github.com/DOI-USGS/ISIS3/issues/5701)
 - Fixed `StripPolygonSeeder` and `GridPolygonSeeder` memory leaks [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
-- Fixed `pointreg` helper function to display deffile to application log [#5806](https://github.com/DOI-USGS/ISIS3/issues/5806)
+- Fixed `pointreg` helper function to display deffile to application log [#5806](https://github.com/DOI-USGS/ISIS3/pull/5806)
 
 ## [9.0.0] - 09-25-2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed findFeaturesSegment.py errors from issues [#5725](https://github.com/DOI-USGS/ISIS3/issues/5725) and [#5702](https://github.com/DOI-USGS/ISIS3/issues/5702)
 - Fixed jigsaw save/apply bug by adding back missing metadata to Instrument Position/Pointing tables [#5701](https://github.com/DOI-USGS/ISIS3/issues/5701)
 - Fixed `StripPolygonSeeder` and `GridPolygonSeeder` memory leaks [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
+- Fixed `pointreg` helper function to display deffile to application log [#5806](https://github.com/DOI-USGS/ISIS3/issues/5806)
 
 ## [9.0.0] - 09-25-2024
 

--- a/isis/src/control/apps/pointreg/main.cpp
+++ b/isis/src/control/apps/pointreg/main.cpp
@@ -5,7 +5,7 @@ For more details about the LICENSE terms and the AUTHORS, you will
 find files of those names at the top level of this repository. **/
 
 /* SPDX-License-Identifier: CC0-1.0 */
-
+#define GUIHELPERS
 #include "Isis.h"
 
 #include "Application.h"
@@ -14,11 +14,32 @@ find files of those names at the top level of this repository. **/
 
 #include "pointreg.h"
 
+using namespace std;
 using namespace Isis;
+
+void printTemp();
+
+map<QString, void *> GuiHelpers() {
+  map<QString, void *> helper;
+  helper["PrintTemp"] = (void *) printTemp;
+  return helper;
+}
 
 void IsisMain() {
 
   UserInterface &ui = Application::GetUserInterface();
   Pvl appLog;
   pointreg(ui, &appLog); 
+}
+
+// Helper function to print out template to session log
+void printTemp() {
+  UserInterface &ui = Application::GetUserInterface();
+
+  // Get template pvl
+  Pvl userTemp;
+  userTemp.read(ui.GetFileName("DEFFILE"));
+
+  //Write template file out to the log
+  Isis::Application::GuiLog(userTemp);
 }

--- a/isis/src/control/apps/pointreg/pointreg.cpp
+++ b/isis/src/control/apps/pointreg/pointreg.cpp
@@ -195,13 +195,6 @@ namespace Isis {
   void verifyCube(Cube & cube);
   bool outputValue(ofstream &os, double value);
   int calcGoodMeasureCount(const ControlPoint *point);
-  void printTemp();
-
-  map<QString, void *> GuiHelpers() {
-    map<QString, void *> helper;
-    helper["PrintTemp"] = (void *) printTemp;
-    return helper;
-  }
 
 
   void pointreg(UserInterface &ui, Pvl *appLog) {
@@ -826,18 +819,5 @@ namespace Isis {
     }
 
     return goodMeasureCount;
-  }
-
-
-  // Helper function to print out template to session log
-  void printTemp() {
-    UserInterface &ui = Application::GetUserInterface();
-
-    // Get template pvl
-    Pvl userTemp;
-    userTemp.read(ui.GetFileName("DEFFILE"));
-
-    //Write template file out to the log
-    Isis::Application::GuiLog(userTemp);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the pointreg helper function for displaying the deffile

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
N/A

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Validated locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
