### PR TITLE
Kplo shadowcam sn fix 6061

### DIFF
--- a/changes/6061.fix.md
+++ b/changes/6061.fix.md
@@ -1,0 +1,1 @@
+Fixed KPLO ShadowCam serial number returning "Unknown" because KploShadowCamCameraSerialNumber.trn used the bare keyword Auto instead of Auto = 1, breaking findimageoverlaps and other tools that require a real serial number.

--- a/isis/appdata/serialnumbers/KploShadowCamCameraSerialNumber.trn
+++ b/isis/appdata/serialnumbers/KploShadowCamCameraSerialNumber.trn
@@ -1,7 +1,7 @@
 ObservationKeys =3 
 
 Group = Keyword1
-  Auto
+  Auto           = 1
   InputKey       = SpacecraftName
   InputGroup     = "IsisCube,Instrument"
   InputPosition  = (IsisCube, Instrument)
@@ -12,7 +12,7 @@ Group = Keyword1
 End_Group
 
 Group = Keyword2
-  Auto
+  Auto           = 1
   InputKey       = ExecutionSpacecraftTime
   InputGroup     = "IsisCube,Instrument"
   InputPosition  = (IsisCube, Instrument)
@@ -22,7 +22,7 @@ Group = Keyword2
 End_Group
 
 Group = Keyword3
-  Auto
+  Auto           = 1
   InputKey       = InstrumentId
   InputGroup     = "IsisCube,Instrument"
   InputPosition  = (IsisCube, Instrument)

--- a/isis/tests/FunctionalTestsGetsn.cpp
+++ b/isis/tests/FunctionalTestsGetsn.cpp
@@ -133,6 +133,26 @@ TEST_F(DefaultCube, FunctionalTestGetsnAppend) {
 }
 
 
+// Regression test for issue #6061: KPLO ShadowCam cubes returned
+// SerialNumber "Unknown" because KploShadowCamCameraSerialNumber.trn used
+// the bare keyword "Auto" instead of "Auto = 1", which the PVL translation
+// table parser does not recognize. Without the .trn fix, this expectation
+// fails and getsn yields "Unknown".
+TEST_F(ShadowCamCube, FunctionalTestGetsnShadowCam) {
+  QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();
+  QString expectedSN = "KPLO/1200:1731688/ShadowCam";
+
+  QVector<QString> args = { "SN=TRUE" };
+  UserInterface options(APP_XML, args);
+  Pvl appLog;
+
+  getsn( testCube.get(), options, &appLog );
+  PvlGroup results = appLog.findGroup("Results");
+
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, results.findKeyword("SerialNumber"), expectedSN);
+}
+
+
 // Test that append false overwrites file
 TEST_F(DefaultCube, FunctionalTestGetsnOverwrite) {
   QString APP_XML = FileName("$ISISROOT/bin/xml/getsn.xml").expanded();


### PR DESCRIPTION
## Description

This fixes Shadowcam issue https://github.com/DOI-USGS/ISIS3/issues/6061, so a failure in findimageoverlap.

The fix is to add to KploShadowCamCameraSerialNumber.trn Auto = 1 (before it was just Auto, without = 1), for consistency with all 56 other SerialNumber translation files in isis/appdata/serialnumbers (for example LroNacSerialNumber.trn, Apollo15SerialNumber.trn). 

A unit test is added to trigger this. It fails without the fix.

## Related Issue

https://github.com/DOI-USGS/ISIS3/issues/6061

## How Has This Been Validated?

Unit test added 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] I have added myself to the [.zenodo.json](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/.zenodo.json) document.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
