### PR TITLE
Gdal Metadata Sync

### DIFF
--- a/changes/6144.change.md
+++ b/changes/6144.change.md
@@ -1,0 +1,1 @@
+Changed PVL label generation from gdal datasets to update the ISIS label Core groups with information from the geotiff

--- a/isis/src/core/src/Pvl.cpp
+++ b/isis/src/core/src/Pvl.cpp
@@ -188,6 +188,23 @@ namespace Isis {
       const char *metadataJsonString = metadata[0];
       nlohmann::ordered_json metadataAsJson = nlohmann::ordered_json::parse(metadataJsonString);
       readObject(*this, metadataAsJson);
+      
+      if (this->hasObject("IsisCube")) {
+        PvlObject &core = this->findObject("IsisCube").findObject("Core");
+
+        PvlGroup &dims = core.findGroup("Dimensions");
+        dims["Samples"] = toString(dataset->GetRasterXSize());
+        dims["Lines"] = toString(dataset->GetRasterYSize());
+        dims["Bands"] = toString(dataset->GetRasterCount());
+
+        GDALRasterBand *band = dataset->GetRasterBand(1);
+
+        PvlGroup &ptype = core.findGroup("Pixels");
+        ptype["Type"] = PixelTypeName(GdalPixelToIsis(band->GetRasterDataType()));
+
+        ptype["Base"] = toString(band->GetOffset());
+        ptype["Multiplier"] = toString(band->GetScale());
+      }
     }
     else {
       // Setup the PVL


### PR DESCRIPTION
## Description
Syncs the ISIS label Core with information from the gdal dataset when reading/generating the a cube PVL label

## Related Issue
N/A

## How Has This Been Validated?
Validated locally. There was an issue when updating the "multiplier" or "scale" on geotiffs because the value was only written to the cube label and not the geotiff itself.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [ ] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
