### PR TITLE
Fix SpiceQL mission name in chan1m32isis

### DIFF
--- a/changes/6092.fix.md
+++ b/changes/6092.fix.md
@@ -1,0 +1,1 @@
+Fixed SpiceQL mission name from "chandrayaan1" to "m3" for chan1m32isis.

--- a/isis/src/chandrayaan1/apps/chan1m32isis/chan1m32isis.cpp
+++ b/isis/src/chandrayaan1/apps/chan1m32isis/chan1m32isis.cpp
@@ -386,12 +386,12 @@ namespace Isis {
       bool useWeb = Preference::Preferences().useWebSpice();
 
       inst.findKeyword("StartTime").setValue(firstEt.UTC());
-      auto [startClockString, kernels] = SpiceQL::doubleEtToSclk(sclkCode, firstEt.Et(), "chandrayaan1", useWeb);
+      auto [startClockString, kernels] = SpiceQL::doubleEtToSclk(sclkCode, firstEt.Et(), "m3", useWeb);
       QString startClock = QString::fromStdString(startClockString);
       inst.findKeyword("SpacecraftClockStartCount").setValue(startClock);
 
       inst.findKeyword("StopTime").setValue(lastEt.UTC());
-      auto [stopClockString, kernels2]= SpiceQL::doubleEtToSclk(sclkCode, lastEt.Et(), "chandrayaan1", useWeb);
+      auto [stopClockString, kernels2]= SpiceQL::doubleEtToSclk(sclkCode, lastEt.Et(), "m3", useWeb);
       QString stopClock = QString::fromStdString(stopClockString);
       inst.findKeyword("SpacecraftClockStopCount").setValue(stopClock);
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Changed mission name in chan1m32isis.cpp from "chandrayaan1" to "m3" because the SpiceQL call `doubleEtToSclk` was not furnishing the correct kernels since it was only pulling base "chandrayaan1" level kernels and not kernels specific to "m3". This was causing the error in the related issue below, changing to "m3" fixes that.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Addresses #6092 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
Was able to reproduce OP's issue, made the fix and validated with downloaded data + through vsicurl. Found data referenced in OP's issue `M3G20090416T081001_V01_L1B.LBL` in [PDS](https://planetarydata.jpl.nasa.gov/img/data/m3/CH1M3_0002/DATA/20090415_20090816/200904/L1B/).

Download from the linked PDS URL and run:
```
chan1m32isis from=M3G20090416T081001_V01_L1B.LBL to=m3.cub loc=m3.loc obs=m3.obs
```

With vsicurl:
*Note: This took like 10 mins so leave it running or just test with downloaded data. Set `export CPL_DEBUG=ON` if you want to see the GDAL logger output while it's running.
```
chan1m32isis from=/vsicurl/https://planetarydata.jpl.nasa.gov/img/data/m3/CH1M3_0002/DATA/20090415_20090816/200904/L1B/M3G20090416T081001_V01_L1B.LBL to=m3_vsicurl.cub loc=m3_vsicurl.loc obs=m3_vsicurl.obs
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
