### PR TITLE
Improve Conda Bullet CMAKE configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,6 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Adds PROJ into ISIS, and exposes the capability with a new class called IProj. [#5317](https://github.com/DOI-USGS/ISIS3/pull/5317)
 
 ### Changed
-- Improved the Conda Bullet CMAKE configuration in FindBulletFloat64.cmake. Adds the Bullet::Bullet_double target to ALLLIBS. [#5899](https://github.com/DOI-USGS/ISIS3/issues/5899)
 - Removed Arm dependency on xalan-c, as it does not build for now on conda-forge. This requires turning off doc building on Arm. Also changed some variables to avoid name clashes on Arm with clang 16. [#5802](https://github.com/DOI-USGS/ISIS3/pull/5802)
 - Update OSIRIS-REx OCams instrument (Map, Poly, & SamCam) support to current state in UofA code base [#5426](https://github.com/DOI-USGS/ISIS3/issues/5426)
 - Enhanced csminit by removing the need to specify model and plugin [#5585](https://github.com/DOI-USGS/ISIS3/issues/5585)
@@ -64,6 +63,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Changed `StripPolygonSeeder` and `GridPolygonSeeder` to seed individual polygons within each images multipolygon footprint [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
 - Pinned SpiceQL to 1.2.0 [#5852](https://github.com/DOI-USGS/ISIS3/pull/5852)
 - Changed `ControlMeasure` object comparison to no longer factor in creation date for equality [#5862](https://github.com/DOI-USGS/ISIS3/pull/5862)
+- Improved the Conda Bullet CMAKE configuration in FindBulletFloat64.cmake. Adds the Bullet::Bullet_double target to ALLLIBS. [#5899](https://github.com/DOI-USGS/ISIS3/issues/5899)
 
 ### Fixed
 - Fixed kaguyatc2isis invalid BandBin values [#5629](https://github.com/DOI-USGS/ISIS3/issues/5629)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Adds PROJ into ISIS, and exposes the capability with a new class called IProj. [#5317](https://github.com/DOI-USGS/ISIS3/pull/5317)
 
 ### Changed
+- Improved the Conda Bullet CMAKE configuration in FindBulletFloat64.cmake. Adds the Bullet::Bullet_double target to ALLLIBS. [#5899](https://github.com/DOI-USGS/ISIS3/issues/5899)
 - Removed Arm dependency on xalan-c, as it does not build for now on conda-forge. This requires turning off doc building on Arm. Also changed some variables to avoid name clashes on Arm with clang 16. [#5802](https://github.com/DOI-USGS/ISIS3/pull/5802)
 - Update OSIRIS-REx OCams instrument (Map, Poly, & SamCam) support to current state in UofA code base [#5426](https://github.com/DOI-USGS/ISIS3/issues/5426)
 - Enhanced csminit by removing the need to specify model and plugin [#5585](https://github.com/DOI-USGS/ISIS3/issues/5585)

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -384,7 +384,7 @@ foreach (_variableName ${_variableNames})
 endforeach()
 
 # add target based linkages to ALLLIBS variable
-list(APPEND ALLLIBS pantor::inja sensorutilities protobuf::libprotobuf embree GDAL::GDAL)
+list(APPEND ALLLIBS pantor::inja sensorutilities protobuf::libprotobuf embree GDAL::GDAL Bullet::Bullet_double)
 
 # Sometimes we add the same lib more than once (especially with LIBDIRS)
 list(REMOVE_DUPLICATES ALLLIBDIRS)

--- a/isis/cmake/FindBulletFloat64.cmake
+++ b/isis/cmake/FindBulletFloat64.cmake
@@ -27,29 +27,58 @@ To add this target to ISIS, just append the Bullet::Bullet_double target
 to ALLLIBS variable in ISIS3/isis/CMakeLists.txt file.
 ]=]
 
+function(prepend_root_dir ifile rootpath outvar)
+  string(FIND "${ifile}" "${rootpath}" _root_pos)
+  set(_outpath "${ifile}")
+  if(_root_pos EQUAL -1)
+    string(PREPEND _outpath "${rootpath}/")
+  endif()
+  set(${outvar} "${_outpath}" PARENT_SCOPE)
+endfunction(prepend_root_dir)
+
+
+function(get_full_library_path inlibs libpath outlibs)
+  # WARNING: This loop is sensitive in that you must use NO_CACHE
+  # AND unset the _lib_t variable in order to find all the libraries.
+  # Otherwise, it only finds the first library! Repeatedly...
+  foreach(_lib IN LISTS inlibs)
+    find_library(_lib_t "${_lib}" PATH "${libpath}" NO_CACHE)
+    list(APPEND _alllibs ${_lib_t})
+    unset(_lib_t) # Must be done or it only finds the first library.
+  endforeach()
+  set(${outlibs} "${_alllibs}" PARENT_SCOPE)
+endfunction(get_full_library_path)
+
 macro(add_bullet_double_target)
 
-  if (NOT TARGET Bullet::Bullet_double)
-    set(Bullet_double_FOUND FALSE)
+  if ( NOT TARGET Bullet::Bullet_double )
     if (BULLET_FOUND OR Bullet_FOUND )
-      if(NOT ${BULLET_DEFINITIONS} MATCHES ".*-DBT_USE_DOUBLE_PRECISION.*")
-        message(FATAL_ERROR "Bullet does not appear to be built with double "
-                  "precision, current definitions: ${BULLET_DEFINITIONS}")
+      if(NOT "${BULLET_DEFINITIONS}" MATCHES ".*-DBT_USE_DOUBLE_PRECISION.*")
+        message(FATAL_ERROR "Bullet does not appear to be built with "
+                   "double precision, current definitions: ${BULLET_DEFINITIONS}")
       endif()
-      message(STATUS "Bullet Compile Definitions: ${BULLET_DEFINITIONS}")
+      message(STATUS "Bullet Double Compile Definitions: ${BULLET_DEFINITIONS}")
 
-      # This configuration ensures the Bullet variable definitions are
-      # also conformant.
-      add_library(Bullet::Bullet_double INTERFACE IMPORTED)
-      set_target_properties(Bullet::Bullet_double
+      # This configuration ensures the Bullet variable definitions are also conformant.
+      # It also set to work with the ISIS system.
+      add_library( Bullet::Bullet_double INTERFACE IMPORTED )
+      set(BULLET_INCLUDE_DIR ${BULLET_INCLUDE_DIRS})
+      prepend_root_dir("${BULLET_INCLUDE_DIR}"    "${BULLET_ROOT_DIR}"     BULLET_INCLUDE_DIR)
+      prepend_root_dir("${BULLET_LIBRARY_DIRS}"   "${BULLET_ROOT_DIR}"     BULLET_LIBRARY_DIRS)
+      get_full_library_path("${BULLET_LIBRARIES}" "${BULLET_LIBRARY_DIRS}" BULLET_LIBRARIES)
+      
+      set_target_properties( Bullet::Bullet_double
         PROPERTIES
           INTERFACE_COMPILE_DEFINITIONS "${BULLET_DEFINITIONS}"
-          INTERFACE_INCLUDE_DIRECTORIES "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}"
-          INTERFACE_LINK_DIRECTORIES "${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIR}"
+          INTERFACE_INCLUDE_DIRECTORIES "${BULLET_INCLUDE_DIR}"
+          INTERFACE_LINK_DIRECTORIES "${BULLET_LIBRARY_DIRS}"
           INTERFACE_LINK_LIBRARIES "${BULLET_LIBRARIES}"
       )
       set(Bullet_double_FOUND TRUE)
-      message(STATUS "Bullet Target Created: Bullet::Bullet_double")
+      message(STATUS "Bullet Double Target Created/Confirmed: Bullet::Bullet_double")
+      message(STATUS "Bullet Includes:  ${BULLET_INCLUDE_DIR}")
+      message(STATUS "Bullet Libdirs:  ${BULLET_LIBRARY_DIRS}")
+      message(STATUS "Bullet Libraries: ${BULLET_LIBRARIES}")
     endif()
   endif()
 

--- a/isis/cmake/FindBulletFloat64.cmake
+++ b/isis/cmake/FindBulletFloat64.cmake
@@ -24,7 +24,16 @@ Bullet::Bullet_double        # INTERFACE IMPORTED library target
 Bullet_double_FOUND          # Module found variable
 
 To add this target to ISIS, just append the Bullet::Bullet_double target
-to ALLLIBS variable in ISIS3/isis/CMakeLists.txt file.
+to ALLLIBS variable in ISIS3/isis/CMakeLists.txt file. This package
+config also produces ISIS compatible variables that can be used instead
+of the Bullet double target if preferred. However, the target is required
+to add the compile definitions in Bullet::Bullet_double target if not
+added explicitly in ISIS cmake system.
+
+BULLET_DEFINITIONS           # Bullet double compile flags
+BULLET_INCLUDE_DIR           # Include directory for Bullet
+BULLET_LIBRARY_DIRS          # Library directory for Bullet
+BULLET_LIBRARIES             # Absolute paths of all Bullet libraries
 ]=]
 
 function(prepend_root_dir ifile rootpath outvar)

--- a/isis/cmake/FindBulletFloat64.cmake
+++ b/isis/cmake/FindBulletFloat64.cmake
@@ -1,60 +1,64 @@
-# CMake module for find_package(BULLET) double precision package
+# CMake module for find_package(BulletFloat64) double precision package
 # Finds include directory and all applicable libraries
 #
+#[=[
+This Bullet find module provides a target definition for the double precision
+version of the Bullet library. The target is provided as an imported library
+interface. It is derived from CMAKE varibles provided in the Bullet package
+configuration. The Bullet package is assumed to be provided in the Conda 
+environment but could be used by other compatible Bullet configurations that
+provide a double precision version the Bullet package.
 
-find_package(
-  Bullet
-  REQUIRED
-  CONFIGS
-  BulletConfig-float64.cmake )
+Note the only thing that differentiates the Conda package manager version is
+the explicit find_package() call that is specific to Conda. In the Conda
+Bullet package, the double precision package configuration is provided in 
+a separate CMAKE file, namely BulletConfig-float64.cmake. Other package
+managers use different techniques. However any package manager that provides
+consistent definitions of the Bullet CMAKE variables can use the 
+add_bullet_double_target() macro to create the Bullet::Bullet_double target.
 
-# Set up Bullet Float64 configuration
-set( BULLETFLOAT64_ROOT_DIR  "${BULLET_ROOT_DIR}" )
+This module provides the following elements:
 
-# Finds the Bullet include directory.
-string(FIND "${BULLET_INCLUDE_DIRS}" "${BULLETFLOAT64_ROOT_DIR}" has_bulletfloat64_dir )
-if( has_bulletfloat64_dir EQUAL -1)
-  cmake_path(APPEND BULLETFLOAT64_ROOT_DIR ${BULLET_INCLUDE_DIRS} 
-             OUTPUT_VARIABLE BULLETFLOAT64_INCLUDE_DIR )
-else()
-  set( BULLETFLOAT64_INCLUDE_DIR ${BULLET_INCLUDE_DIRS} )
-endif()
-set( BULLETFLOAT64_INCLUDE_DIRS  ${BULLETFLOAT64_INCLUDE_DIR} )
+add_bullet_double_target()   # Macro to generate the bullet Target
+Bullet::Bullet_double        # INTERFACE IMPORTED library target
+Bullet_double_FOUND          # Module found variable
 
-# Find the Bullet library directories
-string(FIND "${BULLET_LIBRARY_DIRS}" "${BULLETFLOAT64_ROOT_DIR}" has_bulletfloat64_lib )
-if( has_bulletfloat64_lib EQUAL -1 )
-  cmake_path(APPEND BULLETFLOAT64_ROOT_DIR ${BULLET_LIBRARY_DIRS}
-             OUTPUT_VARIABLE BULLETFLOAT64_LIBRARY_DIRS )
-else()
-  set( BULLETFLOAT64_LIBRARY_DIRS ${BULLET_LIBRARY_DIRS} )
-endif()
-set( BULLETFLOAT64_LIBRARY_DIR  ${BULLETFLOAT64_LIBRARY_DIRS} )
+To add this target to ISIS, just append the Bullet::Bullet_double target
+to ALLLIBS variable in ISIS3/isis/CMakeLists.txt file.
+]=]
 
-# Add the Bullet definitions and float64
-set( BULLETFLOAT64_DEFINITIONS "${BULLET_DEFINITIONS}" )
-set( BULLETFLOAT64_LIBRARIES ${BULLET_LIBRARIES} )
+macro(add_bullet_double_target)
 
-if(NOT
-   ${BULLETFLOAT64_DEFINITIONS}
-   MATCHES
-   ".*-DBT_USE_DOUBLE_PRECISION.*")
-  message(
-    ERROR "Bullet does not appear to be built with double precision, current definitions: ${BULLETFLOAT64_DEFINITIONS}")
-endif()
+  if (NOT TARGET Bullet::Bullet_double)
+    set(Bullet_double_FOUND FALSE)
+    if (BULLET_FOUND OR Bullet_FOUND )
+      if(NOT ${BULLET_DEFINITIONS} MATCHES ".*-DBT_USE_DOUBLE_PRECISION.*")
+        message(FATAL_ERROR "Bullet does not appear to be built with double "
+                  "precision, current definitions: ${BULLET_DEFINITIONS}")
+      endif()
+      message(STATUS "Bullet Compile Definitions: ${BULLET_DEFINITIONS}")
 
-add_definitions( ${BULLETFLOAT64_DEFINITIONS} )
-include_directories( ${BULLETFLOAT64_INCLUDE_DIRS} )
-link_directories( ${BULLETFLOAT64_LIBRARY_DIRS} )
+      # This configuration ensures the Bullet variable definitions are
+      # also conformant.
+      add_library(Bullet::Bullet_double INTERFACE IMPORTED)
+      set_target_properties(Bullet::Bullet_double
+        PROPERTIES
+          INTERFACE_COMPILE_DEFINITIONS "${BULLET_DEFINITIONS}"
+          INTERFACE_INCLUDE_DIRECTORIES "${BULLET_ROOT_DIR}/${BULLET_INCLUDE_DIRS}"
+          INTERFACE_LINK_DIRECTORIES "${BULLET_ROOT_DIR}/${BULLET_LIBRARY_DIR}"
+          INTERFACE_LINK_LIBRARIES "${BULLET_LIBRARIES}"
+      )
+      set(Bullet_double_FOUND TRUE)
+      message(STATUS "Bullet Target Created: Bullet::Bullet_double")
+    endif()
+  endif()
 
-message(STATUS "BULLETFLOAT64 DEFINITIONS:  "  "${BULLETFLOAT64_DEFINITIONS}" )
-message(STATUS "BULLETFLOAT64 INCLUDE DIRS: "  "${BULLETFLOAT64_INCLUDE_DIRS}" )
-message(STATUS "BULLETFLOAT64 LIBRARY DIRS: "  "${BULLETFLOAT64_LIBRARY_DIRS}" )
-message(STATUS "BULLETFLOAT64 LIBRARIES:    "  "${BULLETFLOAT64_LIBRARIES}" )
+endmacro()
 
-# Uniquely add each library for linking
-foreach (_bulletLib ${BULLETFLOAT64_LIBRARIES})
-  find_library( "BULLETFLOAT64_${_bulletLib}_LIBRARY" NAMES ${_bulletLib} 
-                PATHS ${BULLETFLOAT64_LIBRARY_DIRS} )
-  message(STATUS "Bullet Library: " "${BULLETFLOAT64_${_bulletLib}_LIBRARY}")
-endforeach()
+# Call the Conda specific Bullet double precision package
+find_package(Bullet REQUIRED CONFIGS BulletConfig-float64.cmake)
+
+# Create/confirm the Conda Bullet double precision interface target.
+# Note this target needs to be added to the end of the ALLLIBS variable
+# in ISIS3/isis/CMakeLists.txt file.
+add_bullet_double_target()


### PR DESCRIPTION

## Description
This update improves the Conda Bullet double precision package interface in the ISIS system. Creates a Bullet::Bullet_double import interface target that is built from the variables provided in the conda Bullet package. Just append the Bullet::Bullet_double target to the ALLLIBS variable in ISIS3/isis/CMakeLists.txt.

## Related Issue
#5899

## How Has This Been Validated?
Tested on Mac ARM platform.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
