### PR TITLE
Deprecate ctxcal monthlyflat and enable ctxcal tests

### DIFF
--- a/changes/6010.deprec.md
+++ b/changes/6010.deprec.md
@@ -1,0 +1,1 @@
+Deprecated the ctxcal MONTHLYFLAT parameter. This parameter references legacy monthly flat field calibration files that are no longer supported.

--- a/isis/src/mro/apps/ctxcal/ctxcal.cpp
+++ b/isis/src/mro/apps/ctxcal/ctxcal.cpp
@@ -68,6 +68,11 @@ namespace Isis {
       else {
           FileName flat;
           if (ui.GetBoolean("MONTHLYFLAT")) {
+            if (Preference::Preferences().getShowDeprecatedPref()) {
+                QString msg = "MONTHLYFLAT parameter will be deprecated in a future ISIS release. "
+                              "Use default flat file selection instead.";
+                std::cerr << msg << std::endl;
+            }
               FileName outputFileName(icube->fileName());
               QString outputFileBase = outputFileName.baseName();
 

--- a/isis/src/mro/apps/ctxcal/ctxcal.cpp
+++ b/isis/src/mro/apps/ctxcal/ctxcal.cpp
@@ -68,10 +68,10 @@ namespace Isis {
       else {
           FileName flat;
           if (ui.GetBoolean("MONTHLYFLAT")) {
-            if (Preference::Preferences().getShowDeprecatedPref()) {
-                QString msg = "MONTHLYFLAT parameter will be deprecated in a future ISIS release. "
-                              "Use default flat file selection instead.";
-                std::cerr << msg << std::endl;
+              if (Preference::Preferences().getShowDeprecatedPref()) {
+              QString msg = "MONTHLYFLAT parameter will be deprecated in a future ISIS release. "
+                            "Use default flat file selection instead.";
+              std::cerr << msg << std::endl;
             }
               FileName outputFileName(icube->fileName());
               QString outputFileBase = outputFileName.baseName();

--- a/isis/src/mro/apps/ctxcal/ctxcal.xml
+++ b/isis/src/mro/apps/ctxcal/ctxcal.xml
@@ -218,15 +218,17 @@
         </description>
       </parameter>
       <parameter name="MONTHLYFLAT">
-      <brief> Change the default flat file to a monthly mission flat file</brief>
-      <description>
-          If turned on, ctxcal will use the default mission monthly flat file
-          for calibration.
-      </description>
-      <type>boolean</type>
-      <default>
-        <item>No</item>
-      </default>
+        <brief>Deprecated: use default flat file selection</brief>
+        <description>
+          <p>
+            <b>DEPRECATED:</b> This parameter references legacy monthly flat field
+            calibration files that are no longer supported.
+          </p>
+        </description>
+        <type>boolean</type>
+        <default>
+          <item>No</item>
+        </default>
       </parameter>
     </group>
 

--- a/isis/tests/FunctionalTestsCtxcal.cpp
+++ b/isis/tests/FunctionalTestsCtxcal.cpp
@@ -13,7 +13,7 @@ using namespace Isis;
 static QString APP_XML = FileName("$ISISROOT/bin/xml/ctxcal.xml").expanded();
 
 
-TEST_F(MroCtxCube, DISABLED_FunctionalTestCtxcalDefault) {
+TEST_F(MroCtxCube, FunctionalTestCtxcalDefault) {
   QString outCubeFileName = tempDir.path() + "/outTemp.cub";
   QVector<QString> args = {"to="+outCubeFileName};
 
@@ -36,7 +36,7 @@ TEST_F(MroCtxCube, DISABLED_FunctionalTestCtxcalDefault) {
   EXPECT_DOUBLE_EQ(oCubeStats->Average(), 0.080529551990330225);
   EXPECT_DOUBLE_EQ(oCubeStats->Sum(), 32.211820796132088);
   EXPECT_DOUBLE_EQ(oCubeStats->ValidPixels(), 400);
-  EXPECT_DOUBLE_EQ(oCubeStats->StandardDeviation(), 0.0012845090812918776);
+  EXPECT_NEAR(oCubeStats->StandardDeviation(), 0.0012845090812917909, 1e-12);
 }
 
 
@@ -87,7 +87,7 @@ TEST_F(MroCtxCube, FunctionalTestCtxcalMonthlyFlatfile) {
 }
 
 
-TEST_F(MroCtxCube, DISABLED_FunctionalTestCtxcalIofFalse) {
+TEST_F(MroCtxCube, FunctionalTestCtxcalIofFalse) {
   QString outCubeFileName = tempDir.path() + "/outTemp.cub";
   QVector<QString> args = {"to="+outCubeFileName, "iof=false"};
 
@@ -110,7 +110,7 @@ TEST_F(MroCtxCube, DISABLED_FunctionalTestCtxcalIofFalse) {
   EXPECT_DOUBLE_EQ(oCubeStats->Average(), 229.35238750457765);
   EXPECT_DOUBLE_EQ(oCubeStats->Sum(), 91740.955001831055);
   EXPECT_DOUBLE_EQ(oCubeStats->ValidPixels(), 400);
-  EXPECT_DOUBLE_EQ(oCubeStats->StandardDeviation(), 3.6583500046604196);
+  EXPECT_NEAR(oCubeStats->StandardDeviation(), 3.6583500046604196, 1e-12);
 }
 
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Added ctxFlat_0003.cub to ISISDATA, enabled associated tests and deprecated 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#6010

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
