### PR TITLE
Test Consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Changed file format to propagate from the input image format to the output image format [#5737](https://github.com/DOI-USGS/ISIS3/pull/5737)
 - Changed `StripPolygonSeeder` and `GridPolygonSeeder` to seed individual polygons within each images multipolygon footprint [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
 - Pinned SpiceQL to 1.2.0 [#5852](https://github.com/DOI-USGS/ISIS3/pull/5852)
+- Changed `noseam` to apply `highpass` and `lowpass` to the same mosaic [#5862](https://github.com/DOI-USGS/ISIS3/pull/5862)
+- Changed `ControlMeasure` object comparison to no longer factor in creation date for equality [#5862](https://github.com/DOI-USGS/ISIS3/pull/5862)
 
 ### Fixed
 - Fixed kaguyatc2isis invalid BandBin values [#5629](https://github.com/DOI-USGS/ISIS3/issues/5629)

--- a/isis/src/base/apps/noseam/noseam.cpp
+++ b/isis/src/base/apps/noseam/noseam.cpp
@@ -80,40 +80,21 @@ namespace Isis {
 
     QString match = ui.GetAsString("MATCHBANDBIN");
 
-    // Sets up the pathName to be used for most application calls
-    FileName inFile = cubes[0];
-
     QString pathName = FileName("$TEMPORARY/").expanded();
 
     /**
-     * Creates a mosaic from the original images.  It is placed here
-     * so that the failure MATCHBANDBIN causes does not leave
-     * highpasses cubes lying around!
+     * Creates a mosaic from the original images.
     */
     QString parameters = "FROMLIST=" + cubeListFileName.original() + 
                         " MOSAIC=" + pathName + "OriginalMosaic.cub" +
                         " MATCHBANDBIN=" + match;
     ProgramLauncher::RunIsisProgram("automos", parameters);
 
-    // Creates the highpass cubes from the cubes FileList
-    ofstream highPassList;
-    highPassList.open("HighPassList.lis");
-    for(int i = 0; i < cubes.size(); i++) {
-      inFile = cubes[i];
-      QString outParam = pathName + inFile.baseName() + "_highpass.cub";
-      parameters = "FROM=" + inFile.expanded() +
-                   " TO=" + outParam
-                   + " SAMPLES=" + toString(samples) + " LINES=" + toString(lines);
-      ProgramLauncher::RunIsisProgram("highpass", parameters);
-      // Reads the just created highpass cube into a list file for automos
-      highPassList << outParam << endl;
-    }
-    highPassList.close();
-
-    // Makes a mosaic out of the highpass cube filelist
-    parameters = "FROMLIST=HighPassList.lis MOSAIC=" + pathName + "HighpassMosaic.cub"
-                 + " MATCHBANDBIN=" + match;
-    ProgramLauncher::RunIsisProgram("automos", parameters);
+    // Does a highpass on the original mosaic
+    parameters = "FROM=" + pathName + "OriginalMosaic.cub" +
+                  " TO=" + pathName + "HighpassMosaic.cub"
+                  + " SAMPLES=" + toString(samples) + " LINES=" + toString(lines);
+    ProgramLauncher::RunIsisProgram("highpass", parameters);
 
     // Does a lowpass on the original mosaic
     parameters = "FROM=" + pathName + "OriginalMosaic.cub"
@@ -130,20 +111,13 @@ namespace Isis {
 
     // Will remove all of the temp files by default
     if(ui.GetBoolean("REMOVETEMP")) {
-      QString file("HighPassList.lis");
-      remove(file.toLatin1().data());
+      QString file;
       file = pathName + "HighpassMosaic.cub";
       remove(file.toLatin1().data());
       file = pathName + "LowpassMosaic.cub";
       remove(file.toLatin1().data());
       file = pathName + "OriginalMosaic.cub";
       remove(file.toLatin1().data());
-
-      for(int i = 0; i < cubes.size(); i++) {
-        inFile = cubes[i];
-        file = pathName + inFile.baseName() + "_highpass.cub";
-        remove(file.toLatin1().data());
-      }
     }
   }
 }

--- a/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
+++ b/isis/src/control/objs/ControlMeasure/ControlMeasure.cpp
@@ -1088,7 +1088,6 @@ namespace Isis {
     return pMeasure.p_measureType == p_measureType &&
         *pMeasure.p_serialNumber == *p_serialNumber &&
         *pMeasure.p_chooserName == *p_chooserName &&
-        *pMeasure.p_dateTime == *p_dateTime &&
         pMeasure.p_editLock == p_editLock &&
         pMeasure.p_ignore == p_ignore &&
         pMeasure.p_jigsawRejected == p_jigsawRejected &&

--- a/isis/tests/OsirisRexMapCamModuleTests.cpp
+++ b/isis/tests/OsirisRexMapCamModuleTests.cpp
@@ -240,7 +240,7 @@ TEST(OsirisRexMapCamModules, MapCamModuleExplodeReuniteTest) {
    *         2) algebra
    *            - 20190223T023051S790_map_iofL2pan_algebra.cub
    */
-  TEST(OsirisRexMapCamModules, MapCamModuleAlgebraTest) {
+TEST(OsirisRexMapCamModules, MapCamModuleAlgebraTest) {
   QTemporaryDir tempDir;
 
   // ingest mapcam fits format image with ocams2isis
@@ -311,7 +311,7 @@ TEST(OsirisRexMapCamModules, MapCamModuleExplodeReuniteTest) {
    *         5) stats
    *            - 20190223T023051S790_map_iofL2pan_dnstats.pvl
    */
-  TEST(OsirisRexMapCamModules, MapCamModuleInfoAndStatsTest) {
+TEST(OsirisRexMapCamModules, MapCamModuleInfoAndStatsTest) {
   QTemporaryDir tempDir;
 
   // ingest mapcam fits format image with ocams2isis and then spiceinit
@@ -618,7 +618,7 @@ TEST(OsirisRexMapCamModules, MapCamModuleExplodeReuniteTest) {
    *         2) campt
    *            - 20190223T023051S790_map_iofL2pan.cub_campt.pvl
    */
-  TEST(OsirisRexMapCamModules, MapCamModuleCamptTest) {
+TEST(OsirisRexMapCamModules, MapCamModuleCamptTest) {
   QTemporaryDir tempDir;
 
   // ingest mapcam fits format image with ocams2isis and then spiceinit
@@ -1052,7 +1052,7 @@ TEST(OsirisRexMapCamModules, MapCamModuleExplodeReuniteTest) {
    *         9) pointreg
    *            - mapcam_pointreg.net
    */
-  TEST(OsirisRexMapCamModules, MapCamModuleTwoImageTest) {
+TEST(OsirisRexMapCamModules, MapCamModuleTwoImageTest) {
   QTemporaryDir tempDir;
 
   // ingest 1st mapcam fits format image, then spiceinit and footprintinit 
@@ -1282,7 +1282,7 @@ TEST(OsirisRexMapCamModules, MapCamModuleExplodeReuniteTest) {
 
   std::unique_ptr<Histogram> noseamMosaicHist(noseamMosaic.histogram());
   EXPECT_NEAR(noseamMosaicHist->Average(), 0.0040496894214538124, 0.005);
-  EXPECT_NEAR(noseamMosaicHist->Sum(), 7338.8188217326478, 0.005);
+  EXPECT_NEAR(noseamMosaicHist->Sum(), 7338.5876967209242, 0.005);
   EXPECT_EQ(noseamMosaicHist->ValidPixels(), 1812193);
   EXPECT_NEAR(noseamMosaicHist->StandardDeviation(), 0.0037573821357031172, 0.005);
 

--- a/isis/tests/OsirisRexPolyCamModuleTests.cpp
+++ b/isis/tests/OsirisRexPolyCamModuleTests.cpp
@@ -241,7 +241,7 @@ TEST(OsirisRexPolyCamModules, PolyCamModuleExplodeReuniteTest) {
    *         2) algebra
    *            - 20190328T200344S309_pol_iofL2pan_algebra.cub
    */
-  TEST(OsirisRexPolyCamModules, PolyCamModuleAlgebraTest) {
+TEST(OsirisRexPolyCamModules, PolyCamModuleAlgebraTest) {
   QTemporaryDir tempDir;
 
   // ingest polycam fits format image with ocams2isis
@@ -315,7 +315,7 @@ TEST(OsirisRexPolyCamModules, PolyCamModuleExplodeReuniteTest) {
    *         5) stats
    *            - 20190328T200344S309_pol_iofL2pan_dnstats.pvl
    */ 
-  TEST(OsirisRexPolyCamModules, PolyCamModuleInfoAndStatsTest) {
+TEST(OsirisRexPolyCamModules, PolyCamModuleInfoAndStatsTest) {
   QTemporaryDir tempDir;
 
   // ingest polycam fits format image with ocams2isis
@@ -629,7 +629,7 @@ TEST(OsirisRexPolyCamModules, PolyCamModuleExplodeReuniteTest) {
    *         2) campt
    *            - 20190328T200344S309_pol_iofL2pan.cub_campt.pvl
    */
-  TEST(OsirisRexPolyCamModules, PolyCamModuleCamptTest) {
+TEST(OsirisRexPolyCamModules, PolyCamModuleCamptTest) {
   QTemporaryDir tempDir;
 
   // ingest polycam fits format image with ocams2isis
@@ -1067,7 +1067,7 @@ TEST(OsirisRexPolyCamModules, PolyCamModuleExplodeReuniteTest) {
    *         9) pointreg
    *            - polycam_pointreg.net
    */
-  TEST(OsirisRexPolyCamModules, PolyCamModuleTwoImageTest) {
+TEST(OsirisRexPolyCamModules, PolyCamModuleTwoImageTest) {
   QTemporaryDir tempDir;
 
   // ingest 1st polycam fits format image 
@@ -1309,7 +1309,7 @@ TEST(OsirisRexPolyCamModules, PolyCamModuleExplodeReuniteTest) {
 
   std::unique_ptr<Histogram> noseamMosaicHist(noseamMosaic.histogram());
   EXPECT_NEAR(noseamMosaicHist->Average(), 0.013594249872813711, 0.005);
-  EXPECT_NEAR(noseamMosaicHist->Sum(), 28517.09297419725, 0.014);
+  EXPECT_NEAR(noseamMosaicHist->Sum(), 28517.175773404939, 0.014);
   EXPECT_EQ(noseamMosaicHist->ValidPixels(), 2097732);
   EXPECT_NEAR(noseamMosaicHist->StandardDeviation(), 0.0073422521190466645, 0.005);
 

--- a/isis/tests/OsirisRexSamCamModuleTests.cpp
+++ b/isis/tests/OsirisRexSamCamModuleTests.cpp
@@ -655,7 +655,7 @@ TEST(OsirisRexSamCamModules, SamCamModuleInfoAndStatsTest)
  *         2) campt
  *            - 20200811T221418S029_sam_iofL2pan5.cub_campt.pvl
  */
-  TEST(OsirisRexSamCamModules, SamCamModuleCamptTest) {
+TEST(OsirisRexSamCamModules, SamCamModuleCamptTest) {
   QTemporaryDir tempDir;
 
   // ingest polycam fits format image with ocams2isis
@@ -1092,7 +1092,7 @@ TEST(OsirisRexSamCamModules, SamCamModuleInfoAndStatsTest)
  *         9) pointreg
  *            - samcam_pointreg.net
  */
-  TEST(OsirisRexSamCamModules, SamCamModuleTwoImageTest) {
+TEST(OsirisRexSamCamModules, SamCamModuleTwoImageTest) {
   QTemporaryDir tempDir;
 
   // ingest 1st samcam fits format image, then spiceinit and footprintinit
@@ -1330,7 +1330,7 @@ TEST(OsirisRexSamCamModules, SamCamModuleInfoAndStatsTest)
 
   std::unique_ptr<Histogram> noseamMosaicHist(noseamMosaic.histogram());
   EXPECT_NEAR(noseamMosaicHist->Average(), 0.010375753089644776, 0.005);
-  EXPECT_NEAR(noseamMosaicHist->Sum(), 11976.949682191847, 0.005);
+  EXPECT_NEAR(noseamMosaicHist->Sum(), 11976.425999546173, 0.005);
   EXPECT_EQ(noseamMosaicHist->ValidPixels(), 1154321);
   EXPECT_NEAR(noseamMosaicHist->StandardDeviation(), 0.010379350848041419, 0.005);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A few tests have been failing in dev seemingly at random. I was able to reproduce the `cnetcombinept` failure. It was due to different measure creation times between the two runs of `cnetcombinept`. The best solution seemed to be to remove the measure comparing creation dates for equivalency. All else being equal.

I tried to recreate the failing orex tests with no luck. The closest I could find was `noseam` applying `highpass` and `lowpass` on two different mosaics. Both programs in `noseam` now run on the same `automos`d mosiac, hopefully this will stop the tests from failing randomly.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
