### PR TITLE
Fix the isisStartup scripts for users outside of USGS systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ ctest FunctionalTestJigsawApollo to validate this output. [#5710](https://github
 - Fixed `BundleObservationSolveSettings` to properly read empty solve setting xmls [#5822](https://github.com/DOI-USGS/ISIS3/pull/5822)
 - Fixed `footprintinit` to find mapping group (no caps). [#5920](https://github.com/DOI-USGS/ISIS3/pull/5820)
 - Fixed unnecessary un/distortion checks for pixels near the origin. [#5861](https://github.com/DOI-USGS/ISIS3/issues/5861)
+- Fixed the isisStartup scripts for users outside of USGS systems. [#5478](https://github.com/DOI-USGS/ISIS3/issues/5478)
 
 ### Removed
 - QT 6 removed MySQL support so MySQL is no longer supported in `isisminer` [#5909](https://github.com/DOI-USGS/ISIS3/pull/5909)

--- a/isis/scripts/isis3Startup.csh
+++ b/isis/scripts/isis3Startup.csh
@@ -40,7 +40,7 @@ if ($?ISISROOT == 0) then
 endif
 
 # Initialize the ISISDATA environment variable
-if (-d $ISISROOT/../data) then
+if (-d $ISISROOT/../isis_data) then
   setenv ISISDATA $ISISROOT/../isis_data
 else
   setenv ISISDATA /usgs/cpkgs/isis3/isis_data

--- a/isis/scripts/isis3Startup.py
+++ b/isis/scripts/isis3Startup.py
@@ -16,7 +16,7 @@ def setisis():
     os.environ['ISISROOT'] = ISISROOT
 
   #Check for the ISISDATA directory. If it does not exist use a default
-  if os.path.exists("%s/../data" % (ISISROOT)):
+  if os.path.exists("%s/../isis_data" % (ISISROOT)):
     os.environ['ISISDATA'] = "%s/../isis_data" % (ISISROOT)
   else:
     os.environ['ISISDATA'] = "/usgs/cpkgs/isis3/isis_data"

--- a/isis/scripts/isis3Startup.sh
+++ b/isis/scripts/isis3Startup.sh
@@ -16,7 +16,7 @@ if [ ! "$ISISROOT" ]; then
   export ISISROOT
 fi
 
-if [ -d $ISISROOT/../data ]; then
+if [ -d $ISISROOT/../isis_data ]; then
   ISISDATA=$ISISROOT/../isis_data
 else
   ISISDATA=/usgs/cpkgs/isis3/isis_data

--- a/isis/scripts/isisStartup.csh
+++ b/isis/scripts/isisStartup.csh
@@ -18,7 +18,7 @@ if ($?ISISROOT == 0) then
 endif
 
 if ($?ISISDATA == 0) then
-  if (-d $ISISROOT/../data) then
+  if (-d $ISISROOT/../isis_data) then
     setenv ISISDATA $ISISROOT/../isis_data
   else
     setenv ISISDATA /usgs/cpkgs/isis3/isis_data

--- a/isis/scripts/isisStartup.sh
+++ b/isis/scripts/isisStartup.sh
@@ -16,7 +16,7 @@ if [ ! "$ISISROOT" ]; then
 fi
 
 if [ ! "$ISISDATA" ]; then
-  if [ -d $ISISROOT/../data ]; then
+  if [ -d $ISISROOT/../isis_data ]; then
     ISISDATA=$ISISROOT/../isis_data
   else
     ISISDATA=/usgs/cpkgs/isis3/isis_data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
- Fixes the issue #5478 raised by @rvwagner.
- The existence check for the data directory now correctly checks the new data directory path, rather than the old data directory path.
  - The ISISDATA variable assignment was corrected in #3804 to use the new data path, but the existence check was mistakenly left uncorrected.
- The isisStartup scripts now function as they used to pre-4.4.0 and as they were intended to after the incomplete fix in #3804.
- I understand these scripts are not used internally by most of those in the USGS and their continued existence in future versions of ISIS is uncertain. That said, this fix is minor and allows the scripts to function properly for those who do use them. Since they are still included in ISIS, they should at least be working as intended until their fate is decided through fuller discussion in the future.
- Added changelog entry for the fix.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#5478 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
- Validated internally by the LROC team.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
