### PR TITLE
added reading support for Parquet in GUIs

### DIFF
--- a/changes/+20260806131005.added.md
+++ b/changes/+20260806131005.added.md
@@ -1,0 +1,1 @@
+Added support for parquet opening on GUIs

--- a/isis/src/qisis/apps/cneteditor/CnetEditorWindow.cpp
+++ b/isis/src/qisis/apps/cneteditor/CnetEditorWindow.cpp
@@ -50,7 +50,7 @@ namespace Isis {
       QWidget *parent) : QFileDialog(parent) {
 
     setAcceptMode(AcceptSave);
-    setNameFilter("Control Network files (*.net *.bin);;All files (*)");
+    setNameFilter("Control Network files (*.net *.bin *.parquet);;All files (*)");
     QGridLayout *mainLayout = qobject_cast< QGridLayout * >(layout());
 
     if (mainLayout)
@@ -460,7 +460,7 @@ namespace Isis {
   void CnetEditorWindow::openNet() {
     QString filename = QFileDialog::getOpenFileName(this,
         tr("Open a control net file"), ".",
-        tr("Control Network files (*.net *.bin);;All files (*)"));
+        tr("Control Network files (*.net *.bin *.parquet);;All files (*)"));
 
     if (!filename.isEmpty())
       load(filename);
@@ -560,6 +560,11 @@ namespace Isis {
 
 
   void CnetEditorWindow::save() {
+
+    // Parquet output is binary only; Write() rejects Pvl to a Parquet file
+    if (curFile->endsWith(".parquet", Qt::CaseInsensitive)) {
+      saveAsPvl = false;
+    }
 
     if (saveFilteredNetwork) {
       QString newCubeListFileName;
@@ -726,7 +731,14 @@ namespace Isis {
       editorWidget->connectionFilterWidget());
 
     setFileState(HasFile, *curFile);
-    saveAsPvl = !Pvl(*curFile).hasObject("ProtoBuffer");
+
+    // Parquet is binary and cannot be parsed as Pvl
+    if (curFile->endsWith(".parquet", Qt::CaseInsensitive)) {
+      saveAsPvl = false;
+    }
+    else {
+      saveAsPvl = !Pvl(*curFile).hasObject("ProtoBuffer");
+    }
   }
 
 

--- a/isis/src/qisis/objs/MosaicSceneWidget/MosaicControlNetTool.cpp
+++ b/isis/src/qisis/objs/MosaicSceneWidget/MosaicControlNetTool.cpp
@@ -573,7 +573,7 @@ namespace Isis {
       QString netFile = FileDialog::getOpenFileName(getWidget(),
                         "Select Control Net. File",
                         QDir::current().dirName() + "/",
-                        "Control Networks (*.net);;All Files (*.*)");
+                        "Control Networks (*.net *.parquet);;All Files (*.*)");
 
       //--------------------------------------------------------------
       // if the file is not empty attempt to load in the control points

--- a/isis/src/qisis/objs/QnetTools/QnetFileTool.cpp
+++ b/isis/src/qisis/objs/QnetTools/QnetFileTool.cpp
@@ -161,7 +161,7 @@ namespace Isis {
     }
 
     QApplication::restoreOverrideCursor();
-    filter = "Control net (*.net *.cnet *.ctl);;";
+    filter = "Control net (*.net *.cnet *.ctl *.parquet);;";
     filter += "Pvl file (*.pvl);;";
     filter += "Text file (*.txt);;";
     filter += "All (*)";
@@ -277,7 +277,7 @@ namespace Isis {
    *
    */
   void QnetFileTool::saveAs() {
-    QString filter = "Control net (*.net *.cnet *.ctl);;";
+    QString filter = "Control net (*.net *.cnet *.ctl *.parquet);;";
     filter += "Pvl file (*.pvl);;";
     filter += "Text file (*.txt);;";
     filter += "All (*)";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

I didn't add Parquet support to GUIs when IO was added, this adds parquet to gui file filters. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

No related issues

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

Tested locally. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
