### PR TITLE
Fix for json parsing

### DIFF
--- a/changes/6038.fix.md
+++ b/changes/6038.fix.md
@@ -1,0 +1,1 @@
+Fix Cube::open on GeoTIFF cubes whose json:ISIS3 metadata contains nested objects, e.g. where GDAL expanded a slash-named PVL keyword (such as INS-85600_F/RATIO in LROC NAC) into a nested JSON object. Pvl::readObject now flattens such nested objects back to '/'-separated keyword names, while keeping the {value, unit} shape as a single keyword. Issue #6038.

--- a/isis/src/core/src/Pvl.cpp
+++ b/isis/src/core/src/Pvl.cpp
@@ -77,6 +77,41 @@ namespace Isis {
     m_internalTemplate = false;
   }
 
+  // Treat a nested-object value as a single keyword if it has exactly the
+  // {value, unit} shape that GDAL's ISIS3 driver creates. 
+  // Example: "0.636 <ms>".
+  bool isJsonValueUnitObject(const nlohmann::ordered_json &v) {
+    if (!v.is_object()) return false;
+    if (!v.contains("value") || !v.contains("unit")) return false;
+    for (auto &[k, _] : v.items())
+      if (k != "value" && k != "unit") return false;
+    return true;
+  }
+
+  // Parse a JSON entry into one or more PVL keywords. Handles fragments like
+  //   "INS-85600_F": { "RATIO": 3.577 }
+  // produced by GDAL. This results in the intended PVL keyword
+  //   INS-85600_F/RATIO = 3.577
+  template <class Container>
+  void addJsonKeyword(Container &container, const std::string &name,
+                      const nlohmann::ordered_json &val) {
+    if (val.is_object() && !isJsonValueUnitObject(val)) {
+      for (auto &[subkey, subval] : val.items()) {
+        if (subkey == "_type" || subkey == "_container_name" ||
+            subkey == "_filename" || subkey == "_data") continue;
+        addJsonKeyword(container, name + "/" + subkey, subval);
+      }
+      return;
+    }
+    Isis::PvlKeyword keyword;
+    keyword.setName(QString::fromStdString(name));
+    if (val.is_array())
+      keyword.addJsonArrayValue(val);
+    else
+      keyword.setJsonValue(val);
+    container.addKeyword(keyword);
+  }
+
   // This function specifically reads from GDAL-style JSON metadata.  
   Isis::PvlObject &Pvl::readObject(Isis::PvlObject &pvlobj, nlohmann::ordered_json jdata) {
     for(auto &[key, value] : jdata.items()) {
@@ -97,13 +132,7 @@ namespace Isis {
           // parse keys 
           PvlGroup group(QString::fromStdString(name)); 
           for(auto &[pvlkeyword, pvlvalue] : value.items())  { 
-            PvlKeyword keyword;
-            keyword.setName(QString::fromStdString(pvlkeyword));
-            if (pvlvalue.is_array())
-                keyword.addJsonArrayValue(pvlvalue);
-            else 
-              keyword.setJsonValue(pvlvalue);
-            group.addKeyword(keyword);
+            addJsonKeyword(group, pvlkeyword, pvlvalue);
           }
           pvlobj.addGroup(group);
         } // end of group
@@ -111,14 +140,7 @@ namespace Isis {
 
       // not a group or object, must be a keyword
       else if (key != "_type" && key != "_filename" && key != "_data") { 
-        PvlKeyword keyword;
-        keyword.setName(QString::fromStdString(key));
-        if (value.is_array()) 
-          keyword.setJsonArrayValue(value);
-        else 
-          keyword.setJsonValue(value);
-
-        pvlobj.addKeyword(keyword);
+        addJsonKeyword(pvlobj, key, value);
       }
     }
     return pvlobj;

--- a/isis/tests/PvlObjectTests.cpp
+++ b/isis/tests/PvlObjectTests.cpp
@@ -1,4 +1,5 @@
 #include "PvlObject.h"
+#include "Pvl.h"
 #include "IException.h"
 
 #include "TestUtilities.h"
@@ -227,5 +228,35 @@ TEST(PvlObject, PvlGroupEqualTest){
 
   copy.addKeyword(pvlTmplKwrdFour);
   EXPECT_FALSE(AssertPvlGroupEqual("Point_ErrorMagnitude", "Point_ErrorMagnitude", copy, pvlTmplGrp)); // should fail
+}
+
+// Parse a complex JSON string found in an LROC NAC GeoTIFF cube
+// (M181073012LE.ce.cub) after being processed with gdal_translate -of COG. GDAL
+// expanded the PVL keyword INS-85600_F/RATIO into a nested object that is
+// tricky to parse. Expected output PVL:
+//   Object = NaifKeywords
+//     BODY_FRAME_CODE   = 10020
+//     INS-85600_F/RATIO = 3.577
+//   End_Object
+TEST(PvlObject, ReadObjectGdalSlashKeyword) {
+  
+  // Complex json fragment that needs parsing to produce PVL
+  nlohmann::ordered_json j = {
+    {"NaifKeywords", {
+      {"_type", "object"},
+      {"BODY_FRAME_CODE", 10020},
+      {"INS-85600_F", {{"RATIO", 3.577}}}
+    }}
+  };
+
+  Pvl pvl;
+  Pvl::readObject(pvl, j);
+
+  ASSERT_TRUE(pvl.hasObject("NaifKeywords"));
+  PvlObject &nk = pvl.findObject("NaifKeywords");
+  ASSERT_TRUE(nk.hasKeyword("BODY_FRAME_CODE"));
+  EXPECT_EQ((int)nk.findKeyword("BODY_FRAME_CODE"), 10020);
+  ASSERT_TRUE(nk.hasKeyword("INS-85600_F/RATIO"));
+  EXPECT_DOUBLE_EQ((double)nk.findKeyword("INS-85600_F/RATIO"), 3.577);
 }
 


### PR DESCRIPTION
## Description

GDAL expands PVL keywords whose names contain '/' (e.g. INS-85600_F/RATIO in LROC NAC) into nested JSON objects in the json:ISIS3 metadata domain. Pvl::readObject could not read that properly and was throwing nlohmann::json::type_error 302. 

This puts a fix and adds a unit test showing a specific JSON string it was failing on. 

## Related Issue

This fixes https://github.com/DOI-USGS/ISIS3/issues/6038.

## How Has This Been Validated?

Offline testing was done with dataset M181073012LE.ce.cub after running it through gdal_translate -of COG which produces problematic JSON that can't be easily parsed back to PVL.

The actual problematic JSON string was incorporated in a unit test for the fixed function.

<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
