### PR TITLE
Add CSM parameter to campt

### DIFF
--- a/changes/6035.added.md
+++ b/changes/6035.added.md
@@ -1,0 +1,1 @@
+Add CSM parameter to campt for loading a CSM camera (ISD or model state JSON) from an external file instead of the input cube. The cube does not need to be run through spiceinit in this mode. Mirrors the approach used for ISD/CSMLIST in cam2map and jigsaw, and CSM in phocube. Issue #6035.

--- a/isis/src/base/apps/campt/campt.cpp
+++ b/isis/src/base/apps/campt/campt.cpp
@@ -50,7 +50,16 @@ namespace Isis{
     catch (IException &e) {
       inputCubePath = cube->fileName();
     }
-    campt.SetCube(inputCubePath);
+
+    // Optional external CSM camera (ISD or model state JSON). Replaces the
+    // camera attached to the input cube; the cube does not need to be run
+    // through spiceinit in this mode.
+    if (ui.WasEntered("CSM")) {
+      campt.SetCube(inputCubePath, ui.GetFileName("CSM"));
+    }
+    else {
+      campt.SetCube(inputCubePath);
+    }
 
     // Grab the provided points (coordinates)
     QList< QPair<double, double> > points = getPoints(ui, ui.WasEntered("COORDLIST"));

--- a/isis/src/base/apps/campt/campt.xml
+++ b/isis/src/base/apps/campt/campt.xml
@@ -273,9 +273,30 @@ xsi:noNamespaceSchemaLocation=
         <description>
           Input image, which requires <def>SPICE</def> (see <i>spiceinit</i>)
           and must be a <def>Level0</def> or a <def>Level1</def> ISIS cube.
+          If a <def>CSM</def> camera file is provided in the CSM parameter,
+          the cube does not need to be run through spiceinit.
         </description>
         <filter>
           *.cub
+        </filter>
+      </parameter>
+
+      <parameter name="CSM">
+        <type>filename</type>
+        <fileMode>input</fileMode>
+        <brief>
+          Load the camera model in CSM format from this file, rather than the
+          one from the input cube.
+        </brief>
+        <internalDefault>None</internalDefault>
+        <description>
+          JSON file containing either a CSM ISD (Instrument Support Data) or a
+          CSM model state. When provided, the camera is built from this file
+          and used in place of the camera attached to the input cube. The
+          input cube does not need to be run through spiceinit.
+        </description>
+        <filter>
+          *.json
         </filter>
       </parameter>
 

--- a/isis/src/base/objs/CameraPointInfo/CameraPointInfo.cpp
+++ b/isis/src/base/objs/CameraPointInfo/CameraPointInfo.cpp
@@ -12,6 +12,7 @@ find files of those names at the top level of this repository. **/
 
 #include "Brick.h"
 #include "Camera.h"
+#include "CameraFactory.h"
 #include "CameraFocalPlaneMap.h"
 #include "Cube.h"
 #include "CubeManager.h"
@@ -75,6 +76,22 @@ namespace Isis {
   void CameraPointInfo::SetCube(const QString &cubeFileName) {
     m_currentCube = m_usedCubes->OpenCube(cubeFileName);
     m_camera = m_currentCube->camera();
+  }
+
+
+  /**
+   * Open the cube and replace its camera with one built from an external
+   * CSM ISD or model state JSON file. The input cube does not need to be
+   * run through spiceinit in this mode.
+   *
+   * @param cubeFileName A cube file name.
+   * @param csmFileName  A JSON file holding either a CSM ISD or a CSM model state.
+   */
+  void CameraPointInfo::SetCube(const QString &cubeFileName, const QString &csmFileName) {
+    m_currentCube = m_usedCubes->OpenCube(cubeFileName);
+    Camera *cam = CameraFactory::CreateFromIsd(csmFileName, *m_currentCube);
+    m_currentCube->setCamera(cam);
+    m_camera = cam;
   }
 
 

--- a/isis/src/base/objs/CameraPointInfo/CameraPointInfo.h
+++ b/isis/src/base/objs/CameraPointInfo/CameraPointInfo.h
@@ -81,6 +81,7 @@ namespace Isis {
       virtual ~CameraPointInfo();
 
       void SetCube(const QString &cubeFileName);
+      void SetCube(const QString &cubeFileName, const QString &csmFileName);
       void SetCSVOutput(bool csvOutput);
       PvlGroup *SetImage(const double sample, const double line,
                          const bool outside = false, const bool error = false);

--- a/isis/tests/FunctionalTestsCampt.cpp
+++ b/isis/tests/FunctionalTestsCampt.cpp
@@ -1,3 +1,4 @@
+#include <QDir>
 #include <QTextStream>
 #include <QStringList>
 #include <QFile>
@@ -326,4 +327,54 @@ TEST_F(CSMCubeFixture, FunctionalTestCamptCSMCamera) {
   EXPECT_TRUE(groundPoint.findKeyword("LookDirectionCamera").isNull(0));
   EXPECT_TRUE(groundPoint.findKeyword("LookDirectionCamera").isNull(1));
   EXPECT_TRUE(groundPoint.findKeyword("LookDirectionCamera").isNull(2));
+}
+
+
+// Test the CSM= parameter, which loads a CSM camera (ISD or model state JSON)
+// from an external file and uses it in place of the camera attached to the
+// input cube. Mirrors the phocube CSM test.
+// Requires the USGSCSM plugin from ISISROOT or CONDA_PREFIX.
+TEST_F(DefaultCube, FunctionalTestCamptCsm) {
+  auto hasPlugins = [](const char *dir) {
+    return dir && QDir(QString(dir) + "/lib/csmplugins").exists();
+  };
+  const char *isisroot = getenv("ISISROOT");
+  const char *conda = getenv("CONDA_PREFIX");
+  if (!hasPlugins(isisroot) && !hasPlugins(conda))
+    GTEST_SKIP() << "No CSM plugins found (set ISISROOT or CONDA_PREFIX)";
+
+  // Resize testCube to match the CSM framer's 16x16 detector so the queried
+  // sample/line lands inside the CSM detector.
+  resizeCube(16, 16, 1);
+  QString cubePath = testCube->fileName();
+  testCube->close();
+
+  QString isdPath = "data/defaultImage/orbitalMarsFramer.json";
+
+  QVector<QString> args = {"from=" + cubePath,
+                           "csm=" + isdPath,
+                           "sample=8",
+                           "line=8"};
+  UserInterface options(APP_XML, args);
+  Pvl appLog;
+
+  try {
+    campt(options, &appLog);
+  } catch (IException &e) {
+    GTEST_SKIP() << "campt CSM test skipped (environment issue): "
+                 << e.what();
+  }
+
+  PvlGroup groundPoint = appLog.findGroup("GroundPoint");
+
+  // The CSM camera was successfully loaded and queried iff the spacecraft
+  // identifier flowed through from the ISD (the ISIS Viking camera in the
+  // cube fixture would not produce these CSM-derived identifiers).
+  ASSERT_TRUE(groundPoint.hasKeyword("Sample"));
+  EXPECT_DOUBLE_EQ(toDouble(groundPoint.findKeyword("Sample")[0]), 8.0);
+  EXPECT_DOUBLE_EQ(toDouble(groundPoint.findKeyword("Line")[0]), 8.0);
+
+  // The CSM Mars framer points at lon=0, lat=0 from 4000 km, so the queried
+  // pixel must produce a valid ground intersection (no Error keyword).
+  EXPECT_FALSE(groundPoint.hasKeyword("Error"));
 }


### PR DESCRIPTION
## Description

This allows campt to load a CSM camera via a new CSM option. Then, the cube does not need to be run through spiceinit. 

## Related Issue

Fixes https://github.com/DOI-USGS/ISIS3/issues/6035.

## How Has This Been Validated?

I ran campt with a real cub with csm camera as an additional parameter. Results look very plausible given the change in camera. A unit test was added.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
