### PR TITLE
Factor out complex makefile test logic

### DIFF
--- a/changes/5982.change.md
+++ b/changes/5982.change.md
@@ -1,0 +1,1 @@
+Extracted complex shell logic from isismake.tsts into standalone scripts for maintainability.

--- a/isis/make/isismake.tsts
+++ b/isis/make/isismake.tsts
@@ -6,7 +6,7 @@ include $(ISISROOT)/make/isismake.os
 
 .NOTPARALLEL:
 
-# File extensions that valid file types to compare
+# File extensions that are valid file types to compare
 BINFILES =  jpg tif bin fits raw bmp png bc img imq
 PVLFILES =  pvl
 
@@ -140,57 +140,9 @@ help: FORCE
 # printed out. The time that it took for the test to run is also printed.
 #----------------------------------------------------------------------------
 test: FORCE clean
-	TIME1=`date +"%s"`;                                                        \
-	if [ -d "$(TRUTH)" ]; then                                                 \
-	  TRUTHDIR=`$(LS) $(TRUTH)`;                                               \
-	  if [ "$$TRUTHDIR" == "" ]; then                                          \
-	    MSG='$(NOTRUTHFILE)';                                                  \
-	    echo -n $(CURTIMESTAMP) >> errors.txt;                                 \
-	    $(PRINTF) "$(BLANKS)  " >> errors.txt;                                 \
-	    $$MSG >> errors.txt;                                                   \
-	  else                                                                     \
-	    $(MAKE) output;                                                        \
-	    TRUTHFILECOUNT=`$(LS) -p $(TRUTH)/ | $(GREP) -v "/" | wc -l`;          \
-	    OUTPUTFILECOUNT=`$(LS) -p $(OUTPUT)/ | $(GREP) -v "/" | wc -l`;        \
-	    if [ $$TRUTHFILECOUNT -ne $$OUTPUTFILECOUNT ]; then                    \
-	      MSG='$(FILECOUNTMISMATCH)';                                          \
-	      echo -n $(CURTIMESTAMP) >> errors.txt;                               \
-	      $(PRINTF) "$(BLANKS)  " >> errors.txt;                               \
-	      echo $$MSG;                                                          \
-	      echo Truth file count: $$TRUTHFILECOUNT;                             \
-	      echo Output file count: $$OUTPUTFILECOUNT;                           \
-	      $$MSG >> errors.txt;                                                 \
-	    else                                                                   \
-	      $(MAKE) comparefiles;                                                \
-	    fi;                                                                    \
-	  fi;                                                                      \
-	else                                                                       \
-	  MSG='$(NOTRUTH)';                                                        \
-	  echo -n $(CURTIMESTAMP) >> errors.txt;                                   \
-	  $(PRINTF) "$(BLANKS)  " >> errors.txt;                                   \
-	  $$MSG >> errors.txt;                                                     \
-	fi;                                                                        \
-	TIME2=`date +"%s"`;                                                        \
-	TIMEDIFF=`expr $$TIME2 - $$TIME1`;                                         \
-	SEC60=`expr $$TIMEDIFF % 60`;                                              \
-	MIN=`expr $$TIMEDIFF / 60`;                                                \
-	MIN60=`expr $$MIN % 60`;                                                   \
-	HOUR=`expr $$MIN / 60`;                                                    \
-	HOUR60=`expr $$HOUR % 60`;                                                 \
-	echo -n $(CURTIMESTAMP);                                                   \
-	if [ -f casesucceeded.txt ]; then                                          \
-	  eval $(TESTPASSED);                                                      \
-	  $(PRINTF) "Duration [%.2i:%.2i:%.2i]\n" $$HOUR60 $$MIN60 $$SEC60;        \
-	                                                                           \
-	  $(RM) casesucceeded.txt;                                                 \
-	  if [ "$(findstring $(TESTNOCLEAN), $(MODE))" != "$(TESTNOCLEAN)" ]; then \
-	    $(MAKE) ccsafeclean;                                                   \
-	  fi;                                                                      \
-	else                                                                       \
-	  eval $(TESTFAILED);                                                      \
-	  $(PRINTF) "Duration [%.2i:%.2i:%.2i]\n" $$HOUR60 $$MIN60 $$SEC60;        \
-	  echo Summary error file: $(shell pwd)/errors.txt;                        \
-	fi;
+	$(ISISROOT)/scripts/run_test.sh                                            \
+	    "$(TRUTH)" "$(OUTPUT)" "$(CASE)"                                       \
+	    "$(if $(findstring $(TESTNOCLEAN),$(MODE)),yes,no)"
 
 #-------------------------------------------------------------------------
 # Target = compare
@@ -203,47 +155,8 @@ test: FORCE clean
 # encountered (found in errors.txt).
 #-------------------------------------------------------------------------
 compare: FORCE
