### PR TITLE
[Breaking, 11.0] Require single-band match cube for map2cam

### DIFF
--- a/changes/5501.break.md
+++ b/changes/5501.break.md
@@ -1,1 +1,1 @@
-Require `map2cam` MATCH cube to be single-band.
+Changed `map2cam` to reject multi-band MATCH cubes with a user error since only a single MATCH band's geometry is ever used.

--- a/changes/5501.break.md
+++ b/changes/5501.break.md
@@ -1,0 +1,1 @@
+Require `map2cam` MATCH cube to be single-band.

--- a/isis/src/base/apps/map2cam/map2cam.cpp
+++ b/isis/src/base/apps/map2cam/map2cam.cpp
@@ -1,4 +1,5 @@
 #include "Camera.h"
+#include "IException.h"
 #include "ProcessRubberSheet.h"
 #include "TProjection.h"
 #include "UserInterface.h"
@@ -23,6 +24,16 @@ namespace Isis{
     QString fname = ui.GetCubeName("MATCH");
     Isis::CubeAttributeInput &inputAtt = ui.GetInputAttribute("MATCH");
     mcube = p.SetInputCube(fname, inputAtt);
+
+    // Require a single-band MATCH
+    if (mcube->bandCount() > 1) {
+      QString msg = "The MATCH cube [" + fname + "] has ["
+                    + toString(mcube->bandCount()) + "] bands. map2cam reprojects "
+                    "every band of the FROM cube into the geometry of a single "
+                    "MATCH band, so the MATCH cube must have exactly one band.";
+      throw IException(IException::User, msg, _FILEINFO_);
+    }
+
     outcam = mcube->camera();
 
     // Open the input projection cube and get the projection information

--- a/isis/src/base/apps/map2cam/map2cam.xml
+++ b/isis/src/base/apps/map2cam/map2cam.xml
@@ -94,6 +94,9 @@
           using the MOLA base as the FROM file and a MOC Wide Angle Red cube
           as the MATCH, will have labels which indicate geometry for the MOC
           WA red camera but the pixels will contain MOLA elevations.
+          The MATCH cube must be single-band. All bands of the FROM cube are
+          projected into the geometry of this single band, producing an output
+          with the same number of bands as the FROM cube.
         </description>
         <filter>
           *.cub

--- a/isis/tests/Map2camTests.cpp
+++ b/isis/tests/Map2camTests.cpp
@@ -5,6 +5,7 @@
 
 #include "Cube.h"
 #include "CubeAttribute.h"
+#include "IException.h"
 #include "PixelType.h"
 #include "Pvl.h"
 #include "PvlGroup.h"
@@ -29,4 +30,20 @@ TEST_F(DefaultCube, FunctionalTestMap2camTest) {
 
   ASSERT_TRUE(ocube.label()->findObject("IsisCube").hasGroup("Kernels"));
   ASSERT_FALSE(ocube.label()->findObject("IsisCube").hasGroup("Mapping"));
+}
+
+TEST_F(DefaultCube, FunctionalTestMap2camMultiBandMatchError) {
+  // a multi-band MATCH cube is not supported and should produce a user errorExpand commentComment on line R40Resolved
+  resizeCube(testCube->sampleCount(), testCube->lineCount(), 3);
+
+  QVector<QString> args = {"from="+projTestCube->fileName(), "match="+testCube->fileName(), "to="+tempDir.path()+"/level1.cub"};
+  UserInterface ui(APP_XML, args);
+
+  try {
+    map2cam_f(ui);
+    FAIL() << "Expected an exception for a multi-band MATCH cube";
+  }
+  catch (IException &e) {
+    EXPECT_THAT(e.what(), testing::HasSubstr("MATCH cube must have exactly one band"));
+  }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
Erroring on a multi-band MATCH removes previously-working behavior. Updated workflow will now fail when a multi-band MATCH is passed in. This PR targets the **11.0** milestone and should merge **after** #6105.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to #5501 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
