### PR TITLE
isisimport categories, Linked to missions in new astro docs

### DIFF
--- a/changes/5875.misc.md
+++ b/changes/5875.misc.md
@@ -1,0 +1,1 @@
+Updated isisimport docs, and included it mission categories that need it.  Linked to other docs on missions.

--- a/isis/src/base/apps/isisimport/isisimport.xml
+++ b/isis/src/base/apps/isisimport/isisimport.xml
@@ -7,16 +7,30 @@
 
   <description>
     <p>
-      Reads an input label file and image file. The contents of the ISIS cube label file are
-      generated using the template file specified by the TEMPLATE parameter.
+      Imports an input label file and image file to an ISIS cube,
+      using a template file (optionally specified by the TEMPLATE parameter).
+      The primary ISIS ingestion app for PDS4 products.
     </p>
     <p>
-      If a template file for the input label is included in ISIS, 
-      it will be used automatically and does not need to be specified.
-      NOTE: Some template files are incomplete/still being developed.
+      <code>isisimport</code> will auto-select a template based on product type 
+      (PDS3, PDS4, qube), Spacecraft ID, and Instrument ID. 
+      The auto-selection logic can be found in the 
+      <a href="https://github.com/DOI-USGS/ISIS3/blob/dev/isis/appdata/import/fileTemplate.tpl"><code>$ISISROOT/appdata/import/fileTemplate.tpl</code></a> file.
     </p>
     <p>
-      In particular, isisimport can import Chandrayaan 2, TGO Cassis, and Clipper EIS Images.
+      If auto-selection fails, use the TEMPLATE parameter to specify a template.
+    </p>
+    <p>
+      <code>isisimport</code> should be used for any PDS4 product. 
+      Supported PDS4 missions (as of early 2026) include Chandrayaan 2, TGO Cassis, and Clipper EIS. 
+      If a PDS4-format product can't be ingested with isisimport, 
+      make an issue on the <a href="https://github.com/DOI-USGS/ISIS3/issues">ISIS repo</a>.
+    </p>
+    <p>
+      NOTE: Most PDS3 template files are incomplete. 
+      There is no planned work to migrate PDS3 ingestion into isisimport. 
+      Most PDS3 products have dedicated 2isis applications. 
+      See the relevant mission section of the ISIS docs for details.
     </p>
     <p>
       This application uses the <a href="https://pantor.github.io/inja">Inja templating engine</a>

--- a/isis/src/base/apps/isisimport/isisimport.xml
+++ b/isis/src/base/apps/isisimport/isisimport.xml
@@ -7,13 +7,16 @@
 
   <description>
     <p>
-      NOTE: This program and the associated template files are incomplete. The documentation
-      describes what the eventual intended capabilities are. Many capabilities are not implemented
-      at this time.
-    </p>
-    <p>
       Reads an input label file and image file. The contents of the ISIS cube label file are
       generated using the template file specified by the TEMPLATE parameter.
+    </p>
+    <p>
+      If a template file for the input label is included in ISIS, 
+      it will be used automatically and does not need to be specified.
+      NOTE: Some template files are incomplete/still being developed.
+    </p>
+    <p>
+      In particular, isisimport can import Chandrayaan 2, TGO Cassis, and Clipper EIS Images.
     </p>
     <p>
       This application uses the <a href="https://pantor.github.io/inja">Inja templating engine</a>
@@ -26,11 +29,17 @@
 
   <category>
     <categoryItem>Import and Export</categoryItem>
+    <missionItem>Chandrayaan 2</missionItem>
+    <missionItem>ExoMars Trace Gas Orbiter</missionItem>
+    <missionItem>Clipper</missionItem>
   </category>
 
   <history>
     <change name="Kristin Berry and Amy Stamile" date="2021-05-17">
       Original version
+    </change>
+    <change name="Jacob Cain" date="2026-02-05">
+      Listed missions where isisimport is the main method of import.
     </change>
   </history>
 

--- a/isis/src/docsys/Application/build/TOCindex_category.xsl
+++ b/isis/src/docsys/Application/build/TOCindex_category.xsl
@@ -102,6 +102,16 @@ Deborah Lee Soltesz
             </ul>
 
             <h3>Mission Specific Programs</h3>
+            <p>For more info on select missions (LRO, MRO, MGS, Viking, Chandrayaan 2), see 
+              <a href="https://astrogeology.usgs.gov/docs/concepts/missions/" target="_blank" rel="noopener">
+                Astro Software Docs
+              </a>.
+              We are in the process of porting more mission (Cassini, Kaguya) pages from the (deprecated)
+              <a href="https://github.com/DOI-USGS/ISIS3/wiki" target="_blank" rel="noopener">
+                ISIS3 git wiki
+              </a>
+              to Astro Software Docs.
+            </p>
             <ul class="card-list-sm">
                 <xsl:for-each select="//application/category/missionItem[not(normalize-space(.)=preceding::application/category/missionItem)]">
                   <xsl:sort order="ascending" select="normalize-space(.)"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Adds a bit of info on isisimport and the missions it supports.

Under the Astrogeology Software umbrella, the [ISIS Application Docs](https://isis.astrogeology.usgs.gov/Application/index.html) is the location where the most missions are listed. Adding this info there may help it be visible to more users, in particular info on which missions use the isisimport app rather than a mission-specific import app.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#5875
Links to the location of Mission docs in the Astro Software Docs Site.  (Chandrayaan 2 docs, upcoming with ISIS 10.0, will be listed there.)

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
