### PR TITLE
Removed tempdir buildup when running tests

### DIFF
--- a/isis/tests/CameraFixtures.cpp
+++ b/isis/tests/CameraFixtures.cpp
@@ -20,6 +20,7 @@
 #include "TableField.h"
 #include "TableRecord.h"
 
+
 using json = nlohmann::json;
 
 namespace Isis {

--- a/isis/tests/CameraFixtures.cpp
+++ b/isis/tests/CameraFixtures.cpp
@@ -165,7 +165,7 @@ namespace Isis {
 
 
   void DemCube::TearDown() {
-    if (demCube->isOpen()) {
+    if (demCube && demCube->isOpen()) {
       demCube->close();
     }
 
@@ -269,11 +269,11 @@ namespace Isis {
 
 
   void DefaultCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 
-    if (projTestCube->isOpen()) {
+    if (projTestCube && projTestCube->isOpen()) {
       projTestCube->close();
     }
 
@@ -320,11 +320,11 @@ namespace Isis {
 
 
   void LineScannerCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 
-    if (projTestCube->isOpen()) {
+    if (projTestCube && projTestCube->isOpen()) {
       projTestCube->close();
     }
 
@@ -340,7 +340,7 @@ namespace Isis {
 
 
   void OffBodyCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 
@@ -355,7 +355,7 @@ namespace Isis {
 
 
   void MiniRFCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 

--- a/isis/tests/CameraFixtures.h
+++ b/isis/tests/CameraFixtures.h
@@ -41,8 +41,8 @@ namespace Isis {
 
   class DefaultCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
-      Cube *projTestCube;
+      Cube *testCube = nullptr;
+      Cube *projTestCube = nullptr;
 
       Pvl label;
       Pvl projLabel;
@@ -55,8 +55,8 @@ namespace Isis {
 
   class LineScannerCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
-      Cube *projTestCube;
+      Cube *testCube = nullptr;
+      Cube *projTestCube = nullptr;
 
       Pvl label;
       Pvl projLabel;
@@ -68,7 +68,7 @@ namespace Isis {
 
   class OffBodyCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
+      Cube *testCube = nullptr;
 
       void SetUp() override;
       void TearDown() override;
@@ -76,7 +76,7 @@ namespace Isis {
 
   class MiniRFCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
+      Cube *testCube = nullptr;
 
       void SetUp() override;
       void TearDown() override;
@@ -84,7 +84,7 @@ namespace Isis {
 
   class DemCube : public DefaultCube {
     protected:
-      Cube *demCube;
+      Cube *demCube = nullptr;
 
       void SetUp() override;
       void TearDown() override;
@@ -151,7 +151,7 @@ namespace Isis {
 
   class ClipperWacFcCube : public DefaultCube {
     protected:
-      Cube *wacFcCube;
+      Cube *wacFcCube = nullptr;
       Pvl label;
       nlohmann::json isd;
       void SetUp() override;
@@ -166,7 +166,7 @@ namespace Isis {
 
   class ClipperPbCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
+      Cube *testCube = nullptr;
       void setInstrument(QString instrumentId);
   };
 

--- a/isis/tests/CsmFixtures.h
+++ b/isis/tests/CsmFixtures.h
@@ -32,7 +32,7 @@ namespace Isis {
 
   class CSMCameraFixture : public CSMCubeFixture {
     protected:
-      Camera *testCam;
+      Camera *testCam = nullptr;
 
       void SetUp() override;
   };
@@ -51,7 +51,7 @@ namespace Isis {
 
   class CSMCameraDemFixture : public CSMCubeFixture {
     protected:
-      Camera *testCam;
+      Camera *testCam = nullptr;
       double demRadius;
 
       void SetUp() override;
@@ -65,7 +65,7 @@ namespace Isis {
       QVector<FileName> labelFiles;
       QVector<Cube*> cubes;
 
-      FileList *cubeList;
+      FileList *cubeList = nullptr;
       QString cubeListFile;
 
       void SetUp() override;

--- a/isis/tests/CubeFixtures.cpp
+++ b/isis/tests/CubeFixtures.cpp
@@ -48,7 +48,7 @@ namespace Isis {
   }
 
   void SmallCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 
@@ -78,7 +78,7 @@ namespace Isis {
   }
 
   void LargeCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 
@@ -127,7 +127,7 @@ namespace Isis {
   }
 
   void SpecialSmallCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 
@@ -218,13 +218,13 @@ namespace Isis {
 
 
   void SmallGapCube::TearDown() {
-    if (horzCube->isOpen()) {
+    if (horzCube && horzCube->isOpen()) {
       horzCube->close();
     }
-    if (vertCube->isOpen()) {
+    if (vertCube && vertCube->isOpen()) {
       vertCube->close();
     }
-    if (bandCube->isOpen()) {
+    if (bandCube && bandCube->isOpen()) {
       bandCube->close();
     }
 
@@ -259,7 +259,7 @@ namespace Isis {
 
 
   void NullPixelCube::TearDown() {
-    if (testCube->isOpen()) {
+    if (testCube && testCube->isOpen()) {
       testCube->close();
     }
 

--- a/isis/tests/CubeFixtures.h
+++ b/isis/tests/CubeFixtures.h
@@ -22,7 +22,7 @@ namespace Isis {
 
   class SmallCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
+      Cube *testCube = nullptr;
 
       void SetUp() override;
       void TearDown() override;
@@ -31,7 +31,7 @@ namespace Isis {
 
   class LargeCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
+      Cube *testCube = nullptr;
 
       void SetUp() override;
       void TearDown() override;
@@ -40,7 +40,7 @@ namespace Isis {
 
   class SpecialSmallCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
+      Cube *testCube = nullptr;
 
       void SetUp() override;
       void TearDown() override;
@@ -48,9 +48,9 @@ namespace Isis {
 
   class SmallGapCube : public TempTestingFiles {
     protected:
-      Cube *horzCube;
-      Cube *vertCube;
-      Cube *bandCube;
+      Cube *horzCube = nullptr;
+      Cube *vertCube = nullptr;
+      Cube *bandCube = nullptr;
 
       void SetUp() override;
       void TearDown() override;
@@ -59,7 +59,7 @@ namespace Isis {
 
   class NullPixelCube : public TempTestingFiles {
     protected:
-      Cube *testCube;
+      Cube *testCube = nullptr;
       void SetUp() override;
       void TearDown() override;
   };
@@ -77,8 +77,8 @@ namespace Isis {
     protected:
 
       // pixtures of Saturn's rings
-      Cube *ring1;
-      Cube *ring2;
+      Cube *ring1 = nullptr;
+      Cube *ring2 = nullptr;
       FileList cubeFileList;
       QString cubeListPath;
 

--- a/isis/tests/IsisTestMain.cpp
+++ b/isis/tests/IsisTestMain.cpp
@@ -1,10 +1,21 @@
 #include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include <QTemporaryDir>
+
 #include "Preference.h"
 
 using namespace Isis;
 
 int main(int argc, char **argv) {
    Isis::Preference::Preferences(true);
+
+   // Keep SpiceQL from generating a new cache directory per test process
+   QTemporaryDir spiceqlCache;
+   if (spiceqlCache.isValid() && getenv("SPICEQL_CACHE_DIR") == NULL) {
+     setenv("SPICEQL_CACHE_DIR", spiceqlCache.path().toLatin1().data(), 1);
+   }
 
    ::testing::InitGoogleTest(&argc, argv);
    return RUN_ALL_TESTS();

--- a/isis/tests/NetworkFixtures.cpp
+++ b/isis/tests/NetworkFixtures.cpp
@@ -244,15 +244,15 @@ namespace Isis {
 
 
   void MiniRFNetwork::TearDown() {
-    if (testCube1->isOpen()) {
+    if (testCube1 && testCube1->isOpen()) {
       testCube1->close();
     }
     delete testCube1;
-    if (testCube2->isOpen()) {
+    if (testCube2 && testCube2->isOpen()) {
       testCube2->close();
     }
     delete testCube2;
-    if (testCube3->isOpen()) {
+    if (testCube3 && testCube3->isOpen()) {
       testCube3->close();
     }
     delete testCube3;
@@ -289,19 +289,19 @@ namespace Isis {
 
 
   void VikThmNetwork::TearDown() {
-    if (testCube1->isOpen()) {
+    if (testCube1 && testCube1->isOpen()) {
       testCube1->close();
     }
     delete testCube1;
-    if (testCube2->isOpen()) {
+    if (testCube2 && testCube2->isOpen()) {
       testCube2->close();
     }
     delete testCube2;
-    if (testCube3->isOpen()) {
+    if (testCube3 && testCube3->isOpen()) {
       testCube3->close();
     }
     delete testCube3;
-    if (testCube4->isOpen()) {
+    if (testCube4 && testCube4->isOpen()) {
       testCube4->close();
     }
     delete testCube4;

--- a/isis/tests/NetworkFixtures.h
+++ b/isis/tests/NetworkFixtures.h
@@ -15,25 +15,25 @@ namespace Isis {
   class ThreeImageNetwork : public TempTestingFiles {
     protected:
 
-      ControlNet *network;
+      ControlNet *network = nullptr;
       QString networkFile;
 
-      Cube *cube1;
-      Cube *cube2;
-      Cube *cube3;
+      Cube *cube1 = nullptr;
+      Cube *cube2 = nullptr;
+      Cube *cube3 = nullptr;
 
-      Cube *cube1map;
-      Cube *cube2map;
-      Cube *cube3map;
+      Cube *cube1map = nullptr;
+      Cube *cube2map = nullptr;
+      Cube *cube3map = nullptr;
 
-      FileName *isdPath1;
-      FileName *isdPath2;
-      FileName *isdPath3;
+      FileName *isdPath1 = nullptr;
+      FileName *isdPath2 = nullptr;
+      FileName *isdPath3 = nullptr;
 
-      FileName *threeImageOverlapFile;
-      FileName *twoImageOverlapFile;
+      FileName *threeImageOverlapFile = nullptr;
+      FileName *twoImageOverlapFile = nullptr;
 
-      FileList *cubeList;
+      FileList *cubeList = nullptr;
       QString cubeListFile;
       QString twoCubeListFile;
 
@@ -51,19 +51,19 @@ namespace Isis {
   class ObservationPair : public TempTestingFiles {
     protected:
 
-      Cube *cubeL;
-      Cube *cubeR;
+      Cube *cubeL = nullptr;
+      Cube *cubeR = nullptr;
 
       QString cubeLPath;
       QString cubeRPath;
 
-      FileName *isdPathL;
-      FileName *isdPathR;
+      FileName *isdPathL = nullptr;
+      FileName *isdPathR = nullptr;
 
-      FileList *cubeList;
+      FileList *cubeList = nullptr;
       QString cubeListFile;
 
-      ControlNet *network;
+      ControlNet *network = nullptr;
       QString cnetPath;
 
       void SetUp() override;
@@ -76,10 +76,10 @@ namespace Isis {
       QVector<FileName> labelFiles;
       QVector<Cube*> cubes;
 
-      FileList *cubeList;
+      FileList *cubeList = nullptr;
       QString cubeListFile;
 
-      ControlNet *network;
+      ControlNet *network = nullptr;
       QString controlNetPath;
 
       void SetUp() override;
@@ -89,16 +89,16 @@ namespace Isis {
     class LidarObservationPair : public TempTestingFiles {
     protected:
 
-      Cube *cube1;
-      Cube *cube2;
+      Cube *cube1 = nullptr;
+      Cube *cube2 = nullptr;
 
       QString cube1Path;
       QString cube2Path;
 
-      FileName *isdPath1;
-      FileName *isdPath2;
+      FileName *isdPath1 = nullptr;
+      FileName *isdPath2 = nullptr;
 
-      FileList *cubeList;
+      FileList *cubeList = nullptr;
       QString cubeListFile;
 
       QString csvPath;
@@ -113,7 +113,7 @@ namespace Isis {
       LidarData rangeData;
       QString lidarDataPath;
 
-      ControlNet *network;
+      ControlNet *network = nullptr;
       QString controlNetPath;
 
       void SetUp() override;
@@ -122,14 +122,14 @@ namespace Isis {
 
   class MiniRFNetwork : public TempTestingFiles {
     protected:
-      Cube *testCube1;
-      Cube *testCube2;
-      Cube *testCube3;
+      Cube *testCube1 = nullptr;
+      Cube *testCube2 = nullptr;
+      Cube *testCube3 = nullptr;
 
-      FileList *cubeList;
+      FileList *cubeList = nullptr;
       QString cubeListFile;
 
-      ControlNet *network;
+      ControlNet *network = nullptr;
       QString controlNetPath;
 
       void SetUp() override;
@@ -138,15 +138,15 @@ namespace Isis {
 
   class VikThmNetwork : public TempTestingFiles {
     protected:
-      Cube *testCube1;
-      Cube *testCube2;
-      Cube *testCube3;
-      Cube *testCube4;
+      Cube *testCube1 = nullptr;
+      Cube *testCube2 = nullptr;
+      Cube *testCube3 = nullptr;
+      Cube *testCube4 = nullptr;
 
-      FileList *cubeList;
+      FileList *cubeList = nullptr;
       QString cubeListFile;
 
-      ControlNet *network;
+      ControlNet *network = nullptr;
       QString controlNetPath;
 
       void SetUp() override;

--- a/isis/tests/TgoCassisModuleTests.cpp
+++ b/isis/tests/TgoCassisModuleTests.cpp
@@ -2200,7 +2200,6 @@ TEST(TgoCassisModuleTests, TgoCassisUncontrolledSingleColorMosaic) {
 
 TEST_F(TgoCassisModuleKernels, TgoCassisTestProjSingleStitchedFrame) {
   QTemporaryDir prefix;
-  prefix.setAutoRemove(false);
 
   // run tgocassis2isis and spiceinit on pan framelet.
   QString panFileName = prefix.path() + "/panframelet.cub";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Fixes issue in tests where temp directories are not cleaned up when tests fail. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#6060

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

ran locally, temp data stopped being created when running tests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
