### PR TITLE
Fix plot table

### DIFF
--- a/5962.fix.md
+++ b/5962.fix.md
@@ -1,0 +1,1 @@
+Fixes the table generation from plot windows in ISIS qapps not capturing all pixels

--- a/isis/src/qisis/objs/PlotWindow/PlotWindow.cpp
+++ b/isis/src/qisis/objs/PlotWindow/PlotWindow.cpp
@@ -1467,10 +1467,9 @@ namespace Isis {
                      (inverseDataIndex * percentPerDataIndex)) * 1000.0));
 
 
-        QList<QString>::const_iterator foundPos =
-            std::lower_bound(xAxisPoints.begin(), xAxisPoints.end(), xValueString);
+        bool foundPos = std::binary_search(xAxisPoints.begin(), xAxisPoints.end(), xValueString);
 
-        if (foundPos == xAxisPoints.end()) {
+        if (!foundPos) {
           bool inserted = false;
 
           for (int searchIndex = 0;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes issues generating tables from plots in qapps after move to qt 5.15

## Related Issue
#5962 

## How Has This Been Validated?
Validated locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
