### PR TITLE
Dsk2isis test change

### DIFF
--- a/changes/+20260821131534.fix.md
+++ b/changes/+20260821131534.fix.md
@@ -1,0 +1,1 @@
+Fixed dsk2isis to be callable in code

--- a/isis/src/base/apps/dsk2isis/dsk2isis.cpp
+++ b/isis/src/base/apps/dsk2isis/dsk2isis.cpp
@@ -56,7 +56,7 @@ namespace Isis {
     delete proj;
 
     // Create the cube from the projection parameters
-    Cube *ocube = p.SetOutputCube("TO", ns, nl, 1);
+    Cube *ocube = p.SetOutputCube(ui.GetCubeName("TO"), ui.GetOutputAttribute("TO"), ns, nl, 1);
     ocube->putGroup(cleanMap);
     TProjection *tproj = (TProjection *) ocube->projection();
 

--- a/isis/tests/FunctionalTestsDsk2isis.cpp
+++ b/isis/tests/FunctionalTestsDsk2isis.cpp
@@ -14,6 +14,7 @@
 #include "gtest/gtest.h"
 
 using namespace Isis;
+using ::testing::HasSubstr;
 
 static QString APP_XML = FileName("$ISISROOT/bin/xml/dsk2isis.xml").expanded();
 
@@ -236,7 +237,7 @@ TEST_F(Dsk2isisDefault, FunctionalTestDsk2isisInvalidDskFile) {
     dsk2isis(options);
   }
   catch (IException &e) {
-    // FAIL() << "Unable to convert dsk to dem: " <<e.toString().toStdString().c_str() << std::endl;
+    EXPECT_THAT(e.what(), HasSubstr("does not exist"));
   }
 
 }

