### PR TITLE
fixed conf flag for the downloadIsisData script

### DIFF
--- a/changes/+20260825160036.fix.md
+++ b/changes/+20260825160036.fix.md
@@ -1,0 +1,1 @@
+fixed issue where you cannot set a custom conf for downloadIsisData

--- a/isis/scripts/downloadIsisData
+++ b/isis/scripts/downloadIsisData
@@ -267,7 +267,7 @@ if __name__ == '__main__':
     parser.add_argument('dest', help='the destination to download files from source')
     parser.add_argument('-v', '--verbose', action='count', default=0)
     parser.add_argument('-n', '--num-transfers', action='store', default=10)
-    parser.add_argument('--config', action='store', default=find_conf())
+    parser.add_argument('--config', action='store', default=None)
     parser.add_argument('--filter', help='Additional filters for files', nargs='*')
     parser.add_argument('--include', help='files and patterns to include while downloading', nargs='*')
     parser.add_argument('--exclude', help='files and patterns to ignore while downloading', nargs='*')
@@ -275,7 +275,10 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--command', choices=["copy", "sync", "ls", "lsd", "size"], help='files and patterns to ignore while downloading', default="copy")
 
     args, kwargs = parser.parse_known_args()
- 
+
+    if args.config is None:
+        args.config = find_conf()
+    
     log_kwargs = {
       'format': '%(asctime)s %(levelname)-8s %(message)s',
       'level': log.WARN,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->

Fixed issue where the downloadIsisData script fails everytime a custom script is passed in. 

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

None, this fix has been sitting on my drive for some time. 

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [ ] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [ ] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [ ] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
