### PR TITLE
Write projection string to GeoTIFF produced by cam2map

### DIFF
--- a/changes/6033.fix.md
+++ b/changes/6033.fix.md
@@ -1,0 +1,1 @@
+Make cam2map (and any ISIS app writing a GeoTIFF cube via Cube::writeLabels) emit projection geo-tags. Output GeoTIFFs are now usable directly with GDAL and standard GIS tools.

--- a/changes/6033.fix.md
+++ b/changes/6033.fix.md
@@ -1,1 +1,1 @@
-Make cam2map (and any ISIS app writing a GeoTIFF cube via Cube::writeLabels) emit projection geo-tags. Output GeoTIFFs are now usable directly with GDAL and standard GIS tools.
+Write the projection string to the output GeoTIFF for cam2map and other tools that use `Cube::writeLabels` to make a GeoTIFF.

--- a/isis/src/base/apps/cam2map/AspMapProjection.cpp
+++ b/isis/src/base/apps/cam2map/AspMapProjection.cpp
@@ -11,6 +11,7 @@
 #include "Portal.h"
 #include "Preference.h"
 #include "Progress.h"
+#include "ProjectionFactory.h"
 #include "Pvl.h"
 #include "SpecialPixel.h"
 #include "SurfacePoint.h"
@@ -372,146 +373,6 @@ void GeoRef::geodetic_to_cartesian(double lon, double lat, double height,
   x = (N + height) * clat * clon;
   y = (N + height) * clat * slon;
   z = (N * (1.0 - e2) + height) * slat;
-}
-
-// Cartographic utility. Convert an ISIS PVL Mapping group to a WKT string
-// using OGR setters. Mirrors GDAL's ISIS3 driver (frmts/pds/isis3dataset.cpp)
-// for consistency. Radii default to the DEM's if not present in the map file.
-std::string pvlToWkt(const PvlGroup &mapGrp,
-                     double defaultSemiMajor,
-                     double defaultSemiMinor) {
-
-  std::string projName = mapGrp["ProjectionName"][0].toLower().toStdString();
-
-  double a = defaultSemiMajor;
-  double b = defaultSemiMinor;
-  if (mapGrp.hasKeyword("EquatorialRadius"))
-    a = toDouble(mapGrp["EquatorialRadius"][0]);
-  if (mapGrp.hasKeyword("PolarRadius"))
-    b = toDouble(mapGrp["PolarRadius"][0]);
-
-  double lon0 = 0.0;
-  if (mapGrp.hasKeyword("CenterLongitude"))
-    lon0 = toDouble(mapGrp["CenterLongitude"][0]);
-
-  double lat0 = 0.0;
-  if (mapGrp.hasKeyword("CenterLatitude"))
-    lat0 = toDouble(mapGrp["CenterLatitude"][0]);
-
-  double scaleFactor = 1.0;
-  if (mapGrp.hasKeyword("ScaleFactor"))
-    scaleFactor = toDouble(mapGrp["ScaleFactor"][0]);
-
-  // Set projection (matching GDAL ISIS3 driver)
-  OGRSpatialReference oSRS;
-  oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
-
-  if (projName == "pointperspective" || projName == "obliquecylindrical")
-    throw IException(IException::User,
-      "ASP_MAP: projection not yet supported in PVL map file: " +
-      QString::fromStdString(projName) +
-      ". Provide the projection via a georeferenced image "
-      "(e.g., a .cub or .tif) as the map= argument instead.",
-      _FILEINFO_);
-  else if (projName == "equirectangular" || projName == "simplecylindrical")
-    oSRS.SetEquirectangular2(0.0, lon0, lat0, 0, 0);
-  else if (projName == "orthographic")
-    oSRS.SetOrthographic(lat0, lon0, 0, 0);
-  else if (projName == "sinusoidal")
-    oSRS.SetSinusoidal(lon0, 0, 0);
-  else if (projName == "mercator")
-    oSRS.SetMercator(lat0, lon0, scaleFactor, 0, 0);
-  else if (projName == "polarstereographic")
-    oSRS.SetPS(lat0, lon0, scaleFactor, 0, 0);
-  else if (projName == "stereographic")
-    oSRS.SetStereographic(lat0, lon0, scaleFactor, 0, 0);
-  else if (projName == "transversemercator")
-    oSRS.SetTM(lat0, lon0, scaleFactor, 0, 0);
-  else if (projName == "lambertconformal") {
-    double par1 = 0.0, par2 = 0.0;
-    if (mapGrp.hasKeyword("FirstStandardParallel"))
-      par1 = toDouble(mapGrp["FirstStandardParallel"][0]);
-    if (mapGrp.hasKeyword("SecondStandardParallel"))
-      par2 = toDouble(mapGrp["SecondStandardParallel"][0]);
-    oSRS.SetLCC(par1, par2, lat0, lon0, 0, 0);
-  } else if (projName == "lambertazimuthalequalarea")
-    oSRS.SetLAEA(lat0, lon0, 0, 0);
-  else if (projName == "mollweide")
-    oSRS.SetMollweide(lon0, 0, 0);
-  else if (projName == "robinson")
-    oSRS.SetRobinson(lon0, 0, 0);
-  else
-    throw IException(IException::User,
-      "ASP_MAP: unsupported projection in PVL map file: " +
-      QString::fromStdString(projName) +
-      ". Provide the projection via a georeferenced image "
-      "(e.g., a .cub or .tif) as the map= argument instead.",
-      _FILEINFO_);
-
-  // Set ProjCS name, e.g. "Equirectangular Moon"
-  std::string targetName = "Body";
-  if (mapGrp.hasKeyword("TargetName"))
-    targetName = mapGrp["TargetName"][0].toStdString();
-  oSRS.SetProjCS((mapGrp["ProjectionName"][0].toStdString() +
-                  " " + targetName).c_str());
-
-  // Set ellipsoid (matching GDAL ISIS3 driver's per-projection logic)
-  bool bIsGeographic = true;
-  if (mapGrp.hasKeyword("LatitudeType") &&
-      mapGrp["LatitudeType"][0].toLower() == "planetocentric")
-    bIsGeographic = false;
-
-  double iflattening = 0.0;
-  if ((a - b) >= 0.0000001)
-    iflattening = a / (a - b);
-
-  std::string geogName = "GCS_" + targetName;
-  std::string datumName = "D_" + targetName;
-  std::string sphereName = targetName;
-
-  if (projName == "polarstereographic" ||
-      (projName == "stereographic" && fabs(lat0) == 90.0)) {
-    if (bIsGeographic)
-      oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
-                     a, iflattening, "Reference_Meridian", 0.0);
-    else
-      oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(),
-                     (sphereName + "_polarRadius").c_str(),
-                     b, 0.0, "Reference_Meridian", 0.0);
-  } else if (projName == "simplecylindrical" ||
-             projName == "orthographic" ||
-             projName == "sinusoidal") {
-    // ISIS uses spherical equations for these
-    oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
-                   a, 0.0, "Reference_Meridian", 0.0);
-  } else if (projName == "equirectangular") {
-    // Local radius at CenterLatitude
-    double radLat = lat0 * M_PI / 180.0;
-    double meanRadius = sqrt(pow(b * cos(radLat), 2) +
-                             pow(a * sin(radLat), 2));
-    double localRadius = (meanRadius == 0.0) ? 0.0 : a * b / meanRadius;
-    oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(),
-                   (sphereName + "_localRadius").c_str(),
-                   localRadius, 0.0, "Reference_Meridian", 0.0);
-  } else {
-    // Mercator, TM, LCC, LAEA, Mollweide, Robinson
-    if (bIsGeographic)
-      oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
-                     a, iflattening, "Reference_Meridian", 0.0);
-    else
-      oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
-                     a, 0.0, "Reference_Meridian", 0.0);
-  }
-
-  // Export to WKT
-  char *wkt = nullptr;
-  oSRS.exportToWkt(&wkt);
-  if (!wkt)
-    throw IException(IException::Programmer,
-      "Failed to export projection to WKT", _FILEINFO_);
-  std::string result(wkt);
-  CPLFree(wkt);
-  return result;
 }
 
 // Tiled raster reader using ISIS Portal for chunk-cached random access.
