### PR TITLE
tgocassis2isis: populate SpacecraftClockStartCount for PSA-exported CaSSIS products

### DIFF
--- a/changes/6079.fix.md
+++ b/changes/6079.fix.md
@@ -1,0 +1,1 @@
+Fixed `tgocassis2isis` to populate `SpacecraftClockStartCount` for PSA-exported CaSSIS calibrated products by decoding it from the label `exposuretimestamp` field, so these products ingest without a manual `editlab` step.

--- a/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
+++ b/isis/src/tgo/apps/tgocassis2isis/tgocassis2isis.cpp
@@ -10,7 +10,6 @@ find files of those names at the top level of this repository. **/
 
 #include <QString>
 #include <QtMath>
-#include <QFile>
 
 #include "AlphaCube.h"
 #include "Cube.h"
@@ -328,6 +327,34 @@ namespace Isis {
     if (inst.hasKeyword("ExposureDuration")){
       inst.findKeyword("ExposureDuration").setUnits("seconds");
     }
+
+    // The PSA-exported calibrated products (em16_tgo_cas namespace) do not carry
+    // SpacecraftClockStartCount. Their fallback translation table fills only
+    // StartTime. The instrument-team products handled by TgoCassisInstrument.trn
+    // map this keyword from the FSW header, so it is already present for them.
+    // The camera (TgoCassisCamera) and spiceinit require it regardless of the
+    // product, so without it the PSA products fail to ingest. The clock value is
+    // present in the XML as a hex-ASCII em16_tgo_cas:exposuretimestamp field.
+    // Decode it and add the keyword here, so the PSA products work with no manual
+    // editlab step. The translation table alone cannot do this because it cannot
+    // hex-decode. Read the label through OriginalXmlLabel, the same VSI-aware path
+    // the rest of this app uses, so remote (/vsicurl) inputs work too.
+    if (!inst.hasKeyword("SpacecraftClockStartCount")) {
+      // Parse without namespace processing so the prefixed
+      // em16_tgo_cas:exposuretimestamp tag is matched as a literal name.
+      OriginalXmlLabel expLabel;
+      expLabel.readFromXmlFile(inputLabel);
+      QDomDocument expDoc = expLabel.ReturnLabels();
+      QDomNodeList tsNodes = expDoc.elementsByTagName("em16_tgo_cas:exposuretimestamp");
+      if (!tsNodes.isEmpty()) {
+        QString hexAscii = tsNodes.at(0).toElement().text().trimmed();
+        QString clockCount = QString::fromLatin1(QByteArray::fromHex(hexAscii.toLatin1()));
+        if (!clockCount.isEmpty()) {
+          inst.addKeyword(PvlKeyword("SpacecraftClockStartCount", clockCount));
+        }
+      }
+    }
+
     // Translate BandBin group
     FileName bandBinTransFile(missionDir + "TgoCassisBandBin.trn");
     XmlToPvlTranslationManager bandBinXlater(inputLabel, bandBinTransFile.expanded());

--- a/isis/tests/FunctionalTestsTgocassis2isis.cpp
+++ b/isis/tests/FunctionalTestsTgocassis2isis.cpp
@@ -537,6 +537,9 @@ TEST(TgoCassis2Isis, TgoCassis2IsisTestPSALabel) {
   EXPECT_EQ(inst["ExposureDuration"][0].toStdString(), "1.018e-003");
   EXPECT_EQ(int(inst["SummingMode"]), 0);
   EXPECT_EQ(inst["Filter"][0].toStdString(), "PAN");
+  // The PSA-exported label has no SpacecraftClockStartCount in its translation
+  // table, so it is decoded from the hex-ASCII em16_tgo_cas:exposuretimestamp.
+  EXPECT_EQ(inst["SpacecraftClockStartCount"][0].toStdString(), "2f0595a0563cfa83");
 
   // Archive Group
   PvlGroup &archive = isisLabel->findGroup("Archive", Pvl::Traverse);

--- a/isis/tests/data/tgoCassis/tgocassis2isis/MY36_015782_024_0_PAN_cropped.xml
+++ b/isis/tests/data/tgoCassis/tgocassis2isis/MY36_015782_024_0_PAN_cropped.xml
@@ -262,6 +262,11 @@
      <em16_tgo_cas:stp>164</em16_tgo_cas:stp>
      <em16_tgo_cas:mtp>M041</em16_tgo_cas:mtp>
     </em16_tgo_cas:Producer_Data>
+    <em16_tgo_cas:FSW_Header>
+     <em16_tgo_cas:exposuretimestamp>32663035393561303536336366613833</em16_tgo_cas:exposuretimestamp>
+     <em16_tgo_cas:exposuretimestamp_length>8</em16_tgo_cas:exposuretimestamp_length>
+     <em16_tgo_cas:exposuretimestamp_tag>11</em16_tgo_cas:exposuretimestamp_tag>
+    </em16_tgo_cas:FSW_Header>
    </em16_tgo_cas:Cassis_Data>
   </Mission_Area>
   <Discipline_Area>


### PR DESCRIPTION
## Description

When `tgocassis2isis` ingests a TGO CaSSIS calibrated product that was exported to the ESA PSA (the `em16_tgo_cas` namespace labels downloaded from the archive or ODE), it selects the `TgoCassisExportedInstrument_PSA.trn` fallback translation. That table fills `StartTime` but has no `SpacecraftClockStartCount` group, so the cube comes out without that keyword.

`SpacecraftClockStartCount` is required on the cube regardless of camera model. The ISIS `TgoCassisCamera` constructor reads it, and `spiceinit` builds its cache through the camera, so both fail when it is missing. The instrument-team products map it from the FSW header via `TgoCassisInstrument.trn`, but the PSA export drops it, so until now the workaround was a manual `editlab` step to inject it.

This populates the keyword directly in the ingester. The PSA path already opens and parses the same XML to choose its translation; the clock value sits in that document as a hex-ASCII `em16_tgo_cas:exposuretimestamp` field. A few lines read it, hex-decode it, and set `SpacecraftClockStartCount` on the Instrument group. The translation table alone cannot do this because it cannot hex-decode, which is likely why it was left out. The block is guarded by `if (!inst.hasKeyword("SpacecraftClockStartCount"))`, so the instrument-team path, where the keyword is already present, is untouched.

The keyword value is not used for geometry: per the long-standing TODO in `TgoCassisCamera.cpp`, the camera computes time from `StartTime` in UTC. The keyword only has to be present for the camera to construct. Injecting the real decoded timestamp is the clean choice and stays correct if CaSSIS is ever switched to SCLK as that TODO intends.

Result: PSA-exported calibrated products ingest for both the ISIS camera and CSM with no manual step.

A changelog entry was added (`changes/6079.fix.md`).

## Related Issue

Follows up on the discussion in DOI-USGS/ale#720, where this `editlab` workaround came up and the in-ingester fix was proposed.

## How Has This Been Validated?

**New automated test.** The existing `TgoCassis2IsisTestPSALabel` gtest ingests a PSA-exported label but did not previously check the clock (the old PSA path never produced it). Its test label (`MY36_015782_024_0_PAN_cropped.xml`) had been cropped down and no longer contained the `exposuretimestamp` field, so a representative `em16_tgo_cas:exposuretimestamp` was added back to it, and an assertion was added that the ingested cube's `Instrument/SpacecraftClockStartCount` decodes to the expected value. This exercises the new decode path directly. The full `tgocassis2isis` suite passes (10/10), including this case.

**Real data, reproducible.** Fetch one publicly available PSA-exported calibrated framelet (anonymous, no login) and ingest it. Using framelet 0 of orbit 5684, acquisition 280077162:

```bash
PSA=https://archives.esac.esa.int/psa/ftp/ExoMars2016/em16_tgo_cas/data_calibrated/Science_Phase/Orbit_Range_5600_5699/Orbit_5684/Science/280077162/PAN
base=cas_cal_sc_20190303T070517-20190303T070521-5684-8-PAN-280077162-0-0__4_0
wget "$PSA/$base.xml" "$PSA/$base.dat"

tgocassis2isis from=$base.xml to=$base.cub
getkey from=$base.cub grpname=Instrument keyword=SpacecraftClockStartCount
# -> 2f0595a051db5fd9
```

That last `getkey` now returns the clock count. It is the hex-decode of the label's `exposuretimestamp` field, which can be checked independently:

```bash
grep -ioE '<em16_tgo_cas:exposuretimestamp>[0-9a-f]+' $base.xml | sed 's/.*>//' | xxd -r -p
# -> 2f0595a051db5fd9
```

Before this change, the produced cube had no `SpacecraftClockStartCount`, so `spiceinit` failed, and the keyword had to be injected by hand from that same decoded value:

```bash
clk=$(grep -ioE '<em16_tgo_cas:exposuretimestamp>[0-9a-f]+' $base.xml | sed 's/.*>//' | xxd -r -p)
editlab from=$base.cub options=addkey grpname=Instrument keyword=SpacecraftClockStartCount value=$clk
```

With this change that `editlab` step is no longer needed: `tgocassis2isis` sets the keyword during ingest, and `spiceinit from=$base.cub spkpredicted=true` then succeeds directly (kernels required for the `spiceinit` step only; the keyword population itself needs none). The instrument-team (non-PSA) products are unaffected, since the new block only runs when the keyword is absent.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing
- [x] I dedicate any and all copyright interest in this software to the public domain.
