### PR TITLE
Chandrayaan2 fixes and isisimport docs update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed bundle serialization on MacOS for IPCE [#5808](https://github.com/DOI-USGS/ISIS3/pull/5808)
 - Fixed `noseam` to use correct temporary files when running [#5878](https://github.com/DOI-USGS/ISIS3/pull/5878)
 - Fixed `spiceserver` to use CK quality for PCK selection [#5901](https://github.com/DOI-USGS/ISIS3/pull/5901)
+- Fixed Chandrayaan2 TMC2 template in `isisimport` to allow Pixel Resolution to be optional [#5882](https://github.com/DOI-USGS/ISIS3/issues/5882)
 
 ## [9.0.0] - 09-25-2024
 

--- a/isis/appdata/import/PDS3/CassiniISS.tpl
+++ b/isis/appdata/import/PDS3/CassiniISS.tpl
@@ -5,9 +5,9 @@ SpacecraftName          =  Cassini-Huygens
 
 {% set targetName =  TARGET_NAME.Value %}
 {% if targetName == "DARK SKY"%}
-{% set targetName = Sky %}
+{% set targetName = "Sky" %}
 {% else if targetName == "S8_2004" %}
-{% set targetName = Sky %}
+{% set targetName = "Sky" %}
 {% else if targetName == "S12_2004" %}
 {% set targetName = "Sky" %}
 {% else if targetName == "S13_2004" %}
@@ -130,7 +130,7 @@ ReadoutCycleIndex       = {{ ReadoutCycleIndex }}
 
 {% set shutterModeId = SHUTTER_MODE_ID.Value %}
 {% if shutterModeId == "UNK" %}
-{% set shutterModeId = 'Unknown' %}
+{% set shutterModeId = "Unknown" %}
 {% else if shutterModeId == "BOTSIM" %}
 {% set shutterModeId= "BothSim" %}
 {% else if shutterModeId == "NACONLY" %}

--- a/isis/appdata/import/PDS4/Chandrayaan2TMC2.tpl
+++ b/isis/appdata/import/PDS4/Chandrayaan2TMC2.tpl
@@ -106,7 +106,9 @@ Object = IsisCube
       SpacecraftYawDirection = NA
     {% endif %}
     SpacecraftAltitude      = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_spacecraft_altitude._text }} <km>
+    {% if exists("Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pixel_resolution._text") %}
     PixelResolution         = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pixel_resolution._text }} <meters/pixel>
+    {% endif %}
     Roll                    = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_roll._text }} <degrees>
     Pitch                   = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pitch._text }} <degrees>
     Yaw                     = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_yaw._text }} <degrees>

--- a/isis/src/base/apps/isisimport/isisimport.cpp
+++ b/isis/src/base/apps/isisimport/isisimport.cpp
@@ -354,6 +354,11 @@ namespace Isis {
     else if (inputFileName.removeExtension().addExtension("QUB").fileExists()) {
       importer.SetInputFile(inputFileName.removeExtension().addExtension("QUB").expanded());
     }
+    else if (inputFileName.removeExtension().addExtension("tif").fileExists()) {
+    QString msg = "GeoTIFFs may contain ancillary data that isisimport cannot process. "
+                  "Please convert the .TIF to a cube using another tool, such as gdal_translate.";
+      throw IException(IException::User, msg, _FILEINFO_);
+    }
     else {
       importer.SetInputFile(inputFileName.expanded());
     }

--- a/isis/src/base/apps/isisimport/isisimport.xml
+++ b/isis/src/base/apps/isisimport/isisimport.xml
@@ -52,14 +52,15 @@
 
       <parameter name="TEMPLATE">
         <type>filename</type>
-        <internalDefault>None</internalDefault>
+        <internalDefault>auto-selected</internalDefault>
         <fileMode>input</fileMode>
-        <brief>
-          Input template
-        </brief>
+        <brief>Optional custom template</brief>
         <description>
-          The file name of the input template. This file contains "inja" compatible
-          template syntax inside of a ISIS Cube label.
+          The Inja-compatible template used to generate the ISIS Cube label.  
+          By default, <i>isisimport</i> automatically selects the appropriate template based on the input file type.  
+          Specify this parameter only if you wish to override the default with a custom template file.
+          
+          To modify an existing template, refer to the files located in <code>$ISISROOT/appdata/import/PDS3</code> or <code>$ISISROOT/appdata/import/PDS4</code>.
         </description>
       </parameter>
 
@@ -104,4 +105,29 @@
          </parameter>
      </group>
   </groups>
+  <examples>
+    <example>
+      <brief>
+        Default usage of isisimport
+      </brief>
+      <description>
+        This example is for a PDS4 image that uses .xml labels. For isisimport to work, it is expected to have the associated .img file within the same directory.
+      </description>
+      <terminalInterface>
+        <commandLine>
+          from=input.xml to=output.cub
+        </commandLine>
+      </terminalInterface>
+    </example>
+        <example>
+      <brief>
+        Usage of isisimport using custom templates
+      </brief>
+      <terminalInterface>
+        <commandLine>
+          from=input.xml to=custom.cub template=my_custom_template.tpl
+        </commandLine>
+      </terminalInterface>
+    </example>
+  </examples>
 </application>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Some Chandrayaan2 labels do not have pixel resolution. This opened up an issue where pixel resolution is actually missing from ortho labels only and isisimport should not be importing ortho images. Since these images use .tif files, I added a error that says to process these derived images through another tool such as gdal_translate.

I also added in some documentation updates for templates. Originally isisimport required inputting a template but then we created an automated selector but failed to explain this in the docs.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #5882
closes #5819 
close #5834 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Ran the images mentioned in the issues.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