@@ -1376,7 +1237,7 @@ void lonlatBboxToProj(double minLat, double maxLat,
 //   mpp = 2*PI*localRadius / (360*ppd)
 // For a sphere (a == c), localRadius = a regardless of latitude.
 // For an ellipsoid, localRadius = a*c / sqrt((c*cos)^2 + (a*sin)^2).
-// In practice, semiMajor == semiMinor here because pvlToWkt() and the
+// In practice, semiMajor == semiMinor here because PvlToWkt() and the
 // GDAL ISIS3 driver bake the local radius at CenterLatitude into the
 // ellipsoid as a sphere. The ellipsoid case below is kept for correctness
 // if this function is ever called with true ellipsoid axes.
@@ -1722,8 +1583,8 @@ GeoRef geoRefFromMapFile(const std::string &mapFile,
   Pvl mapPvl;
   mapPvl.read(QString::fromStdString(mapFile));
   PvlGroup &mapGrp = mapPvl.findGroup("Mapping", Pvl::Traverse);
-
-  std::string wkt = pvlToWkt(mapGrp, defaultSemiMajor, defaultSemiMinor);
+  std::string wkt = ProjectionFactory::PvlToWkt(mapGrp, defaultSemiMajor,
+                                                defaultSemiMinor);
   bool fromString = true;
   return GeoRef(wkt, fromString);
 }

--- a/isis/src/base/apps/cam2map/cam2map.xml
+++ b/isis/src/base/apps/cam2map/cam2map.xml
@@ -360,8 +360,7 @@
         <description>
           This file is the map projected (level2) image.
           Append <tt>+gtiff</tt> to write a GeoTIFF instead of a native cube.
-          The <tt>.tif</tt> extension is appended to the name you provide,
-          so <tt>to=out+gtiff</tt> writes <tt>out.tif</tt>. When the input
+          Use <tt>to=out+gtiff</tt> to write <tt>out.tif</tt>. When the input
           is a GeoTIFF, the output defaults to GeoTIFF as well; use
           <tt>+tile</tt> or <tt>+bsq</tt> to force a native cube. GeoTIFF
           output is new in ISIS 10 and is still being evaluated.

--- a/isis/src/base/apps/cam2map/cam2map.xml
+++ b/isis/src/base/apps/cam2map/cam2map.xml
@@ -359,11 +359,12 @@
         </brief>
         <description>
           This file is the map projected (level2) image.
-          Append <tt>+gtiff</tt> to write a GeoTIFF instead of a native cube
-          (e.g., <tt>to=out.cub+gtiff</tt>). When the input is a GeoTIFF, the
-          output defaults to GeoTIFF as well; use <tt>+tile</tt> or
-          <tt>+bsq</tt> to force a native cube. GeoTIFF output is new in
-          ISIS 10 and is still being evaluated.
+          Append <tt>+gtiff</tt> to write a GeoTIFF instead of a native cube.
+          The <tt>.tif</tt> extension is appended to the name you provide,
+          so <tt>to=out+gtiff</tt> writes <tt>out.tif</tt>. When the input
+          is a GeoTIFF, the output defaults to GeoTIFF as well; use
+          <tt>+tile</tt> or <tt>+bsq</tt> to force a native cube. GeoTIFF
+          output is new in ISIS 10 and is still being evaluated.
         </description>
         <filter>
           *.cub *.tif

--- a/isis/src/base/apps/cam2map/cam2map.xml
+++ b/isis/src/base/apps/cam2map/cam2map.xml
@@ -306,14 +306,17 @@
         <type>cube</type>
         <fileMode>input</fileMode>
         <brief>
-          Input cube to project
+          Input cube or ISIS GeoTIFF to project
         </brief>
         <description>
           The specification of the input cube to be projected.  The cube must
           have been initialized using the <i>spiceinit</i> program.
+          The input may also be a GeoTIFF previously written by ISIS or by
+          <i>gdal_translate</i> from an ISIS cube. GeoTIFF input is new in
+          ISIS 10 and is still being evaluated.
         </description>
         <filter>
-          *.cub
+          *.cub *.tif
         </filter>
       </parameter>
 
@@ -356,9 +359,14 @@
         </brief>
         <description>
           This file is the map projected (level2) image.
+          Append <tt>+gtiff</tt> to write a GeoTIFF instead of a native cube
+          (e.g., <tt>to=out.cub+gtiff</tt>). When the input is a GeoTIFF, the
+          output defaults to GeoTIFF as well; use <tt>+tile</tt> or
+          <tt>+bsq</tt> to force a native cube. GeoTIFF output is new in
+          ISIS 10 and is still being evaluated.
         </description>
         <filter>
-          *.cub
+          *.cub *.tif
         </filter>
       </parameter>
       <parameter name="MATCHMAP">

--- a/isis/src/base/objs/Cube/Cube.cpp
+++ b/isis/src/base/objs/Cube/Cube.cpp
@@ -2990,9 +2990,20 @@ namespace Isis {
       if (this->label()->findObject("IsisCube").hasGroup("Mapping")) {
         PvlGroup &mappingGroup = this->label()->findObject("IsisCube").findGroup("Mapping");
 
+        // Use ProjStr if present. Otherwise create a WKT from the Mapping fields.
+        std::string srsString;
         if (mappingGroup.hasKeyword("ProjStr")) {
+          srsString = mappingGroup.findKeyword("ProjStr")[0].toStdString();
+        } else if (mappingGroup.hasKeyword("ProjectionName")) {
+          try {
+            srsString = ProjectionFactory::PvlToWkt(mappingGroup);
+          } catch (IException &) {
+          }
+        }
+
+        if (!srsString.empty()) {
           OGRSpatialReference *oSRS = new OGRSpatialReference();
-          oSRS->SetFromUserInput(mappingGroup.findKeyword("ProjStr")[0].toStdString().c_str());
+          oSRS->SetFromUserInput(srsString.c_str());
 
           gdalDataset()->SetSpatialRef(oSRS);
 

--- a/isis/src/base/objs/ProjectionFactory/ProjectionFactory.cpp
+++ b/isis/src/base/objs/ProjectionFactory/ProjectionFactory.cpp
@@ -10,6 +10,9 @@ find files of those names at the top level of this repository. **/
 #include <cfloat>
 #include <cmath>
 #include <iomanip>
+#include <sstream>
+
+#include <ogr_spatialref.h>
 
 #include "Camera.h"
 #include "Cube.h"
@@ -17,8 +20,10 @@ find files of those names at the top level of this repository. **/
 #include "Distance.h"
 #include "FileName.h"
 #include "IException.h"
+#include "IString.h"
 #include "Plugin.h"
 #include "Projection.h"
+#include "PvlGroup.h"
 #include "RingPlaneProjection.h"
 #include "TProjection.h"
 
@@ -1159,4 +1164,168 @@ namespace Isis {
     }
     return (Isis::Projection *) proj;
   }
+  std::string ProjectionFactory::PvlToWkt(const Isis::PvlGroup &mapGrp,
+                                          double defaultSemiMajor,
+                                          double defaultSemiMinor) {
+
+    std::string projName = mapGrp["ProjectionName"][0].toLower().toStdString();
+
+    double a = defaultSemiMajor;
+    double b = defaultSemiMinor;
+    if (mapGrp.hasKeyword("EquatorialRadius"))
+      a = toDouble(mapGrp["EquatorialRadius"][0]);
+    if (mapGrp.hasKeyword("PolarRadius"))
+      b = toDouble(mapGrp["PolarRadius"][0]);
+
+    double lon0 = 0.0;
+    if (mapGrp.hasKeyword("CenterLongitude"))
+      lon0 = toDouble(mapGrp["CenterLongitude"][0]);
+
+    double lat0 = 0.0;
+    if (mapGrp.hasKeyword("CenterLatitude"))
+      lat0 = toDouble(mapGrp["CenterLatitude"][0]);
+
+    double scaleFactor = 1.0;
+    if (mapGrp.hasKeyword("ScaleFactor"))
+      scaleFactor = toDouble(mapGrp["ScaleFactor"][0]);
+
+    OGRSpatialReference oSRS;
+    oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+
+    if (projName == "equirectangular" || projName == "simplecylindrical")
+      oSRS.SetEquirectangular2(0.0, lon0, lat0, 0, 0);
+    else if (projName == "orthographic")
+      oSRS.SetOrthographic(lat0, lon0, 0, 0);
+    else if (projName == "sinusoidal")
+      oSRS.SetSinusoidal(lon0, 0, 0);
+    else if (projName == "mercator")
+      oSRS.SetMercator(lat0, lon0, scaleFactor, 0, 0);
+    else if (projName == "polarstereographic")
+      oSRS.SetPS(lat0, lon0, scaleFactor, 0, 0);
+    else if (projName == "stereographic")
+      oSRS.SetStereographic(lat0, lon0, scaleFactor, 0, 0);
+    else if (projName == "transversemercator")
+      oSRS.SetTM(lat0, lon0, scaleFactor, 0, 0);
+    else if (projName == "lambertconformal") {
+      double par1 = 0.0, par2 = 0.0;
+      if (mapGrp.hasKeyword("FirstStandardParallel"))
+        par1 = toDouble(mapGrp["FirstStandardParallel"][0]);
+      if (mapGrp.hasKeyword("SecondStandardParallel"))
+        par2 = toDouble(mapGrp["SecondStandardParallel"][0]);
+      oSRS.SetLCC(par1, par2, lat0, lon0, 0, 0);
+    } else if (projName == "lambertazimuthalequalarea")
+      oSRS.SetLAEA(lat0, lon0, 0, 0);
+    else if (projName == "mollweide")
+      oSRS.SetMollweide(lon0, 0, 0);
+    else if (projName == "robinson")
+      oSRS.SetRobinson(lon0, 0, 0);
+    else if (projName == "pointperspective") {
+      // Distance is in km in ISIS PVL; convert to meters.
+      // height_above_ground = distance - semi_major (matches GDAL driver).
+      if (!mapGrp.hasKeyword("Distance"))
+        throw IException(IException::User,
+          "PointPerspective Mapping group requires the Distance keyword",
+          _FILEINFO_);
+      double distance = toDouble(mapGrp["Distance"][0]) * 1000.0;
+      double heightAboveGround = distance - a;
+      oSRS.SetVerticalPerspective(lat0, lon0, 0, heightAboveGround, 0, 0);
+    }
+    else if (projName == "obliquecylindrical") {
+      // ISIS3's rotated-pole convention differs from PROJ ob_tran.
+      // Compensate per GDAL ISIS3 driver:
+      //   poleLatitude  ->  180 - poleLatitude
+      //   poleRotation  ->  -poleRotation
+      // See ObliqueCylindrical.cpp in ISIS and src/projections/ob_tran.cpp
+      // in PROJ for the difference.
+      if (!mapGrp.hasKeyword("PoleLatitude") ||
+          !mapGrp.hasKeyword("PoleLongitude") ||
+          !mapGrp.hasKeyword("PoleRotation"))
+        throw IException(IException::User,
+          "ObliqueCylindrical Mapping group requires "
+          "PoleLatitude, PoleLongitude, and PoleRotation keywords",
+          _FILEINFO_);
+      double poleLatitude = toDouble(mapGrp["PoleLatitude"][0]);
+      double poleLongitude = toDouble(mapGrp["PoleLongitude"][0]);
+      double poleRotation = toDouble(mapGrp["PoleRotation"][0]);
+      std::ostringstream oss;
+      oss.precision(17);
+      oss << "+proj=ob_tran +o_proj=eqc"
+          << " +o_lon_p=" << -poleRotation
+          << " +o_lat_p=" << (180.0 - poleLatitude)
+          << " +lon_0=" << poleLongitude;
+      if (oSRS.SetFromUserInput(oss.str().c_str()) != OGRERR_NONE)
+        throw IException(IException::Programmer,
+          "Failed to build ObliqueCylindrical PROJ4 string: " +
+          QString::fromStdString(oss.str()),
+          _FILEINFO_);
+    }
+    else
+      throw IException(IException::User,
+        "Unsupported projection: " + QString::fromStdString(projName),
+        _FILEINFO_);
+
+    std::string targetName = "Body";
+    if (mapGrp.hasKeyword("TargetName"))
+      targetName = mapGrp["TargetName"][0].toStdString();
+    oSRS.SetProjCS((mapGrp["ProjectionName"][0].toStdString() +
+                    " " + targetName).c_str());
+
+    bool bIsGeographic = true;
+    if (mapGrp.hasKeyword("LatitudeType") &&
+        mapGrp["LatitudeType"][0].toLower() == "planetocentric")
+      bIsGeographic = false;
+
+    double iflattening = 0.0;
+    if ((a - b) >= 0.0000001)
+      iflattening = a / (a - b);
+
+    std::string geogName = "GCS_" + targetName;
+    std::string datumName = "D_" + targetName;
+    std::string sphereName = targetName;
+
+    if (projName == "polarstereographic" ||
+        (projName == "stereographic" && fabs(lat0) == 90.0)) {
+      if (bIsGeographic)
+        oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
+                       a, iflattening, "Reference_Meridian", 0.0);
+      else
+        oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(),
+                       (sphereName + "_polarRadius").c_str(),
+                       b, 0.0, "Reference_Meridian", 0.0);
+    } else if (projName == "simplecylindrical" ||
+               projName == "orthographic" ||
+               projName == "sinusoidal" ||
+               projName == "pointperspective") {
+      // ISIS uses spherical equations for these
+      oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
+                     a, 0.0, "Reference_Meridian", 0.0);
+    } else if (projName == "equirectangular") {
+      // Local radius at CenterLatitude
+      double radLat = lat0 * M_PI / 180.0;
+      double meanRadius = sqrt(pow(b * cos(radLat), 2) +
+                               pow(a * sin(radLat), 2));
+      double localRadius = (meanRadius == 0.0) ? 0.0 : a * b / meanRadius;
+      oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(),
+                     (sphereName + "_localRadius").c_str(),
+                     localRadius, 0.0, "Reference_Meridian", 0.0);
+    } else {
+      // Mercator, TM, LCC, LAEA, Mollweide, Robinson
+      if (bIsGeographic)
+        oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
+                       a, iflattening, "Reference_Meridian", 0.0);
+      else
+        oSRS.SetGeogCS(geogName.c_str(), datumName.c_str(), sphereName.c_str(),
+                       a, 0.0, "Reference_Meridian", 0.0);
+    }
+
+    char *wkt = nullptr;
+    oSRS.exportToWkt(&wkt);
+    if (!wkt)
+      throw IException(IException::Programmer,
+        "Failed to export projection to WKT", _FILEINFO_);
+    std::string result(wkt);
+    CPLFree(wkt);
+    return result;
+  }
+
 } //end namespace isis