-	if [ -d "$(OUTPUT)" ]; then                                                \
-	  if [ -d "$(TRUTH)" ]; then                                               \
-	    TRUTHDIR=`$(LS) $(TRUTH)`;                                             \
-	    if [ "$$TRUTHDIR" == "" ]; then                                        \
-	      MSG='$(NOTRUTHFILE)';                                                \
-	      echo -n $(CURTIMESTAMP) >> errors.txt;                               \
-	      $(PRINTF) "$(BLANKS)  " >> errors.txt;                               \
-	      $$MSG >> errors.txt;                                                 \
-	    else                                                                   \
-	      TRUTHFILECOUNT=`$(LS) -p $(TRUTH)/ | $(GREP) -v "/" | wc -l`;        \
-	      OUTPUTFILECOUNT=`$(LS) -p $(OUTPUT)/ | $(GREP) -v "/" | wc -l`;      \
-	      if [ $$TRUTHFILECOUNT -ne $$OUTPUTFILECOUNT ]; then                  \
-	        MSG='$(FILECOUNTMISMATCH)';                                        \
-	        echo -n $(CURTIMESTAMP) >> errors.txt;                             \
-	        $(PRINTF) "$(BLANKS)  " >> errors.txt;                             \
-	        $$MSG >> errors.txt;                                               \
-	      else                                                                 \
-	        $(MAKE) comparefiles;                                              \
-	      fi;                                                                  \
-	    fi;                                                                    \
-	  else                                                                     \
-	    MSG='$(NOTRUTH)';                                                      \
-	    echo -n $(CURTIMESTAMP) >> errors.txt;                                 \
-	    $(PRINTF) "$(BLANKS)  " >> errors.txt;                                 \
-	    $$MSG >> errors.txt;                                                   \
-	  fi;                                                                      \
-	                                                                           \
-	  if [ -f casesucceeded.txt ]; then                                        \
-	    eval $(TESTPASSED);                                                    \
-	    echo;                                                                  \
-	    $(RM) casesucceeded.txt;                                               \
-	  else                                                                     \
-	    eval $(TESTFAILED);                                                    \
-	    echo $(CURTIMESTAMP);                                                  \
-	    $(CAT) errors.txt;                                                     \
-	    $(RM) errors.txt;                                                      \
-	  fi;                                                                      \
-	else                                                                       \
-	  MSG='$(NOOUTPUT)';                                                       \
-	  eval $$MSG;                                                              \
-	fi;
+	$(ISISROOT)/scripts/compare_test_results.sh                                \
+	    "$(TRUTH)" "$(OUTPUT)" "$(CASE)"
 
 #----------------------------------------------------------------------------
 # Target = comparefiles
@@ -267,238 +180,15 @@ compare: FORCE
 # file, but with .TOL appended. Example: labels.pvl.TOL.
  
 comparefiles: FORCE
