### PR TITLE
Coverage Option

### DIFF
--- a/isis/CMakeLists.txt
+++ b/isis/CMakeLists.txt
@@ -73,6 +73,7 @@ option(buildCore       "Build the core ISIS modules"                    ON  )
 option(buildMissions   "Build the mission specific modules"             ON  )
 option(buildStaticCore "Build libisis static as well as dynamic"        OFF )
 option(buildTests      "Set up unit, application, and module tests."    ON  )
+option(buildCoverage   "Set up code coverage"                           OFF  )
 option(buildDocs       "Build the docs."                                ON  )
 option(JP2KFLAG        "Whether or not to build using JPEG2000 support" OFF )
 option(pybindings      "Turn on to build Python bindings"               ON  )
@@ -139,6 +140,7 @@ add_definitions( -DISISBUILDDIR="${CMAKE_BINARY_DIR}" )
 message("CONFIGURATION")
 message("\tBUILD STATIC CORE: ${buildStaticCore}")
 message("\tBUILD TESTS: ${buildTests}")
+message("\tBUILD COVERAGE: ${buildCoverage}")
 message("\tBUILD DOCS: ${buildDocs}")
 message("\tBUILD CORE: ${buildCore}")
 message("\tBUILD MISSIONS: ${buildMissions}")
@@ -170,6 +172,13 @@ if(buildTests)
   include(CodeCoverage)
   enable_testing()
   APPEND_COVERAGE_COMPILER_FLAGS()
+endif()
+
+if(buildCoverage AND buildTests)
+  include(CodeCoverage)
+  APPEND_COVERAGE_COMPILER_FLAGS()
+elseif(buildCoverage)
+  message(WARNING "Cmake configured to build coverage without tests, please enable 'buildTests' to generate coverage")
 endif()
 
 
@@ -647,27 +656,31 @@ add_subdirectory(cmake)
 
 if(buildTests)
   add_subdirectory(tests)
-  SET(COVERAGE_COMMAND ctest -j ${PROCESSOR_COUNT} --output-on-failure --timeout 10000 | true)
-  SET(COVERAGE_EXCLUDE ".*/unitTest.cpp" ".*/tests/.*" ".*/moc_.*" "build/.*" "gtest/.*" ".*/qisis/.*" ".*/.*/.*.h")
-  setup_target_for_coverage_gcovr_xml(
-    NAME test_coverage_xml                    # New target name
-    EXECUTABLE ${COVERAGE_COMMAND} # Executable in PROJECT_BINARY_DIR
-    DEPENDENCIES runISISTests                     # Dependencies to build first
-    BASE_DIRECTORY "${CMAKE_SOURCE_DIR}"        # Base directory for report
-    NO_DEMANGLE                                 # Don't demangle C++ symbols
-                                                #  even if c++filt is found
-    EXCLUDE ${COVERAGE_EXCLUDE}
-    OPTIONS --print-summary
-  )
-  
-  setup_target_for_coverage_gcovr_html(
-    NAME test_coverage_html                    # New target name
-    EXECUTABLE ${COVERAGE_COMMAND} # Executable in PROJECT_BINARY_DIR
-    DEPENDENCIES runISISTests                     # Dependencies to build first
-    BASE_DIRECTORY "${CMAKE_SOURCE_DIR}"        # Base directory for report
-    NO_DEMANGLE                                 # Don't demangle C++ symbols
-                                                #  even if c++filt is found
-    EXCLUDE ${COVERAGE_EXCLUDE}
-    OPTIONS --print-summary
-  )
+
+  if(buildCoverage)
+    SET(COVERAGE_COMMAND ctest -j ${PROCESSOR_COUNT} --output-on-failure --timeout 10000 | true)
+    SET(COVERAGE_EXCLUDE ".*/unitTest.cpp" ".*/tests/.*" ".*/moc_.*" "build/.*" "gtest/.*" ".*/qisis/.*" ".*/.*/.*.h")
+    setup_target_for_coverage_gcovr_xml(
+      NAME test_coverage_xml                    # New target name
+      EXECUTABLE ${COVERAGE_COMMAND} # Executable in PROJECT_BINARY_DIR
+      DEPENDENCIES runISISTests                   # Dependencies to build first
+      BASE_DIRECTORY "${CMAKE_SOURCE_DIR}"        # Base directory for report
+      NO_DEMANGLE                                 # Don't demangle C++ symbols
+                                                  #  even if c++filt is found
+      EXCLUDE ${COVERAGE_EXCLUDE}
+      OPTIONS --print-summary
+    )
+
+    setup_target_for_coverage_gcovr_html(
+      NAME test_coverage_html                    # New target name
+      EXECUTABLE ${COVERAGE_COMMAND} # Executable in PROJECT_BINARY_DIR
+      DEPENDENCIES runISISTests                   # Dependencies to build first
+      BASE_DIRECTORY "${CMAKE_SOURCE_DIR}"        # Base directory for report
+      NO_DEMANGLE                                 # Don't demangle C++ symbols
+                                                  #  even if c++filt is found
+      EXCLUDE ${COVERAGE_EXCLUDE}
+      OPTIONS --print-summary
+    )
+  endif()
 endif()
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds an option in ISIS to build coverage instead of forcing the coverage build. Set the default to off as most people won't be building coverage

## Related Issue
Closes https://github.com/DOI-USGS/ISIS3/issues/5890

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
