### PR TITLE
Add DeepWiki documentation badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/DOI-USGS/ISIS3)
+
 <p align="center">
   <img src="isis/src/docsys/assets/img/image-source-files/ISIS_Logo.svg" alt="ISIS" width=200> 
 </p>


### PR DESCRIPTION
Adds a [DeepWiki](https://deepwiki.com/DOI-USGS/ISIS3) badge to the README for auto-generated interactive documentation.

This is a minimal, single-line addition.