### PR TITLE
Fix lens distortions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed `CubeInfixToPostfix` to safely determine if a known symbol is a function symbol [#5822](https://github.com/DOI-USGS/ISIS3/pull/5822)
 - Fixed `BundleObservationSolveSettings` to properly read empty solve setting xmls [#5822](https://github.com/DOI-USGS/ISIS3/pull/5822)
 - Fixed `footprintinit` to find mapping group (no caps). [#5920](https://github.com/DOI-USGS/ISIS3/pull/5820)
+- Fixed unnecessary un/distortion checks for pixels near the origin. [#5932](https://github.com/DOI-USGS/ISIS3/pull/5932)
 
 ### Removed
 - QT 6 removed MySQL support so MySQL is no longer supported in `isisminer` [#5909](https://github.com/DOI-USGS/ISIS3/pull/5909)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed `CubeInfixToPostfix` to safely determine if a known symbol is a function symbol [#5822](https://github.com/DOI-USGS/ISIS3/pull/5822)
 - Fixed `BundleObservationSolveSettings` to properly read empty solve setting xmls [#5822](https://github.com/DOI-USGS/ISIS3/pull/5822)
 - Fixed `footprintinit` to find mapping group (no caps). [#5920](https://github.com/DOI-USGS/ISIS3/pull/5820)
-- Fixed unnecessary un/distortion checks for pixels near the origin. [#5932](https://github.com/DOI-USGS/ISIS3/pull/5932)
+- Fixed unnecessary un/distortion checks for pixels near the origin. [#5861](https://github.com/DOI-USGS/ISIS3/issues/5861)
 
 ### Removed
 - QT 6 removed MySQL support so MySQL is no longer supported in `isisminer` [#5909](https://github.com/DOI-USGS/ISIS3/pull/5909)

--- a/isis/src/base/objs/CameraDistortionMap/CameraDistortionMap.cpp
+++ b/isis/src/base/objs/CameraDistortionMap/CameraDistortionMap.cpp
@@ -92,14 +92,8 @@ namespace Isis {
       return true;
     }
 
-    // Get the distance from the focal plane center and if we are close
-    // then skip the distortion
+    // Get the distance from the focal plane center
     double r2 = (dx * dx) + (dy * dy);
-    if (r2 <= 1.0E-6) {
-      p_undistortedFocalPlaneX = dx;
-      p_undistortedFocalPlaneY = dy;
-      return true;
-    }
 
     // Ok we need to apply distortion correction
     double drOverR = p_odk[0] + (r2 * (p_odk[1] + (r2 * p_odk[2])));
@@ -140,14 +134,8 @@ namespace Isis {
       return true;
     }
 
-    // Compute the distance from the focal plane center and if we are
-    // close to the center then no distortion is required
+    // Compute the distance from the focal plane center
     double rp2 = (ux * ux) + (uy * uy);
-    if (rp2 <= 1.0E-6) {
-      p_focalPlaneX = ux;
-      p_focalPlaneY = uy;
-      return true;
-    }
 
     // Ok make the correction, start by computing
     // fractional distortion at rp (r-prime)

--- a/isis/src/hayabusa2/objs/Hyb2OncCamera/Hyb2OncDistortionMap.cpp
+++ b/isis/src/hayabusa2/objs/Hyb2OncCamera/Hyb2OncDistortionMap.cpp
@@ -64,16 +64,10 @@ namespace Isis {
     double x = dx;// - p_xp;
     double y = dy;// - p_yp;
     //
-    // Get the distance from the focal plane center and if we are close
-    // then skip the distortion (this prevents division by zero)
+    // Get the distance from the focal plane center
     double r = (x * x) + (y * y);
     double r2 = r*r;
     double r4 = r2*r2;
-    if (r <= 1.0E-6) {
-      p_undistortedFocalPlaneX = dx;
-      p_undistortedFocalPlaneY = dy;
-      return true;
-    }
 
     // apply distortion correction
     // r = x^2 + y^2
@@ -110,8 +104,7 @@ namespace Isis {
     p_undistortedFocalPlaneX = ux;
     p_undistortedFocalPlaneY = uy;
 
-    // Compute the distance from the focal plane center and if we are
-    // close to the center then no distortion is required
+    // Compute the distance from the focal plane center
 
     bool converged = false;
     int iteration = 0;
@@ -119,11 +112,6 @@ namespace Isis {
     double x = ux;
     double y = uy;
     double r = (x * x) + (y * y);
-    if (r <= 1.0E-6) {
-      p_focalPlaneX = ux;
-      p_focalPlaneY = uy;
-      return true;
-    }
     double rPrevious = r;
 
     while (!converged && qAbs(r - rPrevious) > tolMilliMeters) {

--- a/isis/src/juno/objs/JunoCamera/JunoDistortionMap.cpp
+++ b/isis/src/juno/objs/JunoCamera/JunoDistortionMap.cpp
@@ -112,14 +112,8 @@ namespace Isis {
     p_undistortedFocalPlaneX = ux;
     p_undistortedFocalPlaneY = uy;
 
-    // Compute the distance from the focal plane center and if we are
-    // close to the center then assume no distortion
+    // Compute the distance from the focal plane center
     double r2 = (ux * ux) + (uy * uy);
-    if (r2 <= 1.0E-6) {
-      p_focalPlaneX = ux;
-      p_focalPlaneY = uy;
-      return true;
-    }
 
     // The equation given in the IK computes the undistorted focal plane
     // ux = dx * (1 + k1*r^2), r^2 = dx^2 + dy^2
@@ -154,14 +148,8 @@ namespace Isis {
     p_focalPlaneX = dx;
     p_focalPlaneY = dy;
 
-    // Get the distance from the focal plane center and if we are close
-    // then skip the distortion
+    // Get the distance from the focal plane center
     double r2 = (dx * dx) + (dy * dy);
-    if (r2 <= 1.0E-6) {
-      p_undistortedFocalPlaneX = dx;
-      p_undistortedFocalPlaneY = dy;
-      return true;
-    }
 
     bool converged = false;
     int i = 0;

--- a/isis/src/lo/objs/LoHighCamera/LoHighDistortionMap.cpp
+++ b/isis/src/lo/objs/LoHighCamera/LoHighDistortionMap.cpp
@@ -125,14 +125,8 @@ namespace Isis {
     double distx  =  pcx - p_x0;
     double disty  =  pcy - p_y0;
 
-    // Get the distance from the focal plane center and if we are close
-    // skip the distortion
+    // Get the distance from the focal plane center
     double r2 = distx * distx + disty * disty;
-    if(r2 <= 1.0E-6) {
-      p_undistortedFocalPlaneX = pcx;
-      p_undistortedFocalPlaneY = pcy;
-      return true;
-    }
 
     // Otherwise remove distortion
     double drOverR  =  p_odk[0] + p_odk[1] * r2;
@@ -171,25 +165,17 @@ namespace Isis {
     double distux  =  p_undistortedFocalPlaneX - p_x0;
     double distuy  =  p_undistortedFocalPlaneY - p_y0;
 
-    // Compute the distance from the focal plane center and if we are
-    // close to the center then no distortion is required
+    // Compute the distance from the focal plane center
     double rp2 = distux * distux + distuy * distuy;
 
     double pcx, pcy;
 
-    if(rp2 > 1.0E-6) {
+    // Add distortion.  First compute fractional distortion at rp (r-prime)
+    double drOverR   =   p_odk[0]  +  rp2 * p_odk[1];
 
-      // Add distortion.  First compute fractional distortion at rp (r-prime)
-      double drOverR   =   p_odk[0]  +  rp2 * p_odk[1];
-
-      // Compute the perspective corrected x/y
-      pcx  =  p_undistortedFocalPlaneX + (distux * drOverR);
-      pcy  =  p_undistortedFocalPlaneY + (distuy * drOverR);
-    }
-    else {
-      pcx = p_undistortedFocalPlaneX;
-      pcy = p_undistortedFocalPlaneY;
-    }
+    // Compute the perspective corrected x/y
+    pcx  =  p_undistortedFocalPlaneX + (distux * drOverR);
+    pcy  =  p_undistortedFocalPlaneY + (distuy * drOverR);
 
     // Add the perspective error
     double perspectiveCorrection = 1. - (p_xPerspective * pcx) - (p_yPerspective * pcy);

--- a/isis/src/mgs/objs/MocWideAngleCamera/MocWideAngleDistortionMap.cpp
+++ b/isis/src/mgs/objs/MocWideAngleCamera/MocWideAngleDistortionMap.cpp
@@ -70,13 +70,8 @@ namespace Isis {
     p_focalPlaneY = dy;
     double sdy = dy / p_scale;
 
-    // See if we are close to the boresight which implies no distortion
+    // Get the distance from the focal plane center 
     double s2 = dx * dx + sdy * sdy;
-    if(s2 <= 1.0E-6) {
-      p_undistortedFocalPlaneX = dx;
-      p_undistortedFocalPlaneY = sdy;
-      return true;
-    }
 
     // Remove distortion
     double s = sqrt(s2);
@@ -98,13 +93,8 @@ namespace Isis {
     p_undistortedFocalPlaneX = ux;
     p_undistortedFocalPlaneY = uy;
 
-    // See if we are close to boresight
+    // Get the distance from the focal plane center 
     double sp2 = ux * ux + uy * uy;
-    if(sp2 <= 1.0E-6) {
-      p_focalPlaneX = ux;
-      p_focalPlaneY = uy * p_scale;
-      return true;
-    }
 
     // Add distortion
     double sp = sqrt(sp2);

--- a/isis/src/mro/objs/MarciCamera/MarciDistortionMap.cpp
+++ b/isis/src/mro/objs/MarciCamera/MarciDistortionMap.cpp
@@ -50,15 +50,8 @@ namespace Isis {
     double dxPix = p_focalPlaneX / p_camera->PixelPitch();
     double dyPix = p_focalPlaneY / p_camera->PixelPitch();
 
-    // Get the distance from the focal plane center and if we are close
-    // then skip the distortion
+    // Get the distance from the focal plane center
     double radialDist2 = (dxPix * dxPix) + (dyPix * dyPix);
-
-    if(radialDist2 <= 1.0E-3) {
-      p_undistortedFocalPlaneX = dx;
-      p_undistortedFocalPlaneY = dy;
-      return true;
-    }
 
     // Ok we need to apply distortion correction
     double radialDist4 = radialDist2 * radialDist2;
@@ -102,15 +95,8 @@ namespace Isis {
     double dxPix = GuessDx(uxPix);
     double dyPix = uyPix;
 
-    // Get the distance from the focal plane center and if we are close
-    // then skip the distortion
+    // Get the distance from the focal plane center
     double Ru = sqrt((uxPix * uxPix) + (uyPix * uyPix));
-
-    if(Ru <= 1.0E-6) {
-      p_focalPlaneX = ux;
-      p_focalPlaneY = uy;
-      return true;
-    }
 
     double delta = 1.0;
     int iter = 0;

--- a/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexDistortionMap.cpp
+++ b/isis/src/osirisrex/objs/OsirisRexOcamsCamera/OsirisRexDistortionMap.cpp
@@ -308,20 +308,10 @@ namespace Isis {
       std::cout << "xP = " << x0 / m_pixelPitch << ", yP = " << y0 / m_pixelPitch << "\n";
     }
 
-    // Compute the distance from the focal plane center. If we are
-    // close to the center then no distortion is required
+    // Compute the distance from the focal plane center.
     double x = ux;
     double y = uy;
     double r = qSqrt(((x-x0) * (x-x0)) + ((y - y0) * (y-y0)));
-
-    if (r <= 1.0E-6) {
-      p_focalPlaneX = ux;
-      p_focalPlaneY = uy;
-      if ( m_debug ) {
-        std::cout << "Degenerate case at center of distortion!\n";
-      }
-      return true;
-    }
 
     double r2 = r*r;
     double r3 = r2*r;

--- a/isis/src/osirisrex/objs/OsirisRexTagcamsCamera/OsirisRexOcamsDistortionMap.cpp
+++ b/isis/src/osirisrex/objs/OsirisRexTagcamsCamera/OsirisRexOcamsDistortionMap.cpp
@@ -243,17 +243,10 @@ namespace Isis {
     double x0 = (m_distortionOriginLine - m_detectorOriginSample) * m_pixelPitch;
     double y0 = (m_distortionOriginSample - m_detectorOriginLine) * m_pixelPitch;
 
-    // Compute the distance from the focal plane center. If we are
-    // close to the center then no distortion is required
+    // Compute the distance from the focal plane center.
     double x = ux;
     double y = uy;
     double r = qSqrt(((x-x0) * (x-x0)) + ((y - y0) * (y-y0)));
-
-    if (r <= 1.0E-6) {
-      p_focalPlaneX = ux;
-      p_focalPlaneY = uy;
-      return true;
-    }
 
     double r2 = r*r;
     double r3 = r2*r;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Remove checks that treat the pixels around the origin differently in un/distortion operations.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Addresses https://github.com/DOI-USGS/ISIS3/issues/5861

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
