### PR TITLE
Jigsaw CI Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Changed `StripPolygonSeeder` and `GridPolygonSeeder` to seed individual polygons within each images multipolygon footprint [#5193](https://github.com/DOI-USGS/ISIS3/issues/5193)
 - Pinned SpiceQL to 1.2.0 [#5852](https://github.com/DOI-USGS/ISIS3/pull/5852)
 - Changed `ControlMeasure` object comparison to no longer factor in creation date for equality [#5862](https://github.com/DOI-USGS/ISIS3/pull/5862)
+- Changed 'jigsaw' attribute type to account for Linux compiler changes [#5904](https://github.com/DOI-USGS/ISIS3/pull/5904)
 
 ### Fixed
 - Fixed Chandrayaan-2 TMC2 serial numbers by setting InstrumentId to CH2_TMC_FORE/NADIR/AFT based on the filename sensor [#5871](https://github.com/DOI-USGS/ISIS3/issues/5871)

--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -178,6 +178,7 @@ endif()
 # sometimes third parties do not set their rpaths correctly
 set(thirdPartyCppFlags -Wall
                        -fPIC
+                       -fsigned-char
                        -std=c++17
                        -DISIS_LITTLE_ENDIAN=1
                        -Wno-unused-parameter
@@ -256,7 +257,7 @@ find_package(Qt5 COMPONENTS
                 Xml
                 XmlPatterns
                 # Search this path explicitly for MacOS OpenGL Framework
-                PATHS /System/Library/Frameworks/ REQUIRED)
+                PATHS /System/Library/Frameworks/ REQUIRED CONFIG)
 
 find_package(Boost 1.59.0 REQUIRED atomic
                                         log
@@ -356,6 +357,10 @@ foreach (_variableName ${_variableNames})
     list(APPEND ALLINCDIRS "${${_variableName}}")
   endif()
 endforeach()
+
+if (NOT OPENGL_XMESA_FOUND)
+	list(REMOVE_ITEM ALLINCDIRS OPENGL_xmesa_INCLUDE_DIR-NOTFOUND)
+endif()
 
 # get all Library variables
 foreach (_variableName ${_variableNames})

--- a/isis/cmake/Utilities.cmake
+++ b/isis/cmake/Utilities.cmake
@@ -158,7 +158,11 @@ function(get_os_version text)
     #message("name = ${name}")
     #message("version = ${version}")
 
-    set(prefix "Linux_x86_64_")
+    if (CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+      set(prefix "Linux_aarch64_")
+    else()
+      set(prefix "Linux_x86_64_")
+    endif()
 
   # Build the final output string
   elseif(APPLE)

--- a/isis/make/config.linux
+++ b/isis/make/config.linux
@@ -12,4 +12,7 @@ ifeq ($(HOST_ARCH),Linux)
       include $(ISISROOT)/make/config.linux-x86_64
     endif
   endif
+  ifeq ($(HOST_MACH),aarch64)
+    include $(ISISROOT)/make/config.linux-aarch64
+  endif
 endif

--- a/isis/src/control/apps/jigsaw/jigsaw.cpp
+++ b/isis/src/control/apps/jigsaw/jigsaw.cpp
@@ -331,14 +331,16 @@ namespace Isis {
               auto n = count(CMATRIX_KEYS_FOR_STR.begin(), CMATRIX_KEYS_FOR_STR.end(), cmatrixKey);
               auto m = count(CMATRIX_KEYS_FOR_VEC.begin(), CMATRIX_KEYS_FOR_VEC.end(), cmatrixKey);
               if (n > 0) {
-                dataset.createAttribute<string>(cmatrixKey, cmatrixValue["Value"]);
+                std::string cmatrixValueStr = cmatrixValue["Value"].get<std::string>();
+                std::vector<std::string> cmatrixValueStrVec{cmatrixValueStr};
+                dataset.createAttribute(cmatrixKey, cmatrixValueStrVec);
               } else if (m > 0) {
                 dataset.createAttribute<vector<string>>(cmatrixKey, cmatrixValue["Value"]);
               } else {
                 // Do not add as attribute
               }
             }
-  
+            
             std::string spvectorTableStr = Table::toString(spvector).toStdString();
             dataset = file.createDataSet<std::string>(spvectorKey, spvectorTableStr);
 
@@ -349,7 +351,9 @@ namespace Isis {
               auto spvectorValue = spvectorItem.value();
               auto n = count(SPVECTOR_KEYS_FOR_STR.begin(), SPVECTOR_KEYS_FOR_STR.end(), spvectorKey);
               if (n > 0) {
-                dataset.createAttribute<string>(spvectorKey, spvectorValue["Value"]);
+                std::string spvectorValueStr = spvectorValue["Value"].get<std::string>();
+                std::vector<std::string> spvectorValueStrVec{spvectorValueStr};
+                dataset.createAttribute(spvectorKey, spvectorValueStrVec);
               } else {
                 // Do not add as attribute
               }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
MacOS C++ compiler treats the string attribute as scalar but the linux gcc compiler seems to see the string as a container attribute. This change forces HighFive to treat the string attribute as a vector of strings.

Also added cmake changes.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
