### PR TITLE
Noseam Parallel Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,6 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Changed file format to propagate from the input image format to the output image format [#5737](https://github.com/DOI-USGS/ISIS3/pull/5737)
 - Changed `StripPolygonSeeder` and `GridPolygonSeeder` to seed individual polygons within each images multipolygon footprint [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
 - Pinned SpiceQL to 1.2.0 [#5852](https://github.com/DOI-USGS/ISIS3/pull/5852)
-- Changed `noseam` to apply `highpass` and `lowpass` to the same mosaic [#5862](https://github.com/DOI-USGS/ISIS3/pull/5862)
 - Changed `ControlMeasure` object comparison to no longer factor in creation date for equality [#5862](https://github.com/DOI-USGS/ISIS3/pull/5862)
 
 ### Fixed
@@ -87,6 +86,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed campt reporting when `ALLOWERROR` is set to true [#5845](https://github.com/DOI-USGS/ISIS3/pull/5845)
 - Fixed order of observer and target in spiceql call in `ctxcal`. [#5823](https://github.com/DOI-USGS/ISIS3/pull/5823)
 - Fixed bundle serialization on MacOS for IPCE [#5808](https://github.com/DOI-USGS/ISIS3/pull/5808)
+- Fixed `noseam` to use correct temporary files when running [#5878](https://github.com/DOI-USGS/ISIS3/pull/5878)
 
 ## [9.0.0] - 09-25-2024
 

--- a/isis/src/base/apps/noseam/noseam.cpp
+++ b/isis/src/base/apps/noseam/noseam.cpp
@@ -86,7 +86,6 @@ namespace Isis {
     FileName inFile = cubes[0];
 
     FileName mosaicFile = FileName::createTempFile("$TEMPORARY/OriginalMosaic.cub");
-    std::cout << "MOSAIC FILE FROM NOSEAM: " << mosaicFile.expanded() << std::endl;
     tempFiles.push_back(mosaicFile);
 
     /**

--- a/isis/src/base/apps/noseam/noseam.cpp
+++ b/isis/src/base/apps/noseam/noseam.cpp
@@ -74,50 +74,89 @@ namespace Isis {
       string msg = "Parameter [LINES] must be entered.";
       throw IException(IException::User, msg, _FILEINFO_);      
     }
+    std::list<FileName> tempFiles = {};
+
     // Get user parameters
     FileList cubes;
     cubes.read(cubeListFileName);
 
     QString match = ui.GetAsString("MATCHBANDBIN");
 
-    QString pathName = FileName("$TEMPORARY/").expanded();
+    // Sets up the pathName to be used for most application calls
+    FileName inFile = cubes[0];
+
+    FileName mosaicFile = FileName::createTempFile("$TEMPORARY/OriginalMosaic.cub");
+    std::cout << "MOSAIC FILE FROM NOSEAM: " << mosaicFile.expanded() << std::endl;
+    tempFiles.push_back(mosaicFile);
 
     /**
-     * Creates a mosaic from the original images.
+     * Creates a mosaic from the original images.  It is placed here
+     * so that the failure MATCHBANDBIN causes does not leave
+     * highpasses cubes lying around!
     */
     QString parameters = "FROMLIST=" + cubeListFileName.original() + 
-                        " MOSAIC=" + pathName + "OriginalMosaic.cub" +
+                        " MOSAIC=" + mosaicFile.expanded() +
                         " MATCHBANDBIN=" + match;
     ProgramLauncher::RunIsisProgram("automos", parameters);
 
-    // Does a highpass on the original mosaic
-    parameters = "FROM=" + pathName + "OriginalMosaic.cub" +
-                  " TO=" + pathName + "HighpassMosaic.cub"
-                  + " SAMPLES=" + toString(samples) + " LINES=" + toString(lines);
-    ProgramLauncher::RunIsisProgram("highpass", parameters);
+    // Creates the highpass cubes from the cubes FileList
+    FileList highPassList;
+    for(int i = 0; i < cubes.size(); i++) {
+      inFile = cubes[i];
+      FileName highpassCube = FileName::createTempFile("$TEMPORARY/" + inFile.baseName() + "_highpass.cub");
+      tempFiles.push_back(highpassCube);
+      parameters = "FROM=" + inFile.expanded() +
+                   " TO=" + highpassCube.expanded() +
+                   " SAMPLES=" + toString(samples) + 
+                   " LINES=" + toString(lines);
+      ProgramLauncher::RunIsisProgram("highpass", parameters);
+      // Reads the just created highpass cube into a list file for automos
+      highPassList.push_back(highpassCube);
+    }
+    FileName highpassListFile = FileName::createTempFile("$TEMPORARY/HighPassList.lis");
+    highPassList.write(highpassListFile);
+    tempFiles.push_back(highpassListFile);
+
+    // Makes a mosaic out of the highpass cube filelist
+    FileName highpassFile = FileName::createTempFile("$TEMPORARY/HighpassMosaic.cub");
+    tempFiles.push_back(highpassFile);
+
+    parameters = "FROMLIST=" + highpassListFile.expanded() +
+                 " MOSAIC=" + highpassFile.expanded() +
+                 " MATCHBANDBIN=" + match;
+    ProgramLauncher::RunIsisProgram("automos", parameters);
+
+    FileName lowpassFile = FileName::createTempFile("$TEMPORARY/HighpassMosaic.cub");
+    tempFiles.push_back(lowpassFile);
 
     // Does a lowpass on the original mosaic
-    parameters = "FROM=" + pathName + "OriginalMosaic.cub"
-                 + " TO=" + pathName + "LowpassMosaic.cub"
-                 + " SAMPLES=" + toString(samples) + " LINES=" + toString(lines);
+    parameters = "FROM=" + mosaicFile.expanded() +
+                 " TO=" + lowpassFile.expanded() +
+                 " SAMPLES=" + toString(samples) + " LINES=" + toString(lines);
     ProgramLauncher::RunIsisProgram("lowpass", parameters);
 
     // Finally combines the highpass and lowpass mosaics
-    parameters = "FROM=" + pathName + "HighpassMosaic.cub" +
-                 " FROM2=" + pathName + "LowpassMosaic.cub" +
+    parameters = "FROM=" + highpassFile.expanded() +
+                 " FROM2=" + lowpassFile.expanded() +
                  " TO=" + ui.GetCubeName("TO") +
                  " OPERATOR= add";
     ProgramLauncher::RunIsisProgram("algebra", parameters);
 
     // Will remove all of the temp files by default
     if(ui.GetBoolean("REMOVETEMP")) {
-      QString file;
-      file = pathName + "HighpassMosaic.cub";
-      remove(file.toLatin1().data());
-      file = pathName + "LowpassMosaic.cub";
-      remove(file.toLatin1().data());
-      file = pathName + "OriginalMosaic.cub";
-      remove(file.toLatin1().data());
+      QString topLevelMsg = "Failed to remove noseam temp file(s)";
+      IException e(IException::Unknown, topLevelMsg, _FILEINFO_);
+      QString msg = "Failed to remove temp file [";
+      for (FileName file : tempFiles) {
+        remove(file.expanded().toLatin1().data());
+        if (file.fileExists()) {
+          QString fileMsg = msg + file.name() + "]";
+          e.append(IException(IException::Unknown, fileMsg, _FILEINFO_));
+        }
+      }
+      if (e.length() > 0) {
+        throw e;
+      }
     }
   }
 }

--- a/isis/src/base/objs/IException/IException.cpp
+++ b/isis/src/base/objs/IException/IException.cpp
@@ -640,7 +640,12 @@ namespace Isis {
   }
 
   int IException::length() {
-    return m_previousExceptions->length();
+    if (m_previousExceptions) {
+      return m_previousExceptions->length();
+    }
+    else {
+      return 0;
+    }
   }
 
 

--- a/isis/tests/OsirisRexMapCamModuleTests.cpp
+++ b/isis/tests/OsirisRexMapCamModuleTests.cpp
@@ -1282,7 +1282,7 @@ TEST(OsirisRexMapCamModules, MapCamModuleTwoImageTest) {
 
   std::unique_ptr<Histogram> noseamMosaicHist(noseamMosaic.histogram());
   EXPECT_NEAR(noseamMosaicHist->Average(), 0.0040496894214538124, 0.005);
-  EXPECT_NEAR(noseamMosaicHist->Sum(), 7338.5876967209242, 0.005);
+  EXPECT_NEAR(noseamMosaicHist->Sum(), 7338.8188217326478, 0.005);
   EXPECT_EQ(noseamMosaicHist->ValidPixels(), 1812193);
   EXPECT_NEAR(noseamMosaicHist->StandardDeviation(), 0.0037573821357031172, 0.005);
 

--- a/isis/tests/OsirisRexPolyCamModuleTests.cpp
+++ b/isis/tests/OsirisRexPolyCamModuleTests.cpp
@@ -1309,7 +1309,7 @@ TEST(OsirisRexPolyCamModules, PolyCamModuleTwoImageTest) {
 
   std::unique_ptr<Histogram> noseamMosaicHist(noseamMosaic.histogram());
   EXPECT_NEAR(noseamMosaicHist->Average(), 0.013594249872813711, 0.005);
-  EXPECT_NEAR(noseamMosaicHist->Sum(), 28517.175773404939, 0.014);
+  EXPECT_NEAR(noseamMosaicHist->Sum(), 28517.09297419725, 0.014);
   EXPECT_EQ(noseamMosaicHist->ValidPixels(), 2097732);
   EXPECT_NEAR(noseamMosaicHist->StandardDeviation(), 0.0073422521190466645, 0.005);
 

--- a/isis/tests/OsirisRexSamCamModuleTests.cpp
+++ b/isis/tests/OsirisRexSamCamModuleTests.cpp
@@ -1330,7 +1330,7 @@ TEST(OsirisRexSamCamModules, SamCamModuleTwoImageTest) {
 
   std::unique_ptr<Histogram> noseamMosaicHist(noseamMosaic.histogram());
   EXPECT_NEAR(noseamMosaicHist->Average(), 0.010375753089644776, 0.005);
-  EXPECT_NEAR(noseamMosaicHist->Sum(), 11976.425999546173, 0.005);
+  EXPECT_NEAR(noseamMosaicHist->Sum(), 11976.949682191847, 0.005);
   EXPECT_EQ(noseamMosaicHist->ValidPixels(), 1154321);
   EXPECT_NEAR(noseamMosaicHist->StandardDeviation(), 0.010379350848041419, 0.005);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed noseam to correctly create temporary files when processing. This was causing test failures due to noseam being run in parallel in the Orex module tests.

This PR also reverts the noseam logic back to before #5862

## Related Issue
N/A

## How Has This Been Validated?
Validated locally by running the three Orex tests in parallel that use noseam

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
