### PR TITLE
Fix Qmos Qt5 backwards Compatibility

### DIFF
--- a/changes/5995.fix.md
+++ b/changes/5995.fix.md
@@ -1,0 +1,1 @@
+Fixed ability to correctly load Qmos projects made with isis versions older than 10.0.0

--- a/isis/src/qisis/objs/DisplayProperties/DisplayProperties.cpp
+++ b/isis/src/qisis/objs/DisplayProperties/DisplayProperties.cpp
@@ -47,13 +47,7 @@ namespace Isis {
 
     QByteArray hexValues(pvl["Values"][0].toLatin1());
     QDataStream valuesStream(QByteArray::fromHex(hexValues));
-    if (pvl.hasKeyword("QtVersion")) {
-      valuesStream.setVersion(int(pvl["QtVersion"]));
-    }
-    else {
-      // Assume qt5
-      valuesStream.setVersion(QDataStream::Qt_5_15);
-    }
+    valuesStream.setVersion(int(pvl["QtVersion"]));
     valuesStream >> *m_propertyValues;
   }
 
@@ -71,10 +65,6 @@ namespace Isis {
     dataBuffer.open(QIODevice::ReadWrite);
 
     QDataStream propsStream(&dataBuffer);
-    PvlKeyword qtVersionKeyword("QtVersion", QString::number(propsStream.version()));
-    qtVersionKeyword.addCommentWrapped("See QDataStream Version for more info on QT version");
-    output += qtVersionKeyword;
-
     propsStream << *m_propertyValues;
     dataBuffer.seek(0);
 

--- a/isis/src/qisis/objs/DisplayProperties/DisplayProperties.cpp
+++ b/isis/src/qisis/objs/DisplayProperties/DisplayProperties.cpp
@@ -47,6 +47,13 @@ namespace Isis {
 
     QByteArray hexValues(pvl["Values"][0].toLatin1());
     QDataStream valuesStream(QByteArray::fromHex(hexValues));
+    if (pvl.hasKeyword("QtVersion")) {
+      valuesStream.setVersion(int(pvl["QtVersion"]));
+    }
+    else {
+      // Assume qt5
+      valuesStream.setVersion(QDataStream::Qt_5_15);
+    }
     valuesStream >> *m_propertyValues;
   }
 
@@ -64,6 +71,10 @@ namespace Isis {
     dataBuffer.open(QIODevice::ReadWrite);
 
     QDataStream propsStream(&dataBuffer);
+    PvlKeyword qtVersionKeyword("QtVersion", QString::number(propsStream.version()));
+    qtVersionKeyword.addCommentWrapped("See QDataStream Version for more info on QT version");
+    output += qtVersionKeyword;
+
     propsStream << *m_propertyValues;
     dataBuffer.seek(0);
 

--- a/isis/src/qisis/objs/ImageReader/ImageReader.cpp
+++ b/isis/src/qisis/objs/ImageReader/ImageReader.cpp
@@ -130,6 +130,10 @@ namespace Isis {
     return m_progress;
   }
 
+  void ImageReader::setQtVersion(int qtVersion) {
+    m_qtVersion = qtVersion;
+  }
+
 
   void ImageReader::askDefaultAlpha() {
     bool ok = false;
@@ -191,7 +195,7 @@ namespace Isis {
       QFuture< Image * > images = QtConcurrent::mapped(
           culledBacklog,
           VariantToImageFunctor(m_cameraMutex, m_requireFootprints, QThread::currentThread(),
-            m_openFilled, m_defaultAlpha));
+            m_openFilled, m_defaultAlpha, m_qtVersion));
 
       m_watcher->setFuture(images);
       m_mappedRunning = true;
@@ -259,12 +263,13 @@ namespace Isis {
    */
   ImageReader::VariantToImageFunctor::VariantToImageFunctor(
       QMutex *cameraMutex, bool requireFootprints, QThread *targetThread, bool openFilled,
-      int defaultAlpha) {
+      int defaultAlpha, int qtVersion) {
     m_mutex = cameraMutex;
     m_targetThread = targetThread;
     m_openFilled = openFilled;
     m_defaultAlpha = defaultAlpha;
     m_requireFootprints = requireFootprints;
+    m_qtVersion = qtVersion;
   }
 
 
@@ -297,6 +302,8 @@ namespace Isis {
         PvlObject imageObj = imageData.value<PvlObject>();
         fileName = ((IString)imageObj["FileName"][0]).ToQt();
         result = new Image(FileName(fileName).expanded());
+        PvlObject &displayProps = imageObj.findObject("DisplayProperties");
+        displayProps += PvlKeyword("QtVersion", QString::number(m_qtVersion));
         result->fromPvl(imageObj);
       }
 

--- a/isis/src/qisis/objs/ImageReader/ImageReader.h
+++ b/isis/src/qisis/objs/ImageReader/ImageReader.h
@@ -49,6 +49,8 @@ namespace Isis {
       QList<QAction *> actions(ImageDisplayProperties::Property relevantDispProperties);
       QProgressBar *progress();
 
+      void setQtVersion(int qtVersion);
+
     signals:
       void imagesReady(ImageList images);
 
@@ -100,6 +102,8 @@ namespace Isis {
       QPointer<QAction> m_safeFileOpenAct;
       QFutureWatcher<Image *> * m_watcher;
 
+      int m_qtVersion;
+
       bool m_safeFileOpen;
       bool m_openFilled;
       int m_defaultAlpha;
@@ -121,7 +125,7 @@ namespace Isis {
 
         public:
           VariantToImageFunctor(QMutex *cameraMutex, bool requireFootprints, QThread *targetThread,
-              bool openFilled, int defaultAlpha);
+              bool openFilled, int defaultAlpha, int qtVersion);
           Image *operator()(const QVariant &);
 
         private:
@@ -129,6 +133,7 @@ namespace Isis {
           QThread *m_targetThread;
 
           int m_defaultAlpha;
+          int m_qtVersion;
           bool m_openFilled;
           bool m_requireFootprints;
       };

--- a/isis/src/qisis/objs/MosaicMainWindow/MosaicController.cpp
+++ b/isis/src/qisis/objs/MosaicMainWindow/MosaicController.cpp
@@ -121,6 +121,12 @@ namespace Isis {
       imageProps += image->toPvl();
     }
 
+    PvlObject qtInfoObject("QtInfo");
+    QDataStream stream;
+    PvlKeyword qtVersionKeyword("QtVersion", QString::number(stream.version()));
+    qtVersionKeyword.addCommentWrapped("See QDataStream Version for more info on QT version");
+    qtInfoObject += qtVersionKeyword;
+    projFile += qtInfoObject;
     projFile += imageProps;
     projFile += m_fileList->toPvl();
     projFile += m_scene->toPvl();
@@ -242,14 +248,27 @@ namespace Isis {
         convertV1ToV2(projectPvl);
       }
 
+      PvlKeyword qtVersionKeyword;
+      if (projectPvl.hasObject("QtInfo")) {
+        PvlObject &qtInfoObject = projectPvl.findObject("QtInfo");
+        qtVersionKeyword = qtInfoObject["QtVersion"];
+      }
+      else {
+        qtVersionKeyword = PvlKeyword("QtVersion", QString::number(QDataStream::Qt_5_15));
+      }
+
       PvlObject &projImages(projectPvl.findObject("Images"));
 
-      if (projectPvl.hasObject("MosaicScene"))
-        m_scene->fromPvl(projectPvl.findObject("MosaicScene"));
+      if (projectPvl.hasObject("MosaicScene")) {
+        PvlObject &mosaicScene = projectPvl.findObject("MosaicScene");
+        mosaicScene += qtVersionKeyword;
+        m_scene->fromPvl(mosaicScene);
+      }
 
       if (projectPvl.hasObject("ImageFileList"))
         m_fileList->fromPvl(projectPvl.findObject("ImageFileList"));
 
+      m_imageReader->setQtVersion(int(qtVersionKeyword));
       openProjectImages(projImages);
     }
     catch(IException &e) {

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicSceneWidget.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicSceneWidget.cpp
@@ -525,13 +525,13 @@ namespace Isis {
     if (m_projection) {
       output += m_projection->Mapping();
 
-      PvlObject mosaicScenePosition("SceneVisiblePosition");
-
       QBuffer dataBuffer;
       dataBuffer.open(QIODevice::ReadWrite);
       QDataStream transformStream(&dataBuffer);
       transformStream << getView()->transform();
       dataBuffer.seek(0);
+
+      PvlObject mosaicScenePosition("SceneVisiblePosition");
       mosaicScenePosition += PvlKeyword("ViewTransform",
                                         QString(dataBuffer.data().toHex()));
       PvlKeyword scrollPos("ScrollPosition");

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicSceneWidget.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicSceneWidget.cpp
@@ -525,13 +525,17 @@ namespace Isis {
     if (m_projection) {
       output += m_projection->Mapping();
 
+      PvlObject mosaicScenePosition("SceneVisiblePosition");
+
       QBuffer dataBuffer;
       dataBuffer.open(QIODevice::ReadWrite);
       QDataStream transformStream(&dataBuffer);
+      PvlKeyword qtVersionKeyword("QtVersion", QString::number(transformStream.version()));
+      qtVersionKeyword.addCommentWrapped("See QDataStream Version for more info on QT version");
+      mosaicScenePosition += qtVersionKeyword;
+
       transformStream << getView()->transform();
       dataBuffer.seek(0);
-
-      PvlObject mosaicScenePosition("SceneVisiblePosition");
       mosaicScenePosition += PvlKeyword("ViewTransform",
                                         QString(dataBuffer.data().toHex()));
       PvlKeyword scrollPos("ScrollPosition");
@@ -1372,6 +1376,13 @@ namespace Isis {
       PvlObject &positionInfo = *m_projectViewTransform;
       QByteArray hexValues(positionInfo["ViewTransform"][0].toLatin1());
       QDataStream transformStream(QByteArray::fromHex(hexValues));
+      if (positionInfo.hasKeyword("QtVersion")) {
+        transformStream.setVersion(int(positionInfo["QtVersion"]));
+      }
+      else {
+        // Assume qt5
+        transformStream.setVersion(QDataStream::Qt_5_15);
+      }
 
       QTransform viewTransform;
       transformStream >> viewTransform;

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicSceneWidget.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicSceneWidget.cpp
@@ -530,10 +530,6 @@ namespace Isis {
       QBuffer dataBuffer;
       dataBuffer.open(QIODevice::ReadWrite);
       QDataStream transformStream(&dataBuffer);
-      PvlKeyword qtVersionKeyword("QtVersion", QString::number(transformStream.version()));
-      qtVersionKeyword.addCommentWrapped("See QDataStream Version for more info on QT version");
-      mosaicScenePosition += qtVersionKeyword;
-
       transformStream << getView()->transform();
       dataBuffer.seek(0);
       mosaicScenePosition += PvlKeyword("ViewTransform",
@@ -615,6 +611,7 @@ namespace Isis {
 
         delete m_projectViewTransform;
         m_projectViewTransform = new PvlObject(positionInfo);
+        m_projectViewTransform->addKeyword(project.findKeyword("QtVersion"));
       }
     }
   }
@@ -1376,13 +1373,7 @@ namespace Isis {
       PvlObject &positionInfo = *m_projectViewTransform;
       QByteArray hexValues(positionInfo["ViewTransform"][0].toLatin1());
       QDataStream transformStream(QByteArray::fromHex(hexValues));
-      if (positionInfo.hasKeyword("QtVersion")) {
-        transformStream.setVersion(int(positionInfo["QtVersion"]));
-      }
-      else {
-        // Assume qt5
-        transformStream.setVersion(QDataStream::Qt_5_15);
-      }
+      transformStream.setVersion(int(positionInfo["QtVersion"]));
 
       QTransform viewTransform;
       transformStream >> viewTransform;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Added qt version codes for QDataStream output from qmos projects. Any future projections will write out the correct qt version for the data streams. Any exisint Qmos projects will assume a QT 5.15 datastream.

## Related Issue
Closes #5995 

## How Has This Been Validated?
Validated locally using isis 9.0.0 and dev

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
