### PR TITLE
Fix `getkey` to work with geotiffs

### DIFF
--- a/changes/6146.fix.md
+++ b/changes/6146.fix.md
@@ -1,0 +1,1 @@
+Fixed extracting keywords from geotiffs using `getkey`

--- a/isis/src/base/apps/getkey/main.cpp
+++ b/isis/src/base/apps/getkey/main.cpp
@@ -34,8 +34,7 @@ void IsisMain() {
   QString labelFile = ui.GetCubeName("FROM");
 
   // Open the file ... it must be a label-type file
-  Pvl lab;
-  lab.read(labelFile);
+  Pvl lab(labelFile);
   bool recursive = ui.GetBoolean("RECURSIVE");
 
   // Set up the requested object


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes `getkey` to extract PVL keywords from ISIS metadata stored on a geotiff

## Related Issue
Fixes #6146 

## How Has This Been Validated?
Validated locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [ ] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
