### PR TITLE
CH2/TMC-2: set InstrumentId to CH2_TMC_NADIR/FORE/AFT from filename s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ release.
 
 ## [Unreleased]
 
+
 ### Added
 - Added Linux Arm support.
 - Added support for Chandrayaan-2 TMC and OHRC cameras. [#5828](https://github.com/DOI-USGS/ISIS3/pull/5828)
@@ -65,6 +66,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Changed `ControlMeasure` object comparison to no longer factor in creation date for equality [#5862](https://github.com/DOI-USGS/ISIS3/pull/5862)
 
 ### Fixed
+- Fixed Chandrayaan-2 TMC2 serial numbers by setting InstrumentId to CH2_TMC_FORE/NADIR/AFT based on the filename sensor [#5871](https://github.com/DOI-USGS/ISIS3/issues/5871)
 - Fixed kaguyatc2isis invalid BandBin values [#5629](https://github.com/DOI-USGS/ISIS3/issues/5629)
 - Fixed SpiceClient to handle redirect requests.
 - Fixed jigsaw to default OUTADJUSTMENTH5 option to false and allow this feature to run on read-only images [#5700](https://github.com/DOI-USGS/ISIS3/issues/5700)
@@ -87,10 +89,10 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed order of observer and target in spiceql call in `ctxcal`. [#5823](https://github.com/DOI-USGS/ISIS3/pull/5823)
 - Fixed bundle serialization on MacOS for IPCE [#5808](https://github.com/DOI-USGS/ISIS3/pull/5808)
 - Fixed `noseam` to use correct temporary files when running [#5878](https://github.com/DOI-USGS/ISIS3/pull/5878)
-- Fixed `spiceserver` to use CK quality for PCK selection [#5901](https://github.com/DOI-USGS/ISIS3/pull/5901)
-- Fixed Chandrayaan2 TMC2 template in `isisimport` to allow Pixel Resolution to be optional [#5882](https://github.com/DOI-USGS/ISIS3/issues/5882)
+
 
 ## [9.0.0] - 09-25-2024
+
 
 ### Added
 - Added TOVECT output parameter which generate a geospatial CSV file with a VRT metadata sidecar file [#5571](https://github.com/DOI-USGS/ISIS3/issues/5571)  

--- a/isis/appdata/import/PDS4/Chandrayaan2TMC2.tpl
+++ b/isis/appdata/import/PDS4/Chandrayaan2TMC2.tpl
@@ -1,6 +1,15 @@
 {% set file_name = Product_Observational.File_Area_Observational.File.file_name %}
 {% set sensor = CharAt(file_name, 10) %}
 
+{% set viewcode = "" %}
+{% if lower(sensor) == "f" %}
+  {% set viewcode = "FORE" %}
+{% else if lower(sensor) == "a" %}
+  {% set viewcode = "AFT" %}
+{% else if lower(sensor) == "n" %}
+  {% set viewcode = "NADIR" %}
+{% endif %}
+
 {% set ImageArray = Product_Observational.File_Area_Observational.Array_2D_Image %}
 
 Object = IsisCube
@@ -67,56 +76,65 @@ Object = IsisCube
   End_Object
 
   Group = Instrument
-    SpacecraftName            = {{ capitalize(Product_Observational.Observation_Area.Investigation_Area.name) }}
+    SpacecraftName = {{ capitalize(Product_Observational.Observation_Area.Investigation_Area.name) }}
+
     {% set inst_name = Product_Observational.Observation_Area.Observing_System.Observing_System_Component.1.name %}
     {% if inst_name == "terrain mapping camera" %}
-    InstrumentId              = TMC-2
+      {% if viewcode != "" %}
+        InstrumentId = CH2_TMC_{{ viewcode }}
+      {% else %}
+        InstrumentId = CH2_TMC
+      {% endif %}
     {% endif %}
-    TargetName                = {{ Product_Observational.Observation_Area.Target_Identification.name }}
-    StartTime                 = {{ RemoveStartTimeZ(Product_Observational.Observation_Area.Time_Coordinates.start_date_time) }}
-    StopTime                  = {{ RemoveStartTimeZ(Product_Observational.Observation_Area.Time_Coordinates.stop_date_time) }}
+
+    TargetName = {{ Product_Observational.Observation_Area.Target_Identification.name }}
+    StartTime  = {{ RemoveStartTimeZ(Product_Observational.Observation_Area.Time_Coordinates.start_date_time) }}
+    StopTime   = {{ RemoveStartTimeZ(Product_Observational.Observation_Area.Time_Coordinates.stop_date_time) }}
+
     {% if exists("Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_line_exposure_duration") %}
-    LineExposureDuration      = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_line_exposure_duration._text }} <ms>
+    LineExposureDuration = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_line_exposure_duration._text }} <ms>
     {% else %}
-    LineExposureDuration      = 3.236 <ms>
+    LineExposureDuration = 3.236 <ms>
     {% endif %}
   End_Group
 
   {% if exists("Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters") %}
   Group = Archive
-    JobId                   = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_job_id }}
-    OrbitNumber             = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_imaging_orbit_number }}
-    GainType                = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_gain }}
-    ExposureType            = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_exposure }}
-    DetectorPixelWidth      = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_detector_pixel_width._text }} <micrometers>
-    FocalLength             = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_focal_length._text }} <mm>
+    JobId               = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_job_id }}
+    OrbitNumber         = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_imaging_orbit_number }}
+    GainType            = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_gain }}
+    ExposureType        = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_exposure }}
+    DetectorPixelWidth  = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_detector_pixel_width._text }} <micrometers>
+    FocalLength         = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_focal_length._text }} <mm>
+
     {% if exists("Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_reference_data_used") %}
       ReferenceData = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_reference_data_used }}
     {% else %}
       ReferenceData = NA
     {% endif %}
