### PR TITLE
Gdal Projection Parsing Fixes

### DIFF
--- a/changes/5999.fix.md
+++ b/changes/5999.fix.md
@@ -1,0 +1,1 @@
+Allows for slightly unsquare pixels from projected GDAL products and fixes axes parsing for longitude direction.

--- a/isis/src/core/src/Pvl.cpp
+++ b/isis/src/core/src/Pvl.cpp
@@ -190,16 +190,21 @@ namespace Isis {
         projJson = projJson["base_crs"];
       }
 
-      std::string direction = projJson["coordinate_system"]["axis"][1]["direction"];
-      if (direction == "east") {
-        mappingGroup.addKeyword(PvlKeyword("LongitudeDirection", "PositiveEast"));
-      }
-      else if (direction == "west") {
-        mappingGroup.addKeyword(PvlKeyword("LongitudeDirection", "PositiveWest"));
-      }
-      else {
-        QString msg = "Unknown direction [" + QString::fromStdString(direction) + "]";
-        throw IException(IException::Programmer, msg, _FILEINFO_);
+      nlohmann::json axes = projJson["coordinate_system"]["axis"];
+      for (nlohmann::json axis : axes) {
+        if (axis["name"] == "Longitude") {
+          std::string direction = axis["direction"];
+          if (direction == "east") {
+            mappingGroup.addKeyword(PvlKeyword("LongitudeDirection", "PositiveEast"));
+          }
+          else if (direction == "west") {
+            mappingGroup.addKeyword(PvlKeyword("LongitudeDirection", "PositiveWest"));
+          }
+          else {
+            QString msg = "Unknown direction [" + QString::fromStdString(direction) + "]";
+            throw IException(IException::Programmer, msg, _FILEINFO_);
+          }
+        }
       }
       
       if (oSRS.GetSemiMajor() == oSRS.GetSemiMinor()) {

--- a/isis/src/core/src/Pvl.cpp
+++ b/isis/src/core/src/Pvl.cpp
@@ -215,7 +215,7 @@ namespace Isis {
       // Read the GeoTransform and get the elements we care about
       double *padfTransform = new double[6];
       dataset->GetGeoTransform(padfTransform);
-      if (abs(padfTransform[1]) != abs(padfTransform[5])) {
+      if ((abs(padfTransform[1]) - abs(padfTransform[5])) > 1e-2) {
         delete[] padfTransform;
         QString msg = "Vertical and horizontal resolution do not match";
         throw IException(IException::Io, msg, _FILEINFO_);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Allow some loose tolerance comparison for projected images where pixels might not be completely square. This also fixes reading the longitude direction correctly since the axes definition order is not guaranteed.

## Related Issue
Gdal Support

## How Has This Been Validated?
Validated locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
