### PR TITLE
Register GDAL Drivers in qtie for gtiff opening

### DIFF
--- a/changes/6086.fix.md
+++ b/changes/6086.fix.md
@@ -1,0 +1,1 @@
+Register GDAL Drivers in qtie to allow GTIFF opening.

--- a/isis/src/qisis/apps/qtie/main.cpp
+++ b/isis/src/qisis/apps/qtie/main.cpp
@@ -47,6 +47,16 @@ int main(int argc, char *argv[]) {
   }
   Isis::Gui::checkX11();
 
+  // Setup gdal drivers and error handler
+  try {
+    GDALAllRegister();
+    CPLSetErrorHandler(CPLQuietErrorHandler);
+  }
+  catch(std::exception &e) {
+    QString msg = "Failed to load GDAL Drivers, with error [" + QString(e.what()) + "]";
+    throw IException(IException::Unknown, msg, _FILEINFO_);
+  }
+
   try {
 
     // Add the Qt plugin directory to the library path
@@ -98,6 +108,8 @@ int main(int argc, char *argv[]) {
                      SIGNAL(stretchChipViewport(Stretch *, CubeViewport *)),
                      tieTool,
                      SIGNAL(stretchChipViewport(Stretch *, CubeViewport *)));
+
+    
 
     vw->show();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

`qtie` couldn't open GTIFFs - it wasn't finding the GDAL Drivers.  This adds `GDALAllRegister();` to qtie, which registers the drivers and allows GTIFFs to be opened later.

Note: In the long run, it may be better to refactor `qtie` to use QIsisApplication like the other ISIS q-apps - then it would not need to repeat the GDAL Driver Registration in its own code.  In lieu of that, this PR provides a fix that will get `qtie` working for GTIFFs.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #6069 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

Debugged manually on local machine (visual app).  Used two clementine UVVIS images (`lub1171g.281` and `lub1139f.281`) for testing.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
