### PR TITLE
Fix lronacpho error when opening a backplane cube

### DIFF
--- a/changes/+20260911233301.fix.md
+++ b/changes/+20260911233301.fix.md
@@ -1,0 +1,1 @@
+Fixed lronacpho error when opening a backplane cube.

--- a/isis/src/lro/apps/lronacpho/lronacpho.cpp
+++ b/isis/src/lro/apps/lronacpho/lronacpho.cpp
@@ -47,7 +47,8 @@ namespace Isis{
     *  @history 2016-09-19 Victor Silva - Adapted from lrowacpho written by Kris Becker
     *	 @history 2021-03-12 Victor Silva - Updates"PostCall" include ability to run with default values
     * 																			Added new values for 2019 version of LROC Empirical function.
-    *  @history 2022-04-18 Victor Silva - Refactored to make callable for GTest framework                                   
+    *  @history 2022-04-18 Victor Silva - Refactored to make callable for GTest framework
+    *  @history 2026-09-11 Cordell Michaud - Fixed error when opening a backplane cube.
     *
     * @param iCube The input cube to be photometrically corrected.
     * @param ui The user interfact to parse the parameters from. 
@@ -64,7 +65,7 @@ namespace Isis{
       CubeAttributeInput backplaneCai = ui.GetInputAttribute("BACKPLANE");
 
       Cube bpCube;
-      bpCube.open(ui.GetFileName("BACKPLANE"));
+      bpCube.open(ui.GetCubeName("BACKPLANE"));
       int bpBands = bpCube.bandCount();
       bpCube.close();
 
@@ -81,11 +82,11 @@ namespace Isis{
 
       CubeAttributeInput cai;
       bpCaiBands == 3 ? cai.setAttributes("+" + backplaneCai.bands()[0]) : cai.setAttributes("+1" ) ;
-      p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+      p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
       bpCaiBands == 3 ? cai.setAttributes("+" + backplaneCai.bands()[1]) : cai.setAttributes("+2" ) ;
-      p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+      p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
       bpCaiBands == 3 ? cai.setAttributes("+" + backplaneCai.bands()[2]) : cai.setAttributes("+3" ) ;
-      p.SetInputCube(ui.GetFileName("BACKPLANE"), cai);
+      p.SetInputCube(ui.GetCubeName("BACKPLANE"), cai);
 
       useBackplane = true;
     }

--- a/isis/src/lro/apps/lronacpho/lronacpho.xml
+++ b/isis/src/lro/apps/lronacpho/lronacpho.xml
@@ -129,6 +129,9 @@
       Included ability to run with default pvl values
       Added new values for 2019 version of LROC Empirical function
     </change>
+    <change name="Cordell Michaud" date="2026-09-11">
+      Fixed error when opening a backplane cube.
+    </change>
   </history>
 
   <category>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail including motivation and any context -->
- Lronacpho threw an error when opening a backplane cube because it was calling `GetFileName` instead of `GetCubeName`
- I replaced `GetFileName` calls to `GetCubeName` calls for the backplane cube so it will no longer throw an error
- I updated the lronacpho documentation with a history entry for this bugfix
- I created a change file for this bugfix

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## How Has This Been Validated?
<!--- All changes need to be validated to confirm that they produce -->
<!--- scientifically accurate results. -->
<!--- If your changes include any new algorithms or changes to existing algorithms, -->
<!--- please indicate any publications or references for them. -->
<!--- If you manually validated the changes please indicate -->
<!--- what data you used and how you checked the results. -->
- Lronacpho no longer throws an error when opening backplane cube

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation change (update to the documentation; no code change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Infrastructure change (changes to things like CI or the build system that do not impact users)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- - [x] My code follows the code style of this project. -->
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/Code-Of-Conduct.md)
- [x] I have read the [**CONTRIBUTING**](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CONTRIBUTING.md) document.
- [x] My change requires a change to the documentation and I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] My changes include code created using generative AI.
- [x] I have added my user impacting change to the [CHANGELOG.md](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/CHANGELOG.md) document. <!--- NOTE: You can only have one changelog entry per PR, see https://github.com/DOI-USGS/ISIS3/blob/dev/CONTRIBUTING.md -->


## Licensing
This project is mostly composed of free and unencumbered software released into the public domain, and we are unlikely to accept contributions that are not also released into the public domain. Somewhere near the top of each file should have these words:

> This work is free and unencumbered software released into the public domain. In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain.

- [x] I dedicate any and all copyright interest in this software to the public domain. I make this dedication for the benefit of the public at large and to the detriment of my heirs and successors. I intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.
