### PR TITLE
QApps Add Projection Selection

### DIFF
--- a/isis/src/base/objs/GroundGrid/GroundGrid.cpp
+++ b/isis/src/base/objs/GroundGrid/GroundGrid.cpp
@@ -83,7 +83,7 @@ namespace Isis {
 
     p_mapping = new PvlGroup;
 
-    if (p_groundMap->Camera()) {
+    if (p_groundMap->currentPriority() == 0) {
       Pvl tmp;
       p_groundMap->Camera()->BasicMapping(tmp);
       *p_mapping = tmp.findGroup("Mapping");
@@ -146,7 +146,7 @@ namespace Isis {
 
     // p_defaultResolution is in degrees/pixel
 
-    if (p_groundMap->HasCamera()) {
+    if (p_groundMap->currentPriority() == 0) {
       p_defaultResolution =
         (p_groundMap->Camera()->HighestImageResolution() /
          largerRadius.meters()) * 10;

--- a/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.cpp
+++ b/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.cpp
@@ -33,33 +33,33 @@ namespace Isis {
   UniversalGroundMap::UniversalGroundMap(Cube &cube, CameraPriority priority) {
     p_camera = NULL;
     p_projection = NULL;
+    p_priority = priority;
 
     Pvl &pvl = *cube.label();
     try {
-      if(priority == CameraFirst)
-        p_camera = CameraFactory::Create(cube);
-      else
-        p_projection = Isis::ProjectionFactory::CreateFromCube(pvl);
+      p_camera = CameraFactory::Create(cube);
     }
-    catch (IException &firstError) {
+    catch (IException &e) {
+      if (p_priority == CameraFirst) {
+        p_priority = ProjectionFirst;
+      }
       p_camera = NULL;
-      p_projection = NULL;
+    }
 
-      try {
-        if(priority == CameraFirst)
-          p_projection = Isis::ProjectionFactory::CreateFromCube(pvl);
-        else
-          p_camera = CameraFactory::Create(cube);
+    try {
+      p_projection = Isis::ProjectionFactory::CreateFromCube(pvl);
+    }
+    catch (IException &e) {
+      if (p_priority == ProjectionFirst) {
+        p_priority = CameraFirst;
       }
-      catch (IException &secondError) {
-        p_projection = NULL;
-        QString msg = "Could not create camera or projection for [" +
-                          cube.fileName() + "]";
-        IException realError(IException::Unknown, msg, _FILEINFO_);
-        realError.append(firstError);
-        realError.append(secondError);
-        throw realError;
-      }
+      p_projection = NULL;
+    }
+
+    if (p_camera == NULL && p_projection == NULL) {
+      QString msg = "Could not create camera or projection for [" +
+                        cube.fileName() + "]";
+      IException realError(IException::Unknown, msg, _FILEINFO_);
     }
   }
 
@@ -100,7 +100,7 @@ namespace Isis {
    *         false if it was not
    */
   bool UniversalGroundMap::SetUniversalGround(double lat, double lon) {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       if (p_camera->SetUniversalGround(lat, lon)) {  // This should work for rings (radius,azimuth)
         return p_camera->InCube();
       }
@@ -125,7 +125,7 @@ namespace Isis {
    *         false if it was not
    */
   bool UniversalGroundMap::SetGround(Latitude lat, Longitude lon) {
-    if(p_camera != NULL) {
+    if(p_priority == CameraFirst) {
       if(p_camera->SetGround(lat, lon)) {  // This should work for rings (radius,azimuth)
         return p_camera->InCube();
       }
@@ -152,7 +152,7 @@ namespace Isis {
    *         false if it was not
    */
   bool UniversalGroundMap::SetUnboundGround(Latitude lat, Longitude lon) {
-    if(p_camera != NULL) {
+    if(p_priority == CameraFirst) {
       if(p_camera->SetGround(lat, lon)) {  // This should work for rings (radius,azimuth)
         return p_camera->InCube();
       }
@@ -178,7 +178,7 @@ namespace Isis {
    *         otherwise
    */
   bool UniversalGroundMap::SetGround(const SurfacePoint &sp) {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       if (p_camera->SetGround(sp)) {
         return p_camera->InCube();
       }
@@ -198,7 +198,7 @@ namespace Isis {
    * @return Sample value
    */
   double UniversalGroundMap::Sample() const {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       return p_camera->Sample();
     }
     else {
@@ -212,7 +212,7 @@ namespace Isis {
    * @return Line value
    */
   double UniversalGroundMap::Line() const {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       return p_camera->Line();
     }
     else {
@@ -231,7 +231,7 @@ namespace Isis {
    *         false if it was not
    */
   bool UniversalGroundMap::SetImage(double sample, double line) {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       return p_camera->SetImage(sample, line);
     }
     else {
@@ -245,7 +245,7 @@ namespace Isis {
    * @return Universal Latitude
    */
   double UniversalGroundMap::UniversalLatitude() const {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       return p_camera->UniversalLatitude();
     }
     else {
@@ -268,7 +268,7 @@ namespace Isis {
    * @return Universal Longitude
    */
   double UniversalGroundMap::UniversalLongitude() const {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       return p_camera->UniversalLongitude();
     }
     else {
@@ -291,8 +291,22 @@ namespace Isis {
    *
    * @return Resolution
    */
+  double UniversalGroundMap::Radius() const {
+    if (p_priority == CameraFirst) {
+      return p_camera->LocalRadius().meters();
+    }
+    else {
+      return p_projection->LocalRadius();
+    }
+  }
+
+  /**
+   * Returns the resolution of the camera model or projection
+   *
+   * @return Resolution
+   */
   double UniversalGroundMap::Resolution() const {
-    if (p_camera != NULL) {
+    if (p_priority == CameraFirst) {
       return p_camera->PixelResolution();
     }
     else {
@@ -374,7 +388,7 @@ namespace Isis {
 
     if (!minLat.isValid() || !maxLat.isValid() ||
         !minLon.isValid() || !maxLon.isValid()) {
-      if (HasCamera()) {
+      if (p_priority == CameraFirst) {
         // Footprint failed, ask the camera
         PvlGroup mappingGrp("Mapping");
         mappingGrp += PvlKeyword("LatitudeType", "Planetocentric");
@@ -395,7 +409,7 @@ namespace Isis {
         minLon = Longitude(minLonDouble, Angle::Degrees);
         maxLon = Longitude(maxLonDouble, Angle::Degrees);
       }
-      else if (HasProjection()) {
+      else if (p_priority == ProjectionFirst) {
         // Footprint failed, look in the mapping group
         PvlGroup mappingGrp = p_projection->Mapping();
         if (mappingGrp.hasKeyword("MinimumLatitude") &&
@@ -537,5 +551,16 @@ namespace Isis {
     return (minLat.isValid() && maxLat.isValid() &&
             minLon.isValid() && maxLon.isValid() &&
             minLat < maxLat && minLon < maxLon);
+  }
+
+  void UniversalGroundMap::setPriority(int priority)  {
+    if (priority == UniversalGroundMap::CameraFirst && HasCamera()) {
+      std::cout << "Setting camera priority" << std::endl;
+      p_priority = (CameraPriority) priority;
+    }
+    else if (priority == UniversalGroundMap::ProjectionFirst && HasProjection()) {
+      std::cout << "Setting projection priority" << std::endl;
+      p_priority = (CameraPriority) priority;
+    }
   }
 }

--- a/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.cpp
+++ b/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.cpp
@@ -555,11 +555,9 @@ namespace Isis {
 
   void UniversalGroundMap::setPriority(int priority)  {
     if (priority == UniversalGroundMap::CameraFirst && HasCamera()) {
-      std::cout << "Setting camera priority" << std::endl;
       p_priority = (CameraPriority) priority;
     }
     else if (priority == UniversalGroundMap::ProjectionFirst && HasProjection()) {
-      std::cout << "Setting projection priority" << std::endl;
       p_priority = (CameraPriority) priority;
     }
   }

--- a/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.cpp
+++ b/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.cpp
@@ -287,11 +287,11 @@ namespace Isis {
   }
 
   /**
-   * Returns the resolution of the camera model or projection
+   * Returns the radius of the camera model or projection
    *
-   * @return Resolution
+   * @return Radius
    */
-  double UniversalGroundMap::Radius() const {
+  double UniversalGroundMap::LocalRadius() const {
     if (p_priority == CameraFirst) {
       return p_camera->LocalRadius().meters();
     }

--- a/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.h
+++ b/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.h
@@ -99,6 +99,7 @@ namespace Isis {
       bool SetImage(double sample, double line);
       double UniversalLatitude() const;
       double UniversalLongitude() const;
+      double Radius() const;
       double Resolution() const;
 
       bool GroundRange(Cube *cube,
@@ -127,6 +128,12 @@ namespace Isis {
         return p_camera != 0;
       };
 
+      int currentPriority() {
+        return p_priority;
+      };
+
+      void setPriority(int priority);
+
       //! Return the projection associated with the ground map (NULL implies none)
       Isis::Projection *Projection() const {
         return p_projection;
@@ -141,6 +148,7 @@ namespace Isis {
     private:
       Isis::Camera *p_camera;  //!<The camera (if the image has a camera)
       Isis::Projection *p_projection;  //!<The projection (if the image is projected)
+      CameraPriority p_priority;
   };
 };
 

--- a/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.h
+++ b/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.h
@@ -99,7 +99,7 @@ namespace Isis {
       bool SetImage(double sample, double line);
       double UniversalLatitude() const;
       double UniversalLongitude() const;
-      double Radius() const;
+      double LocalRadius() const;
       double Resolution() const;
 
       bool GroundRange(Cube *cube,

--- a/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.truth
+++ b/isis/src/base/objs/UniversalGroundMap/UniversalGroundMap.truth
@@ -30,7 +30,7 @@ Sample = 1203.99978
 Line = 1056.0001
 
   Testing Projection...
-Is Projection? = 1
+Has Projection? = 1
 
 For (2.0, 5.0) ...
 Universal Latitude = 89.9727
@@ -57,7 +57,7 @@ Sample = 23040
 Line = 11520
 
   Testing Camera Model and Projection...
-Is Projection? = 0
+Is Projection? = 1
 
 For (1.0, 5.0) ...
 Universal Latitude = -86.9422124

--- a/isis/src/base/objs/UniversalGroundMap/unitTest.cpp
+++ b/isis/src/base/objs/UniversalGroundMap/unitTest.cpp
@@ -49,7 +49,7 @@ int main(int argc, char *argv[]) {
       if (ugm.SetGround(
           SurfacePoint(Latitude(ugm.UniversalLatitude(), Angle::Degrees),
                        Longitude(ugm.UniversalLongitude(), Angle::Degrees),
-                       ugm.Camera()->LocalRadius()))) {
+                       Distance(ugm.LocalRadius(), Distance::Units::Meters)))) {
         cout << "Sample = " << ugm.Sample() << endl;
         cout << "Line = " << ugm.Line() << endl << endl;
       }
@@ -91,7 +91,7 @@ int main(int argc, char *argv[]) {
     cout << "  Testing Projection..." << endl;
     Cube c2("$base/dems/molaMarsPlanetaryRadius0001.cub", "r");
     UniversalGroundMap ugm2(c2);
-    cout << "Is Projection? = " << ugm2.HasProjection() << endl << endl;
+    cout << "Has Projection? = " << ugm2.HasProjection() << endl << endl;
 
     // Test all four corners to make sure the conversions are right
     cerr << "For (2.0, 5.0) ..." << endl;

--- a/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
+++ b/isis/src/qisis/objs/CubeViewport/CubeViewport.cpp
@@ -147,7 +147,7 @@ namespace Isis {
 
     // Setup a universal ground map
     try {
-      p_groundMap = new UniversalGroundMap(*p_cube, UniversalGroundMap::ProjectionFirst);
+      p_groundMap = new UniversalGroundMap(*p_cube);
     }
     catch(IException &) {
     }

--- a/isis/src/qisis/objs/FindTool/FindTool.cpp
+++ b/isis/src/qisis/objs/FindTool/FindTool.cpp
@@ -634,9 +634,11 @@ namespace Isis {
     // UniversalGroundMaps default to camera priority, so create a new one so that we can use projection if it exists.
     UniversalGroundMap *groundMap = viewport->universalGroundMap();
     Distance viewportResolution;
-    if (groundMap->Camera() != NULL){
-      if (groundMap->Camera()->target()->isSky()) {
-        return Distance(groundMap->Camera()->RaDecResolution(), Distance::Units::Meters);
+    if (groundMap) {
+      if (groundMap->Camera() != NULL) {
+        if (groundMap->Camera()->target()->isSky()) {
+          return Distance(groundMap->Camera()->RaDecResolution(), Distance::Units::Meters);
+        }
       }
     }
 

--- a/isis/src/qisis/objs/FindTool/FindTool.cpp
+++ b/isis/src/qisis/objs/FindTool/FindTool.cpp
@@ -264,7 +264,7 @@ namespace Isis {
     p_groundEngine = new QComboBox();
     p_groundEngine->setEditable(true);
     p_groundEngine->setToolTip("Ground Engine Priority");
-    p_groundEngine->setWhatsThis("<b>Function: </b> Set priortiy use of the projection \
+    p_groundEngine->setWhatsThis("<b>Function: </b> Set priority use of the projection \
                              or the camera to determine ground coordinates. If both are available, \
                              the selected option takes priority. If only one is available, it will \
                              be used by default.");
@@ -682,12 +682,12 @@ namespace Isis {
         if ( groundMap->SetImage(samp - 0.5, line - 0.5) ) {
           double lat1 = groundMap->UniversalLatitude();
           double lon1 = groundMap->UniversalLongitude();
-          double radius1 = groundMap->Radius();
+          double radius1 = groundMap->LocalRadius();
 
           if ( groundMap->SetImage(samp + 0.5, line + 0.5) ) {
             double lat2 = groundMap->UniversalLatitude();
             double lon2 = groundMap->UniversalLongitude();
-            double radius2 = groundMap->Radius();
+            double radius2 = groundMap->LocalRadius();
 
             SurfacePoint point1( Latitude(lat1, Angle::Degrees),
                                  Longitude(lon1, Angle::Degrees),

--- a/isis/src/qisis/objs/FindTool/FindTool.cpp
+++ b/isis/src/qisis/objs/FindTool/FindTool.cpp
@@ -263,13 +263,12 @@ namespace Isis {
 
     p_groundEngine = new QComboBox();
     p_groundEngine->setEditable(true);
-    p_groundEngine->setToolTip("Ground Engine Selection");
-    p_groundEngine->setWhatsThis("<b>Function: </b> Select whether to use the projection \
-                                 to determine ground coordinate or the camera. Images with \
-                                 both can use either, images with only one of either a projection \
-                                 or a camera will use what is available even if the other is \
-                                 requested.");
-    p_groundEngine->insertItem(0, "Camera");  
+    p_groundEngine->setToolTip("Ground Engine Priority");
+    p_groundEngine->setWhatsThis("<b>Function: </b> Set priortiy use of the projection \
+                             or the camera to determine ground coordinates. If both are available, \
+                             the selected option takes priority. If only one is available, it will \
+                             be used by default.");
+    p_groundEngine->insertItem(0, "Camera");
     p_groundEngine->insertItem(1, "Projection");
     p_groundEngine->setCurrentIndex(0);
     connect( p_groundEngine, SIGNAL( currentIndexChanged(int) ), 

--- a/isis/src/qisis/objs/FindTool/FindTool.cpp
+++ b/isis/src/qisis/objs/FindTool/FindTool.cpp
@@ -2,6 +2,7 @@
 
 #include <QApplication>
 #include <QCheckBox>
+#include <QComboBox>
 #include <QDialog>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -260,9 +261,24 @@ namespace Isis {
                            <b>Hint: </b> If the cube is 'None' the find tool \
                            will not be active</p>");
 
+    p_groundEngine = new QComboBox();
+    p_groundEngine->setEditable(true);
+    p_groundEngine->setToolTip("Ground Engine Selection");
+    p_groundEngine->setWhatsThis("<b>Function: </b> Select whether to use the projection \
+                                 to determine ground coordinate or the camera. Images with \
+                                 both can use either, images with only one of either a projection \
+                                 or a camera will use what is available even if the other is \
+                                 requested.");
+    p_groundEngine->insertItem(0, "Camera");  
+    p_groundEngine->insertItem(1, "Projection");
+    p_groundEngine->setCurrentIndex(0);
+    connect( p_groundEngine, SIGNAL( currentIndexChanged(int) ), 
+             this, SLOT( setProjectionEngine(int) ) );
+
     QHBoxLayout *layout = new QHBoxLayout(hbox);
     layout->setContentsMargins(0, 0, 0, 0);
     layout->addWidget(p_statusEdit);
+    layout->addWidget(p_groundEngine);
     layout->addWidget(p_showDialogButton);
     layout->addWidget(p_linkViewportsButton);
     layout->addWidget(p_togglePointVisibleButton);
@@ -548,6 +564,19 @@ namespace Isis {
   }
 
 
+    //! toggles visibility of the red circle
+  void FindTool::setProjectionEngine(int index) {
+    for (int i = 0; i < cubeViewportList()->size(); i++) {
+      MdiCubeViewport *viewport = ( *( cubeViewportList() ) )[i];
+      UniversalGroundMap *groundMap = viewport->universalGroundMap();
+
+      if (groundMap) {
+        groundMap->setPriority(index);
+      }
+    }
+  }
+
+
   //! Links all cubes that have camera models or are map projections
   void FindTool::handleLinkClicked() {
     MdiCubeViewport *d;
@@ -654,22 +683,20 @@ namespace Isis {
         if ( groundMap->SetImage(samp - 0.5, line - 0.5) ) {
           double lat1 = groundMap->UniversalLatitude();
           double lon1 = groundMap->UniversalLongitude();
+          double radius1 = groundMap->Radius();
 
           if ( groundMap->SetImage(samp + 0.5, line + 0.5) ) {
             double lat2 = groundMap->UniversalLatitude();
             double lon2 = groundMap->UniversalLongitude();
-
-            double radius = groundMap->HasProjection()?
-                groundMap->Projection()->LocalRadius() :
-                groundMap->Camera()->LocalRadius().meters();
+            double radius2 = groundMap->Radius();
 
             SurfacePoint point1( Latitude(lat1, Angle::Degrees),
                                  Longitude(lon1, Angle::Degrees),
-                                 Distance(radius, Distance::Meters) );
+                                 Distance(radius1, Distance::Meters) );
 
             SurfacePoint point2( Latitude(lat2, Angle::Degrees),
                                  Longitude(lon2, Angle::Degrees),
-                                 Distance(radius, Distance::Meters) );
+                                 Distance(radius2, Distance::Meters) );
 
             viewportResolution = point1.GetDistanceToPoint(point2);
           }

--- a/isis/src/qisis/objs/FindTool/FindTool.h
+++ b/isis/src/qisis/objs/FindTool/FindTool.h
@@ -15,6 +15,7 @@ find files of those names at the top level of this repository. **/
 
 class QAction;
 class QCheckBox;
+class QComboBox;
 class QLineEdit;
 class QTabWidget;
 class QToolButton;
@@ -148,6 +149,7 @@ namespace Isis {
       void handleLinkClicked();
       void handleRecordClicked();
       void togglePointVisible();
+      void setProjectionEngine(int index);
 
     private: // methods
       void centerLinkedViewports();
@@ -163,6 +165,7 @@ namespace Isis {
       QToolButton *p_togglePointVisibleButton;
       QCheckBox *p_syncScale;
       QLineEdit *p_statusEdit;
+      QComboBox *p_groundEngine;
       QTabWidget *p_tabWidget;
       GroundTab *p_groundTab;
       ImageTab *p_imageTab;

--- a/isis/src/qisis/objs/SpatialPlotTool/SpatialPlotTool.cpp
+++ b/isis/src/qisis/objs/SpatialPlotTool/SpatialPlotTool.cpp
@@ -290,13 +290,7 @@ namespace Isis {
     SurfacePoint result;
 
     if (groundMap) {
-      Distance radius;
-
-      if (groundMap->Camera())
-        radius = groundMap->Camera()->LocalRadius();
-      else if (groundMap->Projection())
-        radius = Distance(groundMap->Projection()->LocalRadius(), Distance::Meters);
-
+      Distance radius(groundMap->LocalRadius(), Distance::Units::Meters);
       result = SurfacePoint(Latitude(groundMap->UniversalLatitude(), Angle::Degrees),
           Longitude(groundMap->UniversalLongitude(), Angle::Degrees), radius);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Issues arise when comparing cameras to map projected images in qview, and likely other ISIS QApps. As noted in issues in the related issues sections. Projected images where scaling differently when compared to the associated images with just a camera model. This is due to the `distancePerPixel` method in the FindTool.

There are two situations to consider with this problem:

1. Comparing an image with camera information to a projected image with the same camera information
2. Comparing a projected image with no camera information to a the same projected image with camera information

The FindTool requests the radii from either the camera or the projection depending on what is present. The old behavior always used the camera which is fine for situation 1.

There are instances in ISIS where one can create an identical projected product but remove the old camera information (automos, and other mosaic apps where only one image is used). In these cases comparing a camera to the projection in the old code resulted in scale disparities, see the UniversalGroundMap class and the FindTool classes `distancePerPixel` function. This issue arose in situation 2.

If we fix situation 2 by forcing to use the projection as the priority we introduce the same bug/issues into situation 1. 

This PR allows users to select the projection priority so that both situations can be accessed by users.

## Related Issue
#5896
#5508

## How Has This Been Validated?
Validated locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
