### PR TITLE
fixes appjit test failures

### DIFF
--- a/changes/+20260219074823.fix.md
+++ b/changes/+20260219074823.fix.md
@@ -1,0 +1,1 @@
+Fixes appjit to load kernels by bypassing ale.

--- a/isis/src/base/apps/appjit/LineScanCameraRotation.cpp
+++ b/isis/src/base/apps/appjit/LineScanCameraRotation.cpp
@@ -41,8 +41,9 @@ namespace Isis {
     p_yaw = 0.;
 
     // Load the Spice kernels to get state matrices
+    bool useIsis = true;
     p_spi = 0;
-    p_spi = new Isis::Spice(cube);
+    p_spi = new Isis::Spice(cube, useIsis);
 
     // Make sure the kernels are written to the labels and not just the tables (blobs)
     Pvl &lab = *cube.label();

--- a/isis/src/base/objs/Spice/Spice.cpp
+++ b/isis/src/base/objs/Spice/Spice.cpp
@@ -103,6 +103,27 @@ namespace Isis {
     }
   }
 
+  /**
+   * Constructs a Spice Object to load kernels
+   * by bypassing use of ale.
+   *
+   * @param cube Isis Cube
+   * @param useIsis Override using ale to load kernels
+   */
+  Spice::Spice(Cube &cube, bool useIsis)
+    : Spice(cube)   {
+    if (useIsis) {
+      Pvl &lab = *cube.label();
+      PvlGroup kernels = lab.findGroup("Kernels", Pvl::Traverse);
+      bool hasTables = (kernels["TargetPosition"][0] == "Table");
+
+      m_usingNaif = !lab.hasObject("NaifKeywords") || !hasTables;
+      m_usingAle = false;
+
+      init(cube, lab, !hasTables);
+    }
+  }
+
 
   /**
    * Constructs a Spice Object

--- a/isis/src/base/objs/Spice/Spice.h
+++ b/isis/src/base/objs/Spice/Spice.h
@@ -285,6 +285,7 @@ namespace Isis {
       // constructors
       Spice(Cube &cube);
       Spice(Pvl &lab, nlohmann::json isd);
+      Spice(Cube &cube, bool useIsis);
 
       // destructor
       virtual ~Spice();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Latest ale update (1.1.0) fixed hirise isd generation which exposed a bug in appjit where if it constructs a spice object for the purpose of loading kernels but kernels do not load in if an ale isd is generated. I added a constructor in Spice that purposely bypasses the use of ale so that apps can load in kernels.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
