### PR TITLE
Fixed gui exiting when Ok is clicked

### DIFF
--- a/changes/6128.fix.md
+++ b/changes/6128.fix.md
@@ -1,1 +1,1 @@
-Fix GUI closeing after clicking Ok from the Exception dialog
+Fix GUI closing after clicking Ok from the Exception dialog

--- a/changes/6128.fix.md
+++ b/changes/6128.fix.md
@@ -1,0 +1,1 @@
+Fix GUI closeing after clicking Ok from the Exception dialog

--- a/isis/src/base/objs/Gui/Gui.cpp
+++ b/isis/src/base/objs/Gui/Gui.cpp
@@ -611,7 +611,8 @@ namespace Isis {
                                       QMessageBox::Ok | QMessageBox::Abort,
                                       QMessageBox::Ok);
     p_errorString.clear();
-    return status;
+    bool shouldExit = status != QMessageBox::Ok;
+    return shouldExit;
   }
 
   //! Write text to the gui log


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes the ISIS GUIs from exiting when ok is clicked from the Exception dialog popup

## Related Issue
N/A

## How Has This Been Validated?
Validated locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
