### PR TITLE
fix modulus operator bug in fx

### DIFF
--- a/changes/5727.fix.md
+++ b/changes/5727.fix.md
@@ -1,0 +1,1 @@
+Fixed bug where modulus operator (%) was implemented in Calculator but not added to the known operators/functions list, causing % to be rejected as an unrecognized operator in fx.

--- a/isis/src/base/apps/fx/fx.xml
+++ b/isis/src/base/apps/fx/fx.xml
@@ -136,8 +136,8 @@
       The equation parser is case insensitive and all braces, such as
       "[{[{ }]}]" are converted to parentheses "(((( ))))" first.  Whitespace
       is ignored.  Currently, you must explicitly state all multiplication
-      operations (e.g. 2pi will not work, but 2*pi will).  The modulus (%),
-      AND, and OR operators are not implemented yet.  Functions
+      operations (e.g. 2pi will not work, but 2*pi will).  The 
+      AND and OR operators are not implemented yet.  Functions
       such as pha, ina, ema, lat, lon, radius, and resolution require a
       <def>Level1</def> input file with <def>SPICE</def> information in the
       image labels.  That is, the program <i>spiceinit</i> should be executed on the

--- a/isis/src/base/apps/fx/tsts/operators/Makefile
+++ b/isis/src/base/apps/fx/tsts/operators/Makefile
@@ -20,3 +20,6 @@ commands:
 	$(APPNAME) f1=$(INPUT)/peaks.cub+1 \
 	to=$(OUTPUT)/rads.cub \
 	equation="rads(360.0)" > /dev/null;
+	$(APPNAME) f1=$(INPUT)/peaks.cub+1 \
+	to=$(OUTPUT)/mod.cub \
+	equation="sample%2" > /dev/null;

--- a/isis/src/base/objs/InfixToPostfix/InfixToPostfix.cpp
+++ b/isis/src/base/objs/InfixToPostfix/InfixToPostfix.cpp
@@ -32,6 +32,7 @@ namespace Isis {
     p_operators.push_back(new InfixOperator(7, "^"));
     p_operators.push_back(new InfixOperator(5, "/"));
     p_operators.push_back(new InfixOperator(5, "*"));
+    p_operators.push_back(new InfixOperator(5, "%"));
     p_operators.push_back(new InfixOperator(3, "<<"));
     p_operators.push_back(new InfixOperator(3, ">>"));
     p_operators.push_back(new InfixOperator(2, "+"));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Fixed bug where modulus operator (%) was implemented in Calculator but not added to the known operators/functions list, causing % to be rejected as an unrecognized operator in fx.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #5727 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
