### PR TITLE
Fix equalizer test data path resolution

### DIFF
--- a/isis/tests/FunctionalTestsEqualizer.cpp
+++ b/isis/tests/FunctionalTestsEqualizer.cpp
@@ -34,7 +34,7 @@ protected:
     QTextStream out(&file);
 
     for (const QString& name : cubeNames) {
-      QString fullPath = FileName("$ISISROOT/../isis/tests/" + testDataDir + "/" + name).expanded();
+      QString fullPath = testDataDir + "/" + name;
       out << fullPath << "\n";
     }
     file.close();
@@ -49,7 +49,7 @@ protected:
     QTextStream out(&file);
 
     for (const QString& name : cubeNames) {
-      QString fullPath = FileName("$ISISROOT/../isis/tests/" + testDataDir + "/" + name).expanded();
+      QString fullPath = testDataDir + "/" + name;
       out << fullPath << "\n";
     }
     file.close();

--- a/isis/tests/FunctionalTestsEqualizer.cpp
+++ b/isis/tests/FunctionalTestsEqualizer.cpp
@@ -23,7 +23,7 @@ protected:
 
   void SetUp() override {
     TempTestingFiles::SetUp();
-    testDataDir = "data/equalizer";
+    testDataDir = QString(_SOURCE_PREFIX) + "/data/equalizer";
   }
 
   // Helper: Create fromlist file from local test data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes the equalizer gtest fixture path resolution under Linux CI.

The tests were writing absolute fixture paths expanded through `$ISISROOT/../isis/tests/...`. Under CodeBuild, this resolved incorrectly as `build/../isis/tests/...`, causing the Equalizer tests to fail opening the repo-local cropped `.cub` fixtures.

This updates the fromlist/holdlist helpers to write relative `data/equalizer/...` paths, matching the pattern used by other gtests.

## Validation

Ran from the build directory:

```bash
ctest -R Equalizer --output-on-failure

100% tests passed, 0 tests failed out of 9
The following tests did not run:
  EqualizerTest.FunctionalTestEqualizerNoHoldApplyInputStats (Disabled)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
