### PR TITLE
Revert "Adds support for accessing COG shape models from STAC API"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,6 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Added PAD or SHRINK options to crop for crops that extend beyond the source image [#5843](https://github.com/DOI-USGS/ISIS3/pull/5843)
 - Added std:: namespace for isinf, fixes build errors for some versions of c++
 - Adds PROJ into ISIS, and exposes the capability with a new class called IProj. [#5317](https://github.com/DOI-USGS/ISIS3/pull/5317)
-- Added support for accessing Cloud Optimized GeoTIFF (COG) shape models via STAC API. [#5919](https://github.com/DOI-USGS/ISIS3/pull/5919)
 
 ### Changed
 - Removed Arm dependency on xalan-c, as it does not build for now on conda-forge. This requires turning off doc building on Arm. Also changed some variables to avoid name clashes on Arm with clang 16. [#5802](https://github.com/DOI-USGS/ISIS3/pull/5802)

--- a/isis/src/base/apps/spiceinit/spiceinit.cpp
+++ b/isis/src/base/apps/spiceinit/spiceinit.cpp
@@ -186,15 +186,6 @@ namespace Isis {
       else if (ui.GetString("SHAPE") == "SYSTEM") {
         dem = baseKernels.dem(lab);
       }
-      else if (ui.GetString("SHAPE") == "WEB") {
-        QString tiffUrl = baseKernels.getDemTiffUrl(lab);
-        if (!tiffUrl.isEmpty()) {
-          dem.push_back(tiffUrl);
-        } 
-        else {
-          dem = baseKernels.dem(lab);
-        }
-      }
 
       bool kernelSuccess = false;
 

--- a/isis/src/base/apps/spiceinit/spiceinit.xml
+++ b/isis/src/base/apps/spiceinit/spiceinit.xml
@@ -805,16 +805,6 @@
                the <b>ShapeModel</b> keyword.
             </description>
           </option>
-          <option value="WEB">
-            <brief>Search default shape model from ISIS STAC API</brief>
-            <description>
-              This option searches the ISIS STAC API for a shape model that matches the target of 
-              the input cube. If no matching shape model is found, spiceinit will fall back to using 
-              SYSTEM to search for a shape model in the data area. The label will contain a vsicurl 
-              URL pointing to the GeoTIFF shape model file in an S3 bucket and can be found in the cube labels
-              Kernels Group under the <b>ShapeModel</b> keyword.
-            </description>
-          </option>
         </list>
       </parameter>
 

--- a/isis/src/system/objs/KernelDb/KernelDb.cpp
+++ b/isis/src/system/objs/KernelDb/KernelDb.cpp
@@ -691,55 +691,6 @@ namespace Isis {
     return matchKeywords && matchTime;
   }
 
-  QString KernelDb::getDemTiffUrl(const Pvl &lab) {
-    QString tiffUrl;
-
-    PvlGroup inst = lab.findGroup("Instrument", Pvl::Traverse);
-    std::string target = (inst.findKeyword("TargetName")[0]).toStdString();
-
-    std::string url = "https://3hr5l9mbj6.execute-api.us-west-2.amazonaws.com/prod/search";
-    std::string jsonData = "{ \"query\": { \"target\": {\"eq\": \"" + target + "\"} } }";
-
-
-    std::string responseBody = curlPostRequest(url, jsonData);
-
-    auto json = nlohmann::json::parse(responseBody);
-
-    if (json.contains("tiff_url")) {
-      tiffUrl = "/vsicurl/" + QString::fromStdString(json["tiff_url"]);
-    }
-
-    return tiffUrl;
-  }
-
-  std::string KernelDb::curlPostRequest(const std::string url, const std::string jsonData) {
-    CURL *curl = curl_easy_init();
-    if (!curl) {
-      throw IException(IException::Programmer, "Failed to initialize CURL", _FILEINFO_);
-    }
-
-    std::string responseBody;
-    struct curl_slist* headers = nullptr;
-    headers = curl_slist_append(headers, "Content-Type: application/json");
-
-    curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, jsonData.c_str());
-    curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, &KernelDb::writeCallback);
-    curl_easy_setopt(curl, CURLOPT_WRITEDATA, &responseBody);
-
-    CURLcode res = curl_easy_perform(curl);
-
-    curl_easy_cleanup(curl);
-    curl_slist_free_all(headers);
-
-    if (res != CURLE_OK) {
-      throw IException(IException::Io, "CURL error: " + QString(curl_easy_strerror(res)), _FILEINFO_);
-    }
-
-    return responseBody;
-  }
-
   /**
    * Loads the appropriate kernel database files with the defined BASE and
    * MISSION info for each type of kernel.

--- a/isis/src/system/objs/KernelDb/KernelDb.h
+++ b/isis/src/system/objs/KernelDb/KernelDb.h
@@ -20,7 +20,6 @@ find files of those names at the top level of this repository. **/
 #include "iTime.h"//???
 #include "Kernel.h"
 #include "Pvl.h"
-#include <curl/curl.h>
 
 class  KernelDbFixture_TestKernelsSmithOffset_Test;
 
@@ -122,9 +121,6 @@ namespace Isis {
       Kernel frame(Pvl &lab);
       Kernel instrumentAddendum(Pvl &lab);
       Kernel dem(Pvl &lab);
-      QString getDemTiffUrl(const Pvl &lab);
-
-      virtual std::string curlPostRequest(const std::string url, const std::string jsonData);
 
       Kernel findLast(const QString &entry, Pvl &lab);
       QList< std::priority_queue<Kernel> > findAll(const QString &entry,
@@ -160,16 +156,6 @@ namespace Isis {
       Pvl m_kernelData; /**< Pvl containing the information in the kernel
                              database(s) that is read in from the constructor
                              and whenever the loadSystemDb() method is called.*/
-
-      static size_t writeCallback(void* ptr, size_t size, size_t nmemb, void* userdata){
-          const size_t total = size * nmemb;
-          if (!ptr || !userdata || total == 0) return 0;
-
-          auto* response = static_cast<std::string*>(userdata);
-          response->append(static_cast<char*>(ptr), total);
-
-          return total;
-      }
   };
 };
 

--- a/isis/tests/KernelDbTests.cpp
+++ b/isis/tests/KernelDbTests.cpp
@@ -6,7 +6,6 @@
 
 #include "FileName.h"
 #include "KernelDb.h"
-#include "Mocks.h"
 #include "Pvl.h"
 #include "PvlGroup.h"
 #include "TestUtilities.h"
@@ -48,7 +47,6 @@ class KernelDbFixture : public ::testing::Test {
         Group = Instrument
           SpacecraftName = IdealSpacecraft
           InstrumentId   = IdealCamera
-          TargetName     = Mars
           StartTime      = "2005 JUN 15 12:00:00.000 TDB"
           StopTime       = "2005 DEC 15 12:00:00.000 TDB"
         End_Group
@@ -296,7 +294,7 @@ TEST_F(KernelDbFixture, SystemKernels) {
   ASSERT_EQ(dbFiles.size(), 10);
 
   QStringList tspks = db.targetPosition(cubeLabel).kernels();
-  ASSERT_EQ(tspks.size(), 2);
+  ASSERT_EQ(tspks.size(), 1);
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, tspks[0], "$base/kernels/spk/de430.bsp");
 
   QList< std::priority_queue<Kernel> > cklist = db.spacecraftPointing(cubeLabel);
@@ -363,14 +361,4 @@ TEST_F(KernelDbFixture, TestKernelsSmithOffset) {
   Kernel cKernels(ck[0].top());
   QStringList cklist = cKernels.kernels();
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, cklist[0], "data/kerneldbgen/thmIR.bc");
-}
-
-TEST_F(KernelDbFixture, TestDemTiffUrl) {
-    MockKernelDb db(Kernel::Predicted);
-
-    EXPECT_CALL(db, curlPostRequest(testing::_, testing::_))
-        .WillOnce(testing::Return("{\"id\": \"molaMarsPlanetaryRadius0005\", \"tiff_url\": \"https://asc-isisdata.s3.us-west-2.amazonaws.com/isis-stac/isis-dtm-collection/molaMarsPlanetaryRadius0005.tiff\"}"));
-
-    QString url = db.getDemTiffUrl(cubeLabel);
-    EXPECT_PRED_FORMAT2(AssertQStringsEqual, url, "/vsicurl/https://asc-isisdata.s3.us-west-2.amazonaws.com/isis-stac/isis-dtm-collection/molaMarsPlanetaryRadius0005.tiff");
 }

--- a/isis/tests/Mocks.h
+++ b/isis/tests/Mocks.h
@@ -12,7 +12,6 @@
 #include "Distance.h"
 #include "Interpolator.h"
 #include "iTime.h"
-#include "KernelDb.h"
 #include "Latitude.h"
 #include "Longitude.h"
 #include "Process.h"
@@ -68,13 +67,6 @@ class MockCamera : public Camera {
     MOCK_METHOD(std::vector<double>, lookDirectionJ2000, (), (const, override));
     MOCK_METHOD(void, instrumentBodyFixedPosition, (double p[3]), (const, override));
     MOCK_METHOD(iTime, time, (), (const, override));
-};
-
-
-class MockKernelDb : public KernelDb {
-  public:
-    MockKernelDb(Kernel::Type type) : KernelDb(type) {}
-    MOCK_METHOD(std::string, curlPostRequest, (const std::string url, const std::string jsonData), (override));
 };
 
 class MockTProjection : public TProjection {


### PR DESCRIPTION
Reverts DOI-USGS/ISIS3#5919


More discussions are needed on query standards for metadata. This means the query parameters will likely change. We came to a conclusion we don't want to have to maintain the old query parameters for version 10.0.0 of isis. We will wait to push these changes until we have the API in a stable state.