-	TRUTHFILECOUNT=`$(LS) -p $(TRUTH)/ | $(GREP) -v "/" | wc -l`;              \
-	SUCCESSFULCOMPARISONS=0;                                                   \
-	                                                                           \
-	FILES="$(notdir $(wildcard $(TRUTH)/*))";                                  \
-	for FILE in $$FILES; do                                                    \
-	                                                                           \
-	  if [ ! -f $(OUTPUT)/$$FILE ]; then                                       \
-	    MSG="$(FILENOTFOUND) [$$FILE]";                                        \
-	    echo -n $(CURTIMESTAMP) >> errors.txt;                                 \
-	    $(PRINTF) "$(BLANKS)   " >> errors.txt;                                \
-	    $$MSG >> errors.txt;                                                   \
-	  else                                                                     \
-	    FILETYPE=$${FILE##*.};                                                 \
-	    FAILURE_REPORT=$(OUTPUT)/$$FILE.err.txt;                               \
-	                                                                           \
-	    if [ "$$FILETYPE" == "cub" ]; then                                     \
-	      # Parse .cub tolerance based on cub name                             \
-	      TOLERANCESTR="";                                                     \
-	      FILETOLERANCES="$(foreach TOLERANCEVAR,                              \
-	                          $(filter %.TOLERANCE,$(.VARIABLES)),             \
-	                          $(TOLERANCEVAR);$($(TOLERANCEVAR)))";            \
-	      TOLERANCESTR=`echo "$$FILETOLERANCES"                                \
-	                     | perl -p -e "s#\s#\n#g"                              \
-	                     | grep $$FILE | grep TOLERANCE                        \
-	                     | perl -p -e "s#^.*?TOLERANCE;##g"`;                  \
-	      if [ "$$TOLERANCESTR" != "" ]; then                                  \
-	        echo Tolerance from Makefile for $$FILE: $$TOLERANCESTR;           \
-	      else                                                                 \
-	        TOLERANCESTR=1e-8;                                                 \
-	        echo Default tolerance for $$FILE: $$TOLERANCESTR;                 \
-	      fi;                                                                  \
-	                                                                           \
-	      IGNORESTR="";                                                        \
-	      FILESTOIGNORESPECIALS="$(foreach IGNOREVAR,$(filter                  \
-	                                 %.IGNORESPECIAL,$(.VARIABLES)),           \
-	                                 $(IGNOREVAR);$($(IGNOREVAR)))";           \
-	      if [ -n "$$FILESTOIGNORESPECIALS" ]; then                            \
-	        for IGNOREDFILE in $$FILESTOIGNORESPECIALS; do                     \
-	          IGNOREDNAME=`echo "$$IGNOREDFILE" | sed "s/;.*//"`;              \
-	          if [ "$$IGNOREDNAME" == "$$FILE.IGNORESPECIAL" ]; then           \
-	            IGNOREDVALUE=`echo "$$IGNOREDFILE" | sed "s/^.*;//"`;          \
-	            IGNORESTR="ignorespecial=$$IGNOREDVALUE";                      \
-	            break;                                                         \
-	          fi;                                                              \
-	        done;                                                              \
-	      fi;                                                                  \
-	    else                                                                   \
-	      # Parse tolerance for non-cub                                        \
-	      TOL_FILE="$(INPUT)/$$FILE.TOL";                                      \
-	      REPO_TOL_FILE="$(shell pwd)/$$FILE.TOL";                             \
-	      if [ -f "$$REPO_TOL_FILE" ]; then                                    \
-	        # A few tests have the tol file in the isis repo, then use that.   \
-	        TOL_FILE="$$REPO_TOL_FILE";                                        \
-	      fi;                                                                  \
-	      TOLERANCESTR=1e-8;                                                   \
-	      if [ -f "$$TOL_FILE" ]; then                                         \
-	        TOLERANCESTR=`$(CAT) $$TOL_FILE`;                                  \
-	      fi;                                                                  \
-	    fi;                                                                    \
-	                                                                           \
-	    DIFFFILE_CANDIDATE="$(INPUT)/$$FILE.DIFF";                             \
-	    DIFFFILE=$$DIFFFILE_CANDIDATE;                                         \
-	    if [ ! -f $$DIFFFILE ]; then                                           \
-	      DIFFFILE='';                                                         \
-	    fi;                                                                    \
-	                                                                           \
-	    # cub                                                                  \
-	    if [ "$$FILETYPE" == "cub" ]; then                                     \
-	      $(ISISROOT)/bin/cubediff                                             \
-	         $(TSTARGS)                                                        \
-	         from=$(TRUTH)/$$FILE                                              \
-	         from2=$(OUTPUT)/$$FILE                                            \
-	         to=$$FAILURE_REPORT                                               \
-	         TOLERANCE=$$TOLERANCESTR                                          \
-	         $$IGNORESTR 1>>/dev/null 2> $$FAILURE_REPORT;                     \
-	      res=$$?;                                                             \
-	      if [ $$res != 0 ]; then                                              \
-	        # cubediff cannot handle different number of special pixels.       \
-	        echo cubediff failed. Try GDAL.;                                   \
-	        truthStats=$${FILE}.truth.txt; currStats=$${FILE}.curr.txt;        \
-	        gdalinfo -stats $(TRUTH)/$$FILE > $$truthStats;                    \
-	        gdalinfo -stats $(OUTPUT)/$$FILE > $$currStats;                    \
-	        $(RM) $(TRUTH)/$$FILE.aux.xml $(OUTPUT)/$$FILE.aux.xml;            \
-	        python $(ISISROOT)/scripts/textdiff.py $$truthStats                \
-	            $$currStats -abs_err $$TOLERANCESTR $$DIFFFILE                 \
-	            > $$FAILURE_REPORT 2>&1;                                       \
-	        res=$$?;                                                           \
-	      fi;                                                                  \
-	                                                                           \
-	      if [ $$res != 0 ]; then                                              \
-	        COMPRESULT="ERROR";                                                \
-	      else                                                                 \
-	        COMPRESULT="identical";                                            \
-	      fi;                                                                  \
-	      if [ "$$COMPRESULT" != "identical" ]; then                           \
-	        MSG="$(TESTFILEFAILED) [$$FILE]";                                  \
-	        echo -n $(CURTIMESTAMP) >> errors.txt;                             \
-	        $(PRINTF) "$(BLANKS)   " >> errors.txt;                            \
-	        $$MSG >> errors.txt;                                               \
-	        if [ "$$COMPRESULT" == "ERROR" ]; then                             \
-	          cat $$FAILURE_REPORT >> errors.txt;                              \
-	        fi;                                                                \
-	        echo Failed comparing cubes. Report: $(shell pwd)/$$FAILURE_REPORT;\
-	        echo Add/update the truth cube tolerance in the test Makefile.;    \
-	        echo Truth cube that needs tolerance: $$FILE;                      \
-	        echo File with fields to ignore: $$DIFFFILE_CANDIDATE;             \
-	        tail -n 1 $$FAILURE_REPORT;                                        \
-	      else                                                                 \
-	        let SUCCESSFULCOMPARISONS++;                                       \
-	        $(RM) $$FAILURE_REPORT 2>/dev/null;                                \
-	        $(RM) $$truthStats     2>/dev/null;                                \
-	        $(RM) $$currStats      2>/dev/null;                                \
-	        $(RM) errors.txt       2>/dev/null;                                \
-	      fi;                                                                  \
-	                                                                           \
-	    # txt, csv, pvl                                                        \
-	    elif [ "$$FILETYPE" == "txt" ] || [ "$$FILETYPE" == "csv" ] ||         \
-	         [ "$$FILETYPE" == "pvl" ]; then                                   \
-	      python $(ISISROOT)/scripts/textdiff.py $(TRUTH)/$$FILE               \
-	          $(OUTPUT)/$$FILE -abs_err $$TOLERANCESTR $$DIFFFILE              \
-	          > $$FAILURE_REPORT 2>&1;                                         \
-	                                                                           \
-	      if [ $$? -ne 0 ]; then                                               \
-	        MSG="$(TESTFILEFAILED) [$$FILE]";                                  \
-	        echo -n $(CURTIMESTAMP) >> errors.txt;                             \
-	        $(PRINTF) "$(BLANKS)   " >> errors.txt;                            \
-	        $$MSG >> errors.txt;                                               \
-	        cat $$FAILURE_REPORT >> errors.txt;                                \
-	        echo Failed comparing txt. Report: $(shell pwd)/$$FAILURE_REPORT;  \
-	        echo Tolerance: $$TOLERANCESTR;                                    \
-	        echo Tolerance file to update: $$TOL_FILE;                         \
-	        echo File with fields to ignore: $$DIFFFILE_CANDIDATE;             \
-	        tail -n 1 $$FAILURE_REPORT;                                        \
-	      else                                                                 \
-	        let SUCCESSFULCOMPARISONS++;                                       \
-	        if [ -f $$FAILURE_REPORT ]; then                                   \
-	          $(RM) $$FAILURE_REPORT;                                          \
-	        fi;                                                                \
-	      fi;                                                                  \
-	                                                                           \
-	    # cnet                                                                 \
-	    elif [ "$$FILETYPE" == "net" ]; then                                   \
-	      $(ISISROOT)/bin/cnetdiff                                             \
-	          $(TSTARGS)                                                       \
-	          from=$(TRUTH)/$$FILE                                             \
-	          from2=$(OUTPUT)/$$FILE                                           \
-	          to=compare.txt                                                   \
-	          diff=$$DIFFFILE 1>>/dev/null 2>cnetdiffError.txt;                \
-	      if [ $$? != 0 ]; then                                                \
-	        COMPRESULT="ERROR";                                                \
-	      else                                                                 \
-	        COMPRESULT=`$(ISISROOT)/bin/getkey from=compare.txt                \
-	          grp=Results keyword=Compare | tr '[:upper:]' '[:lower:]'`;       \
-	      fi;                                                                  \
-	      if [ "$$COMPRESULT" != "identical" ]; then                           \
-	        MSG="$(TESTFILEFAILED) [$$FILE]";                                  \
-	        echo -n $(CURTIMESTAMP) >> errors.txt;                             \
-	        $(PRINTF) "$(BLANKS)   " >> errors.txt;                            \
-	        $$MSG >> errors.txt;                                               \
-	        if [ "$$COMPRESULT" == "ERROR" ]; then                             \
-	          cat cnetdiffError.txt >> errors.txt;                             \
-	        fi;                                                                \
-	        echo Failed comparing cnet;                                        \
-	        cat compare.txt;                                                   \
-	        echo File with fields to ignore: $$DIFFFILE_CANDIDATE;             \
-	      else                                                                 \
-	        let SUCCESSFULCOMPARISONS++;                                       \
-	      fi;                                                                  \
-	      $(RM) compare.txt;                                                   \
-	      if [ -f cnetdiffError.txt ]; then                                    \
-	        $(RM) cnetdiffError.txt;                                           \
-	      fi;                                                                  \
-	                                                                           \
-	    # binary                                                               \
-	    elif [[ "$(BINFILES)" =~ "$$FILETYPE" ]]; then                         \
-	      $(DIFF) $(TRUTH)/$$FILE $(OUTPUT)/$$FILE > /dev/null;                \
-	      res=$$?;                                                             \
-	      if [ $$res != 0 ]; then                                              \
-	        # Fallback to GDAL-based comparison                                \
-	        truthCub=$${FILE}.truth.cub; currCub=$${FILE}.curr.cub;            \
-	        truthStats=$${FILE}.truth.txt; currStats=$${FILE}.curr.txt;        \
-	        raw2isis lines=100 samples=100 from = $(TRUTH)/$$FILE              \
-	          to = $$truthCub;                                                 \
-	        raw2isis lines=100 samples=100 from = $(OUTPUT)/$$FILE             \
-	          to = $$currCub;                                                  \
-	        gdalinfo -stats $$truthCub > $$truthStats;                         \
-	        gdalinfo -stats $$currCub > $$currStats;                           \
-	        $(RM) $${truthCub}.aux.xml $${currCub}.aux.xml;                    \
-	        python $(ISISROOT)/scripts/textdiff.py $$truthStats                \
-	            $$currStats -abs_err $$TOLERANCESTR $$DIFFFILE                 \
-	            > $$FAILURE_REPORT 2>&1;                                       \
-	        res=$$?;                                                           \
-	      fi;                                                                  \
-	      if [ $$res != 0 ]; then                                              \
-	        MSG="$(TESTFILEFAILED) [$$FILE]";                                  \
-	        echo -n $(CURTIMESTAMP) >> errors.txt;                             \
-	        $(PRINTF) "$(BLANKS)   " >> errors.txt;                            \
-	        $$MSG >> errors.txt;                                               \
-	        cat $$FAILURE_REPORT >> errors.txt;                                \
-	        echo Failed comparing binary.;                                     \
-	        echo Report: $(shell pwd)/$$FAILURE_REPORT;                        \
-	        echo Tolerance: $$TOLERANCESTR;                                    \
-	        echo Tolerance file to update: $$TOL_FILE;                         \
-	        echo File with fields to ignore: $$DIFFFILE_CANDIDATE;             \
-	        tail -n 1 $$FAILURE_REPORT;                                        \
-	      else                                                                 \
-	        let SUCCESSFULCOMPARISONS++;                                       \
-	        $(RM) $$FAILURE_REPORT 2>/dev/null;                                \
-	        $(RM) $$truthCub       2>/dev/null;                                \
-	        $(RM) $$currCub        2>/dev/null;                                \
-	        $(RM) $$truthStats     2>/dev/null;                                \
-	        $(RM) $$currStats      2>/dev/null;                                \
-	      fi;                                                                  \
-	                                                                           \
-	    # unknown                                                              \
-	    else                                                                   \
-	      MSG="$(UNKNOWNFILE) [$$FILE]";                                       \
-	      echo Unknown file type: $FFILE;                                      \
-	      echo -n $(CURTIMESTAMP) >> errors.txt;                               \
-	      $(PRINTF) "$(BLANKS)   " >> errors.txt;                              \
-	      $$MSG >> errors.txt;                                                 \
-	    fi;                                                                    \
-	  fi;                                                                      \
-	done;                                                                      \
-	                                                                           \
-	if [ $$SUCCESSFULCOMPARISONS -eq $$TRUTHFILECOUNT ]; then                  \
-	  touch casesucceeded.txt;                                                 \
-	elif [ ! -s errors.txt ]; then                                             \
-	  MSG='$(NOTALLMATCH)';                                                    \
-	  $(PRINTF) "$(BLANKS)   " >> errors.txt;                                  \
-	  $$MSG >> errors.txt;                                                     \
-	fi;
+	TOLERANCES="$(foreach TOLERANCEVAR,                                        \
+	    $(filter %.TOLERANCE,$(.VARIABLES)),                                   \
+	    $(TOLERANCEVAR);$($(TOLERANCEVAR)))";                                  \
+	IGNORESPECIALS="$(foreach IGNOREVAR,                                       \
+	    $(filter %.IGNORESPECIAL,$(.VARIABLES)),                               \
+	    $(IGNOREVAR);$($(IGNOREVAR)))";                                        \
+	$(ISISROOT)/scripts/compare_test_files.sh                                  \
+	    "$(TRUTH)" "$(OUTPUT)" "$(INPUT)" "$(ISISROOT)"                        \
+	    "$(TSTARGS)" "$(BINFILES)" "$$TOLERANCES" "$$IGNORESPECIALS"
 
 #----------------------------------------------------------------------------
 # Target = truthdata
@@ -584,8 +274,8 @@ ccsafeclean: FORCE
 # Performs the modifications to the files in the output
 # directory.  Iterates over the output files and modifies
 # the file based on variables such as .SKIPLINES
-# Utilizes the modText and modBin targets to carryout
-# the modifactions.
+# Utilizes the modText and modBin targets to carry out
+# the modifications.
 #----------------------------------------------------------------------------
 modifyFiles: FORCE
 	files="$(notdir $(wildcard $(OUTPUT)/*.txt) )"; \
@@ -605,7 +295,7 @@ modifyFiles: FORCE
 # Target = modText
 # Dependencies =
 #
-# Handles the modifactions of text files in the output
+# Handles the modifications of text files in the output
 # directory.  Looks at variables .SKIPLINES and .IGNORELINES.
 # The variable FILE must be set to the name of the file in
 # the output directory to be modified.
@@ -640,7 +330,7 @@ modText: FORCE
 # Target = modBin
 # Dependencies =
 #
-# Handles the modifactions of bin files in the output
+# Handles the modifications of bin files in the output
 # directory.  Looks at variables .BINSKIP and .BINCOUNT.
 # The variable FILE must be set to the name of the file in
 # the output directory to be modified.
@@ -675,7 +365,7 @@ modBin: FORCE
 # Modified so we can do "make checkin" for files/dirs we do not own in the
 # testdata area.
 # The reasons for the (RM):
-#   NOTE: chmod docs say you can not set permissioins unless you own the file
+#   NOTE: chmod docs say you can not set permissions unless you own the file
 #   NOTE: rsync can not set the times on directories you do not own
 # Thus the (RM) makes everything work
 # Modified by: Steven Lambright 2007-07-18
@@ -863,7 +553,7 @@ dirs: FORCE
 # Dependencies =
 #
 # Changes the directory permissions starting at DEST_PATH
-# and preceding up the directory path till a directory is found
+# and proceeding up the directory path till a directory is found
 # that matches the DIRLISTPATTERN variable.  Both the
 # LOOKUP and DEST_PATH variables need to be set in order
 # to work properly.  LOOKUP is the first directory to start checking

--- a/isis/scripts/compare_test_files.sh
+++ b/isis/scripts/compare_test_files.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# Compare truth and output files for ISIS legacy Makefile tests.
+# Called from isismake.tsts comparefiles target.
+#
+# Usage:
+#   compare_test_files.sh TRUTH OUTPUT INPUT ISISROOT TEST_ARGS \
+#     BINFILES TOLERANCES IGNORESPECIALS
+#
+# Arguments:
+#   TRUTH          - truth directory path
+#   OUTPUT         - output directory path
+#   INPUT          - input directory path
+#   ISISROOT       - ISIS root (build dir)
+#   TEST_ARGS        - test arguments (e.g., -preference=...)
+#   BINFILES       - space-separated binary file extensions
+#   TOLERANCES     - Make-collected tolerance string
+#                    (e.g., "file.cub.TOLERANCE;0.001 file2.cub.TOLERANCE;0.01")
+#   IGNORESPECIALS - Make-collected ignore-special string
+#                    (e.g., "file.cub.IGNORESPECIAL;yes")
+
+TRUTH="$1"
+OUTPUT="$2"
+INPUT="$3"
+ISISROOT="$4"
+TEST_ARGS="$5"
+BINFILES="$6"
+TOLERANCES="$7"
+IGNORESPECIALS="$8"
+
+FILES=$(ls -1 "$TRUTH"/ 2>/dev/null | grep -v '/$')
+TRUTHFILECOUNT=$(echo "$FILES" | grep -c .)
+SUCCESSFULCOMPARISONS=0
+
+for FILE in $FILES; do
+
+  if [ ! -f "$OUTPUT/$FILE" ]; then
+    echo "Failed ... File does not exist [$FILE]"
+    echo "  Failed ... File does not exist [$FILE]" >> errors.txt
+  else
+    FILETYPE=${FILE##*.}
+    FAILURE_REPORT="$OUTPUT/$FILE.err.txt"
+
+    if [ "$FILETYPE" == "cub" ]; then
+      # Parse .cub tolerance based on cub name
+      TOLERANCESTR=""
+      if [ -n "$TOLERANCES" ]; then
+        TOLERANCESTR=$(echo "$TOLERANCES" \
+                       | perl -p -e "s#\s#\n#g" \
+                       | grep "$FILE" | grep TOLERANCE \
+                       | perl -p -e "s#^.*?TOLERANCE;##g")
+      fi
+      if [ "$TOLERANCESTR" != "" ]; then
+        echo "Tolerance from Makefile for $FILE: $TOLERANCESTR"
+      else
+        TOLERANCESTR=1e-8
+        echo "Default tolerance for $FILE: $TOLERANCESTR"
+      fi
+
+      # Parse ignore-special
+      IGNORESTR=""
+      if [ -n "$IGNORESPECIALS" ]; then
+        for IGNOREDFILE in $IGNORESPECIALS; do
+          IGNOREDNAME=$(echo "$IGNOREDFILE" | sed "s/;.*//")
+          if [ "$IGNOREDNAME" == "$FILE.IGNORESPECIAL" ]; then
+            IGNOREDVALUE=$(echo "$IGNOREDFILE" | sed "s/^.*;//")
+            IGNORESTR="ignorespecial=$IGNOREDVALUE"
+            break
+          fi
+        done
+      fi
+    else
+      # Parse tolerance for non-cub
+      TOL_FILE="$INPUT/$FILE.TOL"
+      REPO_TOL_FILE="$(pwd)/$FILE.TOL"
+      if [ -f "$REPO_TOL_FILE" ]; then
+        TOL_FILE="$REPO_TOL_FILE"
+      fi
+      TOLERANCESTR=1e-8
+      if [ -f "$TOL_FILE" ]; then
+        TOLERANCESTR=$(cat "$TOL_FILE")
+      fi
+    fi
+
+    DIFFFILE_CANDIDATE="$INPUT/$FILE.DIFF"
+    DIFFFILE="$DIFFFILE_CANDIDATE"
+    if [ ! -f "$DIFFFILE" ]; then
+      DIFFFILE=""
+    fi
+
+    # cub
+    if [ "$FILETYPE" == "cub" ]; then
+      "$ISISROOT/bin/cubediff" \
+         $TEST_ARGS \
+         "from=$TRUTH/$FILE" \
+         "from2=$OUTPUT/$FILE" \
+         "to=$FAILURE_REPORT" \
+         "TOLERANCE=$TOLERANCESTR" \
+         $IGNORESTR 1>>/dev/null 2> "$FAILURE_REPORT"
+      res=$?
+      if [ $res != 0 ]; then
+        # cubediff cannot handle different number of special pixels.
+        echo "cubediff failed. Try GDAL."
+        truthStats="${FILE}.truth.txt"; currStats="${FILE}.curr.txt"
+        gdalinfo -stats "$TRUTH/$FILE" > "$truthStats"
+        gdalinfo -stats "$OUTPUT/$FILE" > "$currStats"
+        rm -f "$TRUTH/$FILE.aux.xml" "$OUTPUT/$FILE.aux.xml"
+        python "$ISISROOT/scripts/textdiff.py" "$truthStats" \
+            "$currStats" -abs_err "$TOLERANCESTR" $DIFFFILE \
+            > "$FAILURE_REPORT" 2>&1
+        res=$?
+      fi
+
+      if [ $res != 0 ]; then
+        COMPRESULT="ERROR"
+      else
+        COMPRESULT="identical"
+      fi
+      if [ "$COMPRESULT" != "identical" ]; then
+        echo "Failed ... File [$FILE]"
+        echo "  Failed ... File [$FILE]" >> errors.txt
+        if [ "$COMPRESULT" == "ERROR" ]; then
+          cat "$FAILURE_REPORT" >> errors.txt
+        fi
+        echo "Failed comparing cubes. Report: $(pwd)/$FAILURE_REPORT"
+        echo "Add/update the truth cube tolerance in the test Makefile."
+        echo "Truth cube that needs tolerance: $FILE"
+        echo "File with fields to ignore: $DIFFFILE_CANDIDATE"
+        tail -n 1 "$FAILURE_REPORT"
+      else
+        SUCCESSFULCOMPARISONS=$((SUCCESSFULCOMPARISONS + 1))
+        rm -f "$FAILURE_REPORT" 2>/dev/null
+        rm -f "$truthStats"     2>/dev/null
+        rm -f "$currStats"      2>/dev/null
+        rm -f errors.txt        2>/dev/null
+      fi
+
+    # txt, csv, pvl
+    elif [ "$FILETYPE" == "txt" ] || [ "$FILETYPE" == "csv" ] || \
+         [ "$FILETYPE" == "pvl" ]; then
+      python "$ISISROOT/scripts/textdiff.py" "$TRUTH/$FILE" \
+          "$OUTPUT/$FILE" -abs_err "$TOLERANCESTR" $DIFFFILE \
+          > "$FAILURE_REPORT" 2>&1
+
+      if [ $? -ne 0 ]; then
+        echo "Failed ... File [$FILE]"
+        echo "  Failed ... File [$FILE]" >> errors.txt
+        cat "$FAILURE_REPORT" >> errors.txt
+        echo "Failed comparing txt. Report: $(pwd)/$FAILURE_REPORT"
+        echo "Tolerance: $TOLERANCESTR"
+        echo "Tolerance file to update: $TOL_FILE"
+        echo "File with fields to ignore: $DIFFFILE_CANDIDATE"
+        tail -n 1 "$FAILURE_REPORT"
+      else
+        SUCCESSFULCOMPARISONS=$((SUCCESSFULCOMPARISONS + 1))
+        if [ -f "$FAILURE_REPORT" ]; then
+          rm -f "$FAILURE_REPORT"
+        fi
+      fi
+
+    # cnet
+    elif [ "$FILETYPE" == "net" ]; then
+      "$ISISROOT/bin/cnetdiff" \
+          $TEST_ARGS \
+          "from=$TRUTH/$FILE" \
+          "from2=$OUTPUT/$FILE" \
+          to=compare.txt \
+          "diff=$DIFFFILE" 1>>/dev/null 2>cnetdiffError.txt
+      if [ $? != 0 ]; then
+        COMPRESULT="ERROR"
+      else
+        COMPRESULT=$("$ISISROOT/bin/getkey" from=compare.txt \
+          grp=Results keyword=Compare | tr '[:upper:]' '[:lower:]')
+      fi
+      if [ "$COMPRESULT" != "identical" ]; then
+        echo "Failed ... File [$FILE]"
+        echo "  Failed ... File [$FILE]" >> errors.txt
+        if [ "$COMPRESULT" == "ERROR" ]; then
+          cat cnetdiffError.txt >> errors.txt
+        fi
+        echo "Failed comparing cnet"
+        cat compare.txt
+        echo "File with fields to ignore: $DIFFFILE_CANDIDATE"
+      else
+        SUCCESSFULCOMPARISONS=$((SUCCESSFULCOMPARISONS + 1))
+      fi
+      rm -f compare.txt
+      if [ -f cnetdiffError.txt ]; then
+        rm -f cnetdiffError.txt
+      fi
+
+    # binary
+    elif echo "$BINFILES" | grep -qw "$FILETYPE"; then
+      diff "$TRUTH/$FILE" "$OUTPUT/$FILE" > /dev/null
+      res=$?
+      if [ $res != 0 ]; then
+        # Fallback to GDAL-based comparison
+        truthCub="${FILE}.truth.cub"; currCub="${FILE}.curr.cub"
+        truthStats="${FILE}.truth.txt"; currStats="${FILE}.curr.txt"
+        raw2isis lines=100 samples=100 "from=$TRUTH/$FILE" \
+          "to=$truthCub"
+        raw2isis lines=100 samples=100 "from=$OUTPUT/$FILE" \
+          "to=$currCub"
+        gdalinfo -stats "$truthCub" > "$truthStats"
+        gdalinfo -stats "$currCub" > "$currStats"
+        rm -f "${truthCub}.aux.xml" "${currCub}.aux.xml"
+        python "$ISISROOT/scripts/textdiff.py" "$truthStats" \
+            "$currStats" -abs_err "$TOLERANCESTR" $DIFFFILE \
+            > "$FAILURE_REPORT" 2>&1
+        res=$?
+      fi
+      if [ $res != 0 ]; then
+        echo "Failed ... File [$FILE]"
+        echo "  Failed ... File [$FILE]" >> errors.txt
+        cat "$FAILURE_REPORT" >> errors.txt
+        echo "Failed comparing binary."
+        echo "Report: $(pwd)/$FAILURE_REPORT"
+        echo "Tolerance: $TOLERANCESTR"
+        echo "Tolerance file to update: $TOL_FILE"
+        echo "File with fields to ignore: $DIFFFILE_CANDIDATE"
+        tail -n 1 "$FAILURE_REPORT"
+      else
+        SUCCESSFULCOMPARISONS=$((SUCCESSFULCOMPARISONS + 1))
+        rm -f "$FAILURE_REPORT" 2>/dev/null
+        rm -f "$truthCub"       2>/dev/null
+        rm -f "$currCub"        2>/dev/null
+        rm -f "$truthStats"     2>/dev/null
+        rm -f "$currStats"      2>/dev/null
+      fi
+
+    # unknown
+    else
+      echo "Failed ... Unknown file type [$FILE]"
+      echo "  Failed ... Unknown file type [$FILE]" >> errors.txt
+    fi
+  fi
+done
+
+if [ $SUCCESSFULCOMPARISONS -eq $TRUTHFILECOUNT ]; then
+  touch casesucceeded.txt
+elif [ ! -s errors.txt ]; then
+  echo "  Failed ... Not all files in truth and output folders match" >> errors.txt
+fi

--- a/isis/scripts/compare_test_results.sh
+++ b/isis/scripts/compare_test_results.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Manual re-comparison of truth vs output for ISIS legacy Makefile tests.
+# Called from isismake.tsts compare target. Allows re-running the comparison
+# without re-running the test commands.
+#
+# Usage:
+#   compare_test_results.sh TRUTH OUTPUT CASE
+
+TRUTH="$1"
+OUTPUT="$2"
+CASE="$3"
+
+CURTIMESTAMP="[$(date +'%Y-%m-%d %H:%M:%S')]"
+
+if [ -d "$OUTPUT" ]; then
+  if [ -d "$TRUTH" ]; then
+    TRUTHDIR=$(ls "$TRUTH" 2>/dev/null)
+    if [ "$TRUTHDIR" == "" ]; then
+      echo -n "$CURTIMESTAMP" >> errors.txt
+      echo "  Failed ... No files in truth directory" >> errors.txt
+    else
+      TRUTHFILECOUNT=$(ls -p "$TRUTH"/ | grep -v "/" | wc -l)
+      OUTPUTFILECOUNT=$(ls -p "$OUTPUT"/ | grep -v "/" | wc -l)
+      if [ $TRUTHFILECOUNT -ne $OUTPUTFILECOUNT ]; then
+        echo -n "$CURTIMESTAMP" >> errors.txt
+        echo "  Failed ... Number of files in truth and output folder do not match" >> errors.txt
+      else
+        make comparefiles
+      fi
+    fi
+  else
+    echo -n "$CURTIMESTAMP" >> errors.txt
+    echo "  Failed ... No truth folder or files" >> errors.txt
+  fi
+
+  if [ -f casesucceeded.txt ]; then
+    echo " OK ... Case [$CASE]"
+    rm -f casesucceeded.txt
+  else
+    echo " Failed ... Case [$CASE]"
+    echo "$CURTIMESTAMP"
+    if [ -f errors.txt ]; then
+      cat errors.txt
+      rm -f errors.txt
+    fi
+  fi
+else
+  echo "Error ... Output folder does not exist"
+fi

--- a/isis/scripts/run_test.sh
+++ b/isis/scripts/run_test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Run an ISIS legacy Makefile test: generate output, compare, report.
+# Called from isismake.tsts test target (after clean).
+#
+# Usage:
+#   run_test.sh TRUTH OUTPUT CASE NOCLEAN
+#
+# Arguments:
+#   TRUTH   - truth directory path
+#   OUTPUT  - output directory path
+#   CASE    - test case name (for display)
+#   NOCLEAN - "yes" to keep output after success, anything else to clean
+
+TRUTH="$1"
+OUTPUT="$2"
+CASE="$3"
+NOCLEAN="$4"
+
+TIME1=$(date +"%s")
+
+if [ -d "$TRUTH" ]; then
+  TRUTHDIR=$(ls "$TRUTH" 2>/dev/null)
+  if [ "$TRUTHDIR" == "" ]; then
+    CURTIMESTAMP="[$(date +'%Y-%m-%d %H:%M:%S')]"
+    echo -n "$CURTIMESTAMP" >> errors.txt
+    echo "  Failed ... No files in truth directory" >> errors.txt
+  else
+    make output
+    TRUTHFILECOUNT=$(ls -p "$TRUTH"/ | grep -v "/" | wc -l)
+    OUTPUTFILECOUNT=$(ls -p "$OUTPUT"/ | grep -v "/" | wc -l)
+    if [ $TRUTHFILECOUNT -ne $OUTPUTFILECOUNT ]; then
+      CURTIMESTAMP="[$(date +'%Y-%m-%d %H:%M:%S')]"
+      echo -n "$CURTIMESTAMP" >> errors.txt
+      echo "  Failed ... Number of files in truth and output folder do not match" >> errors.txt
+      echo "Failed ... Number of files in truth and output folder do not match"
+      echo "Truth file count: $TRUTHFILECOUNT"
+      echo "Output file count: $OUTPUTFILECOUNT"
+    else
+      make comparefiles
+    fi
+  fi
+else
+  CURTIMESTAMP="[$(date +'%Y-%m-%d %H:%M:%S')]"
+  echo -n "$CURTIMESTAMP" >> errors.txt
+  echo "  Failed ... No truth folder or files" >> errors.txt
+fi
+
+TIME2=$(date +"%s")
+TIMEDIFF=$((TIME2 - TIME1))
+SEC60=$((TIMEDIFF % 60))
+MIN=$((TIMEDIFF / 60))
+MIN60=$((MIN % 60))
+HOUR=$((MIN / 60))
+HOUR60=$((HOUR % 60))
+
+CURTIMESTAMP="[$(date +'%Y-%m-%d %H:%M:%S')]"
+echo -n "$CURTIMESTAMP"
+
+if [ -f casesucceeded.txt ]; then
+  echo -n " OK ... Case [$CASE] "
+  printf "Duration [%.2i:%.2i:%.2i]\n" $HOUR60 $MIN60 $SEC60
+  rm -f casesucceeded.txt
+  if [ "$NOCLEAN" != "yes" ]; then
+    make ccsafeclean
+  fi
+else
+  echo -n " Failed ... Case [$CASE] "
+  printf "Duration [%.2i:%.2i:%.2i]\n" $HOUR60 $MIN60 $SEC60
+  echo "Summary error file: $(pwd)/errors.txt"
+fi


### PR DESCRIPTION
## Description 

This is a proposed fix for https://github.com/DOI-USGS/ISIS3/issues/5982.

Most frequently used and largest parts of isis/make/isismake.tsts are factored out as shell scripts. These are put in the same scripts directory used for other test infrastructure.

## How Has This Been Validated?

I tested carefully by triggering these after the move and they work as expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