--- a/isis/src/base/objs/ProjectionFactory/ProjectionFactory.h
+++ b/isis/src/base/objs/ProjectionFactory/ProjectionFactory.h
@@ -6,6 +6,8 @@ For more details about the LICENSE terms and the AUTHORS, you will
 find files of those names at the top level of this repository. **/
 
 /* SPDX-License-Identifier: CC0-1.0 */
+#include <string>
+
 #include "Plugin.h"
 #include "WorldMapper.h"
 
@@ -13,6 +15,7 @@ namespace Isis {
   class Camera;
   class Cube;
   class Projection;
+  class PvlGroup;
   class RingPlaneProjection;
 
   /**
@@ -92,6 +95,15 @@ namespace Isis {
                                                    int &samples, int &lines,
                                                    Camera &cam);
 
+      // Build an OGR WKT string from an ISIS Mapping PVL group. Mirrors the
+      // per-projection logic in GDAL's ISIS3 driver
+      // (frmts/pds/isis3dataset.cpp). Throws IException for unsupported
+      // projections (e.g. PointPerspective, ObliqueCylindrical). Radii fall
+      // back to the defaults if EquatorialRadius/PolarRadius are missing
+      // from the Mapping group.
+      static std::string PvlToWkt(const Isis::PvlGroup &mapGrp,
+                                  double defaultSemiMajor = 0.0,
+                                  double defaultSemiMinor = 0.0);
 
     private:
       /**

--- a/isis/tests/Cam2mapTests.cpp
+++ b/isis/tests/Cam2mapTests.cpp
@@ -1,6 +1,9 @@
 #include <iostream>
 #include <QTemporaryFile>
 
+#include <gdal_priv.h>
+#include <ogr_spatialref.h>
+
 #include "cam2map.h"
 
 #include "Cube.h"
@@ -181,6 +184,83 @@ TEST_F(DefaultCube, FunctionalTestCam2mapDefault) {
 
   ASSERT_EQ(cubeMapGroup.findKeyword("PixelResolution"), userGrp.findKeyword("PixelResolution"));
   ASSERT_EQ(cubeMapGroup.findKeyword("Scale"), userGrp.findKeyword("Scale"));
+}
+
+// Test cam2map with GTiff output and saving the projection string.
+TEST_F(DefaultCube, FunctionalTestCam2mapGTiffOutputDefault) {
+  std::istringstream labelStrm(R"(
+    Group = Mapping
+      ProjectionName  = Sinusoidal
+      CenterLongitude = 0.0 <degrees>
+
+      TargetName         = MARS
+      EquatorialRadius   = 3396190.0 <meters>
+      PolarRadius        = 3376200.0 <meters>
+
+      LatitudeType       = Planetocentric
+      LongitudeDirection = PositiveEast
+      LongitudeDomain    = 360 <degrees>
+
+      MinimumLatitude    = 0 <degrees>
+      MaximumLatitude    = 5 <degrees>
+      MinimumLongitude   = 0 <degrees>
+      MaximumLongitude   = 5 <degrees>
+
+      PixelResolution    = 100000 <meters/pixel>
+      Scale              = 512.0 <pixels/degree>
+    End_Group
+  )");
+
+  Pvl userMap;
+  labelStrm >> userMap;
+  PvlGroup &userGrp = userMap.findGroup("Mapping", Pvl::Traverse);
+
+  QString tifPath = tempDir.path() + "/level2.cub.tif";
+  QVector<QString> args = {"to=" + tempDir.path() + "/level2.cub+gtiff",
+                           "pixres=map"};
+  UserInterface ui(APP_XML, args);
+
+  GDALAllRegister();
+
+  Pvl log;
+  cam2map(testCube, userMap, userGrp, ui, &log);
+
+  GDALDataset *ds =
+    (GDALDataset *) GDALOpen(tifPath.toStdString().c_str(), GA_ReadOnly);
+  ASSERT_NE(ds, nullptr);
+  const OGRSpatialReference *srs = ds->GetSpatialRef();
+  ASSERT_NE(srs, nullptr);
+  EXPECT_DOUBLE_EQ(srs->GetSemiMajor(nullptr), 3396190.0);
+  const char *proj = srs->GetAttrValue("PROJECTION");
+  ASSERT_NE(proj, nullptr);
+  EXPECT_STREQ(proj, "Sinusoidal");
+  GDALClose(ds);
+}
+
+// Test cam2map useproj=true with GTiff output: exercises the ProjStr
+// override path in Cube::writeLabels (the Mapping group already has
+// ProjStr from the user's projstring=, so PvlToWkt is bypassed).
+TEST_F(DefaultCube, FunctionalTestCam2mapGTiffOutputUseproj) {
+  QString outPath = tempDir.path() + "/level2_useproj.cub";
+  QString tifPath = outPath + ".tif";
+
+  QVector<QString> args = {"from=" + testCube->fileName(),
+                           "to=" + outPath + "+gtiff",
+                           "useproj=true",
+                           "projstring=+proj=eqc +R=3396190 +units=m"};
+  UserInterface ui(APP_XML, args);
+  Pvl log;
+
+  GDALAllRegister();
+  cam2map(ui, &log);
+
+  GDALDataset *ds =
+    (GDALDataset *) GDALOpen(tifPath.toStdString().c_str(), GA_ReadOnly);
+  ASSERT_NE(ds, nullptr);
+  const OGRSpatialReference *srs = ds->GetSpatialRef();
+  ASSERT_NE(srs, nullptr);
+  EXPECT_DOUBLE_EQ(srs->GetSemiMajor(nullptr), 3396190.0);
+  GDALClose(ds);
 }
 
 TEST_F(DefaultCube, FunctionalTestCam2mapMismatch) {
@@ -680,6 +760,37 @@ TEST_F(DemCube, FunctionalTestCam2mapAspMap) {
 
   // Check pixel values across all bands
   checkPixelValues(ocube, ocube.bandCount());
+}
+
+// Test cam2map asp_map=true with GTiff output: verify the resulting
+// .cub.tif carries projection geo-tags via Cube::writeLabels +
+// ProjectionFactory::PvlToWkt. Issue #6033 sibling test.
+TEST_F(DemCube, FunctionalTestCam2mapAspMapGTiffOutput) {
+  QString heightDemPath = createHeightDem(tempDir.path(),
+                                          -35.0, 55.0, 200.0, 290.0, 245.0);
+
+  QString outPath = tempDir.path() + "/aspmap_gtiff.cub";
+  QString tifPath = outPath + ".tif";
+
+  QVector<QString> args = {"from=" + testCube->fileName(),
+                           "to=" + outPath + "+gtiff",
+                           "asp_map=true",
+                           "dem=" + heightDemPath,
+                           "pixres=mpp",
+                           "resolution=500"};
+  UserInterface ui(APP_XML, args);
+  Pvl log;
+
+  GDALAllRegister();
+  cam2map(ui, &log);
+
+  GDALDataset *ds =
+    (GDALDataset *) GDALOpen(tifPath.toStdString().c_str(), GA_ReadOnly);
+  ASSERT_NE(ds, nullptr);
+  const OGRSpatialReference *srs = ds->GetSpatialRef();
+  ASSERT_NE(srs, nullptr);
+  EXPECT_DOUBLE_EQ(srs->GetSemiMajor(nullptr), 3396190.0);
+  GDALClose(ds);
 }
 
 // Test ASP_MAP matchmap=true with a PVL .map file.

--- a/isis/tests/Cam2mapTests.cpp
+++ b/isis/tests/Cam2mapTests.cpp
@@ -215,8 +215,8 @@ TEST_F(DefaultCube, FunctionalTestCam2mapGTiffOutputDefault) {
   labelStrm >> userMap;
   PvlGroup &userGrp = userMap.findGroup("Mapping", Pvl::Traverse);
 
-  QString tifPath = tempDir.path() + "/level2.cub.tif";
-  QVector<QString> args = {"to=" + tempDir.path() + "/level2.cub+gtiff",
+  QString tifPath = tempDir.path() + "/level2.tif";
+  QVector<QString> args = {"to=" + tempDir.path() + "/level2+gtiff",
                            "pixres=map"};
   UserInterface ui(APP_XML, args);
 
@@ -241,11 +241,11 @@ TEST_F(DefaultCube, FunctionalTestCam2mapGTiffOutputDefault) {
 // override path in Cube::writeLabels (the Mapping group already has
 // ProjStr from the user's projstring=, so PvlToWkt is bypassed).
 TEST_F(DefaultCube, FunctionalTestCam2mapGTiffOutputUseproj) {
-  QString outPath = tempDir.path() + "/level2_useproj.cub";
-  QString tifPath = outPath + ".tif";
+  QString outStem = tempDir.path() + "/level2_useproj";
+  QString tifPath = outStem + ".tif";
 
   QVector<QString> args = {"from=" + testCube->fileName(),
-                           "to=" + outPath + "+gtiff",
+                           "to=" + outStem + "+gtiff",
                            "useproj=true",
                            "projstring=+proj=eqc +R=3396190 +units=m"};
   UserInterface ui(APP_XML, args);
@@ -762,18 +762,17 @@ TEST_F(DemCube, FunctionalTestCam2mapAspMap) {
   checkPixelValues(ocube, ocube.bandCount());
 }
 
-// Test cam2map asp_map=true with GTiff output: verify the resulting
-// .cub.tif carries projection geo-tags via Cube::writeLabels +
-// ProjectionFactory::PvlToWkt. Issue #6033 sibling test.
+// Test cam2map asp_map=true with GTiff output: verify the projection
+// string is written to the output GeoTIFF.
 TEST_F(DemCube, FunctionalTestCam2mapAspMapGTiffOutput) {
   QString heightDemPath = createHeightDem(tempDir.path(),
                                           -35.0, 55.0, 200.0, 290.0, 245.0);
 
-  QString outPath = tempDir.path() + "/aspmap_gtiff.cub";
-  QString tifPath = outPath + ".tif";
+  QString outStem = tempDir.path() + "/aspmap_gtiff";
+  QString tifPath = outStem + ".tif";
 
   QVector<QString> args = {"from=" + testCube->fileName(),
-                           "to=" + outPath + "+gtiff",
+                           "to=" + outStem + "+gtiff",
                            "asp_map=true",
                            "dem=" + heightDemPath,
                            "pixres=mpp",


### PR DESCRIPTION
Write projection string to GeoTIFF produced by cam2map

## Description

This fixes #6033. When cam2map or any other geotiff writing logic (via Cube::writeLabels) writes a GeoTIFF cube, the proj string is always written. Before, this was true only when a projection string was set as argument.

This uses a function named PvlToWkt that was previously used only for writing a cam2map-ed cub in asp_map format. 

The documentation in cam2map.xml got expanded a bit to reflect that geotiffs can be inputs and outputs.

## How Has This Been Validated?

Manually ran cam2map on an MRO CTX cube (B17_016219_1978_XN_17N282W.cub) before and after the fix. 

Cross-checked against the GDAL ISIS3 driver which can convert a cam2map-ed cub to geotif. 

Added three unit tests to create a geotif with and without setting a projection string, and when writing a geotiff with asp_map = true. 

## Types of changes

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Documentation change (update to the documentation; no code change)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:

- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json)
  document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. (Added as `changes/6033.fix.md`.)

## Licensing

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the
  benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an
  overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

