### PR TITLE
Jigsaw fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Changed `StripPolygonSeeder` and `GridPolygonSeeder` to seed individual polygons within each images multipolygon footprint [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
 
 ### Fixed
+- Fixed a failure for jigsaw crashing when encountering an invalid control point. Now it is ignored. Added a warning when the problem is underconstrained. 
 - Fixed kaguyatc2isis invalid BandBin values [#5629](https://github.com/DOI-USGS/ISIS3/issues/5629)
 - Fixed SpiceClient to handle redirect requests.
 - Fixed jigsaw to default OUTADJUSTMENTH5 option to false and allow this feature to run on read-only images [#5700](https://github.com/DOI-USGS/ISIS3/issues/5700)

--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -224,7 +224,7 @@ namespace Isis {
                                                    under review and is likely resulting \
                                                    in addition error in the bundle adjust. \
                                                    We recommend that you do not solve for radii at this moment."));
-        Application::Log(radiusSolveWarning);
+        Application::AppendAndLog(radiusSolveWarning, log);
       }
     }
     settings->setCubeList(cubeList);

--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -209,7 +209,7 @@ namespace Isis {
         "failure may result.";
       PvlGroup radiusSolveWarning("RadiusSolveWarning");
       radiusSolveWarning.addKeyword(PvlKeyword("Warning", msg.c_str()));
-      Application::AppendLog(radiusSolveWarning, log);
+      Application::AppendAndLog(radiusSolveWarning, log);
     }
 
     QString cnetFile = ui.GetFileName("CNET");

--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -202,6 +202,19 @@ namespace Isis {
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
+    std::cout << "--twist is: " << (ui.GetBoolean("TWIST") ? "true" : "false") << std::endl;
+    std::cout << "radius is : " << (ui.GetBoolean("RADIUS") ? "true" : "false") << std::endl;
+    std::cout << "radius sigma " << ui.WasEntered("POINT_RADIUS_SIGMA") << std::endl;
+    if (ui.GetBoolean("TWIST") && ui.GetBoolean("RADIUS") && 
+        !ui.WasEntered("POINT_RADIUS_SIGMA")) {
+      string msg = "If solving for both twist and radius, must set a value "
+        "for point_radius_sigma, as otherwise the problem is under-constrained and a "
+        "failure may result.";
+      PvlGroup radiusSolveWarning("RadiusSolveWarning");
+      radiusSolveWarning.addKeyword(PvlKeyword("Warning", msg.c_str()));
+      Application::Log(radiusSolveWarning);
+    }
+
     QString cnetFile = ui.GetFileName("CNET");
 
     // retrieve settings from jigsaw gui

--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -202,14 +202,14 @@ namespace Isis {
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
-    if (ui.GetBoolean("TWIST") && ui.GetBoolean("RADIUS") && 
+    if (ui.GetBoolean("TWIST") && ui.GetBoolean("RADIUS") &&
         !ui.WasEntered("POINT_RADIUS_SIGMA")) {
       string msg = "If solving for both twist and radius, must set a value "
         "for point_radius_sigma, as otherwise the problem is under-constrained and a "
         "failure may result.";
       PvlGroup radiusSolveWarning("RadiusSolveWarning");
       radiusSolveWarning.addKeyword(PvlKeyword("Warning", msg.c_str()));
-      Application::Log(radiusSolveWarning);
+      Application::AppendLog(radiusSolveWarning, log);
     }
 
     QString cnetFile = ui.GetFileName("CNET");

--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -202,9 +202,6 @@ namespace Isis {
       throw IException(IException::User, msg, _FILEINFO_);
     }
 
-    std::cout << "--twist is: " << (ui.GetBoolean("TWIST") ? "true" : "false") << std::endl;
-    std::cout << "radius is : " << (ui.GetBoolean("RADIUS") ? "true" : "false") << std::endl;
-    std::cout << "radius sigma " << ui.WasEntered("POINT_RADIUS_SIGMA") << std::endl;
     if (ui.GetBoolean("TWIST") && ui.GetBoolean("RADIUS") && 
         !ui.WasEntered("POINT_RADIUS_SIGMA")) {
       string msg = "If solving for both twist and radius, must set a value "

--- a/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
+++ b/isis/src/control/objs/BundleAdjust/BundleAdjust.cpp
@@ -510,8 +510,7 @@ namespace Isis {
 
         BundleControlPointQsp bundleControlPoint(new BundleControlPoint
                             (m_bundleSettings, point));
-        m_bundleControlPoints.append(bundleControlPoint);
-
+        
         // set parent observation for each BundleMeasure
         int numMeasures = bundleControlPoint->size();
         for (int j = 0; j < numMeasures; j++) {
@@ -524,11 +523,18 @@ namespace Isis {
 
           measure->setParentObservation(observation);
           measure->setParentImage(image);
-        measure->setSigma(1.4);
+          measure->setSigma(1.4);
         }
 
-      point->ComputeApriori();
-    }
+        // Compute apriori. That can result in ignoring failed points.
+        point->ComputeApriori();
+        if (point->IsIgnored()) {
+          continue;
+        }
+        
+        // Add a successful point to the bundle control points
+        m_bundleControlPoints.append(bundleControlPoint);
+      }
 
     // set up vector of BundleLidarControlPoints
     int numLidarPoints = 0;

--- a/isis/src/control/objs/ControlPoint/ControlPoint.cpp
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.cpp
@@ -968,6 +968,7 @@ namespace Isis {
       msg += "no measures which project to the body. Will ignore it.";
       SetIgnored(true);
       std::cerr << msg << std::endl;
+      adjustedSurfacePoint = aprioriSurfacePoint;
       return Success;
     }
 

--- a/isis/src/control/objs/ControlPoint/ControlPoint.cpp
+++ b/isis/src/control/objs/ControlPoint/ControlPoint.cpp
@@ -962,12 +962,13 @@ namespace Isis {
 
     // if point is Free, we continue to compute a priori coordinates
 
-    // if no good measures, we're done
-    // TODO: is the message true/meaningful?
+    // If no good measures, this point is ignored
     if (goodMeasures == 0) {
-      QString msg = "in method ControlPoint::ComputeApriori(). ControlPoint [" + GetId() + "] has ";
-      msg += "no measures which project to the body";
-      throw IException(IException::User, msg, _FILEINFO_);
+      QString msg = "In method ControlPoint::ComputeApriori(): ControlPoint [" + GetId() + "] has ";
+      msg += "no measures which project to the body. Will ignore it.";
+      SetIgnored(true);
+      std::cerr << msg << std::endl;
+      return Success;
     }
 
     // Compute the averages if all coordinates are free


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

These are proposed fixes for jigsaw issues https://github.com/DOI-USGS/ISIS3/issues/5821 and https://github.com/DOI-USGS/ISIS3/issues/5818.

 - When an invalid control point is encountered, it should be ignored with a warning, rather than the program failing.
 - When solving for both twist and radius, and not setting point radius sigma, the tool will print a warning about the problem being under-constrained. This is not a fatal failure, for now, as I don't fully understand the implications of prohibiting this mode, but usually the program will fail soon enough in either case if the solution goes wild, and then the warning at least will explain why that may be.
  
## How Has This Been Validated?

I tested with a control network I had.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
