### PR TITLE
Extrapolate the reseau distortion model smoothly outside the image area

### DIFF
--- a/changes/+20260801215210.change.md
+++ b/changes/+20260801215210.change.md
@@ -1,0 +1,1 @@
+Made the reseau distortion model (Viking, Voyager, Mariner 10, Apollo Metric) extrapolate smoothly outside the image area instead of failing, so a ground point that projects just off the sensor still yields a focal plane position. This helps bundle adjustment and map projection near image edges. Behavior inside the image is unchanged.

--- a/isis/src/base/objs/ReseauDistortionMap/ReseauDistortionMap.cpp
+++ b/isis/src/base/objs/ReseauDistortionMap/ReseauDistortionMap.cpp
@@ -88,14 +88,31 @@ namespace Isis {
     double focalLine = dy / p_pixelPitch +
                        p_camera->FocalPlaneMap()->DetectorLineOrigin();
 
-    // Find distance from input point to all nominal reseaus
+    // The local affine fit is anchored at a query point clamped to the distorted
+    // image box. Inside the image the query equals the input point, so the result
+    // is identical to before. Outside the image the query slides onto the nearest
+    // box edge, so the five closest reseaus always form a two dimensional
+    // neighborhood (never colinear) and yield a well conditioned affine. That
+    // affine is then evaluated at the true input point below, which extrapolates
+    // the distortion smoothly and linearly past the image edges. This lets ground
+    // points that project just off the sensor still return a usable focal plane
+    // position, as needed by bundle adjustment and map projection, instead of a
+    // hard failure at the image boundary.
+    double querySamp = focalSamp;
+    double queryLine = focalLine;
+    if(querySamp < 0.5) querySamp = 0.5;
+    if(querySamp > p_distortedSamps + 0.5) querySamp = p_distortedSamps + 0.5;
+    if(queryLine < 0.5) queryLine = 0.5;
+    if(queryLine > p_distortedLines + 0.5) queryLine = p_distortedLines + 0.5;
+
+    // Find distance from the query point to all nominal reseaus
     std::vector<double> distances(p_numRes, 0.0);
     double wt[5];
     int closepts[5];
     double ldiffsq, sdiffsq;
     for(int i = 0; i < p_numRes; i++) {
-      sdiffsq = (focalSamp - p_rsamps[i]) * (focalSamp - p_rsamps[i]);
-      ldiffsq = (focalLine - p_rlines[i]) * (focalLine - p_rlines[i]);
+      sdiffsq = (querySamp - p_rsamps[i]) * (querySamp - p_rsamps[i]);
+      ldiffsq = (queryLine - p_rlines[i]) * (queryLine - p_rlines[i]);
       distances[i]  =  ldiffsq + sdiffsq;
     }
 
@@ -154,16 +171,15 @@ namespace Isis {
       lsqX.Solve();
       lsqY.Solve();
 
+      // Evaluate the fitted affine at the true input point. Inside the image this
+      // is the usual interpolation. Outside, since the query was clamped to the
+      // box edge while the evaluation point is the true (off image) location, the
+      // affine is extrapolated smoothly rather than rejected.
       known[1] = focalSamp;
       known[2] = focalLine;
 
-      // Test to make sure the point is inside of the image
       double undistortedFocalSamp = lsqX.Evaluate(known);
       double undistortedFocalLine = lsqY.Evaluate(known);
-      if(undistortedFocalSamp < 0.5) return false;
-      if(undistortedFocalLine < 0.5) return false;
-      if(undistortedFocalSamp > p_undistortedSamps + 0.5) return false;
-      if(undistortedFocalLine > p_undistortedLines + 0.5) return false;
 
       // Convert undistorted sample, line position to an x,y position
       p_undistortedFocalPlaneX = (undistortedFocalSamp - p_undistortedSamps
@@ -199,16 +215,29 @@ namespace Isis {
     double undistortedFocalSamp = ux / p_pixelPitch + p_undistortedSamps / 2.0;
     double undistortedFocalLine = uy / p_pixelPitch + p_undistortedLines / 2.0;
 
-    // Find distance from input point to all nominal reseaus
+    // Clamp a query point to the undistorted image box. Inside the image the
+    // query equals the input point, so the result is unchanged. Outside, the
+    // query slides onto the nearest box edge so the five closest reseaus form a
+    // two dimensional neighborhood and the fitted affine is well conditioned. It
+    // is evaluated at the true input point below, extrapolating smoothly past the
+    // image edges rather than rejecting the point. See SetFocalPlane for details.
+    double querySamp = undistortedFocalSamp;
+    double queryLine = undistortedFocalLine;
+    if(querySamp < 0.5) querySamp = 0.5;
+    if(querySamp > p_undistortedSamps + 0.5) querySamp = p_undistortedSamps + 0.5;
+    if(queryLine < 0.5) queryLine = 0.5;
+    if(queryLine > p_undistortedLines + 0.5) queryLine = p_undistortedLines + 0.5;
+
+    // Find distance from the query point to all nominal reseaus
     std::vector<double> distances(p_numRes, 0.0);
     double wt[5];
     int closepts[5];
     double ldiffsq, sdiffsq;
     for(int i = 0; i < p_numRes; i++) {
-      sdiffsq = (undistortedFocalSamp - p_msamps[i]) *
-                (undistortedFocalSamp - p_msamps[i]);
-      ldiffsq = (undistortedFocalLine - p_mlines[i]) *
-                (undistortedFocalLine - p_mlines[i]);
+      sdiffsq = (querySamp - p_msamps[i]) *
+                (querySamp - p_msamps[i]);
+      ldiffsq = (queryLine - p_mlines[i]) *
+                (queryLine - p_mlines[i]);
       distances[i]  =  ldiffsq + sdiffsq;
     }
 
@@ -266,16 +295,15 @@ namespace Isis {
       lsqX.Solve();
       lsqY.Solve();
 
+      // Evaluate the fitted affine at the true input point. Inside the image this
+      // is the usual interpolation. Outside, the query was clamped to the box edge
+      // while the evaluation point is the true (off image) location, so the affine
+      // is extrapolated smoothly rather than rejected.
       known[1] = undistortedFocalSamp;
       known[2] = undistortedFocalLine;
 
-      // Test points to make sure they are in the image
       double distortedFocalSamp = lsqX.Evaluate(known);
       double distortedFocalLine = lsqY.Evaluate(known);
-      if(distortedFocalSamp < 0.5) return false;
-      if(distortedFocalLine < 0.5) return false;
-      if(distortedFocalSamp > p_undistortedSamps + 0.5) return false;
-      if(distortedFocalLine > p_undistortedLines + 0.5) return false;
 
       // Convert distorted sample, line position back to an x,y position
       p_focalPlaneX = (distortedFocalSamp -

--- a/isis/src/base/objs/ReseauDistortionMap/ReseauDistortionMap.cpp
+++ b/isis/src/base/objs/ReseauDistortionMap/ReseauDistortionMap.cpp
@@ -88,16 +88,10 @@ namespace Isis {
     double focalLine = dy / p_pixelPitch +
                        p_camera->FocalPlaneMap()->DetectorLineOrigin();
 
-    // The local affine fit is anchored at a query point clamped to the distorted
-    // image box. Inside the image the query equals the input point, so the result
-    // is identical to before. Outside the image the query slides onto the nearest
-    // box edge, so the five closest reseaus always form a two dimensional
-    // neighborhood (never colinear) and yield a well conditioned affine. That
-    // affine is then evaluated at the true input point below, which extrapolates
-    // the distortion smoothly and linearly past the image edges. This lets ground
-    // points that project just off the sensor still return a usable focal plane
-    // position, as needed by bundle adjustment and map projection, instead of a
-    // hard failure at the image boundary.
+    // Anchor the local affine fit at a query point clamped to the image box, then
+    // evaluate that fit at the true point. Inside the box this is unchanged.
+    // Outside, the fit stays well conditioned and extrapolates the distortion
+    // smoothly past the edges instead of rejecting the point.
     double querySamp = focalSamp;
     double queryLine = focalLine;
     if(querySamp < 0.5) querySamp = 0.5;
@@ -171,10 +165,8 @@ namespace Isis {
       lsqX.Solve();
       lsqY.Solve();
 
-      // Evaluate the fitted affine at the true input point. Inside the image this
-      // is the usual interpolation. Outside, since the query was clamped to the
-      // box edge while the evaluation point is the true (off image) location, the
-      // affine is extrapolated smoothly rather than rejected.
+      // Evaluate the fit at the true input point (interpolation inside the box,
+      // smooth extrapolation outside).
       known[1] = focalSamp;
       known[2] = focalLine;
 
@@ -215,12 +207,9 @@ namespace Isis {
     double undistortedFocalSamp = ux / p_pixelPitch + p_undistortedSamps / 2.0;
     double undistortedFocalLine = uy / p_pixelPitch + p_undistortedLines / 2.0;
 
-    // Clamp a query point to the undistorted image box. Inside the image the
-    // query equals the input point, so the result is unchanged. Outside, the
-    // query slides onto the nearest box edge so the five closest reseaus form a
-    // two dimensional neighborhood and the fitted affine is well conditioned. It
-    // is evaluated at the true input point below, extrapolating smoothly past the
-    // image edges rather than rejecting the point. See SetFocalPlane for details.
+    // Clamp a query point to the image box for the fit, then evaluate at the true
+    // point, extrapolating smoothly outside rather than rejecting it. See
+    // SetFocalPlane for details.
     double querySamp = undistortedFocalSamp;
     double queryLine = undistortedFocalLine;
     if(querySamp < 0.5) querySamp = 0.5;
@@ -295,10 +284,8 @@ namespace Isis {
       lsqX.Solve();
       lsqY.Solve();
 
-      // Evaluate the fitted affine at the true input point. Inside the image this
-      // is the usual interpolation. Outside, the query was clamped to the box edge
-      // while the evaluation point is the true (off image) location, so the affine
-      // is extrapolated smoothly rather than rejected.
+      // Evaluate the fit at the true input point (interpolation inside the box,
+      // smooth extrapolation outside).
       known[1] = undistortedFocalSamp;
       known[2] = undistortedFocalLine;
 

--- a/isis/src/viking/objs/VikingCamera/VikingCamera.truth
+++ b/isis/src/viking/objs/VikingCamera/VikingCamera.truth
@@ -31,6 +31,15 @@ For center pixel position ...
 Latitude OK
 Longitude OK
 
+Testing extrapolation outside the image box:
+
+SetImage(1300.000000000, 1200.000000000) = OK
+Round trip within 1 pixel = OK
+
+SetImage(-100.000000000, -100.000000000) = OK
+Round trip within 1 pixel = OK
+
+
 --------------------------------------------
 
 Testing name methods:

--- a/isis/src/viking/objs/VikingCamera/unitTest.cpp
+++ b/isis/src/viking/objs/VikingCamera/unitTest.cpp
@@ -26,9 +26,11 @@ using namespace std;
 using namespace Isis;
 
 void TestLineSamp(Camera *cam, double samp, double line);
+void TestExtrapolation(Camera *cam, double samp, double line);
 
 int main(void) {
   Preference::Preferences(true);
+  GDALAllRegister();
 
   cout << "Unit Test for VikingCamera..." << endl;
   /* VIKING: The lon difference tolerance was increased for this
@@ -109,6 +111,23 @@ int main(void) {
       else {
         cout << setprecision(16) << "Longitude off by: " << cam->UniversalLongitude() - knownLon[i] << endl;
       }
+      // Extrapolation past the image edges. The Viking VIS detector is 1204
+      // samples by 1056 lines, so the two pixels below lie well outside the image
+      // box (sample 1300, line 1200 is past the right and bottom edges; sample
+      // -100, line -100 is past the left and top edges). The reseau distortion
+      // map used to reject any point whose fitted position fell outside that box,
+      // so SetImage returned false and these points could not be projected. The
+      // map now extrapolates the local reseau affine smoothly past the edges, so
+      // an off-sensor pixel still projects to the ground and the round trip
+      // closes to within a pixel. This is what lets a ground point that projects
+      // just off the image still yield a residual in bundle adjustment and map
+      // projection, instead of a hard failure at the image boundary. Only
+      // OK/ERROR is printed, so the result is stable across platforms; the
+      // quantitative deformation is illustrated in the project documentation.
+      cout << endl << "Testing extrapolation outside the image box:" << endl << endl;
+      TestExtrapolation(cam, 1300.0, 1200.0);
+      TestExtrapolation(cam, -100.0, -100.0);
+
       cout << endl << "--------------------------------------------" << endl;
     }
 
@@ -155,4 +174,25 @@ void TestLineSamp(Camera *cam, double samp, double line) {
     cout << "DeltaSample = ERROR" << endl;
     cout << "DeltaLine = ERROR" << endl << endl;
   }
+}
+
+// Project an off-image pixel and round trip it back. Prints only OK/ERROR so the
+// result is stable across platforms. SetImage must succeed (it failed before the
+// reseau map could extrapolate) and the image to ground to image round trip must
+// close to within a pixel.
+void TestExtrapolation(Camera *cam, double samp, double line) {
+  bool ok = cam->SetImage(samp, line);
+  cout << "SetImage(" << samp << ", " << line << ") = "
+       << (ok ? "OK" : "ERROR") << endl;
+  if (!ok) {
+    cout << "Round trip within 1 pixel = ERROR" << endl << endl;
+    return;
+  }
+
+  bool roundTrip = cam->SetUniversalGround(cam->UniversalLatitude(),
+                                           cam->UniversalLongitude());
+  roundTrip = roundTrip && (fabs(samp - cam->Sample()) < 1.0)
+                        && (fabs(line - cam->Line()) < 1.0);
+  cout << "Round trip within 1 pixel = " << (roundTrip ? "OK" : "ERROR")
+       << endl << endl;
 }

--- a/isis/tests/FunctionalTestsCampt.cpp
+++ b/isis/tests/FunctionalTestsCampt.cpp
@@ -251,8 +251,9 @@ TEST_F(DefaultCube, FunctionalTestCamptCoordList) {
   groundPoint = appLog.group(2);
   EXPECT_DOUBLE_EQ( (double) groundPoint.findKeyword("Sample"), 100.0);
   EXPECT_DOUBLE_EQ( (double) groundPoint.findKeyword("Line"), 10000.0);
-  QString ErrorMsg = "Requested position does not project in camera model; no surface intersection";
-  EXPECT_PRED_FORMAT2(AssertQStringsEqual, groundPoint.findKeyword("Error"), ErrorMsg);
+  // Line 10000 is far outside the image; the reseau distortion now
+  // extrapolates outside the image domain, so the point projects (intended).
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, groundPoint.findKeyword("Error"), "NULL");
 }
 
 
@@ -274,8 +275,9 @@ TEST_F(DefaultCube, FunctionalTestCamptAllowError) {
 
   campt(testCube, options, &appLog);
   PvlGroup groundPoint = appLog.findGroup("GroundPoint");
-  QString ErrorMsg = "Requested position does not project in camera model; no surface intersection";
-  EXPECT_PRED_FORMAT2(AssertQStringsEqual, groundPoint.findKeyword("Error"), ErrorMsg);
+  // Sample/line -100 are outside the image; the reseau distortion now
+  // extrapolates outside the image domain, so the point projects (intended).
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, groundPoint.findKeyword("Error"), "NULL");
 }
 
 TEST_F(CSMCubeFixture, FunctionalTestCamptCSMCamera) {

--- a/isis/tests/FunctionalTestsCampt.cpp
+++ b/isis/tests/FunctionalTestsCampt.cpp
@@ -268,16 +268,30 @@ TEST_F(DefaultCube, FunctionalTestCamptAllowOutside) {
   EXPECT_DOUBLE_EQ( (double) groundPoint.findKeyword("Line"), -1.0);
 }
 
-TEST_F(DefaultCube, FunctionalTestCamptAllowError) {
+// A point just outside the image now projects. The reseau distortion extrapolates
+// smoothly past the image edges instead of rejecting the point, matching how the
+// polynomial and linescan camera models already behave outside the field of view.
+TEST_F(DefaultCube, FunctionalTestCamptOutsideImageProjects) {
   QVector<QString> args = {"sample=-100", "line=-100", "allowerror=true"};
   UserInterface options(APP_XML, args);
   Pvl appLog;
 
   campt(testCube, options, &appLog);
   PvlGroup groundPoint = appLog.findGroup("GroundPoint");
-  // Sample/line -100 are outside the image; the reseau distortion now
-  // extrapolates outside the image domain, so the point projects (intended).
   EXPECT_PRED_FORMAT2(AssertQStringsEqual, groundPoint.findKeyword("Error"), "NULL");
+}
+
+// A pixel whose look ray misses the body has no ground intersection. With
+// allowerror set, campt reports the error in the group instead of throwing.
+TEST_F(DefaultCube, FunctionalTestCamptAllowError) {
+  QVector<QString> args = {"sample=100000", "line=100000", "allowerror=true"};
+  UserInterface options(APP_XML, args);
+  Pvl appLog;
+
+  campt(testCube, options, &appLog);
+  PvlGroup groundPoint = appLog.findGroup("GroundPoint");
+  QString ErrorMsg = "Requested position does not project in camera model; no surface intersection";
+  EXPECT_PRED_FORMAT2(AssertQStringsEqual, groundPoint.findKeyword("Error"), ErrorMsg);
 }
 
 TEST_F(CSMCubeFixture, FunctionalTestCamptCSMCamera) {


### PR DESCRIPTION
## Description

The reseau distortion model (*ReseauDistortionMap*, used by the Viking, Voyager, Mariner 10, and Apollo Metric cameras) fits a local inverse-distance-weighted affine to the five nearest reseaus. Both directions (the forward and inverse distortion maps, *SetFocalPlane* and *SetUndistortedFocalPlane*) reject (returning false) any point whose fitted position fell outside the image box. So a ground point that projects a few pixels off the sensor has no image position.

The result is that  bundle adjustment and map projection fail at the image boundary, and the camera projection is discontinuous there. This is very problematic for numerical differentiation and inconsistent with polynomial lens distortion models that continue nicely for a while outside the precise image box.

The proposed fix anchors the local affine fit at a query point clamped to the image box, then evaluates that affine at the true input point, and drops the out-of-bounds rejection.

- Inside the image the clamp is the identity, so the same neighbors are chosen and the same affine is fit and evaluated. Results are unchanged (identical output).
- Outside the image the query slides onto the nearest box edge, where the five nearest reseaus are always a two dimensional neighborhood (never colinear), so the affine is well conditioned. Evaluating it at the true point extrapolates the distortion linearly: continuous across the boundary and bounded (it grows only linearly, it does not diverge).

Cross section of the displacement magnitude along the detector mid line. The current curve lies on top of the new curve inside the detector and stops at the edges; the new curve continues smoothly and grows only linearly outside.
<img width="1100" height="520" alt="reseau_deformation_magnitude" src="https://github.com/user-attachments/assets/e9b11dfc-b2d9-4fcf-ae20-60e6655ed90c" />

Displacement magnitude across the plane, current model (defined only near the detector) versus new model (one continuous field past the black 1204x1056 box).
<img width="750" height="440" alt="reseau_deformation_profile" src="https://github.com/user-attachments/assets/249f2dc0-c31f-4bdb-9fef-bd235cf0a0bf" />

The nonlinear part of the distortion (global affine removed, arrows scaled up). The interior is identical in both panels; the new model extends the field smoothly outside.
<img width="1100" height="540" alt="reseau_deformation_vectors" src="https://github.com/user-attachments/assets/77648ace-736d-45f0-bc02-cf12828c27ce" />

This PR was created with Claude (AI assistance) and reviewed and approved by me.

## Related Issue

Continues the theme of #5861 (closed), making the ISIS distortion models well-behaved analytic operations instead of relying on special cases near the edges. That issue did not touch the out-of-box rejection. There is no open issue specifically for reseau extrapolation outside the image box.

## How Has This Been Validated?

*ReseauDistortionMap* has only a stub unit test and is exercised through the camera unit tests.

- Tests that pass unchanged: the Viking camera unit test passes, and its interior lines (the four corner round trips and the center latitude/longitude) are byte identical to the previous truth. Running the test with this PR reverted produces the same interior output, confirming inside the image is unchanged. Apollo Metric passes. Mariner 10 and Voyager reproduce their existing truths on every line that executed (their only failures on my machine are missing local kernel/reseau data, not this PR), which confirms the shared code preserves interior behavior for all four cameras.

- Test modified: *isis/src/viking/objs/VikingCamera/unitTest.cpp*. I also added *GDALAllRegister()* at the top of *main*, matching three other object unit tests. Without it the unmodified test segfaults on the current dev under the GDAL backed Cube IO (a driver is not registered in the raw test), independent of this PR.

- New test for the outside logic: a small section round trips two pixels outside the 1204x1056 detector (sample 1300 line 1200, and sample -100 line -100). With the previous code *SetImage* returns false and these print ERROR; with this PR they project and round trip within a pixel and print OK. Only OK/ERROR is printed so the result is stable across platforms. The truth was regenerated for the added lines only.

- Figure validation: the deformation figures were generated by a transcription of the algorithm checked against a grid dumped from the real ISIS C++ model; they agree to 0.037 pixel over 13,431 inside and outside points.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:

- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document.

## Licensing

This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.





