### PR TITLE
Fix Qview crashing while viewing GeoTiffs

### DIFF
--- a/isis/src/base/objs/Buffer/Buffer.cpp
+++ b/isis/src/base/objs/Buffer/Buffer.cpp
@@ -333,14 +333,14 @@ namespace Isis {
 
     // If one rectangle is on left side of other
     // if (l1.x > r2.x || l2.x > r1.x)
-    if (p_line > in.p_line + in.p_nlines ||
-        in.p_line > p_line + p_nlines)
+    if (p_line >= in.p_line + in.p_nlines ||
+        in.p_line >= p_line + p_nlines)
       isSubareaOfIn = false;
 
     // If one rectangle is above other
     // if (r1.y > l2.y || r2.y > l1.y)
-    if (p_sample + p_nsamps < in.p_sample ||
-        in.p_sample + in.p_nsamps < p_sample)
+    if (p_sample >= in.p_sample + in.p_nsamps || 
+        in.p_sample >= p_sample + p_nsamps)
       isSubareaOfIn = false;
 
     if (isSubareaOfIn) {
@@ -386,24 +386,6 @@ namespace Isis {
         }
       }
     }
-
-    isSubareaOfIn = (p_npixels <= in.size());
-    isSubareaOfIn &= (p_sample >= in.p_sample);
-    isSubareaOfIn &= (p_line >= in.p_line);
-    isSubareaOfIn &= (p_band >= in.p_band);
-
-    int endSample = p_sample + p_nsamps - 1;
-    int otherEndSample = in.p_sample + in.p_nsamps - 1;
-
-    int endLine = p_line + p_nlines - 1;
-    int otherEndLine = in.p_line + in.p_nlines - 1;
-
-    int endBand = p_band + p_nbands - 1;
-    int otherEndBand = in.p_band + in.p_nbands - 1;
-
-    isSubareaOfIn &= (endSample <= otherEndSample);
-    isSubareaOfIn &= (endLine <= otherEndLine);
-    isSubareaOfIn &= (endBand <= otherEndBand);
 
     return isSubareaOfIn;
   }