+
     {% if exists("Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_orbit_limb_direction") %}
       OrbitLimbDirection = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_orbit_limb_direction }}
     {% else %}
       OrbitLimbDirection = NA
     {% endif %}
+
     {% if exists("Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_spacecraft_yaw_direction") %}
       SpacecraftYawDirection = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_spacecraft_yaw_direction }}
     {% else %}
       SpacecraftYawDirection = NA
     {% endif %}
-    SpacecraftAltitude      = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_spacecraft_altitude._text }} <km>
-    {% if exists("Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pixel_resolution._text") %}
-    PixelResolution         = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pixel_resolution._text }} <meters/pixel>
-    {% endif %}
-    Roll                    = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_roll._text }} <degrees>
-    Pitch                   = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pitch._text }} <degrees>
-    Yaw                     = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_yaw._text }} <degrees>
-    SunAzimuth              = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_sun_azimuth._text }} <degrees>
-    SunElevation            = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_sun_elevation._text }} <degrees>
-    SolarIncidence          = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_solar_incidence._text }} <degrees>
-    Projection              = "{{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_projection }}"
-    Area                    = "{{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_area }}"
+
+    SpacecraftAltitude  = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_spacecraft_altitude._text }} <km>
+    PixelResolution     = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pixel_resolution._text }} <meters/pixel>
+    Roll                = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_roll._text }} <degrees>
+    Pitch               = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_pitch._text }} <degrees>
+    Yaw                 = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_yaw._text }} <degrees>
+    SunAzimuth          = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_sun_azimuth._text }} <degrees>
+    SunElevation        = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_sun_elevation._text }} <degrees>
+    SolarIncidence      = {{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_solar_incidence._text }} <degrees>
+    Projection          = "{{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_projection }}"
+    Area                = "{{ Product_Observational.Observation_Area.Mission_Area.isda_Product_Parameters.isda_area }}"
   End_Group
   {% endif %}
 
@@ -130,8 +148,8 @@ Object = IsisCube
                     {% else if sensor == "f" %}-152211
                     {% else if sensor == "n" %}-152210
                     {% endif %}
-
   End_Group
+
 End_Object
 
 Object = Translation


### PR DESCRIPTION
## Description
This PR updates the PDS4 import template for Chandrayaan-2 TMC-2 data (`Chandrayaan2TMC2.tpl`) so that the `InstrumentId` is set based on the view encoded in the filename. It now uses:

- `CH2_TMC_NADIR`
- `CH2_TMC_FORE`
- `CH2_TMC_AFT`

for nadir / fore / aft images, respectively. This prevents duplicate serial numbers when importing TMC-2 triplets.

## Related Issue
Fixes #5871

## Validation
- Imported a TMC-2 nadir/fore/aft triplet with `isisimport` using the updated template.
- Verified via `catlab` that the `InstrumentId` values are:
  - `CH2_TMC_NADIR`
  - `CH2_TMC_FORE`
  - `CH2_TMC_AFT`
- Confirmed that the three cubes now differ in `InstrumentId`, addressing the duplicate-serial-number problem described in the issue.