### PR TITLE
Add Individual List Option Exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Added ShowDeprecated option to show or hide warnings in IsisPreferences. [#5611](https://github.com/DOI-USGS/ISIS3/issues/5611)
 - Added SpiceQL integration to replace cspice calls. [#5545](https://github.com/DOI-USGS/ISIS3/pull/5545)
 - Added initial `eisstitch` app [#5591](https://github.com/DOI-USGS/ISIS3/pull/5591)
+- Added the ability to disable individual options for parameters in ISIS GUIs [#5849](https://github.com/DOI-USGS/ISIS3/pull/5849)
 
 ### Changed
 - Removed Arm dependency on xalan-c, as it does not build for now on conda-forge. This requires turning off doc building on Arm. Also changed some variables to avoid name clashes on Arm with clang 16. [#5802](https://github.com/DOI-USGS/ISIS3/pull/5802)

--- a/isis/src/base/objs/Gui/Gui.cpp
+++ b/isis/src/base/objs/Gui/Gui.cpp
@@ -819,8 +819,17 @@ namespace Isis {
       for(int i = 0; i < (int)excludeList.size(); i++) {
         for(unsigned int e = 0; e < p_parameters.size(); e++) {
           GuiParameter &exclude = *(p_parameters[e]);
-          if(exclude.Name() != excludeList[i]) continue;
-          exclude.SetEnabled(false, (param.Type()==GuiParameter::ComboWidget));
+          if (excludeList[i].contains('.')) {
+            QStringList liststr = excludeList[i].split('.', Qt::SkipEmptyParts);
+            QString exclusionName = liststr[0];
+            QString exclusionOption = liststr[1];
+            if(exclude.Name() != exclusionName) continue;
+            exclude.SetEnabledOption(false, exclusionOption, (param.Type()==GuiParameter::ComboWidget));
+          }
+          else {
+            if(exclude.Name() != excludeList[i]) continue;
+            exclude.SetEnabled(false, (param.Type()==GuiParameter::ComboWidget));
+          }
         }
       }
     }

--- a/isis/src/base/objs/Gui/GuiListParameter.cpp
+++ b/isis/src/base/objs/Gui/GuiListParameter.cpp
@@ -40,31 +40,25 @@ namespace Isis {
       btext += ui.ParamListValue(group, param, item);
       btext += ")";
 
-      // If there's helper buttons, they need to be added with the 1st value in
-      // the list
+      // If there's helper buttons, create a vertical box layout
+      // and add it next to the radio buttons
       if((item == 0) && (p_ui->HelpersSize(group, param) != 0)) {
-        // Create Horizontal layout box
-        QHBoxLayout *hlo = new QHBoxLayout;
-        lo->addLayout(hlo);
+        // Create Vertical layout box
+        QVBoxLayout *vlo = new QVBoxLayout;
+        grid->addLayout(vlo, 0, 3);
 
-        // Create radio button & add to horizontal layout
-        QRadioButton *rb = new QRadioButton(btext);
-        hlo->addWidget(rb);
-        p_buttonGroup->addButton(rb);
-
-        // Get helpers and add to horizontal layout
+        // Get helpers and add to vertical layout
         QWidget *helper = AddHelpers(p_buttonGroup);
-        hlo->addWidget(helper);
+        vlo->addWidget(helper, 0, Qt::AlignTop);
 
-        RememberWidget(rb);
         RememberWidget(helper);
       }
-      else {
-        QRadioButton *rb = new QRadioButton(btext);
-        lo->addWidget(rb);
-        p_buttonGroup->addButton(rb);
-        RememberWidget(rb);
-      }
+      // Create radio button & add to vertical layout
+      QRadioButton *rb = new QRadioButton(btext);
+      rb->setObjectName(ui.ParamListValue(group, param, item));
+      lo->addWidget(rb);
+      p_buttonGroup->addButton(rb);
+      RememberWidget(rb);
     }
     connect(p_buttonGroup, SIGNAL(buttonClicked(QAbstractButton *)),
             this, SIGNAL(ValueChanged()));

--- a/isis/src/base/objs/Gui/GuiParameter.cpp
+++ b/isis/src/base/objs/Gui/GuiParameter.cpp
@@ -213,6 +213,20 @@ namespace Isis {
     p_widgetList.push_back(w);
   }
 
+  //! Enable or disable individual radio/combo options
+  void GuiParameter::SetEnabledOption(bool enabled, QString option, bool isParentCombo) {
+    for(int i = 0; i < p_widgetList.size(); i++) {
+      QString objectName = p_widgetList[i]->objectName();
+      if (objectName == option) {
+        p_widgetList[i]->setEnabled(enabled);
+        p_widgetList[i]->setVisible(true);
+        if(isParentCombo && !enabled) {
+          p_widgetList[i]->setVisible(false);
+        }
+      }
+    }
+  }
+
   //! Enable or disable the parameter
   void GuiParameter::SetEnabled(bool enabled, bool isParentCombo) {
     if(p_type != ComboWidget) {

--- a/isis/src/base/objs/Gui/GuiParameter.h
+++ b/isis/src/base/objs/Gui/GuiParameter.h
@@ -55,6 +55,8 @@ namespace Isis {
 
       void SetEnabled(bool enabled, bool isParentCombo=false);
 
+      void SetEnabledOption(bool enabled, QString option, bool isParentCombo);
+
       //! Is the parameter enabled
       bool IsEnabled() const {
         return p_label->isEnabled();

--- a/isis/src/base/objs/IsisAml/IsisAml.cpp
+++ b/isis/src/base/objs/IsisAml/IsisAml.cpp
@@ -2866,7 +2866,8 @@ void IsisAml::VerifyAll() {
       }
 
       // If this parameter has a value, and a list/option/exclude, make sure
-      // the excluded parameter has NO value
+      // the excluded parameter has NO value or is not set to an excluded 
+      // value
       if(((param->values.size() > 0) || (param->defaultValues.size())) > 0) {
         for(unsigned int o2 = 0; o2 < param->listOptions.size(); o2++) {
           QString value, option;
@@ -2884,14 +2885,29 @@ void IsisAml::VerifyAll() {
           }
           if(value == option) {
             for(unsigned int e2 = 0; e2 < param->listOptions[o2].exclude.size(); e2++) {
-              const IsisParameterData *param2 =
-                ReturnParam(param->listOptions[o2].exclude[e2]);
-              if(param2->values.size() > 0) {
-                QString message = "Parameter [" + param2->name +
-                                 "] can not be entered if parameter [" +
-                                 param->name + "] is equal to [" +
-                                 value + "]";
-                throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
+              const IsisParameterData *param2 = nullptr;
+              QString exclude = param->listOptions[o2].exclude[e2];
+              if (exclude.contains('.')) {
+                QStringList splitList = exclude.split('.', Qt::SkipEmptyParts);
+                param2 = ReturnParam(splitList[0]);
+                exclude = splitList[1].toUpper();
+                if (exclude == param2->values[0].toUpper()) {
+                  QString message = "Parameter [" + param2->name +
+                                    "] can not be be used with option [" + exclude + "] "
+                                    "if parameter [" +param->name + "] is equal to [" +
+                                    exclude + "]";
+                  throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
+                }
+              }
+              else {
+                param2 = ReturnParam(exclude);
+                if(param2->values.size() > 0) {
+                  QString message = "Parameter [" + param2->name +
+                                    "] can not be entered if parameter [" +
+                                    param->name + "] is equal to [" +
+                                    value + "]";
+                  throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
+                }
               }
             }
           }

--- a/isis/src/base/objs/IsisAml/IsisAml.cpp
+++ b/isis/src/base/objs/IsisAml/IsisAml.cpp
@@ -2150,7 +2150,7 @@ Isis::CubeAttributeOutput &IsisAml::GetOutputAttribute(const QString &paramName)
  * @throws iException::User (Unknown Parameter)
  */
 const IsisParameterData *IsisAml::ReturnParam(const QString &paramName) const {
-  Isis::IString pn = paramName;
+  Isis::IString pn = paramName.split('.', Qt::SkipEmptyParts)[0];
   pn.UpCase();
   int found = 0;
   bool exact = false;
@@ -2644,10 +2644,22 @@ void IsisAml::VerifyAll() {
 
             const IsisParameterData *param2 = ReturnParam(param->exclude[item]);
             if(param2->values.size() > 0) {
-              QString message = "Parameter [" + param2->name +
-                               "] must NOT be used if parameter [" +
-                               param->name + "] equates to true.";
-              throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
+              QString exclude = param->exclude[item];
+              if (exclude.contains('.')) {
+                exclude = exclude.split('.', Qt::SkipEmptyParts)[1].toUpper();
+                if (exclude == param2->values[0].toUpper()) {
+                  QString message = "Parameter [" + param2->name +
+                                  "] must NOT be used with option [" + exclude + "]"
+                                  " if parameter [" + param->name + "] equates to true.";
+                  throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
+                }
+              }
+              else {
+                QString message = "Parameter [" + param2->name +
+                  "] must NOT be used if parameter [" +
+                  param->name + "] equates to true.";
+                throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
+              }
             }
           }
         }
@@ -2914,7 +2926,7 @@ void IsisAml::VerifyAll() {
 
       // If this parameter has a value, and a list/option/include, make sure
       // the included parameter has a value
-      if(((param->values.size() > 0) || (param->defaultValues.size())) > 0) {
+      if ((param->values.size() > 0) || (param->defaultValues.size() > 0)) {
         for(unsigned int o2 = 0; o2 < param->listOptions.size(); o2++) {
           QString value, option;
           if(param->type == "string"  || param->type == "combo") {

--- a/isis/src/base/objs/IsisAml/IsisAml.cpp
+++ b/isis/src/base/objs/IsisAml/IsisAml.cpp
@@ -2581,111 +2581,85 @@ void IsisAml::VerifyAll() {
 
       // Check the values for inclusive clauses
       for(unsigned int item = 0; item < param->include.size(); item++) {
-        // If this parameter is a boolean and it is true/yes
-        // all included parameters must have some type of value
-        if(param->type == "boolean") {
-          if(((param->values.size() > 0) && StringToBool(param->values[0])) ||
-              ((param->values.size() == 0) && (param->defaultValues.size() > 0)
-               && StringToBool(param->defaultValues[0]))) {
-
-            const IsisParameterData *param2 = ReturnParam(param->include[item]);
-            if((param2->values.size()) == 0 &&
-                (param2->defaultValues.size() == 0) &&
-                (param2->internalDefault.size() == 0)) {
-              QString message = "Parameter [" + param2->name +
-                               "] must be used if parameter [" +
-                               param->name + "] equates to true.";
-              throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
-            }
+        bool paramOneSet = false;
+        try {
+          QString parameterValue = GetAsString(param->name);
+          paramOneSet = true;
+          if (param->type == "boolean") {
+            paramOneSet = Isis::toBool(parameterValue);
           }
         }
-        // This parameter is NOT a boolean but the other one might be
-        else {
-          // If the other parameter is a boolean and it is true/yes
-          // then this parameter must have some type of value
-          const IsisParameterData *param2 = ReturnParam(param->include[item]);
-          if(param2->type == "boolean") {
-            if(((param2->values.size() > 0) && StringToBool(param2->values[0])) ||
-                ((param2->values.size() == 0) && (param2->defaultValues.size() > 0) &&
-                 StringToBool(param2->defaultValues[0]))) {
-              if((param->values.size()) == 0 &&
-                  (param->defaultValues.size() == 0) &&
-                  (param->internalDefault.size() == 0)) {
-                QString message = "Parameter [" + param2->name +
-                                 "] must be used if parameter [" +
-                                 param->name + "] is used.";
-                throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
-              }
-            }
+        catch (Isis::IException &e) {
+          if (param->internalDefault.size() > 0) {
+            paramOneSet = true;
           }
-          // Neithter parameter is a boolean so
-          // If this one has a value the other parameter must have some type of value
-          else {
-            if(param->values.size() > 0 &&
-                param2->values.size() == 0 &&
-                param2->defaultValues.size() == 0 &&
-                param2->internalDefault.size() == 0) {
-              QString message = "Parameter [" + param2->name +
-                               "] must be used if parameter [" +
-                               param->name + "] is used.";
-              throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
-            }
+        }
+
+        const IsisParameterData *param2 = ReturnParam(param->include[item]);
+        bool paramTwoSet = false;
+        try {
+          QString parameterValue = GetAsString(param2->name);
+          paramTwoSet = true;
+        }
+        catch (Isis::IException &e) {
+          if (param2->internalDefault.size() > 0) {
+            paramTwoSet = true;
           }
+        }
+
+        if (paramOneSet && !paramTwoSet) {
+          QString messageEnd = "is used.";
+          if (param->type == "boolean") {
+            messageEnd = "equates to true.";
+          }
+          QString message = "Parameter [" + param2->name +
+                            "] must be used if parameter [" +
+                            param->name + "] " + messageEnd;
+          throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
         }
       }
+
       // Check the values for exclusive clauses
       for(unsigned int item = 0; item < param->exclude.size(); item++) {
-        // If this parameter is a boolean that is true/yes
-        // the other parameter should not have a value
-        if(param->type == "boolean") {
-          if(((param->values.size() > 0) && StringToBool(param->values[0])) ||
-              ((param->values.size() == 0) && (param->defaultValues.size() > 0) &&
-               StringToBool(param->defaultValues[0]))) {
-
-            const IsisParameterData *param2 = ReturnParam(param->exclude[item]);
-            if(param2->values.size() > 0) {
-              QString exclude = param->exclude[item];
-              if (exclude.contains('.')) {
-                exclude = exclude.split('.', Qt::SkipEmptyParts)[1].toUpper();
-                if (exclude == param2->values[0].toUpper()) {
-                  QString message = "Parameter [" + param2->name +
-                                  "] must NOT be used with option [" + exclude + "]"
-                                  " if parameter [" + param->name + "] equates to true.";
-                  throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
-                }
-              }
-              else {
-                QString message = "Parameter [" + param2->name +
-                  "] must NOT be used if parameter [" +
-                  param->name + "] equates to true.";
-                throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
-              }
-            }
+        bool paramOneSet = false;
+        try {
+          paramOneSet = WasEntered(param->name);
+          if (param->type == "boolean") {
+            paramOneSet = GetBoolean(param->name);
           }
         }
-        // This parameter is NOT a boolean but the other one might be
-        else {
-          const IsisParameterData *param2 = ReturnParam(param->exclude[item]);
-          if(param2->type == "boolean") {
-            if(((param2->values.size() > 0) && StringToBool(param2->values[0])) ||
-                ((param2->values.size() == 0) && (param2->defaultValues.size() > 0) &&
-                 StringToBool(param2->defaultValues[0]))) {
-              if(param->values.size() > 0) {
-                QString message = "Parameter [" + param2->name +
-                                 "] must be used if parameter [" +
-                                 param->name + "] is used.";
-                throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
-              }
-            }
+        catch (Isis::IException &e) {}
+
+        const IsisParameterData *param2 = ReturnParam(param->exclude[item]);
+        bool paramTwoSet = false;
+        try {
+          paramTwoSet = WasEntered(param2->name);
+          if (param2->type == "boolean") {
+            paramTwoSet = GetBoolean(param2->name);
           }
-          // Neither parameter is a boolean
-          else {
-            if(param->values.size() > 0 && param2->values.size() > 0) {
+        }
+        catch (Isis::IException &e) {}
+
+        if (paramOneSet && paramTwoSet) {
+          QString messageEnd = "is used.";
+          if (param->type == "boolean") {
+            messageEnd = "equates to true.";
+          }
+          QString exclude = param->exclude[item];
+          if (exclude.contains('.')) {
+            exclude = exclude.split('.', Qt::SkipEmptyParts)[1].toUpper();
+            if (exclude == param2->values[0].toUpper()) {
               QString message = "Parameter [" + param2->name +
-                               "] must NOT be used if parameter [" +
-                               param->name + "] is used.";
+                                "] must NOT be used with option [" + exclude + "]"
+                                " if parameter [" + param->name + "] " + messageEnd;
               throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
             }
+          }
+          else {
+            QString message = "Parameter [" + param2->name +
+                              "] must NOT be used if parameter [" +
+                              param->name + "] " + messageEnd;;
+            throw Isis::IException(Isis::IException::User, message, _FILEINFO_);
           }
         }
       }
@@ -3014,7 +2988,7 @@ void IsisAml::VerifyAll() {
         }
 
         // See if this parameter excludes any other (this implies the other
-        // one also excludes this one too
+        // one also excludes this one too)
         for(unsigned int item = 0; item < param->exclude.size(); item++) {
           const IsisParameterData *param2 = ReturnParam(param->exclude[item]);
           if((param2->values.size() != 0) ||

--- a/isis/src/base/objs/IsisAml/IsisAml.truth
+++ b/isis/src/base/objs/IsisAml/IsisAml.truth
@@ -627,6 +627,7 @@ Create the aml object
         [1] = G5P2
       Exclude parameters:
         [0] = G5P3
+        [1] = G5P4.2
       List data:
     parameter 1, name = G5P1
       type = integer
@@ -706,6 +707,36 @@ Create the aml object
         [1] = G5P1
         [2] = G5P2
       List data:
+    parameter 4, name = G5P4
+      type = integer
+      brief = Brief for parameter G5P4
+      description = Description for G5P4.
+      internal def = 
+      helpers = 0
+      count = 
+      minimum = 
+      minimum inclusive = 
+      maximum = 
+      maximum inclusive = 
+      filter = 
+      file mode = 
+      odd = 
+      Values:
+      Default Values:
+      Greater Than:
+      Greater or Equal Than:
+      Less Than:
+      Less Than or Equal:
+      Not equal to:
+      Include parameters:
+      Exclude parameters:
+      List data:
+        value [0] = 1
+        brief [0] = 
+        description [0] = 
+        value [1] = 2
+        brief [1] = 
+        description [1] = 
   group 6 name = Group 6, boolean tests
     parameter 0, name = G6P0
       type = boolean
@@ -737,6 +768,7 @@ Create the aml object
         [0] = G6P1
       Exclude parameters:
         [0] = G6P2
+        [1] = G6P4.G6P4L0
       List data:
     parameter 1, name = G6P1
       type = integer
@@ -811,6 +843,70 @@ Create the aml object
       Include parameters:
       Exclude parameters:
       List data:
+    parameter 4, name = G6P4
+      type = string
+      brief = Brief for parameter G6P4
+      description = Description for G6P4.
+      internal def = 
+      helpers = 0
+      count = 
+      minimum = 
+      minimum inclusive = 
+      maximum = 
+      maximum inclusive = 
+      filter = 
+      file mode = 
+      odd = 
+      Values:
+      Default Values:
+      Greater Than:
+      Greater or Equal Than:
+      Less Than:
+      Less Than or Equal:
+      Not equal to:
+      Include parameters:
+      Exclude parameters:
+      List data:
+        value [0] = G6P4L0
+        brief [0] = Brief for list item G6P4L0
+        description [0] = Description for list item G6P4L0
+        value [1] = G6P4L1
+        brief [1] = Brief for list item G6P4L1
+        description [1] = Description for list item G6P4L1
+        value [2] = G6P4L2
+        brief [2] = Brief for list item G6P4L2
+        description [2] = Description for list item G6P4L2
+          exclude = G6P5.G6P5L0
+    parameter 5, name = G6P5
+      type = string
+      brief = Brief for parameter G6P5
+      description = Description for G6P5.
+      internal def = None
+      helpers = 0
+      count = 
+      minimum = 
+      minimum inclusive = 
+      maximum = 
+      maximum inclusive = 
+      filter = 
+      file mode = 
+      odd = 
+      Values:
+      Default Values:
+      Greater Than:
+      Greater or Equal Than:
+      Less Than:
+      Less Than or Equal:
+      Not equal to:
+      Include parameters:
+      Exclude parameters:
+      List data:
+        value [0] = G6P5L0
+        brief [0] = Brief for list item G6P5L0
+        description [0] = Description for list item G6P5L0
+        value [1] = G6P5L1
+        brief [1] = Brief for list item G6P5L1
+        description [1] = Description for list item G6P5L1
   group 7 name = Group 7, name search test
     parameter 0, name = FROM
       type = string
@@ -1265,6 +1361,26 @@ Parameter information:
       File Mode: 
       Helper Information:
       List Information:
+    Parameter number: 4
+      Name: G5P4
+      Type: integer
+      Brief: Brief for parameter G5P4
+      Default: 
+      Internal default: 
+      Filter: 
+      File Mode: 
+      Helper Information:
+      List Information:
+        Value: 1
+        Brief: 
+        Description: 
+        List exclusions: 
+        List inclusions: 
+        Value: 2
+        Brief: 
+        Description: 
+        List exclusions: 
+        List inclusions: 
   Group number: 6
   Group name : Group 6, boolean tests
     Parameter number: 0
@@ -1312,6 +1428,52 @@ Parameter information:
       File Mode: 
       Helper Information:
       List Information:
+    Parameter number: 4
+      Name: G6P4
+      Type: string
+      Brief: Brief for parameter G6P4
+      Default: 
+      Internal default: 
+      Filter: 
+      File Mode: 
+      Helper Information:
+      List Information:
+        Value: G6P4L0
+        Brief: Brief for list item G6P4L0
+        Description: Description for list item G6P4L0
+        List exclusions: 
+        List inclusions: 
+        Value: G6P4L1
+        Brief: Brief for list item G6P4L1
+        Description: Description for list item G6P4L1
+        List exclusions: 
+        List inclusions: 
+        Value: G6P4L2
+        Brief: Brief for list item G6P4L2
+        Description: Description for list item G6P4L2
+        List exclusions: 
+          Exclude parameter: G6P5.G6P5L0
+        List inclusions: 
+    Parameter number: 5
+      Name: G6P5
+      Type: string
+      Brief: Brief for parameter G6P5
+      Default: 
+      Internal default: None
+      Filter: 
+      File Mode: 
+      Helper Information:
+      List Information:
+        Value: G6P5L0
+        Brief: Brief for list item G6P5L0
+        Description: Description for list item G6P5L0
+        List exclusions: 
+        List inclusions: 
+        Value: G6P5L1
+        Brief: Brief for list item G6P5L1
+        Description: Description for list item G6P5L1
+        List exclusions: 
+        List inclusions: 
   Group number: 7
   Group name : Group 7, name search test
     Parameter number: 0
@@ -1528,10 +1690,13 @@ Group = UserParameters
   G5P0  = 9
   G5P1  = 10
   G5P2  = 11
+  G5P4  = 1
   G6P0  = yes
   G6P1  = 13
   G6P2  = 100
   G6P3  = STRING2
+  G6P4  = G6P4L1
+  G6P5  = G6P5L1
   FROM  = STRING3
   FROM1 = STRING4
   FR    = STRING4
@@ -1545,6 +1710,13 @@ End
 **USER ERROR** Parameter [G1P3] must be entered if parameter [G1P0] is equal to [G1P0L1X].
 
 ---------- Check for value in an option/list/excluded parameter ----------
+**USER ERROR** Parameter [G6P4] must NOT be used with option [G6P4L0] if parameter [G6P0] equates to true.
+
+**USER ERROR** Parameter [G5P4] must NOT be used with option [2] if parameter [G5P0] is used.
+
+**USER ERROR** Parameter [G6P5] can not be be used with option [G6P5L0] if parameter [G6P4] is equal to [G6P5L0].
+
+---------- Check for list value exclude in a parameter ----------
 **USER ERROR** Parameter [G2P0] can not be entered if parameter [G1P0] is equal to [G1P0L0].
 
 ---------- Check error for unknown parameter ----------

--- a/isis/src/base/objs/IsisAml/unitTest.cpp
+++ b/isis/src/base/objs/IsisAml/unitTest.cpp
@@ -652,6 +652,9 @@ int main(void) {
 
   aml->Clear("G5P3");
 
+  aml->Clear("G5P4");
+  aml->PutAsString("G5P4", "1");
+
   aml->Clear("G6P0");
   aml->PutAsString("G6P0", "yes");
 
@@ -662,6 +665,12 @@ int main(void) {
 
   aml->Clear("G6P3");
   aml->PutAsString("G6P3", "STRING2");
+
+  aml->Clear("G6P4");
+  aml->PutAsString("G6P4", "G6P4L1");
+
+  aml->Clear("G6P5");
+  aml->PutAsString("G6P5", "G6P5L1");
 
   aml->Clear("FROM");
   aml->PutAsString("FROM", "STRING3");
@@ -714,6 +723,59 @@ int main(void) {
   aml->PutAsString("G1P0", "G1P0L0");
 
   cout << "---------- Check for value in an option/list/excluded parameter ----------" << endl;
+  aml->Clear("G6P4");
+  aml->PutAsString("G6P4", "G6P4L0");
+  try { // PARAMETER CAN NOT BE ENTERED IF OTHER PARAMETER HAS PARTICULAR VALUE
+    aml->VerifyAll();
+  }
+  catch(IException &error) {
+    ReportError(error.toString());
+  }
+  aml->Clear("G6P4");
+
+  aml->Clear("G5P4");
+  aml->PutAsString("G5P4", "2");
+  try { // PARAMETER CAN NOT BE ENTERED IF OTHER PARAMETER HAS PARTICULAR VALUE
+    aml->VerifyAll();
+  }
+  catch(IException &error) {
+    ReportError(error.toString());
+  }
+  aml->Clear("G5P4");
+  aml->PutAsString("G5P4", "1");
+
+  aml->Clear("G6P4");
+  aml->PutAsString("G6P4", "G6P4L2");
+  aml->Clear("G6P5");
+  aml->PutAsString("G6P5", "G6P5L0");
+  try { // PARAMETER CAN NOT BE ENTERED IF OTHER PARAMETER HAS PARTICULAR VALUE
+    aml->VerifyAll();
+  }
+  catch(IException &error) {
+    ReportError(error.toString());
+  }
+
+  aml->Clear("G6P5");
+  aml->PutAsString("G6P5", "G6P5L1");
+  try { // PARAMETER CAN NOT BE ENTERED IF OTHER PARAMETER HAS PARTICULAR VALUE
+    aml->VerifyAll();
+  }
+  catch(IException &error) {
+    ReportError(error.toString());
+  }
+  aml->Clear("G6P4");
+  aml->Clear("G6P5");
+
+  aml->Clear("G6P4");
+  aml->PutAsString("G6P4", "G6P4L2");
+  try { // PARAMETER CAN NOT BE ENTERED IF OTHER PARAMETER HAS PARTICULAR VALUE
+    aml->VerifyAll();
+  }
+  catch(IException &error) {
+    ReportError(error.toString());
+  }
+
+  cout << "---------- Check for list value exclude in a parameter ----------" << endl;
   aml->PutAsString("G2P0", "0");
   try { // PARAMETER CAN NOT BE ENTERED IF OTHER PARAMETER HAS PARTICULAR VALUE
     aml->VerifyAll();

--- a/isis/src/base/objs/IsisAml/unitTest.xml
+++ b/isis/src/base/objs/IsisAml/unitTest.xml
@@ -415,6 +415,7 @@
         </inclusions>
         <exclusions>
           <item>G5P3</item>
+          <item>G5P4.2</item>
         </exclusions>
       </parameter>
 
@@ -453,6 +454,20 @@
           <item>G5P2</item>
         </exclusions>
       </parameter>
+
+      <parameter name="G5P4">
+        <type>integer</type>
+        <brief>Brief for parameter G5P4</brief>
+        <description>
+          Description for G5P4.
+        </description>
+        <list>
+          <option value="1">
+          </option>
+          <option value="2">
+          </option>
+        </list>
+      </parameter>
     </group>
 
     <group name="Group 6, boolean tests">
@@ -476,6 +491,7 @@
         </inclusions>
         <exclusions>
           <item>G6P2</item>
+          <item>G6P4.G6P4L0</item>
         </exclusions>
       </parameter>
 
@@ -497,12 +513,69 @@
           <item>100</item>
         </default>
       </parameter>
+
       <parameter name="G6P3">
         <type>string</type>
         <brief>Brief for parameter G6P3</brief>
         <description>
           Description for G6P3.
         </description>
+      </parameter>
+
+      <parameter name="G6P4">
+        <type>string</type>
+        <brief>Brief for parameter G6P4</brief>
+        <description>
+          Description for G6P4.
+        </description>
+        <list>
+          <option value="G6P4L0">
+            <brief>Brief for list item G6P4L0</brief>
+            <description>
+              Description for list item G6P4L0
+            </description>
+          </option>
+          <option value="G6P4L1">
+            <brief>Brief for list item G6P4L1</brief>
+            <description>
+              Description for list item G6P4L1
+            </description>
+          </option>
+          <option value="G6P4L2">
+            <brief>Brief for list item G6P4L2</brief>
+            <description>
+              Description for list item G6P4L2
+            </description>
+            <exclusions>
+              <item>G6P5.G6P5L0</item>
+            </exclusions>
+          </option>
+        </list>
+      </parameter>
+
+      <parameter name="G6P5">
+        <type>string</type>
+        <brief>Brief for parameter G6P5</brief>
+        <description>
+          Description for G6P5.
+        </description>
+        <internalDefault>
+          None
+        </internalDefault>
+        <list>
+          <option value="G6P5L0">
+            <brief>Brief for list item G6P5L0</brief>
+            <description>
+              Description for list item G6P5L0
+            </description>
+          </option>
+          <option value="G6P5L1">
+            <brief>Brief for list item G6P5L1</brief>
+            <description>
+              Description for list item G6P5L1
+            </description>
+          </option>
+        </list>
       </parameter>
     </group>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allows developers to exclude individual `<list><option>`s within app `.xml`. Given the following:
```
  <parameter name="PIXRES">
    <type>string</type>
    <default><item>CAMERA</item></default>
    <list>
      <option value="CAMERA">
      </option>

      <option value="MAP">
      </option>
    </list>
  </parameter>
```

You can add an exclusion to another parameter as `PIXRES.MAP` and this will exclude the `MAP` option in `PIXRES`

Here is a case where enabling `USEPROJ`, disables the `MAP` option in `PIXRES`.
<img width="720" alt="Screenshot 2025-07-08 at 3 27 01 PM" src="https://github.com/user-attachments/assets/68965c25-4c51-49ac-820f-425e2f1def15" />

<img width="720" alt="Screenshot 2025-07-08 at 3 27 18 PM" src="https://github.com/user-attachments/assets/806b73aa-efca-4e29-aa6b-a8aff43736de" />


This PR also adjusts the helper icon position within the GUI to be better aligned with the options for the parameter.
Before:
<img width="711" alt="Screenshot 2025-07-08 at 3 31 39 PM" src="https://github.com/user-attachments/assets/4ee52719-4986-4f35-95e0-802e99248bfd" />

After:
<img width="712" alt="Screenshot 2025-07-08 at 3 31 54 PM" src="https://github.com/user-attachments/assets/d25e4e67-3ca1-4c12-b4c2-d9d089684ff4" />


## Related Issue
IAA PROJ integration

## How Has This Been Validated?
Validated locally, needs regression tests. Does not break current test suite

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