--- a/isis/src/base/objs/Buffer/Buffer.cpp
+++ b/isis/src/base/objs/Buffer/Buffer.cpp
@@ -317,7 +317,6 @@ namespace Isis {
   /**
    * Allows copying of the buffer contents of a larger buffer to another same size or smaller
    *   Buffer, using their base positions to relate data. This does not copy the raw buffer.
-   *   This method does not guarantee consistent data translation when buffers have scale disparities.
    *
    * @param in The Buffer to be copied.
    * @return The operation was successful (the buffers overlapped)
@@ -347,29 +346,15 @@ namespace Isis {
       int firstBand = max(in.p_band, p_band);
       int lastBand = min(in.p_band + in.p_nbands, p_band + p_nbands);
 
-      for (int b = firstBand; b < lastBand; b++) {
-        for (int i = topLine; i < bottomLine; i++) {
-          for (int j = topSamp; j < bottomSamp; j++) {
-            int inIndex = -1;
-            int index = -1;
-            try {
-              inIndex = in.Index(j, i, b);
-            }
-            catch(...) {
-            }
-            try {
-              index = Index(j, i, b);
-            }
-            catch(...) {
-            }
-            double value = NULL8;
-            if (inIndex > -1 && inIndex < in.size()) {
-              value = in[inIndex];
-            }
+      int lineIncrement = (double)LineDimension() / (double)LineDimensionScaled();
+      int sampleIncrement = (double)SampleDimension() / (double)SampleDimensionScaled();
 
-            if (index > -1 && index < size()) {
-              (*this)[index] = value;
-            }
+      for (int b = firstBand; b < lastBand; b++) {
+        for (int i = topLine; i < bottomLine; i+=lineIncrement) {
+          for (int j = topSamp; j < bottomSamp; j+=sampleIncrement) {
+            int index = Index(j, i, b);
+            int inIndex = in.Index(j, i, b);
+            (*this)[index] = in[inIndex];
           }
         }
       }

--- a/isis/src/base/objs/Buffer/Buffer.cpp
+++ b/isis/src/base/objs/Buffer/Buffer.cpp
@@ -68,9 +68,16 @@ namespace Isis {
     if (p_nsampsScaled <= 0) {
       p_nsampsScaled = 1;
     }
+    if (int((p_nsamps - 1) * p_scale) == p_nsampsScaled) {
+      p_nsampsScaled += 1;
+    }
+
     p_nlinesScaled = int(p_nlines * p_scale);
     if (p_nlinesScaled <= 0) {
       p_nlinesScaled = 1;
+    }
+    if (int((p_nlines - 1) * p_scale) == p_nlinesScaled) {
+      p_nlinesScaled += 1;
     }
 
     p_npixels = (p_nsampsScaled * p_nlinesScaled) * p_nbands;
@@ -412,8 +419,8 @@ namespace Isis {
    * @throws Isis::iException::System - Memory allocation failed
    */
   void Buffer::Allocate() {
-    p_buf = NULL;
-    p_rawbuf = NULL;
+    p_buf = nullptr;
+    p_rawbuf = nullptr;
     try {
       p_buf = new double [p_npixels];
       size_t n = Isis::SizeOf(p_pixelType);
@@ -424,16 +431,16 @@ namespace Isis {
       try {
         if(p_buf) {
           delete [] p_buf;
-          p_buf = NULL;
+          p_buf = nullptr;
         }
         if(p_rawbuf) {
           delete [](char *)p_rawbuf;
-          p_rawbuf = NULL;
+          p_rawbuf = nullptr;
         }
       }
       catch(...) {
-        p_buf = NULL;
-        p_rawbuf = NULL;
+        p_buf = nullptr;
+        p_rawbuf = nullptr;
       }
       QString message = Message::MemoryAllocationFailed();
       throw IException(IException::Unknown, message, _FILEINFO_);

--- a/isis/src/base/objs/Buffer/Buffer.cpp
+++ b/isis/src/base/objs/Buffer/Buffer.cpp
@@ -352,16 +352,36 @@ namespace Isis {
 
       int firstBand = max(in.p_band, p_band);
       int lastBand = min(in.p_band + in.p_nbands, p_band + p_nbands);
-
+    
       int lineIncrement = (double)LineDimension() / (double)LineDimensionScaled();
       int sampleIncrement = (double)SampleDimension() / (double)SampleDimensionScaled();
 
       for (int b = firstBand; b < lastBand; b++) {
-        for (int i = topLine; i < bottomLine; i+=lineIncrement) {
-          for (int j = topSamp; j < bottomSamp; j+=sampleIncrement) {
-            int index = Index(j, i, b);
+        int lineIndex = -1;
+        for (int i = topLine; i < bottomLine;) {
+          int nextLineIndex = Index(topSamp, i, b);
+
+          int sampleIndex = -1;
+          for (int j = topSamp; j < bottomSamp;) {
+            int nextSampleIndex = Index(j, i, b);
             int inIndex = in.Index(j, i, b);
-            (*this)[index] = in[inIndex];
+            if (sampleIndex == nextSampleIndex) {
+              j++;
+              continue;
+            }
+            else {
+              j += sampleIncrement;
+              sampleIndex = nextSampleIndex;
+            }
+            (*this)[sampleIndex] = in[inIndex];
+          }
+          if (lineIndex == nextLineIndex) {
+            i++;
+            continue;
+          }
+          else {
+            i += lineIncrement;
+            lineIndex = nextLineIndex;
           }
         }
       }

--- a/isis/src/base/objs/Buffer/Buffer.cpp
+++ b/isis/src/base/objs/Buffer/Buffer.cpp
@@ -317,6 +317,7 @@ namespace Isis {
   /**
    * Allows copying of the buffer contents of a larger buffer to another same size or smaller
    *   Buffer, using their base positions to relate data. This does not copy the raw buffer.
+   *   This method does not guarantee consistent data translation when buffers have scale disparities.
    *
    * @param in The Buffer to be copied.
    * @return The operation was successful (the buffers overlapped)
@@ -349,11 +350,25 @@ namespace Isis {
       for (int b = firstBand; b < lastBand; b++) {
         for (int i = topLine; i < bottomLine; i++) {
           for (int j = topSamp; j < bottomSamp; j++) {
+            int inIndex = -1;
+            int index = -1;
             try {
-              (*this)[Index(j, i, b)] = in[in.Index(j, i, b)];
+              inIndex = in.Index(j, i, b);
             }
             catch(...) {
-              (*this)[Index(j, i, b)] = NULL8;
+            }
+            try {
+              index = Index(j, i, b);
+            }
+            catch(...) {
+            }
+            double value = NULL8;
+            if (inIndex != -1 && inIndex < in.size()) {
+              value = in[in.Index(j, i, b)];
+            }
+
+            if (index != -1 && index < size()) {
+              (*this)[index] = value;
             }
           }
         }

--- a/isis/src/base/objs/Buffer/Buffer.cpp
+++ b/isis/src/base/objs/Buffer/Buffer.cpp
@@ -363,11 +363,11 @@ namespace Isis {
             catch(...) {
             }
             double value = NULL8;
-            if (inIndex != -1 && inIndex < in.size()) {
-              value = in[in.Index(j, i, b)];
+            if (inIndex > -1 && inIndex < in.size()) {
+              value = in[inIndex];
             }
 
-            if (index != -1 && index < size()) {
+            if (index > -1 && index < size()) {
               (*this)[index] = value;
             }
           }

--- a/isis/src/base/objs/Cube/CubeIoHandler.cpp
+++ b/isis/src/base/objs/Cube/CubeIoHandler.cpp
@@ -1359,10 +1359,6 @@ namespace Isis {
           for(int x = startX; x < endX; x = x + sampleIncrement) {
             const int &sampleIntoChunk = x - chunkStartSample;
             int bufferIndex = output.Index(x, y, virtualBand);
-            // Avoid rolling back onto your buffer
-            if (bufferIndex >= output.size()) {
-              bufferIndex = output.size() - 1;
-            }
 
             const int &chunkIndex = sampleIntoChunk +
                 (chunkLineSize * lineIntoChunk) +

--- a/isis/src/base/objs/Cube/CubeIoHandler.cpp
+++ b/isis/src/base/objs/Cube/CubeIoHandler.cpp
@@ -1343,7 +1343,7 @@ namespace Isis {
     // Scale the sampleand line increment, only necessary in read for Q apps
     int lineIncrement = (double)output.LineDimension() / (double)output.LineDimensionScaled();
     int sampleIncrement = (double)output.SampleDimension() / (double)output.SampleDimensionScaled();
-
+    
     for(int z = startZ; z <= endZ; z++) {
       const int &bandIntoChunk = z - chunkStartBand;
       int virtualBand = z;
@@ -1353,18 +1353,34 @@ namespace Isis {
       if(virtualBand != 0 && virtualBand >= bufferBand &&
          virtualBand <= bufferBand + bufferBands - 1) {
 
-        for(int y = startY; y < endY; y = y + lineIncrement) {
+        int bufferLineIndex = -1;
+        for(int y = startY; y < endY;) {
           const int &lineIntoChunk = y - chunkStartLine;
+          int nextLineBufferIndex = output.Index(startX, y, virtualBand);
 
-          for(int x = startX; x < endX; x = x + sampleIncrement) {
+          int bufferSampleIndex = -1;
+          for(int x = startX; x < endX;) {
+            int nextSampleBufferIndex = output.Index(x, y, virtualBand);
             const int &sampleIntoChunk = x - chunkStartSample;
-            int bufferIndex = output.Index(x, y, virtualBand);
+            // Handle sample iteration
+            // If we continue to compute the same bufferIndex just iterate by 1
+            // If we compute the next index, increment by the 
+            // floored sample increment and read the DN value
+            // at newly computed index
+            if (bufferSampleIndex == nextSampleBufferIndex) {
+              x++;
+              continue;
+            }
+            else {
+              x += sampleIncrement;
+              bufferSampleIndex = nextSampleBufferIndex;
+            }
 
             const int &chunkIndex = sampleIntoChunk +
                 (chunkLineSize * lineIntoChunk) +
                 (chunkBandSize * bandIntoChunk);
 
-            double &bufferVal = buffersDoubleBuf[bufferIndex];
+            double &bufferVal = buffersDoubleBuf[bufferSampleIndex];
 
             if(m_pixelType == Real) {
               float raw = ((float *)chunkBuf)[chunkIndex];
@@ -1389,7 +1405,7 @@ namespace Isis {
                   bufferVal = LOW_REPR_SAT8;
               }
 
-              ((float *)buffersRawBuf)[bufferIndex] = raw;
+              ((float *)buffersRawBuf)[bufferSampleIndex] = raw;
             }
 
             else if(m_pixelType == SignedWord) {
@@ -1415,7 +1431,7 @@ namespace Isis {
                   bufferVal = LOW_REPR_SAT8;
               }
 
-              ((short *)buffersRawBuf)[bufferIndex] = raw;
+              ((short *)buffersRawBuf)[bufferSampleIndex] = raw;
             }
 
 
@@ -1446,7 +1462,7 @@ namespace Isis {
                   bufferVal = LOW_REPR_SAT8;
               }
 
-              ((unsigned short *)buffersRawBuf)[bufferIndex] = raw;
+              ((unsigned short *)buffersRawBuf)[bufferSampleIndex] = raw;
             }
 
             else if(m_pixelType == UnsignedInteger) {
@@ -1477,7 +1493,7 @@ namespace Isis {
                   bufferVal = LOW_REPR_SAT8;
               }
 
-              ((unsigned int *)buffersRawBuf)[bufferIndex] = raw;
+              ((unsigned int *)buffersRawBuf)[bufferSampleIndex] = raw;
 
 
 
@@ -1496,10 +1512,21 @@ namespace Isis {
                 bufferVal = (double) raw * m_multiplier + m_base;
               }
 
-              ((unsigned char *)buffersRawBuf)[bufferIndex] = raw;
+              ((unsigned char *)buffersRawBuf)[bufferSampleIndex] = raw;
             }
+          }
 
-            bufferIndex++;
+          // Handle line iteration
+          // If we continue to compute the same bufferIndex just iterate by 1
+          // If we compute a next index, increment by the floored 
+          // line increment
+          if (bufferLineIndex == nextLineBufferIndex) {
+            y++;
+            continue;
+          }
+          else {
+            y += lineIncrement;
+            bufferLineIndex = nextLineBufferIndex;
           }
         }
       }

--- a/isis/tests/BufferTests.cpp
+++ b/isis/tests/BufferTests.cpp
@@ -126,7 +126,7 @@ TEST(BufferTest, TestBufferOutOfBound) {
   }
 }
 
-TEST(BufferTest, TestBufferScale) {
+TEST(BufferTest, TestBufferScaleSmallToBig) {
   Buffer b(4, 3, 2, Isis::SignedInteger, 0.5);
 
   EXPECT_EQ(b.SampleDimension(), 4);
@@ -134,9 +134,9 @@ TEST(BufferTest, TestBufferScale) {
   EXPECT_EQ(b.BandDimension(), 2);
 
   EXPECT_EQ(b.SampleDimensionScaled(), 2);
-  EXPECT_EQ(b.LineDimensionScaled(), 1);
+  EXPECT_EQ(b.LineDimensionScaled(), 2);
 
-  EXPECT_EQ(b.size(), 4);
+  EXPECT_EQ(b.size(), 8);
 
   for(int i = 0; i < b.size(); i++) {
     b[i] = i;
@@ -146,12 +146,40 @@ TEST(BufferTest, TestBufferScale) {
   d.CopyOverlapFrom(b);
   std::vector<int> truthBuffer = {0, 0, 1, 1,
                                   0, 0, 1, 1,
-                                  0, 0, 1, 1,
+                                  2, 2, 3, 3,
                                   // Second band
-                                  2, 2, 3, 3,
-                                  2, 2, 3, 3,
-                                  2, 2, 3, 3};
-  for (int i = 0; i < truthBuffer.size(); i++) {
+                                  4, 4, 5, 5,
+                                  4, 4, 5, 5,
+                                  6, 6, 7, 7};
+  for (int i = 0; i < d.size(); i++) {
+    EXPECT_EQ(truthBuffer[i], d[i]);
+  }
+}
+
+TEST(BufferTest, TestBufferScaleBigToSmall) {
+  Buffer b(4, 3, 2, Isis::SignedInteger, 1);
+
+  EXPECT_EQ(b.SampleDimension(), 4);
+  EXPECT_EQ(b.LineDimension(), 3);
+  EXPECT_EQ(b.BandDimension(), 2);
+
+  EXPECT_EQ(b.SampleDimensionScaled(), 4);
+  EXPECT_EQ(b.LineDimensionScaled(), 3);
+
+  EXPECT_EQ(b.size(), 24);
+
+  for(int i = 0; i < b.size(); i++) {
+    b[i] = i;
+  }
+
+  Buffer d(4, 3, 2, Isis::SignedInteger, 0.5);
+  d.CopyOverlapFrom(b);
+  std::vector<int> truthBuffer = {4, 6,
+                                  8, 10,
+                                  // Second band
+                                  16, 18,
+                                  20, 22,};
+  for (int i = 0; i < d.size(); i++) {
     EXPECT_EQ(truthBuffer[i], d[i]);
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
The `GdalIoHandler` has to manage buffers requesting data outside of the image. It creates a smaller buffer, then copies the overlap back into the originally requested buffer. When working with buffers that have a scale less than 1.0, indexing into the buffer can result in going off the end of the buffer.

This change ensures that the buffer cannot write off the end of the buffer when copying between scaled buffers.

## Related Issue
Gdal Integration

## How Has This Been Validated?
Validated through qview locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
