### PR TITLE
Fixed Qview Histogram Tool crash when dragging right-to-left

### DIFF
--- a/changes/5792.fix.md
+++ b/changes/5792.fix.md
@@ -1,0 +1,1 @@
+Fixed Qview Histogram Tool crash when dragging right-to-left due to incorrect sample range ordering causing invalid nsamps.

--- a/isis/src/qisis/objs/HistogramTool/HistogramTool.cpp
+++ b/isis/src/qisis/objs/HistogramTool/HistogramTool.cpp
@@ -272,7 +272,7 @@ namespace Isis {
           return;
         }
 
-        hist = std::make_unique<ImageHistogram>(ImageHistogram(*cube, band, NULL, ssamp, sline, esamp, eline));
+        hist = std::make_unique<ImageHistogram>(ImageHistogram(*cube, band, NULL, std::min(ssamp, esamp),  std::min(sline, eline), std::max(ssamp, esamp), std::max(sline, eline)));
         Brick *brick = new Brick(*cube, 1, 1, 1);
 
         //For each point read that value from the cube and add it to the histogram
@@ -305,8 +305,8 @@ namespace Isis {
         esamp = round(esamp);
         eline = round(eline);
 
-        hist = std::make_unique<ImageHistogram>(ImageHistogram(*cube, band, NULL, ssamp, sline, esamp, eline));
-        int nsamps = (int)(std::fabs(esamp - ssamp) + 1);
+        hist = std::make_unique<ImageHistogram>(ImageHistogram(*cube, band, NULL, std::min(ssamp, esamp), std::min(sline, eline), std::max(ssamp, esamp), std::max(sline, eline)));
+        int nsamps = std::max(ssamp, esamp) - std::min(ssamp, esamp) + 1;
 
         Brick *brick = new Brick(*cube, nsamps, 1, 1);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
PR #5445 introduced a bug in Qview where the Histogram Tool would crash when dragging a selection right-to-left due to incorrect sample/line range ordering, resulting in invalid nsamps being passed to ImageHistogram. This was fixed by normalizing the start/end sample and line values before constructing the histogram.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
closes #5792 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