--- a/isis/tests/FunctionalTestsDsk2isis.cpp
+++ b/isis/tests/FunctionalTestsDsk2isis.cpp
@@ -128,23 +128,15 @@ TEST_F(Dsk2isisDefault, FunctionalTestDsk2isisRayMethod) {
   QString dskFile = testDataPath("hay_a_amica_5_itokawashape_v1_0_64q.bds");
   QString outputCube = tempDir.path() + "/dsk_ray_output.cub";
 
-  // Run dsk2isis as subprocess
-  QString dsk2isisApp = FileName("$ISISROOT/bin/dsk2isis").expanded();
-  QStringList args;
-  args << "from=" + dskFile
-       << "map=" + mapFile
-       << "to=" + outputCube
-       << "method=RAY";
+  QVector<QString> args = {"from="+dskFile, "map=" + mapFile, "to="+outputCube, "method=RAY"};
 
-  QProcess dsk2isis;
-  dsk2isis.setProgram(dsk2isisApp);
-  dsk2isis.setArguments(args);
-  dsk2isis.start();
-  bool finished = dsk2isis.waitForFinished(60000);
-
-  ASSERT_TRUE(finished) << "dsk2isis did not finish within timeout";
-  EXPECT_EQ(dsk2isis.exitCode(), 0) << "dsk2isis failed with exit code: " << dsk2isis.exitCode()
-                                     << "\nStderr: " << dsk2isis.readAllStandardError().toStdString();
+  UserInterface options(APP_XML, args);
+  try {
+    dsk2isis(options);
+  }
+  catch (IException &e) {
+    FAIL() << "Unable to convert dsk to dem: " <<e.toString().toStdString().c_str() << std::endl;
+  }
 
   // Verify output cube was created
   Cube output(outputCube);
@@ -192,23 +184,15 @@ TEST_F(Dsk2isisDefault, FunctionalTestDsk2isisHigherScale) {
   QString dskFile = testDataPath("hay_a_amica_5_itokawashape_v1_0_64q.bds");
   QString outputCube = tempDir.path() + "/dsk_hiscale_output.cub";
 
-  // Run dsk2isis as subprocess
-  QString dsk2isisApp = FileName("$ISISROOT/bin/dsk2isis").expanded();
-  QStringList args;
-  args << "from=" + dskFile
-       << "map=" + mapFile
-       << "to=" + outputCube
-       << "method=GRID";
+  QVector<QString> args = {"from="+dskFile, "map=" + mapFile, "to="+outputCube, "method=GRID"};
 
-  QProcess dsk2isis;
-  dsk2isis.setProgram(dsk2isisApp);
-  dsk2isis.setArguments(args);
-  dsk2isis.start();
-  bool finished = dsk2isis.waitForFinished(60000);
-
-  ASSERT_TRUE(finished) << "dsk2isis did not finish within timeout";
-  EXPECT_EQ(dsk2isis.exitCode(), 0) << "dsk2isis failed with exit code: " << dsk2isis.exitCode()
-                                     << "\nStderr: " << dsk2isis.readAllStandardError().toStdString();
+  UserInterface options(APP_XML, args);
+  try {
+    dsk2isis(options);
+  }
+  catch (IException &e) {
+    FAIL() << "Unable to convert dsk to dem: " <<e.toString().toStdString().c_str() << std::endl;
+  }
 
   // Verify output
   Cube output(outputCube);
@@ -245,24 +229,14 @@ TEST_F(Dsk2isisDefault, FunctionalTestDsk2isisInvalidDskFile) {
 
   QString outputCube = tempDir.path() + "/output.cub";
 
-  // Run dsk2isis as subprocess with invalid DSK file
-  QString dsk2isisApp = FileName("$ISISROOT/bin/dsk2isis").expanded();
-  QStringList args;
-  args << "from=/nonexistent/file.bds"
-       << "map=" + mapFile
-       << "to=" + outputCube
-       << "method=GRID";
+  QVector<QString> args = {"from=/nonexistent/file.bds", "map=" + mapFile, "to=" + outputCube, "method=GRID"};
 
-  QProcess dsk2isis;
-  dsk2isis.setProgram(dsk2isisApp);
-  dsk2isis.setArguments(args);
-  dsk2isis.start();
-  bool finished = dsk2isis.waitForFinished(10000);
+  UserInterface options(APP_XML, args);
+  try {
+    dsk2isis(options);
+  }
+  catch (IException &e) {
+    // FAIL() << "Unable to convert dsk to dem: " <<e.toString().toStdString().c_str() << std::endl;
+  }
 
-  ASSERT_TRUE(finished) << "dsk2isis did not finish within timeout";
-  EXPECT_NE(dsk2isis.exitCode(), 0) << "dsk2isis should have failed with invalid file";
-
-  QString stderr_output = dsk2isis.readAllStandardError();
-  EXPECT_TRUE(stderr_output.contains("does not exist") || stderr_output.contains("USER ERROR"))
-      << "Expected error message about missing file, got: " << stderr_output.toStdString();
 }

--- a/isis/tests/FunctionalTestsDsk2isis.cpp
+++ b/isis/tests/FunctionalTestsDsk2isis.cpp
@@ -73,24 +73,15 @@ TEST_F(Dsk2isisDefault, FunctionalTestDsk2isisGridMethod) {
   QString dskFile = testDataPath("hay_a_amica_5_itokawashape_v1_0_64q.bds");
   QString outputCube = tempDir.path() + "/dsk_grid_output.cub";
 
-  // Run dsk2isis as subprocess to avoid NAIF global state issues
-  QString dsk2isisApp = FileName("$ISISROOT/bin/dsk2isis").expanded();
-  QStringList args;
-  args << "from=" + dskFile
-       << "map=" + mapFile
-       << "to=" + outputCube
-       << "method=GRID";
+  QVector<QString> args = {"from="+dskFile, "map=" + mapFile, "to="+outputCube, "method=GRID"};
 
-  QProcess dsk2isis;
-  dsk2isis.setProgram(dsk2isisApp);
-  dsk2isis.setArguments(args);
-  dsk2isis.start();
-  bool finished = dsk2isis.waitForFinished(60000); // 60 second timeout
-
-  ASSERT_TRUE(finished) << "dsk2isis did not finish within timeout";
-  EXPECT_EQ(dsk2isis.exitCode(), 0) << "dsk2isis failed with exit code: " << dsk2isis.exitCode()
-                                     << "\nStderr: " << dsk2isis.readAllStandardError().toStdString();
-
+  UserInterface options(APP_XML, args);
+  try {
+    dsk2isis(options);
+  }
+  catch (IException &e) {
+    FAIL() << "Unable to convert dsk to dem: " <<e.toString().toStdString().c_str() << std::endl;
+  }
   // Verify output cube was created and has expected properties
   Cube output(outputCube);
   EXPECT_GT(output.sampleCount(), 0);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change dsk2isis tests to run as function calls rather than subprocesses. Subpossedly all ctests discovered using `gtest_discover_tests` run as seperate processes so any race conditions don't seem to be an issue. `NaifDskPlateModel` also doesn't use the kernel pool but DSA and DSK utility functions to read/handle the DSKs. There is also no writing to the DSKs only reading.

## Related Issue
N/A

## How Has This Been Validated?
These are changes to tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
