### PR TITLE
Changed mechanism for specifying shapemodel RayTraceEngine keywords from IsisPreferences to BulletEngineSelect.pref preference file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Added ShowDeprecated option to show or hide warnings in IsisPreferences. [#5611](https://github.com/DOI-USGS/ISIS3/issues/5611)
 
 ### Changed
+- Changed mechanism for specifying shapemodel RayTraceEngine keywords from IsisPreferences to BulletEngineSelect.pref file. BulletEngineSelect.pref was added to ISIS3/isis and CMakeLists.txt updated so that the file is copied to $ISISROOT by cmake. [#5807](https://github.com/DOI-USGS/ISIS3/issues/5807)
 - Removed Arm dependency on xalan-c, as it does not build for now on conda-forge. This requires turning off doc building on Arm. Also changed some variables to avoid name clashes on Arm with clang 16. [#5802])(https://github.com/DOI-USGS/ISIS3/pull/5802)
 - Update OSIRIS-REx OCams instrument (Map, Poly, & SamCam) support to current state in UofA code base [#5426](https://github.com/DOI-USGS/ISIS3/issues/5426)
 - Enhanced csminit by removing the need to specify model and plugin [#5585](https://github.com/DOI-USGS/ISIS3/issues/5585)

--- a/isis/BulletEngineSelect.pref
+++ b/isis/BulletEngineSelect.pref
@@ -1,0 +1,13 @@
+#######################################################
+# This file allows the user to customize their Isis
+# configuration.  See the Isis Preference Dictionary
+# on our website isis.astrogeology.usgs.gov for a
+# full description of each group.
+########################################################
+
+Group = ShapeModel
+  RayTraceEngine = Bullet
+  OnError = Continue
+EndGroup
+
+End

--- a/isis/BulletEngineSelect.pref
+++ b/isis/BulletEngineSelect.pref
@@ -1,8 +1,13 @@
-#######################################################
-# This file allows the user to customize their Isis
-# configuration.  See the Isis Preference Dictionary
-# on our website isis.astrogeology.usgs.gov for a
-# full description of each group.
+########################################################
+# Specifies Bullet ray-tracing engine for processing with
+# shape models.
+#
+# RayTraceEngine = Bullet
+# OnError = Continue | Fail
+# Tolerance = { numerical value that will be set as the
+#           tolerance for the Bullet or Embree shape
+#           model }
+#
 ########################################################
 
 Group = ShapeModel

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -421,6 +421,7 @@ install(CODE "EXECUTE_PROCESS(COMMAND rm -f ${CMAKE_INSTALL_PREFIX}/lib/libisis$
 install(CODE "EXECUTE_PROCESS(COMMAND rm -f ${CMAKE_INSTALL_PREFIX}/lib/libisis${VERSION_MAJOR}${SO})")
 EXECUTE_PROCESS(COMMAND cp -f ${CMAKE_SOURCE_DIR}/TestPreferences ${CMAKE_BINARY_DIR}/)
 install(CODE "EXECUTE_PROCESS(COMMAND cp -f ${CMAKE_SOURCE_DIR}/IsisPreferences ${CMAKE_INSTALL_PREFIX}/)")
+install(CODE "EXECUTE_PROCESS(COMMAND cp -f ${CMAKE_SOURCE_DIR}/BulletEngineSelect.pref ${CMAKE_INSTALL_PREFIX}/)")
 
 # Install the header files
 install(CODE "EXECUTE_PROCESS(COMMAND mkdir -p ${CMAKE_INSTALL_PREFIX}/include/isis)")
@@ -615,12 +616,14 @@ add_custom_target(clean_source COMMAND rm -rf "${CMAKE_BINARY_DIR}/*" "${CMAKE_I
 
 # Set up a few top level files for installation.
 EXECUTE_PROCESS(COMMAND cp -f  ${CMAKE_SOURCE_DIR}/IsisPreferences   ${CMAKE_BINARY_DIR})
+EXECUTE_PROCESS(COMMAND cp -f  ${CMAKE_SOURCE_DIR}/BulletEngineSelect.pref   ${CMAKE_BINARY_DIR})
 EXECUTE_PROCESS(COMMAND cp -rf ${CMAKE_SOURCE_DIR}/scripts           ${CMAKE_BINARY_DIR})
 EXECUTE_PROCESS(COMMAND cp -f  ${CMAKE_SOURCE_DIR}/../LICENSE.md    ${CMAKE_BINARY_DIR})
 EXECUTE_PROCESS(COMMAND cp -rf ${CMAKE_SOURCE_DIR}/make              ${CMAKE_BINARY_DIR})
 
 # Copy the files on make install as well
 install(FILES     ${CMAKE_SOURCE_DIR}/IsisPreferences DESTINATION  ${CMAKE_INSTALL_PREFIX})
+install(FILES     ${CMAKE_SOURCE_DIR}/BulletEngineSelect.pref DESTINATION  ${CMAKE_INSTALL_PREFIX})
 install(FILES     ${CMAKE_SOURCE_DIR}/../LICENSE.md   DESTINATION  ${CMAKE_INSTALL_PREFIX})
 install(FILES     ${CMAKE_SOURCE_DIR}/../AUTHORS.rst  DESTINATION  ${CMAKE_INSTALL_PREFIX})
 install(FILES     ${CMAKE_SOURCE_DIR}/../CHANGELOG.md DESTINATION  ${CMAKE_INSTALL_PREFIX})

--- a/isis/IsisPreferences
+++ b/isis/IsisPreferences
@@ -52,28 +52,6 @@ Group = ErrorFacility
 EndGroup
 
 ########################################################
-# Specify which ray-tracing engine to use for shape
-# models.
-#
-# Leave the ShapeModel Group commented-out to continue
-# using the ISIS default.
-#
-# RayTraceEngine = Bullet | Embree
-# OnError = Continue | Fail
-# Tolerance = { numerical value that will be set as the
-#           tolerance for the Bullet or Embree shape
-#           model }
-#
-########################################################
-
-#Group = ShapeModel
-#  RayTraceEngine = Embree
-#  OnError = Continue
-#  CubeSupported = False
-#  Tolerance = DBL_MAX
-#EndGroup
-
-########################################################
 # Customize how session logging is handled
 #
 # TerminalOutput = On | Off

--- a/isis/TestPreferences
+++ b/isis/TestPreferences
@@ -50,28 +50,6 @@ Group = ErrorFacility
 EndGroup
 
 ########################################################
-# Specify which ray-tracing engine to use for shape
-# models.
-#
-# Leave the ShapeModel Group commented-out to continue
-# using the ISIS default.
-#
-# RayTraceEngine = Bullet | Embree
-# OnError = Continue | Fail
-# Tolerance = { numerical value that will be set as the
-#           tolerance for the Bullet or Embree shape
-#           model }
-#
-########################################################
-
-#Group = ShapeModel
-#  RayTraceEngine = Embree
-#  OnError = Continue
-#  CubeSupported = False
-#  Tolerance = DBL_MAX
-#EndGroup
-
-########################################################
 # Customize how session logging is handled
 #
 # TerminalOutput = On | Off

--- a/isis/src/base/apps/spiceinit/spiceinit.xml
+++ b/isis/src/base/apps/spiceinit/spiceinit.xml
@@ -90,9 +90,11 @@
        not have their paths expanded.  This is to allow variables like $msg/ to work correctly.
     </p>
     <p>
-      The spiceinit program will also add the RayTraceEngine, OnError, and Tolerance keywords to the Kernels
-      group if specified in the IsisPreferences file. If included, these keywords specify the ray-tracing engine to use and how to use it for shapemodels.
-      Please see the IsisPreferences file for more details.
+      The <i>spiceinit</i> program will add the RayTraceEngine, OnError, and Tolerance keywords to the Kernels
+      group if specified in the preference file <i>BulletEngineSelect.pref</i>. These keywords set the
+      ray-tracing engine to use and how to use it for processing with shapemodels. To include these
+      keywords, run <i>spiceinit</i> with shape=user, a specified shape model, and
+      -pref=$ISISROOT/BulletEngineSelect.pref on the command line. 
 
     </p>
     <p><b>Troubleshooting:</b> If spiceinit is failing with the error


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Currently, _spiceinit_ adds the RayTraceEngine, OnError, and Tolerance keywords to the Kernels group from the IsisPreferences file to specify the ray-tracing engine for shapemodel processing. Having these keywords loaded via IsisPreferences is not desirable because it is loaded by every ISIS program every time they run. This has the potential to override existing selections used in spiceinit and produce unintended consequences. Providing these keywords in a dedicated preference file (e.g. BulletEngineSelect.pref) gives the user much more control over when they are applied.

The BulletEngineSelect.pref preference file was added to the "ISIS3/isis folder". This file contains the following...

Group = ShapeModel
   RayTraceEngine = Bullet
   OnError = Continue
EndGroup

and enables the user to set the RayTraceEngine to Bullet, in particular when running spiceinit on a cube.

Additionally, the CMakeLists.txt file was modifed to ensure BulletEngineSelect.pref is copied to $ISISROOT when running cmake.

References to RayTraceEngine keywords were removed from the IsisPreferences and TestPreferences files.

Documentation for _spiceinit_ was updated to reflect these changes.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/DOI-USGS/ISIS3/issues/5807

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
All ctests passing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [X] My code follows the code style of this project. -->
- [X] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [X] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [X] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [X] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [X] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
