### PR TITLE
allow opening .tiff/.tif cubes in q Apps

### DIFF
--- a/changes/6073.change.md
+++ b/changes/6073.change.md
@@ -1,0 +1,1 @@
+Added cubes with .tif and .tiff file extensions to q-apps file-open dialogs.

--- a/changes/6073.change.md
+++ b/changes/6073.change.md
@@ -1,1 +1,1 @@
-Added cubes with .tif and .tiff file extensions to q-apps file-open dialogs.
+Added .tif and .tiff file extensions to q-apps cube file open dialogs/commands.

--- a/isis/src/qisis/apps/qtie/QtieFileTool.cpp
+++ b/isis/src/qisis/apps/qtie/QtieFileTool.cpp
@@ -86,7 +86,7 @@ namespace Isis {
 
     QString baseFile, matchFile;
     QString dir;
-    QString filter = "Isis Cubes (*.cub);;";
+    QString filter = "Isis Cubes (*.cub *.tif *.tiff);;";
     filter += "Detached labels (*.lbl);;";
     filter += "All (*)";
 

--- a/isis/src/qisis/objs/FileTool/FileTool.cpp
+++ b/isis/src/qisis/objs/FileTool/FileTool.cpp
@@ -214,8 +214,8 @@ namespace Isis {
    */
   void FileTool::open() {
     //Set up the list of filters that are default with this dialog.
-    if (!p_filterList.contains("Isis cubes (*.cub)")) {
-      p_filterList.append("Isis cubes (*.cub)");
+    if (!p_filterList.contains("Isis cubes (*.cub *.tif *.tiff)")) {
+      p_filterList.append("Isis cubes (*.cub *.tif *.tiff)");
       p_filterList.append("All files (*)");
     }
     if (!p_dir.exists()) {
@@ -235,8 +235,8 @@ namespace Isis {
    */
   void FileTool::browse() {
     //Set up the list of filters that are default with this dialog.
-    if (!p_filterList.contains("Isis cubes (*.cub)")) {
-      p_filterList.append("Isis cubes (*.cub)");
+    if (!p_filterList.contains("Isis cubes (*.cub *.tif *.tiff)")) {
+      p_filterList.append("Isis cubes (*.cub *.tif *.tiff)");
       p_filterList.append("All files (*)");
     }
     if (!p_dir.exists()) {
@@ -288,8 +288,8 @@ namespace Isis {
       return;
     }
     //Set up the list of filters that are default with this dialog.
-    if (!p_filterList.contains("Isis cubes (*.cub)")) {
-      p_filterList.append("Isis cubes (*.cub)");
+    if (!p_filterList.contains("Isis cubes (*.cub *.tif *.tiff)")) {
+      p_filterList.append("Isis cubes (*.cub *.tif *.tiff)");
     }
     if (!p_dir.exists()) {
       p_dir = QDir(p_lastDir);

--- a/isis/src/qisis/objs/MosaicMainWindow/MosaicMainWindow.cpp
+++ b/isis/src/qisis/objs/MosaicMainWindow/MosaicMainWindow.cpp
@@ -104,7 +104,7 @@ namespace Isis {
     bool projectLoaded = false;
 
     foreach (QString argument, args) {
-      QRegExp cubeName(".*\\.cub$", Qt::CaseInsensitive);
+      QRegExp cubeName(".*\\.(cub|tif|tiff)$", Qt::CaseInsensitive);
       QRegExp cubeListName(".*\\.(lis|txt)$", Qt::CaseInsensitive);
       QRegExp projectName(".*\\.mos$", Qt::CaseInsensitive);
 
@@ -275,7 +275,7 @@ namespace Isis {
    */
   void MosaicMainWindow::open() {
     QStringList filterList;
-    filterList.append("Isis cubes (*.cub)");
+    filterList.append("Isis Cubes (*.cub *.tif *.tiff)");
     filterList.append("All Files (*)");
 
     QDir directory = m_lastOpenedFile.dir();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Adds .tif and .tiff cube file formats to file dialogs in isis q-apps, and allows opining tiff in qmos from the command line.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Part of #6069 


## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
