### PR TITLE
Fixes Dev CI to build docs with partial failures

### DIFF
--- a/.github/workflows/dev-biweekly-release.yml
+++ b/.github/workflows/dev-biweekly-release.yml
@@ -12,62 +12,87 @@ on:
   workflow_dispatch:     # Option to manually run pipeline in Actions
   
 jobs:
-  build:
-    strategy:
-      fail-fast: false
-      matrix:
-          os: [ubuntu-latest, macos-13, macos-15]
-    runs-on: ${{ matrix.os }}
-
+  build-ubuntu:
+    runs-on: ubuntu-latest
     steps:
-      # - name: Skip odd weeks
-      #   run: |
-      #     WEEK_NUM=$(date +%V)
-      #     if (( WEEK_NUM % 2 != 0 )); then
-      #       echo "Skipping this week ($WEEK_NUM is odd)."
-      #       exit 0
-      #     fi
-
       - uses: actions/checkout@v4
-
       - name: Set up Mambaforge
         uses: conda-incubator/setup-miniconda@v3
         with:
           miniforge-variant: Miniforge3
           auto-update-conda: true
           use-mamba: true
-
       - name: Build Release
         run: |
           export ISIS_VERSION=$(date +%Y.%m.%d)
           echo $ISIS_VERSION
-
           mamba install conda-build anaconda-client
           git fetch origin
           git checkout dev
           cd recipe
-
           echo $ENCRYPTION_KEY | openssl enc -aes-256-cbc -d -in kakadu/kakadu_7_9.zip.enc -out kakadu/kakadu_7_9.zip -pbkdf2 -iter 10000 -pass stdin
           unzip -j kakadu/kakadu_7_9.zip -d /tmp/kakadu_7_9 -x "__MACOSX/*"
+          sed -i "s|/isisData/kakadu|/tmp/kakadu_7_9|g" build.sh
+          sed -i "s/{% set version = \"[^\"]*\" %}/{% set version = \"$ISIS_VERSION\" %}/" meta.yaml
+          sed -i "s/version: {{ version }}.0_RC[^ ]*/version: {{ version }}/" meta.yaml
+          sed -i "s/git_tag: {{ version }}/git_tag: 'dev'/" meta.yaml
+          conda build . -c usgs-astrogeology -c conda-forge --override-channels --user usgs-astrogeology --label dev
 
-          if [[ "$OSTYPE" == "darwin"* ]]; then
-            sed -i '' "s|/isisData/kakadu|/tmp/kakadu_7_9|g" build.sh
-            sed -i '' "s/{% set version = \"[^\"]*\" %}/{% set version = \"$ISIS_VERSION\" %}/" meta.yaml
-            sed -i '' "s/version: {{ version }}.0_RC[^ ]*/version: {{ version }}/" meta.yaml
-            sed -i '' "s/git_tag: {{ version }}/git_tag: 'dev'/" meta.yaml
-          else
-            sed -i "s|/isisData/kakadu|/tmp/kakadu_7_9|g" build.sh
-            sed -i "s/{% set version = \"[^\"]*\" %}/{% set version = \"$ISIS_VERSION\" %}/" meta.yaml
-            sed -i "s/version: {{ version }}.0_RC[^ ]*/version: {{ version }}/" meta.yaml
-            sed -i "s/git_tag: {{ version }}/git_tag: 'dev'/" meta.yaml
-          fi
+  build-macos13-x64:
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Mambaforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          auto-update-conda: true
+          use-mamba: true
+      - name: Build Release
+        run: |
+          export ISIS_VERSION=$(date +%Y.%m.%d)
+          echo $ISIS_VERSION
+          mamba install conda-build anaconda-client
+          git fetch origin
+          git checkout dev
+          cd recipe
+          echo $ENCRYPTION_KEY | openssl enc -aes-256-cbc -d -in kakadu/kakadu_7_9.zip.enc -out kakadu/kakadu_7_9.zip -pbkdf2 -iter 10000 -pass stdin
+          unzip -j kakadu/kakadu_7_9.zip -d /tmp/kakadu_7_9 -x "__MACOSX/*"
+          sed -i '' "s|/isisData/kakadu|/tmp/kakadu_7_9|g" build.sh
+          sed -i '' "s/{% set version = \"[^\"]*\" %}/{% set version = \"$ISIS_VERSION\" %}/" meta.yaml
+          sed -i '' "s/version: {{ version }}.0_RC[^ ]*/version: {{ version }}/" meta.yaml
+          sed -i '' "s/git_tag: {{ version }}/git_tag: 'dev'/" meta.yaml
+          conda build . -c usgs-astrogeology -c conda-forge --override-channels --user usgs-astrogeology --label dev
 
+  build-macos15-arm64:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Mambaforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          auto-update-conda: true
+          use-mamba: true
+      - name: Build Release
+        run: |
+          export ISIS_VERSION=$(date +%Y.%m.%d)
+          echo $ISIS_VERSION
+          mamba install conda-build anaconda-client
+          git fetch origin
+          git checkout dev
+          cd recipe
+          echo $ENCRYPTION_KEY | openssl enc -aes-256-cbc -d -in kakadu/kakadu_7_9.zip.enc -out kakadu/kakadu_7_9.zip -pbkdf2 -iter 10000 -pass stdin
+          unzip -j kakadu/kakadu_7_9.zip -d /tmp/kakadu_7_9 -x "__MACOSX/*"
+          sed -i '' "s|/isisData/kakadu|/tmp/kakadu_7_9|g" build.sh
+          sed -i '' "s/{% set version = \"[^\"]*\" %}/{% set version = \"$ISIS_VERSION\" %}/" meta.yaml
+          sed -i '' "s/version: {{ version }}.0_RC[^ ]*/version: {{ version }}/" meta.yaml
+          sed -i '' "s/git_tag: {{ version }}/git_tag: 'dev'/" meta.yaml
           conda build . -c usgs-astrogeology -c conda-forge --override-channels --user usgs-astrogeology --label dev
 
   test-ubuntu:
     runs-on: ubuntu-latest
-    needs: build
-    continue-on-error: true
+    needs: build-ubuntu
     steps:
       - name: Set up Miniforge
         uses: conda-incubator/setup-miniconda@v3
@@ -93,8 +118,7 @@ jobs:
   
   test-macos13-x64:
     runs-on: macos-13
-    needs: build
-    continue-on-error: true
+    needs: build-macos13-x64
     steps:
       - name: Set up Miniforge
         uses: conda-incubator/setup-miniconda@v3
@@ -117,8 +141,7 @@ jobs:
   
   test-macos15-arm64:
     runs-on: macos-15
-    needs: build
-    continue-on-error: true
+    needs: build-macos15-arm64
     steps:
       - name: Set up Miniforge
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/dev-biweekly-release.yml
+++ b/.github/workflows/dev-biweekly-release.yml
@@ -1,3 +1,5 @@
+# See https://github.com/actions/runner-images?tab=readme-ov-file#available-images for Github's Available Images
+
 name: Github Actions - Build Dev Biweekly Anaconda Release
 
 env:
@@ -14,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ubuntu-latest, macos-13, macos-14]
+          os: [ubuntu-latest, macos-15-large, macos-15]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -61,15 +63,38 @@ jobs:
           fi
 
           conda build . -c usgs-astrogeology -c conda-forge --override-channels --user usgs-astrogeology --label dev
-  
-  test:
-    runs-on: ${{ matrix.os }}
+
+  test-ubuntu:
+    runs-on: ubuntu-latest
     needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-13, macos-14]
-      
+    continue-on-error: true
+    steps:
+      - name: Set up Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          auto-update-conda: true
+          activate-environment: isis-test
+          use-mamba: true
+          mamba-version: "1.5.3"
+          
+      - name: Conda install and test spiceinit
+        run: |
+          export ISIS_VERSION=$(date +%Y.%m.%d)
+
+          source "${CONDA}/etc/profile.d/conda.sh"
+          conda activate isis-test
+
+          conda install -c conda-forge -c usgs-astrogeology usgs-astrogeology/label/dev::isis=${ISIS_VERSION} -y
+
+          export ISISROOT=$CONDA_PREFIX
+          conda list isis
+          spiceinit -h
+  
+  test-macos15-x64:
+    runs-on: macos-15-large
+    needs: build
+    continue-on-error: true
     steps:
       - name: Set up Miniforge
         uses: conda-incubator/setup-miniconda@v3
@@ -83,12 +108,33 @@ jobs:
       - name: Conda install and test spiceinit
         run: |
           export ISIS_VERSION=$(date +%Y.%m.%d)
-
           source "${CONDA}/etc/profile.d/conda.sh"
           conda activate isis-test
-
           conda install -c conda-forge -c usgs-astrogeology usgs-astrogeology/label/dev::isis=${ISIS_VERSION} -y
+          export ISISROOT=$CONDA_PREFIX
+          conda list isis
+          spiceinit -h
+  
+  test-macos15-arm64:
+    runs-on: macos-15
+    needs: build
+    continue-on-error: true
+    steps:
+      - name: Set up Miniforge
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          miniforge-variant: Miniforge3
+          auto-update-conda: true
+          activate-environment: isis-test
+          use-mamba: true
+          mamba-version: "1.5.3"
 
+      - name: Conda install and test spiceinit
+        run: |
+          export ISIS_VERSION=$(date +%Y.%m.%d)
+          source "${CONDA}/etc/profile.d/conda.sh"
+          conda activate isis-test
+          conda install -c conda-forge -c usgs-astrogeology usgs-astrogeology/label/dev::isis=${ISIS_VERSION} -y
           export ISISROOT=$CONDA_PREFIX
           conda list isis
           spiceinit -h
@@ -96,8 +142,11 @@ jobs:
   docs:
     name: Build and Upload ISIS Dev Docs
     runs-on: ubuntu-latest
-    needs: test
-    if: ${{ success() }}
+    needs: [test-ubuntu, test-macos15-x64, test-macos15-arm64]
+    if: |
+      needs.test-ubuntu.result == 'success' ||
+      needs.test-macos15-x64.result == 'success' ||
+      needs.test-macos15-arm64.result == 'success'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/dev-biweekly-release.yml
+++ b/.github/workflows/dev-biweekly-release.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-          os: [ubuntu-latest, macos-15-large, macos-15]
+          os: [ubuntu-latest, macos-13, macos-15]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -91,8 +91,8 @@ jobs:
           conda list isis
           spiceinit -h
   
-  test-macos15-x64:
-    runs-on: macos-15-large
+  test-macos13-x64:
+    runs-on: macos-13
     needs: build
     continue-on-error: true
     steps:
@@ -142,10 +142,10 @@ jobs:
   docs:
     name: Build and Upload ISIS Dev Docs
     runs-on: ubuntu-latest
-    needs: [test-ubuntu, test-macos15-x64, test-macos15-arm64]
+    needs: [test-ubuntu, test-macos13-x64, test-macos15-arm64]
     if: |
       needs.test-ubuntu.result == 'success' ||
-      needs.test-macos15-x64.result == 'success' ||
+      needs.test-macos13-x64.result == 'success' ||
       needs.test-macos15-arm64.result == 'success'
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev-biweekly-release.yml
+++ b/.github/workflows/dev-biweekly-release.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           export ISIS_VERSION=$(date +%Y.%m.%d)
           echo $ISIS_VERSION
-          mamba install conda-build anaconda-client
+          mamba install python=3.12 conda-build anaconda-client
           git fetch origin
           git checkout dev
           cd recipe


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Docs need to be built if atleast one of the os builds passes and pushes to anaconda. Right now the CI skips the docs for any failures. Fixed this by separating the build/test sections per os. 

<img width="943" height="328" alt="Screenshot 2025-09-24 at 2 58 41 PM" src="https://github.com/user-attachments/assets/f00f43ac-b13f-4593-9cc2-6509a6838910" />


## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
I have not fully tested this CI due to recent cspice issues. Waiting on #5886 to be merged before testing that docs builds correctly after atleast one build is successful.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
